### PR TITLE
Improve `ScanResultSummary` filtering 

### DIFF
--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -110,14 +110,19 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
     if (scansSearchText && scansSearchText.length > 0) {
       const lowerSearch = scansSearchText.toLowerCase();
       textFiltered = scannerSummaries.filter((s) => {
-        const idStr = resultIdentifierStr(s) || "";
-        const logStr = resultLog(s) || "";
-        const labelStr = s.label || "";
-        return (
-          idStr.toLowerCase().includes(lowerSearch) ||
-          logStr.toLowerCase().includes(lowerSearch) ||
-          labelStr.toLowerCase().includes(lowerSearch)
-        );
+        const searchable = [
+          resultIdentifierStr(s),
+          resultLog(s),
+          s.label,
+          s.explanation,
+          s.transcriptModel,
+          s.scanError,
+          stringifyValue(s),
+        ]
+          .filter(Boolean)
+          .join("\n")
+          .toLowerCase();
+        return searchable.includes(lowerSearch);
       });
     }
 
@@ -426,6 +431,23 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
       )}
     </div>
   );
+};
+
+/**
+ * Stringify a ScanResultSummary value for text search.
+ * Handles all valueType variants so search covers the displayed result content.
+ */
+const stringifyValue = (s: ScanResultSummary): string => {
+  if (s.value === null || s.value === undefined) return "";
+  if (isStringValue(s)) return s.value;
+  if (isNumberValue(s) || isBooleanValue(s)) return String(s.value);
+  if (isArrayValue(s)) return s.value.map(String).join(" ");
+  if (isObjectValue(s)) {
+    return Object.entries(s.value)
+      .map(([k, v]) => `${k} ${v !== null && v !== undefined ? String(v) : ""}`)
+      .join(" ");
+  }
+  return String(s.value);
 };
 
 // Type-aware comparison for ScanResultSummary values.

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -15,19 +15,12 @@ import { useStore } from "../../../../state/store";
 import { Status } from "../../../../types/api-types";
 import { useScanResultSummaries } from "../../../hooks/useScanResultSummaries";
 import { useScanRoute } from "../../../hooks/useScanRoute";
+import { ScanResultSummary } from "../../../types";
 import {
-  isArrayValue,
-  isBooleanValue,
-  isNumberValue,
-  isObjectValue,
-  isStringValue,
-  ScanResultSummary,
-  SortColumn,
-} from "../../../types";
-import {
-  resultIdentifier,
   resultIdentifierStr,
   resultLog,
+  sortByColumns,
+  stringifyValue,
 } from "../../../utils/results";
 import {
   kFilterAllResults,
@@ -431,138 +424,6 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
       )}
     </div>
   );
