### PR TITLE
fix page breaks

### DIFF
--- a/apps/inspect/src/app/App.css
+++ b/apps/inspect/src/app/App.css
@@ -1142,6 +1142,11 @@ pre[class*="language-"] {
     print-color-adjust: exact !important;
   }
 
+  body {
+    orphans: 3;
+    widows: 3;
+  }
+
   #app,
   .app-main-grid {
     height: auto !important;

--- a/apps/inspect/src/app/samples/chat/ChatMessageRow.module.css
+++ b/apps/inspect/src/app/samples/chat/ChatMessageRow.module.css
@@ -19,3 +19,9 @@
 .container {
   padding: 0.4em 0.4em 0.4em 0.4em;
 }
+
+@media print {
+  .container {
+    break-inside: avoid;
+  }
+}

--- a/apps/inspect/src/app/samples/transcript/TranscriptVirtualListComponent.module.css
+++ b/apps/inspect/src/app/samples/transcript/TranscriptVirtualListComponent.module.css
@@ -17,3 +17,9 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+@media print {
+  .node {
+    break-inside: avoid;
+  }
+}

--- a/apps/inspect/src/app/samples/transcript/event/EventPanel.module.css
+++ b/apps/inspect/src/app/samples/transcript/event/EventPanel.module.css
@@ -94,3 +94,9 @@
 .dongleIcon {
   padding-right: 0.3em;
 }
+
+@media print {
+  .card {
+    break-inside: avoid;
+  }
+}

--- a/apps/inspect/src/components/Card.css
+++ b/apps/inspect/src/components/Card.css
@@ -60,3 +60,9 @@
 .card-body.card-no-padding {
   padding: 0;
 }
+
+@media print {
+  .card {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When the user is printing, page breaks are inserted into MODEL CALL, etc. panels, MESSAGES rows, and METADATA and SCORING cards.

A minimum of 2 line boxes in a block container must be left in a fragment before (and after) a break.

### What is the new behavior?

The breaks aren't inserted.

A minimum of 3 line boxes in a block container must be left in a fragment before (and after) a break.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I ran

```
inspect eval repro_many_turns.py --model openai/gpt-5-nano
inspect view
```
where `repro_many_turns.py` is

```
from inspect_ai import Task, task
from inspect_ai.dataset import Sample
from inspect_ai.scorer import includes
from inspect_ai.solver import basic_agent
from inspect_ai.tool import tool


@tool
def log_number():
    async def execute(number: int) -> str:
        return f"Logged {number}."

    return execute


@task
def many_turns():
    return Task(
        dataset=[
            Sample(
                input="Call the log_number tool with every number from 1 to 120, one number per message. After logging 120, call submit() with answer '120'.",
                target="120",
            )
        ],
        solver=basic_agent(tools=[log_number()], message_limit=250),
        scorer=includes(),
    )
```
.

Then for TRANSCRIPTS, MESSAGES, SCORING, and METADATA, I used Command-P and looked at the pages to print.