### PR TITLE
revert inspect build to unminified, unhashed output

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -116,15 +116,7 @@ export default defineConfig(({ mode }) => {
       build: {
         outDir: "dist",
         emptyOutDir: true,
-        minify: mode !== "development",
-        rollupOptions: {
-          output: {
-            entryFileNames: `assets/[name]-[hash].js`,
-            chunkFileNames: `assets/[name]-[hash].js`,
-            assetFileNames: `assets/[name]-[hash].[ext]`,
-          },
-        },
-        sourcemap: true,
+        minify: false,
       },
     };
   }

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -104,6 +104,7 @@ export default defineConfig(({ mode }) => {
     return {
       ...baseConfig,
       plugins: [...baseConfig.plugins, copyToPythonRepo()],
+      mode: "development",
       base: "",
       server: {
         proxy: {
@@ -117,6 +118,14 @@ export default defineConfig(({ mode }) => {
         outDir: "dist",
         emptyOutDir: true,
         minify: false,
+        rollupOptions: {
+          output: {
+            entryFileNames: `assets/index.js`,
+            chunkFileNames: `assets/[name].js`,
+            assetFileNames: `assets/[name].[ext]`,
+          },
+        },
+        sourcemap: true,
       },
     };
   }


### PR DESCRIPTION
## Summary
- Remove minification, content-hash filenames, and sourcemaps from inspect app build
- Reverting LFS for inspect dist — these build options only made sense with LFS tracking

## Test plan
- [ ] `pnpm --filter inspect build` produces unhashed, unminified output