### PR TITLE
Derive inner types from schema; stop naming them in Python

### DIFF
--- a/apps/inspect/src/@types/extraInspect.ts
+++ b/apps/inspect/src/@types/extraInspect.ts
@@ -1,8 +1,11 @@
 import type {
   ChatMessage,
+  ContentAudio,
+  ContentVideo,
   EvalLog,
   EvalPlanStep,
   EvalSample,
+  EvalSampleLimit,
   EvalScore,
   EvalSpec,
   EvalStats,
@@ -14,9 +17,12 @@ import type {
 
 export type ChatMessageContent = ChatMessage["content"];
 export type ChatMessages = ChatMessage[];
+export type ContentAudioFormat = ContentAudio["format"];
+export type ContentVideoFormat = ContentVideo["format"];
 export type EvalLogStatus = EvalLog["status"];
 export type EvalLogVersion = EvalLog["version"];
 export type EvalPlanSteps = EvalPlanStep[];
+export type EvalSampleLimitType = EvalSampleLimit["type"];
 export type EvalSampleScore = EvalSample["scores"];
 export type EvalSampleTarget = EvalSample["target"];
 export type EvalSampleWorkingTime = EvalSample["working_time"];
@@ -24,6 +30,7 @@ export type EvalScores = EvalScore[];
 export type EvalSpecModelRoles = EvalSpec["model_roles"];
 export type EvalStatsModelUsage = EvalStats["model_usage"];
 export type Events = Event[];
+export type JsonChangeOp = JsonChange["op"];
 export type JsonChanges = JsonChange[];
 export type ScoreValue = Score["value"];
 export type ToolInfos = ToolInfo[];

--- a/apps/inspect/src/app/samples/chat/MessageContent.tsx
+++ b/apps/inspect/src/app/samples/chat/MessageContent.tsx
@@ -4,7 +4,6 @@ import { FC, Fragment, ReactNode } from "react";
 import {
   Citation,
   ContentAudio,
-  ContentAudioFormat,
   ContentData,
   ContentDocument,
   ContentImage,
@@ -12,10 +11,13 @@ import {
   ContentText,
   ContentToolUse,
   ContentVideo,
-  ContentVideoFormat,
 } from "@tsmono/inspect-common/types";
 import { isJson } from "@tsmono/util";
 
+import {
+  ContentAudioFormat,
+  ContentVideoFormat,
+} from "../../../@types/extraInspect";
 import { ContentTool } from "../../../app/types";
 import { CodePanel } from "../../../components/CodePanel";
 import ExpandablePanel from "../../../components/ExpandablePanel";

--- a/apps/inspect/src/app/samples/transcript/state/StateEventView.tsx
+++ b/apps/inspect/src/app/samples/transcript/state/StateEventView.tsx
@@ -5,12 +5,11 @@ import { FC, useEffect, useMemo } from "react";
 
 import {
   JsonChange,
-  JsonChangeOp,
   StateEvent,
   StoreEvent,
 } from "@tsmono/inspect-common/types";
 
-import { JsonChanges } from "../../../../@types/extraInspect";
+import { JsonChangeOp, JsonChanges } from "../../../../@types/extraInspect";
 import { useStore } from "../../../../state/store";
 import { formatDateTime } from "../../../../utils/format";
 import { EventPanel } from "../event/EventPanel";

--- a/apps/scout/src/components/chat/MessageContent.tsx
+++ b/apps/scout/src/components/chat/MessageContent.tsx
@@ -5,7 +5,6 @@ import { isJson } from "@tsmono/util";
 
 import {
   ContentAudio,
-  ContentAudioFormat,
   ContentData,
   ContentDocument,
   ContentImage,
@@ -13,7 +12,6 @@ import {
   ContentText,
   ContentToolUse,
   ContentVideo,
-  ContentVideoFormat,
 } from "../../types/api-types";
 import { RenderedText } from "../content/RenderedText";
 import ExpandablePanel from "../ExpandablePanel";
@@ -259,7 +257,7 @@ const messageRenderers: Record<string, MessageRenderer> = {
  * Supports rendering strings, images, and tools using specific renderers.
  */
 const mimeTypeForFormat = (
-  format: ContentAudioFormat | ContentVideoFormat
+  format: ContentAudio["format"] | ContentVideo["format"]
 ): string => {
   switch (format) {
     case "mov":

--- a/apps/scout/src/components/transcript/SampleLimitEventView.tsx
+++ b/apps/scout/src/components/transcript/SampleLimitEventView.tsx
@@ -1,12 +1,13 @@
 import clsx from "clsx";
 import { FC } from "react";
 
-import { EvalSampleLimitType, SampleLimitEvent } from "../../types/api-types";
+import { EvalSampleLimit, SampleLimitEvent } from "../../types/api-types";
 import { ApplicationIcons } from "../icons";
 
 import { EventPanel } from "./event/EventPanel";
 import { EventNode } from "./types";
 
+type EvalSampleLimitType = EvalSampleLimit["type"];
 interface SampleLimitEventViewProps {
   eventNode: EventNode<SampleLimitEvent>;
   className?: string | string[];

--- a/apps/scout/src/components/transcript/state/StateEventView.tsx
+++ b/apps/scout/src/components/transcript/state/StateEventView.tsx
@@ -6,12 +6,7 @@ import { FC, ReactNode, useEffect, useMemo } from "react";
 import { formatDateTime } from "@tsmono/util";
 
 import { useStore } from "../../../state/store";
-import {
-  JsonChange,
-  JsonChangeOp,
-  StateEvent,
-  StoreEvent,
-} from "../../../types/api-types";
+import { JsonChange, StateEvent, StoreEvent } from "../../../types/api-types";
 import { EventPanel } from "../event/EventPanel";
 import { EventNode, kTranscriptCollapseScope } from "../types";
 
@@ -28,6 +23,7 @@ interface StateEventViewProps {
   className?: string | string[];
 }
 
+type JsonChangeOp = JsonChange["op"];
 /**
  * Renders the StateEventView component.
  */

--- a/apps/scout/src/types/api-types.ts
+++ b/apps/scout/src/types/api-types.ts
@@ -55,11 +55,7 @@ export type {
   ToolEvent,
   ToolFunction,
   ToolInfo,
-  JsonChangeOp,
   UrlCitation,
-  ContentAudioFormat,
-  ContentVideoFormat,
-  EvalSampleLimitType,
 } from "@tsmono/inspect-common/types";
 
 type S = components["schemas"];

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -55,40 +55,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/content-audio-format": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Content Audio Format */
-        get: operations["_content_audio_format_content_audio_format_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/content-video-format": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Content Video Format */
-        get: operations["_content_video_format_content_video_format_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/eval-log": {
         parameters: {
             query?: never;
@@ -98,23 +64,6 @@ export interface paths {
         };
         /** Eval Log */
         get: operations["_eval_log_eval_log_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/eval-sample-limit-type": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Eval Sample Limit Type */
-        get: operations["_eval_sample_limit_type_eval_sample_limit_type_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -149,23 +98,6 @@ export interface paths {
         };
         /** Event */
         get: operations["_event_event_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/json-change-op": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Json Change Op */
-        get: operations["_json_change_op_json_change_op_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -515,11 +447,6 @@ export interface components {
             type: "audio";
         };
         /**
-         * ContentAudioFormat
-         * @enum {string}
-         */
-        ContentAudioFormat: "wav" | "mp3";
-        /**
          * ContentCitation
          * @description A generic content citation.
          */
@@ -690,11 +617,6 @@ export interface components {
             /** Video */
             video: string;
         };
-        /**
-         * ContentVideoFormat
-         * @enum {string}
-         */
-        ContentVideoFormat: "mp4" | "mpeg" | "mov";
         /**
          * DocumentCitation
          * @description A citation that refers to a page range in a document.
@@ -1102,11 +1024,6 @@ export interface components {
              */
             type: "context" | "time" | "working" | "message" | "token" | "cost" | "operator" | "custom";
         };
-        /**
-         * EvalSampleLimitType
-         * @enum {string}
-         */
-        EvalSampleLimitType: "context" | "time" | "working" | "message" | "token" | "cost" | "operator" | "custom";
         /**
          * EvalSampleReductions
          * @description Score reductions.
@@ -1533,11 +1450,6 @@ export interface components {
             replaced: components["schemas"]["JsonValue"];
             value: components["schemas"]["JsonValue"];
         };
-        /**
-         * JsonChangeOp
-         * @enum {string}
-         */
-        JsonChangeOp: "remove" | "add" | "replace" | "move" | "test" | "copy";
         JsonValue: JsonValue;
         /**
          * LogUpdate
@@ -2682,46 +2594,6 @@ export interface operations {
             };
         };
     };
-    _content_audio_format_content_audio_format_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContentAudioFormat"];
-                };
-            };
-        };
-    };
-    _content_video_format_content_video_format_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ContentVideoFormat"];
-                };
-            };
-        };
-    };
     _eval_log_eval_log_get: {
         parameters: {
             query?: never;
@@ -2738,26 +2610,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EvalLog"];
-                };
-            };
-        };
-    };
-    _eval_sample_limit_type_eval_sample_limit_type_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EvalSampleLimitType"];
                 };
             };
         };
@@ -2798,26 +2650,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Event"];
-                };
-            };
-        };
-    };
-    _json_change_op_json_change_op_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JsonChangeOp"];
                 };
             };
         };

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -30,7 +30,6 @@ export type EvalResults = S["EvalResults"];
 export type EvalRevision = S["EvalRevision"];
 export type EvalSample = S["EvalSample"];
 export type EvalSampleLimit = S["EvalSampleLimit"];
-export type EvalSampleLimitType = S["EvalSampleLimitType"];
 export type EvalSampleReductions = S["EvalSampleReductions"];
 export type EvalSampleScore = S["EvalSampleScore"];
 export type EvalScore = S["EvalScore"];
@@ -73,7 +72,6 @@ export type ChatMessageUser = S["ChatMessageUser"];
 export type Citation = S["Citation"];
 export type Content = S["Content"];
 export type ContentAudio = S["ContentAudio"];
-export type ContentAudioFormat = S["ContentAudioFormat"];
 export type ContentCitation = S["ContentCitation"];
 export type ContentData = S["ContentData"];
 export type ContentDocument = S["ContentDocument"];
@@ -82,7 +80,6 @@ export type ContentReasoning = S["ContentReasoning"];
 export type ContentText = S["ContentText"];
 export type ContentToolUse = S["ContentToolUse"];
 export type ContentVideo = S["ContentVideo"];
-export type ContentVideoFormat = S["ContentVideoFormat"];
 
 // Model types
 export type ModelCall = S["ModelCall"];
@@ -124,7 +121,6 @@ export type ApproverPolicyConfig = S["ApproverPolicyConfig"];
 
 // Other types
 export type JsonChange = S["JsonChange"];
-export type JsonChangeOp = S["JsonChangeOp"];
 export type JsonValue = S["JsonValue"];
 export type LogUpdate = S["LogUpdate"];
 export type LoggingMessage = S["LoggingMessage"];


### PR DESCRIPTION
## Summary

Follows up on #26. Removes `JsonChangeOp`, `EvalSampleLimitType`, `ContentAudioFormat`, and `ContentVideoFormat` as named schemas — these are now derived via indexed access in TypeScript (e.g. `ContentAudio["format"]`) rather than artificially named in the Python OpenAPI generation.