### PR TITLE
ci: add manypkg check to lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check workspace dependency consistency
+        run: pnpm manypkg:check
+
       - name: Check linting
         run: pnpm lint
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "//": "manypkg requires root deps in 'dependencies', not 'devDependencies'. The root is private and never published, so the distinction is meaningless here — it's a consistency convention.",
   "dependencies": {
-    "@manypkg/cli": "^0.22.0",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+    "@manypkg/cli": "^0.22.0",
     "@tsmono/prettier-config": "workspace:*",
     "picocolors": "^1.1.1",
     "prettier": "^3.7.4",


### PR DESCRIPTION
## Summary
- Adds `pnpm manypkg:check` step to the CI `lint` job to catch inconsistent workspace dependency declarations
- Includes minor alphabetical sort fix in root `package.json`

## Test plan
- [ ] Verify CI lint job passes with the new step