-};
-
-/**
- * Stringify a ScanResultSummary value for text search.
- * Handles all valueType variants so search covers the displayed result content.
- */
-const stringifyValue = (s: ScanResultSummary): string => {
-  if (s.value === null || s.value === undefined) return "";
-  if (isStringValue(s)) return s.value;
-  if (isNumberValue(s) || isBooleanValue(s)) return String(s.value);
-  if (isArrayValue(s)) return s.value.map(String).join(" ");
-  if (isObjectValue(s)) {
-    return Object.entries(s.value)
-      .map(([k, v]) => `${k} ${v !== null && v !== undefined ? String(v) : ""}`)
-      .join(" ");
-  }
-  return String(s.value);
-};
-
-// Type-aware comparison for ScanResultSummary values.
-// Uses valueType to compare numerics, booleans, strings, arrays, and objects correctly.
-// Nulls always sort last.
-const sortValue = (a: ScanResultSummary, b: ScanResultSummary): number => {
-  // Nulls sort last (after all other types)
-  if (a.value === null || a.value === undefined || a.valueType === "null") {
-    if (b.value === null || b.value === undefined || b.valueType === "null") {
-      return 0;
-    }
-    return 1;
-  }
-  if (b.value === null || b.value === undefined || b.valueType === "null") {
-    return -1;
-  }
-
-  // Same type: compare natively
-  if (a.valueType === b.valueType) {
-    if (isNumberValue(a) && isNumberValue(b)) {
-      return a.value - b.value;
-    }
-    if (isBooleanValue(a) && isBooleanValue(b)) {
-      return (a.value ? 1 : 0) - (b.value ? 1 : 0);
-    }
-    if (isStringValue(a) && isStringValue(b)) {
-      return a.value.localeCompare(b.value);
-    }
-    if (isArrayValue(a) && isArrayValue(b)) {
-      return (
-        a.value.length - b.value.length ||
-        String(a.value).localeCompare(String(b.value))
-      );
-    }
-    if (isObjectValue(a) && isObjectValue(b)) {
-      return JSON.stringify(a.value).localeCompare(JSON.stringify(b.value));
-    }
-  }
-
-  // Different types: fall back to string comparison
-  return String(a.value).localeCompare(String(b.value));
-};
-
-// Sorts scan results by multiple columns and directions.
-// Applies sorting rules in order, falling back to the next rule if values are equal.
-const sortByColumns = (
-  a: ScanResultSummary,
-  b: ScanResultSummary,
-  sortColumns: SortColumn[]
-): number => {
-  for (const sortCol of sortColumns) {
-    let comparison = 0;
-
-    switch (sortCol.column.toLowerCase()) {
-      case "id": {
-        const identifierA = resultIdentifier(a);
-        const identifierB = resultIdentifier(b);
-
-        if (
-          typeof identifierA.id === "number" &&
-          typeof identifierB.id === "number"
-        ) {
-          comparison = identifierA.id - identifierB.id;
-        } else {
-          comparison = String(identifierA.id).localeCompare(
-            String(identifierB.id)
-          );
-        }
-
-        if (comparison === 0 && identifierA.epoch && identifierB.epoch) {
-          comparison = identifierA.epoch - identifierB.epoch;
-        }
-        break;
-      }
-      case "explanation": {
-        const explA = a.explanation || "";
-        const explB = b.explanation || "";
-        comparison = explA.localeCompare(explB);
-        break;
-      }
-      case "label": {
-        const labelA = a.label || "";
-        const labelB = b.label || "";
-        comparison = labelA.localeCompare(labelB);
-        break;
-      }
-      case "value": {
-        comparison = sortValue(a, b);
-        break;
-      }
-      case "error": {
-        const errorA = a.scanError || "";
-        const errorB = b.scanError || "";
-        comparison = errorA.localeCompare(errorB);
-        break;
-      }
-      case "validation": {
-        const validationA = a.validationResult ? 1 : 0;
-        const validationB = b.validationResult ? 1 : 0;
-        comparison = validationA - validationB;
-        break;
-      }
-      default:
-        // Unknown column, skip
-        continue;
-    }
-
-    // Apply direction (asc or desc)
-    if (comparison !== 0) {
-      return sortCol.direction === "asc" ? comparison : -comparison;
-    }
-  }
-
-  // All comparisons are equal
-  return 0;
 };
 
 const optimalColumnLayout = (

--- a/apps/scout/src/app/types.ts
+++ b/apps/scout/src/app/types.ts
@@ -159,7 +159,10 @@ export function isArrayValue(
 
 export function isObjectValue(
   result: ScanResultSummary
-): result is ScanResultSummary & { valueType: "object"; value: object } {
+): result is ScanResultSummary & {
+  valueType: "object";
+  value: Record<string, unknown>;
+} {
   return result.valueType === "object";
 }
 

--- a/apps/scout/src/app/utils/results.test.ts
+++ b/apps/scout/src/app/utils/results.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+
+import { ScanResultSummary } from "../types";
+
+import { sortByColumns, sortValue, stringifyValue } from "./results";
+
+const baseSummary: ScanResultSummary = {
+  identifier: "test-1",
+  inputType: "transcript",
+  eventReferences: [],
+  messageReferences: [],
+  validationResult: false,
+  validationTarget: null,
+  value: null,
+  valueType: "null",
+  transcriptSourceId: "src-1",
+  transcriptMetadata: {},
+};
+
+/** Create a ScanResultSummary with only the fields under test overridden. */
+const make = (overrides: Partial<ScanResultSummary>): ScanResultSummary => ({
+  ...baseSummary,
+  ...overrides,
+});
+
+describe("stringifyValue", () => {
+  it.each<{ name: string; summary: ScanResultSummary; expected: string }>([
+    {
+      name: "null value",
+      summary: make({ value: null, valueType: "null" }),
+      expected: "",
+    },
+    {
+      name: "string value",
+      summary: make({ value: "hello world", valueType: "string" }),
+      expected: "hello world",
+    },
+    {
+      name: "number value",
+      summary: make({ value: 42, valueType: "number" }),
+      expected: "42",
+    },
+    {
+      name: "boolean true",
+      summary: make({ value: true, valueType: "boolean" }),
+      expected: "true",
+    },
+    {
+      name: "boolean false",
+      summary: make({ value: false, valueType: "boolean" }),
+      expected: "false",
+    },
+    {
+      name: "array value",
+      summary: make({ value: ["a", "b", "c"], valueType: "array" }),
+      expected: "a b c",
+    },
+    {
+      name: "object value",
+      summary: make({
+        value: { score: 0.95, label: "pass" },
+        valueType: "object",
+      }),
+      expected: "score 0.95 label pass",
+    },
+    {
+      name: "object with null value field",
+      summary: make({
+        value: { key: null },
+        valueType: "object",
+      }),
+      expected: "key ",
+    },
+  ])("$name", ({ summary, expected }) => {
+    expect(stringifyValue(summary)).toBe(expected);
+  });
+});
+
+describe("sortValue", () => {
+  it("sorts nulls last", () => {
+    const a = make({ value: null, valueType: "null" });
+    const b = make({ value: 1, valueType: "number" });
+    expect(sortValue(a, b)).toBeGreaterThan(0);
+    expect(sortValue(b, a)).toBeLessThan(0);
+  });
+
+  it("treats two nulls as equal", () => {
+    const a = make({ value: null, valueType: "null" });
+    const b = make({ value: null, valueType: "null" });
+    expect(sortValue(a, b)).toBe(0);
+  });
+
+  it("compares numbers numerically", () => {
+    const a = make({ value: 2, valueType: "number" });
+    const b = make({ value: 10, valueType: "number" });
+    expect(sortValue(a, b)).toBeLessThan(0);
+  });
+
+  it("compares booleans (false < true)", () => {
+    const a = make({ value: false, valueType: "boolean" });
+    const b = make({ value: true, valueType: "boolean" });
+    expect(sortValue(a, b)).toBeLessThan(0);
+  });
+
+  it("compares strings lexicographically", () => {
+    const a = make({ value: "apple", valueType: "string" });
+    const b = make({ value: "banana", valueType: "string" });
+    expect(sortValue(a, b)).toBeLessThan(0);
+  });
+
+  it("compares arrays by length first", () => {
+    const a = make({ value: [1], valueType: "array" });
+    const b = make({ value: [1, 2], valueType: "array" });
+    expect(sortValue(a, b)).toBeLessThan(0);
+  });
+
+  it("falls back to string comparison for different types", () => {
+    const a = make({ value: "z", valueType: "string" });
+    const b = make({ value: 1, valueType: "number" });
+    // "z" vs "1" — string comparison
+    expect(sortValue(a, b)).toBeGreaterThan(0);
+  });
+});
+
+describe("sortByColumns", () => {
+  const summaryA = make({
+    identifier: "a",
+    explanation: "alpha",
+    label: "L1",
+    value: 1,
+    valueType: "number",
+    scanError: "",
+    transcriptSourceId: "src-a",
+  });
+  const summaryB = make({
+    identifier: "b",
+    explanation: "beta",
+    label: "L2",
+    value: 2,
+    valueType: "number",
+    scanError: "timeout",
+    transcriptSourceId: "src-b",
+  });
+
+  it("sorts by explanation ascending", () => {
+    const result = sortByColumns(summaryA, summaryB, [
+      { column: "Explanation", direction: "asc" },
+    ]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it("sorts by explanation descending", () => {
+    const result = sortByColumns(summaryA, summaryB, [
+      { column: "Explanation", direction: "desc" },
+    ]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("sorts by value", () => {
+    const result = sortByColumns(summaryA, summaryB, [
+      { column: "Value", direction: "asc" },
+    ]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it("sorts by error", () => {
+    const result = sortByColumns(summaryA, summaryB, [
+      { column: "Error", direction: "desc" },
+    ]);
+    // summaryA has "" error, summaryB has "timeout" — desc puts "timeout" first
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("uses secondary sort when primary is equal", () => {
+    const s1 = make({
+      explanation: "same",
+      value: 10,
+      valueType: "number",
+      transcriptSourceId: "src-1",
+    });
+    const s2 = make({
+      explanation: "same",
+      value: 20,
+      valueType: "number",
+      transcriptSourceId: "src-2",
+    });
+    const result = sortByColumns(s1, s2, [
+      { column: "Explanation", direction: "asc" },
+      { column: "Value", direction: "asc" },
+    ]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it("returns 0 when all columns are equal", () => {
+    const result = sortByColumns(summaryA, summaryA, [
+      { column: "Explanation", direction: "asc" },
+      { column: "Value", direction: "asc" },
+    ]);
+    expect(result).toBe(0);
+  });
+
+  it("skips unknown columns", () => {
+    const result = sortByColumns(summaryA, summaryB, [
+      { column: "nonexistent", direction: "asc" },
+    ]);
+    expect(result).toBe(0);
+  });
+});

--- a/apps/scout/src/app/utils/results.ts
+++ b/apps/scout/src/app/utils/results.ts
@@ -1,4 +1,12 @@
-import { ScanResultSummary } from "../types";
+import {
+  isArrayValue,
+  isBooleanValue,
+  isNumberValue,
+  isObjectValue,
+  isStringValue,
+  ScanResultSummary,
+  SortColumn,
+} from "../types";
 
 export interface IdentifierInfo {
   taskSet?: string;
@@ -89,4 +97,139 @@ export const resultLog = (summary: ScanResultSummary): string | undefined => {
     return summary.transcriptMetadata["log"] as string;
   }
   return undefined;
+};
+
+/**
+ * Stringify a ScanResultSummary value for text search.
+ * Handles all valueType variants so search covers the displayed result content.
+ */
+export const stringifyValue = (s: ScanResultSummary): string => {
+  if (s.value === null || s.value === undefined) return "";
+  if (isStringValue(s)) return s.value;
+  if (isNumberValue(s) || isBooleanValue(s)) return String(s.value);
+  if (isArrayValue(s)) return s.value.map(String).join(" ");
+  if (isObjectValue(s)) {
+    return Object.entries(s.value)
+      .map(([k, v]) => `${k} ${v !== null && v !== undefined ? String(v) : ""}`)
+      .join(" ");
+  }
+  return String(s.value);
+};
+
+// Type-aware comparison for ScanResultSummary values.
+// Uses valueType to compare numerics, booleans, strings, arrays, and objects correctly.
+// Nulls always sort last.
+export const sortValue = (
+  a: ScanResultSummary,
+  b: ScanResultSummary
+): number => {
+  // Nulls sort last (after all other types)
+  if (a.value === null || a.value === undefined || a.valueType === "null") {
+    if (b.value === null || b.value === undefined || b.valueType === "null") {
+      return 0;
+    }
+    return 1;
+  }
+  if (b.value === null || b.value === undefined || b.valueType === "null") {
+    return -1;
+  }
+
+  // Same type: compare natively
+  if (a.valueType === b.valueType) {
+    if (isNumberValue(a) && isNumberValue(b)) {
+      return a.value - b.value;
+    }
+    if (isBooleanValue(a) && isBooleanValue(b)) {
+      return (a.value ? 1 : 0) - (b.value ? 1 : 0);
+    }
+    if (isStringValue(a) && isStringValue(b)) {
+      return a.value.localeCompare(b.value);
+    }
+    if (isArrayValue(a) && isArrayValue(b)) {
+      return (
+        a.value.length - b.value.length ||
+        String(a.value).localeCompare(String(b.value))
+      );
+    }
+    if (isObjectValue(a) && isObjectValue(b)) {
+      return JSON.stringify(a.value).localeCompare(JSON.stringify(b.value));
+    }
+  }
+
+  // Different types: fall back to string comparison
+  return String(a.value).localeCompare(String(b.value));
+};
+
+// Sorts scan results by multiple columns and directions.
+// Applies sorting rules in order, falling back to the next rule if values are equal.
+export const sortByColumns = (
+  a: ScanResultSummary,
+  b: ScanResultSummary,
+  sortColumns: SortColumn[]
+): number => {
+  for (const sortCol of sortColumns) {
+    let comparison = 0;
+
+    switch (sortCol.column.toLowerCase()) {
+      case "id": {
+        const identifierA = resultIdentifier(a);
+        const identifierB = resultIdentifier(b);
+
+        if (
+          typeof identifierA.id === "number" &&
+          typeof identifierB.id === "number"
+        ) {
+          comparison = identifierA.id - identifierB.id;
+        } else {
+          comparison = String(identifierA.id).localeCompare(
+            String(identifierB.id)
+          );
+        }
+
+        if (comparison === 0 && identifierA.epoch && identifierB.epoch) {
+          comparison = identifierA.epoch - identifierB.epoch;
+        }
+        break;
+      }
+      case "explanation": {
+        const explA = a.explanation || "";
+        const explB = b.explanation || "";
+        comparison = explA.localeCompare(explB);
+        break;
+      }
+      case "label": {
+        const labelA = a.label || "";
+        const labelB = b.label || "";
+        comparison = labelA.localeCompare(labelB);
+        break;
+      }
+      case "value": {
+        comparison = sortValue(a, b);
+        break;
+      }
+      case "error": {
+        const errorA = a.scanError || "";
+        const errorB = b.scanError || "";
+        comparison = errorA.localeCompare(errorB);
+        break;
+      }
+      case "validation": {
+        const validationA = a.validationResult ? 1 : 0;
+        const validationB = b.validationResult ? 1 : 0;
+        comparison = validationA - validationB;
+        break;
+      }
+      default:
+        // Unknown column, skip
+        continue;
+    }
+
+    // Apply direction (asc or desc)
+    if (comparison !== 0) {
+      return sortCol.direction === "asc" ? comparison : -comparison;
+    }
+  }
+
+  // All comparisons are equal
+  return 0;
 };


### PR DESCRIPTION
@dragonstyle and I noticed some surprising behavior when searching through scan results. Each of these results starts with "The agent demonstrates" but searching for "agents" produces no results.

| Full list | Searching for "agents" |
| ---- | ---- |
| <img width="1352" height="726" alt="Screenshot 2026-04-01 at 12 28 45 PM 1" src="https://github.com/user-attachments/assets/f4ac8e02-09b1-4cf8-a43a-0fdd23f4ff9e" /> | <img width="1352" height="723" alt="Screenshot 2026-04-01 at 12 28 59 PM" src="https://github.com/user-attachments/assets/d30ada4c-e98e-4dea-b15f-39297c182022" /> |

With these changes, we'll look for more exhaustively through `ScanResultSummary` for text that matches the search query.

<img width="1284" height="282" alt="Screenshot 2026-04-01 at 12 31 33 PM" src="https://github.com/user-attachments/assets/26b32b1a-cac6-4071-8e8d-ca29ce48d4f9" />

I added tests for the new `stringifyValue` and some other existing functions