### PR TITLE
fix: handle missing scan_events column

### DIFF
--- a/apps/scout/src/app/types.ts
+++ b/apps/scout/src/app/types.ts
@@ -61,7 +61,7 @@ export interface ScanResultData extends ScanResultSummary {
   scanError?: string;
   scanErrorTraceback?: string;
   scanErrorRefusal?: boolean;
-  scanEvents: Event[];
+  scanEvents?: Event[];
   scanId: string;
   scanMetadata: Record<string, JsonValue>;
   scanModelUsage: Record<string, ModelUsage>;

--- a/apps/scout/src/app/utils/arrowHelpers.test.ts
+++ b/apps/scout/src/app/utils/arrowHelpers.test.ts
@@ -179,4 +179,11 @@ describe("parseScanResultData", () => {
       expect(result).toMatchObject(expected);
     }
   );
+
+  it("handles missing scan_events column", async () => {
+    const { scan_events: _, ...withoutScanEvents } = typicalColumnData;
+    const table = from([withoutScanEvents]);
+    const result = await parseScanResultData(table);
+    expect(result.scanEvents).toBeUndefined();
+  });
 });

--- a/apps/scout/src/app/utils/arrowHelpers.ts
+++ b/apps/scout/src/app/utils/arrowHelpers.ts
@@ -47,7 +47,9 @@ export const parseScanResultData = async (
     parseJson(filtered.get("input_ids", 0) as string),
     parseJson(filtered.get("message_references", 0) as string),
     parseJson(filtered.get("metadata", 0) as string),
-    parseJson(filtered.get("scan_events", 0) as string),
+    parseJson(
+      getOptionalColumn<string>(filtered, "scan_events", 0) ?? null
+    ),
     parseJson(filtered.get("scan_metadata", 0) as string),
     parseJson(filtered.get("scan_model_usage", 0) as string),
     parseJson(filtered.get("scan_tags", 0) as string),


### PR DESCRIPTION
## Summary
- Companion frontend change for https://github.com/meridianlabs-ai/inspect_scout/pull/367, which removes eager loading of the `scan_events` column to improve load times for large scans
- Without this change, the frontend crashes with `TypeError: Cannot read properties of undefined (reading 'at')` when `scan_events` is not present in the response
- Uses `getOptionalColumn` instead of direct `filtered.get()` for `scan_events`, matching the pattern used for other optional columns
- Makes `scanEvents` optional in the `ScanResultData` type (consumers already handle this with optional chaining)

## Test plan
- [x] Added test case for missing `scan_events` column
- [x] All existing tests pass
- [x] Type check passes
- [ ] Verify fix resolves the issue on https://viewer.hawk.prd.metr.org/scan/pip-test-scan-vy497diikwkomi4i

🤖 Generated with [Claude Code](https://claude.com/claude-code)