### PR TITLE
timeline: branch visualization with fork-relative positioning

### DIFF
--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -155,6 +155,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
     setActiveTimeline,
     regionCounts,
     branchScrollTarget,
+    highlightedKeys,
   } = useTranscriptTimeline(
     events,
     resolvedMarkerConfig,
@@ -294,6 +295,15 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
 
   const effectiveInitialEventId =
     initialEventId ?? resolved?.eventId ?? branchScrollTarget ?? null;
+
+  // Suppress headroom collapse when a branch click triggers a programmatic
+  // scroll to the branch separator. Without this, the scroll-down is
+  // interpreted as a user gesture and collapses the swimlanes.
+  useEffect(() => {
+    if (branchScrollTarget) {
+      onHeadroomResetAnchor?.(true);
+    }
+  }, [branchScrollTarget, onHeadroomResetAnchor]);
 
   // ---------------------------------------------------------------------------
   // Sticky swimlane state
@@ -526,6 +536,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
                 onLayoutShift={onHeadroomResetAnchor}
                 regionCounts={regionCounts}
                 defaultCollapsed={swimlanesDefaultCollapsed}
+                highlightedKeys={highlightedKeys}
               />
             </div>
           </StickyScroll>

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -471,7 +471,9 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
   const swimlanesDefaultCollapsed =
     timelineProp === "auto" && !hasTimeline && regionCounts.size === 0
       ? true
-      : undefined;
+      : hasTimeline
+        ? false
+        : undefined;
 
   const scrollToTop = useCallback(() => {
     scrollRef.current?.scrollTo({ top: 0 });

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -154,6 +154,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
     activeTimelineIndex,
     setActiveTimeline,
     regionCounts,
+    branchScrollTarget,
   } = useTranscriptTimeline(
     events,
     resolvedMarkerConfig,
@@ -291,7 +292,8 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
     }
   }, [resolvedRoot, selectBySpanId, clearSelection, timelineState.selected]);
 
-  const effectiveInitialEventId = initialEventId ?? resolved?.eventId ?? null;
+  const effectiveInitialEventId =
+    initialEventId ?? resolved?.eventId ?? branchScrollTarget ?? null;
 
   // ---------------------------------------------------------------------------
   // Sticky swimlane state

--- a/apps/scout/src/app/timeline/components/TimelineMinimap.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineMinimap.tsx
@@ -172,8 +172,8 @@ export const TimelineMinimap: FC<TimelineMinimapProps> = ({
             root.endTime().getTime()
           )
         )
-      : formatDuration(root.startTime(), root.endTime());
-  const tokenRightLabel = formatTokenCount(root.totalTokens());
+      : formatDuration(root.startTime(false), root.endTime(false));
+  const tokenRightLabel = formatTokenCount(root.totalTokens(false));
 
   const computeSectionLabel = (): string => {
     if (!selection) return "";

--- a/apps/scout/src/app/timeline/components/TimelineOptionsPopover.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineOptionsPopover.tsx
@@ -95,6 +95,22 @@ export const TimelineOptionsPopover: FC<TimelineOptionsPopoverProps> = ({
           />
           Branches
         </div>
+        {config.showBranches && (
+          <div
+            className={styles.row}
+            onClick={() => config.setForkRelative(!config.forkRelative)}
+          >
+            <input
+              type="checkbox"
+              checked={config.forkRelative}
+              onChange={(e) => {
+                e.stopPropagation();
+                config.setForkRelative(!config.forkRelative);
+              }}
+            />
+            Fork-relative branches
+          </div>
+        )}
       </div>
     </PopOver>
   );

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
@@ -348,9 +348,22 @@
   height: 0;
   border-top: 3px solid transparent;
   border-bottom: 3px solid transparent;
-  border-left: 4px solid var(--vscode-foreground);
+  border-left: 4px solid var(--vscode-descriptionForeground);
   pointer-events: none;
 }
+
+/* Horizontal line extending back from arrowhead to the SVG horizontal endpoint */
+.connectorArrow::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 3px;
+  width: 5px;
+  height: 1px;
+  background: var(--vscode-descriptionForeground);
+  transform: translateY(-50%);
+}
+
 
 /* Branch popover */
 

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
@@ -343,7 +343,7 @@
 .connectorArrow {
   position: absolute;
   top: 50%;
-  transform: translate(-1px, -50%);
+  transform: translate(-1px, calc(-50% + 0.5px));
   width: 0;
   height: 0;
   border-top: 3px solid transparent;

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
@@ -130,6 +130,12 @@
   color: var(--vscode-textLink-foreground);
 }
 
+/* Ancestor rows of the selected branch — subtler than selected */
+.labelHighlighted {
+  color: var(--vscode-textLink-foreground);
+  opacity: 0.6;
+}
+
 /* Expand/collapse chevron in label */
 
 .chevron {
@@ -192,6 +198,19 @@
 .fillSelected {
   opacity: 0.7;
   box-shadow: inset 0 0 0 1px var(--bs-primary);
+}
+
+/* Partial highlight overlay — sibling of .fill in barInner.
+   Shows the "active" portion of a bar (e.g. parent bar up to fork point
+   when a branch is selected). Independent opacity, not stacked with .fill. */
+.fillHighlight {
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  border-radius: 2px;
+  background-color: var(--bs-primary);
+  opacity: 0.45;
+  pointer-events: none;
 }
 
 /* Row is selected but a different span within the row is focused */

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.module.css
@@ -364,7 +364,6 @@
   transform: translateY(-50%);
 }
 
-
 /* Branch popover */
 
 /* Breadcrumb row */

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
@@ -1124,7 +1124,7 @@ const BranchConnectorLine: FC<{ connector: BranchConnector }> = ({
           y1={topY}
           x2={`${markerLeft}%`}
           y2={midY + 0.5}
-          stroke="var(--vscode-foreground)"
+          stroke="var(--vscode-descriptionForeground)"
           strokeWidth={1}
         />
         {/* Horizontal segment: from marker position rightward to branch bar */}
@@ -1133,12 +1133,15 @@ const BranchConnectorLine: FC<{ connector: BranchConnector }> = ({
           y1={midY}
           x2={`${endLeft}%`}
           y2={midY}
-          stroke="var(--vscode-foreground)"
+          stroke="var(--vscode-descriptionForeground)"
           strokeWidth={1}
         />
       </svg>
-      {/* Right-pointing arrowhead: CSS border-triangle, 6px tall */}
-      <div className={styles.connectorArrow} style={{ left: `${endLeft}%` }} />
+      {/* Right-pointing arrowhead: positioned at the inset bar edge */}
+      <div
+        className={styles.connectorArrow}
+        style={{ left: `calc(${endLeft}% + 4px)` }}
+      />
     </>
   );
 };

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
@@ -683,6 +683,7 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
                   hasMultipleSpans ? onSelectSpan(spanIndex) : onSelectRow()
                 }
                 onDoubleClick={onToggleExpand}
+                insetPx={connector ? 1.5 : undefined}
               />
             );
           })}
@@ -812,6 +813,8 @@ interface BarFillProps {
   onSelect: () => void;
   /** Toggle expand/collapse on double-click. Only for rows with children. */
   onDoubleClick?: () => void;
+  /** Pixel inset from the left edge (for branch connector visibility). */
+  insetPx?: number;
 }
 
 const BarFill: FC<BarFillProps> = ({
@@ -821,6 +824,7 @@ const BarFill: FC<BarFillProps> = ({
   isDimmed,
   onSelect,
   onDoubleClick,
+  insetPx,
 }) => {
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -847,8 +851,12 @@ const BarFill: FC<BarFillProps> = ({
         isDimmed && styles.fillDimmed
       )}
       style={{
-        left: `${span.bar.left}%`,
-        width: `${span.bar.width}%`,
+        left: insetPx
+          ? `calc(${span.bar.left}% + ${insetPx}px)`
+          : `${span.bar.left}%`,
+        width: insetPx
+          ? `calc(${span.bar.width}% - ${insetPx}px)`
+          : `${span.bar.width}%`,
       }}
       title={span.description ?? undefined}
       onClick={handleClick}

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
@@ -254,7 +254,22 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
     [isRowCollapsed, setRowCollapsed]
   );
 
-  // Branch marker click → toggle showBranches.
+  // Branch marker click → ensure showBranches is on and expand the row.
+  // This reveals nested branch rows beneath the clicked marker's row.
+  const handleBranchMarkerClick = useCallback(
+    (rowKey: string) => {
+      if (!header?.timelineConfig?.showBranches) {
+        header?.timelineConfig?.setShowBranches(true);
+      }
+      // Expand the row so nested branches become visible
+      if (isRowCollapsed(rowKey)) {
+        setRowCollapsed("timeline-swimlane-rows", rowKey, false);
+      }
+    },
+    [header?.timelineConfig, isRowCollapsed, setRowCollapsed]
+  );
+
+  // Options popover / breadcrumb toggle → toggle showBranches on/off.
   // When turning branches off, clear selection if it points to a branch row
   // so the URL override in useTimeline doesn't force branches back on.
   const handleBranchToggle = useCallback(() => {
@@ -348,7 +363,7 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
         onSelectRegion={(spanIndex, regionIndex) =>
           onSelect(buildSelectionKey(layout.key, spanIndex, regionIndex))
         }
-        onBranchToggle={handleBranchToggle}
+        onBranchToggle={() => handleBranchMarkerClick(layout.key)}
         onMarkerNavigate={onMarkerNavigate}
         connector={branchConnectors.get(layout.key)}
       />
@@ -383,16 +398,14 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
         )}
       >
         <div className={styles.collapsibleInner}>
-          {parentRow &&
-            renderRow(
-              parentRow,
-              parentRow.name === "solvers" ? "main" : undefined
-            )}
-          {childRows.length > 0 && (
-            <div className={styles.scrollSection}>
-              {childRows.map((layout) => renderRow(layout))}
-            </div>
-          )}
+          <div className={styles.scrollSection}>
+            {parentRow &&
+              renderRow(
+                parentRow,
+                parentRow.name === "solvers" ? "main" : undefined
+              )}
+            {childRows.map((layout) => renderRow(layout))}
+          </div>
         </div>
       </div>
 
@@ -1022,12 +1035,9 @@ const BranchConnectorLine: FC<{ connector: BranchConnector }> = ({
 }) => {
   const { markerLeft, barLeft, rowGap } = connector;
   // y=0 is the top of the current (branch) row's barInner.
-  // The parent row is rowGap rows above, so the vertical line starts at
-  // the center of the parent row and drops to the center of this row.
-  // Start at the top of the parent row so the line visually originates from
-  // behind the branch marker icon. The collapsible section adds padding
-  // between the parent and branch rows that isn't captured by rowGap alone.
-  const topY = -(rowGap * kRowHeight);
+  // The parent row is rowGap rows above. Start the vertical line at the
+  // center of the parent row — the branch marker diamond sits there.
+  const topY = -(rowGap * kRowHeight) + kRowHeight / 2;
   const midY = kRowHeight / 2; // vertical center of this row
 
   // Always draw an L-shape: vertical down then horizontal right with arrow.

--- a/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineSwimLanes.tsx
@@ -120,6 +120,9 @@ interface TimelineSwimLanesProps {
   /** Default collapsed state when user has no stored preference.
    *  Falls back to `isFlat` (layouts.length <= 1) when undefined. */
   defaultCollapsed?: boolean;
+  /** Row key → highlight clip percentage (0–100).
+   *  The selected branch clips at 100; ancestors clip at the fork marker position. */
+  highlightedKeys?: ReadonlyMap<string, number>;
 }
 
 // =============================================================================
@@ -149,6 +152,7 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
   onLayoutShift,
   regionCounts,
   defaultCollapsed: defaultCollapsedProp,
+  highlightedKeys,
 }) => {
   const { selected, select: onSelect, clearSelection } = timeline;
 
@@ -349,6 +353,7 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
         layout={layout}
         displayName={displayName}
         isRowSelected={isRowSelected}
+        highlightClip={highlightedKeys?.get(layout.key)}
         selectedSpanIndex={selectedSpanIndex}
         selectedRegionIndex={selectedRegionIndex}
         regionCount={regionCounts?.get(layout.key)}
@@ -520,6 +525,9 @@ interface SwimlaneRowProps {
   onSelectRegion: (spanIndex: number | undefined, regionIndex: number) => void;
   onBranchToggle: () => void;
   onMarkerNavigate?: (eventId: string, selectedKey?: string) => void;
+  /** Highlight clip percentage (0–100) for partial bar highlighting.
+   *  undefined = no highlight. 100 = full bar. <100 = clip at fork marker. */
+  highlightClip?: number;
   /** Connector line from parent's branch marker to this branch row. */
   connector?: BranchConnector;
 }
@@ -528,6 +536,7 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
   layout,
   displayName,
   isRowSelected,
+  highlightClip,
   selectedSpanIndex,
   selectedRegionIndex,
   regionCount,
@@ -575,7 +584,13 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
     <div className={styles.row} role="row">
       {/* Label cell — depth-based indentation; clicking selects the whole row */}
       <div
-        className={clsx(styles.label, isRowSelected && styles.labelSelected)}
+        className={clsx(
+          styles.label,
+          isRowSelected && styles.labelSelected,
+          highlightClip !== undefined &&
+            !isRowSelected &&
+            styles.labelHighlighted
+        )}
         style={{ paddingLeft: `${0.3 + layout.depth * 0.5}rem` }}
         onClick={onSelectRow}
       >
@@ -671,6 +686,12 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
               />
             );
           })}
+
+          {/* Highlight overlay — rendered as a sibling of .fill so it has
+              independent opacity (not stacked with the fill's own opacity). */}
+          {highlightClip !== undefined && !isRowSelected && (
+            <HighlightOverlay spans={layout.spans} clipRight={highlightClip} />
+          )}
 
           {/* Markers */}
           {layout.markers.map((marker, i) => (
@@ -832,6 +853,47 @@ const BarFill: FC<BarFillProps> = ({
       title={span.description ?? undefined}
       onClick={handleClick}
       onDoubleClick={onDoubleClick ? handleDoubleClick : undefined}
+    />
+  );
+};
+
+// =============================================================================
+// HighlightOverlay (internal) — partial bar highlight for branch context
+// =============================================================================
+
+/**
+ * Renders an overlay on the bar area to indicate which portion of the row's
+ * spans are "active" (shown in the transcript). Positioned as a sibling of
+ * .fill so it has independent opacity instead of stacking with the bar's own.
+ *
+ * - clipRight = 100 → covers the full span range (e.g. the branch row itself).
+ * - clipRight < 100 → covers from the first span's left edge to the clip
+ *   percentage (e.g. a parent bar up to the fork point marker).
+ */
+const HighlightOverlay: FC<{
+  spans: PositionedSpan[];
+  /** Absolute bar-area percentage (0–100) where the highlight stops. */
+  clipRight: number;
+}> = ({ spans, clipRight }) => {
+  const firstSpan = spans[0];
+  if (!firstSpan) return null;
+
+  const barLeft = firstSpan.bar.left;
+  // For clipRight=100, extend to the rightmost span edge.
+  const lastSpan = spans[spans.length - 1] ?? firstSpan;
+  const barRight = lastSpan.bar.left + lastSpan.bar.width;
+  const right = clipRight >= 100 ? barRight : Math.min(clipRight, barRight);
+  const width = Math.max(0, right - barLeft);
+
+  if (width <= 0) return null;
+
+  return (
+    <div
+      className={styles.fillHighlight}
+      style={{
+        left: `${barLeft}%`,
+        width: `${width}%`,
+      }}
     />
   );
 };

--- a/apps/scout/src/app/timeline/contentItems.ts
+++ b/apps/scout/src/app/timeline/contentItems.ts
@@ -161,7 +161,9 @@ function findEventByMessageId(items: ContentItem[], messageId: string): number {
       }
     }
   }
-  // Pass 2: input message IDs (fallback)
+  // Pass 2: input message IDs (fallback). If the message ID appears in a
+  // model event's input, the message was produced by an earlier event and
+  // is being replayed here. Return the previous event (the producer).
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (!item || item.type !== "event") continue;
@@ -170,6 +172,10 @@ function findEventByMessageId(items: ContentItem[], messageId: string): number {
       const input = event.input as Array<Record<string, unknown>>;
       for (const msg of input) {
         if (typeof msg.id === "string" && msg.id === messageId) {
+          // Walk backward to find the previous event item
+          for (let j = i - 1; j >= 0; j--) {
+            if (items[j]?.type === "event") return j;
+          }
           return i;
         }
       }

--- a/apps/scout/src/app/timeline/hooks/useTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTimeline.ts
@@ -102,6 +102,8 @@ export interface TimelineOptions {
   includeUtility?: boolean;
   /** Show branches as swimlane rows. Default: false. */
   showBranches?: boolean;
+  /** Position branches at their fork point instead of wall-clock time. Default: false. */
+  forkRelative?: boolean;
 }
 
 export function useTimeline(

--- a/apps/scout/src/app/timeline/hooks/useTimelineConfig.ts
+++ b/apps/scout/src/app/timeline/hooks/useTimelineConfig.ts
@@ -31,11 +31,14 @@ export interface UseTimelineConfigResult {
   includeUtility: boolean;
   /** Whether branches are shown as swimlane rows. */
   showBranches: boolean;
+  /** Whether branches are positioned at their fork point. */
+  forkRelative: boolean;
 
   setMarkerKinds: (kinds: MarkerKind[]) => void;
   setMarkerDepth: (depth: MarkerDepth) => void;
   setIncludeUtility: (include: boolean) => void;
   setShowBranches: (show: boolean) => void;
+  setForkRelative: (forkRelative: boolean) => void;
   toggleMarkerKind: (kind: MarkerKind) => void;
   resetToDefaults: () => void;
   /** True when all settings match their defaults. */
@@ -50,6 +53,7 @@ const kDefaultMarkerKinds = defaultMarkerConfig.kinds;
 const kDefaultMarkerDepth = defaultMarkerConfig.depth;
 const kDefaultIncludeUtility = false;
 const kDefaultShowBranches = false;
+const kDefaultForkRelative = false;
 
 function arraysEqual<T>(a: T[], b: T[]): boolean {
   if (a.length !== b.length) return false;
@@ -83,11 +87,20 @@ export function useTimelineConfig(): UseTimelineConfigResult {
     "showBranches",
     { cleanup: false }
   );
+  const [storedForkRelative, setStoredForkRelative] = useProperty<boolean>(
+    "timeline",
+    "forkRelative",
+    { cleanup: false }
+  );
 
   const markerKinds = storedKinds ?? kDefaultMarkerKinds;
   const markerDepth = storedDepth ?? kDefaultMarkerDepth;
   const includeUtility = storedUtility ?? kDefaultIncludeUtility;
   const showBranches = storedShowBranches ?? kDefaultShowBranches;
+  // Default fork-relative to on when branches are shown and the user hasn't
+  // explicitly toggled it (storedForkRelative is undefined).
+  const forkRelative =
+    storedForkRelative ?? (showBranches || kDefaultForkRelative);
 
   const markerConfig: MarkerConfig = useMemo(
     () => ({ kinds: markerKinds, depth: markerDepth }),
@@ -95,15 +108,16 @@ export function useTimelineConfig(): UseTimelineConfigResult {
   );
 
   const agentConfig: TimelineOptions = useMemo(
-    () => ({ includeUtility, showBranches }),
-    [includeUtility, showBranches]
+    () => ({ includeUtility, showBranches, forkRelative }),
+    [includeUtility, showBranches, forkRelative]
   );
 
   const isDefault =
     arraysEqual(markerKinds, kDefaultMarkerKinds) &&
     markerDepth === kDefaultMarkerDepth &&
     includeUtility === kDefaultIncludeUtility &&
-    showBranches === kDefaultShowBranches;
+    showBranches === kDefaultShowBranches &&
+    forkRelative === kDefaultForkRelative;
 
   const toggleMarkerKind = useCallback(
     (kind: MarkerKind) => {
@@ -121,7 +135,14 @@ export function useTimelineConfig(): UseTimelineConfigResult {
     setStoredDepth(kDefaultMarkerDepth);
     setStoredUtility(kDefaultIncludeUtility);
     setStoredShowBranches(kDefaultShowBranches);
-  }, [setStoredKinds, setStoredDepth, setStoredUtility, setStoredShowBranches]);
+    setStoredForkRelative(kDefaultForkRelative);
+  }, [
+    setStoredKinds,
+    setStoredDepth,
+    setStoredUtility,
+    setStoredShowBranches,
+    setStoredForkRelative,
+  ]);
 
   return {
     markerConfig,
@@ -130,10 +151,12 @@ export function useTimelineConfig(): UseTimelineConfigResult {
     markerDepth,
     includeUtility,
     showBranches,
+    forkRelative,
     setMarkerKinds: setStoredKinds,
     setMarkerDepth: setStoredDepth,
     setIncludeUtility: setStoredUtility,
     setShowBranches: setStoredShowBranches,
+    setForkRelative: setStoredForkRelative,
     toggleMarkerKind,
     resetToDefaults,
     isDefault,

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -27,14 +27,22 @@ import {
   getSelectedSpans,
   parseSelection,
 } from "../timelineEventNodes";
-import { defaultMarkerConfig, type MarkerConfig } from "../utils/markers";
+import {
+  defaultMarkerConfig,
+  resolveForkTimestamp,
+  type MarkerConfig,
+} from "../utils/markers";
 import {
   computeRowLayouts,
   rowHasEvents,
   type RowLayout,
 } from "../utils/swimlaneLayout";
-import { isSingleSpan } from "../utils/swimlaneRows";
-import { computeTimeMapping, type TimeMapping } from "../utils/timeMapping";
+import { isSingleSpan, type SwimlaneRow } from "../utils/swimlaneRows";
+import {
+  computeTimeMapping,
+  createShiftedMapping,
+  type TimeMapping,
+} from "../utils/timeMapping";
 
 import { useActiveTimeline } from "./useActiveTimeline";
 import {
@@ -90,6 +98,7 @@ export function useTranscriptTimeline(
 ): TranscriptTimelineResult {
   const includeUtility = timelineOptions?.includeUtility ?? false;
   const showBranches = timelineOptions?.showBranches ?? false;
+  const forkRelative = timelineOptions?.forkRelative ?? false;
   const builtTimeline = useMemo(() => buildTimeline(events), [events]);
   const convertedTimelines = useMemo(
     () =>
@@ -125,15 +134,30 @@ export function useTranscriptTimeline(
     [timeline.root]
   );
 
+  // Compute per-branch shifted time mappings when fork-relative mode is active.
+  // Each branch row gets a mapping where its bar starts at the fork marker's
+  // percentage position, preserving duration proportionality.
+  const branchMappings = useMemo(() => {
+    if (!forkRelative || !showBranches) return undefined;
+    return computeBranchMappings(visibleRows, timeMapping, state.node);
+  }, [forkRelative, showBranches, visibleRows, timeMapping, state.node]);
+
   const layouts = useMemo(
     () =>
       computeRowLayouts(
         visibleRows,
         timeMapping,
         markerConfig.depth,
-        markerConfig.kinds
+        markerConfig.kinds,
+        branchMappings
       ),
-    [visibleRows, timeMapping, markerConfig.depth, markerConfig.kinds]
+    [
+      visibleRows,
+      timeMapping,
+      markerConfig.depth,
+      markerConfig.kinds,
+      branchMappings,
+    ]
   );
 
   const { selectedEvents, sourceSpans, branchScrollTarget } = useMemo(() => {
@@ -274,4 +298,84 @@ export function useTranscriptTimeline(
     branchScrollTarget,
     highlightedKeys,
   };
+}
+
+// =============================================================================
+// Fork-relative branch mapping computation
+// =============================================================================
+
+const kBranchKeyPattern = /\/branch-([^/]*)-(\d+)$/;
+
+/**
+ * Computes shifted time mappings for branch rows so their bars start at
+ * the fork marker's position. Non-branch rows are omitted (they use the
+ * trunk mapping).
+ *
+ * Processes rows in order, so parent branches are computed before nested
+ * branches, allowing nested branches to shift relative to their parent's
+ * shifted mapping.
+ */
+function computeBranchMappings(
+  rows: ReadonlyArray<SwimlaneRow>,
+  trunkMapping: TimeMapping,
+  node: TimelineSpan
+): ReadonlyMap<string, TimeMapping> {
+  const mappings = new Map<string, TimeMapping>();
+
+  // Build a lookup from row key → row for finding parent rows.
+  const rowByKey = new Map<string, SwimlaneRow>();
+  for (const row of rows) {
+    rowByKey.set(row.key, row);
+  }
+
+  // Compute the parent's total time range for proportional width scaling.
+  const nodeStartMs = node.startTime(false).getTime();
+  const nodeEndMs = node.endTime(false).getTime();
+  const parentTotalRangeMs = nodeEndMs - nodeStartMs;
+
+  for (const row of rows) {
+    if (!row.branch || !row.branchedFrom) continue;
+
+    // Find parent row by stripping the /branch-...-N suffix.
+    const parentKey = row.key.replace(kBranchKeyPattern, "");
+    const parentRow = rowByKey.get(parentKey);
+    if (!parentRow) continue;
+
+    // Get the parent span to resolve the fork timestamp.
+    const parentFirstSpan = parentRow.spans[0];
+    const parentSpan =
+      parentRow.spans.length === 1 &&
+      parentFirstSpan &&
+      isSingleSpan(parentFirstSpan)
+        ? parentFirstSpan.agent
+        : null;
+    if (!parentSpan) continue;
+
+    // Get the branch span from this row.
+    const branchFirstSpan = row.spans[0];
+    const branchSpan =
+      row.spans.length === 1 && branchFirstSpan && isSingleSpan(branchFirstSpan)
+        ? branchFirstSpan.agent
+        : null;
+    if (!branchSpan) continue;
+
+    // Resolve the fork timestamp from the parent's content.
+    const forkTimestamp = resolveForkTimestamp(parentSpan, branchSpan);
+
+    // Use the parent's mapping (which may itself be shifted for nested branches).
+    const parentMapping = mappings.get(parentKey) ?? trunkMapping;
+    const forkPercent = parentMapping.toPercent(forkTimestamp);
+
+    mappings.set(
+      row.key,
+      createShiftedMapping(
+        row.startTime,
+        row.endTime,
+        forkPercent,
+        parentTotalRangeMs
+      )
+    );
+  }
+
+  return mappings;
 }

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -21,6 +21,7 @@ import type { MinimapSelection } from "../components/TimelineMinimap";
 import {
   collectRawEvents,
   computeMinimapSelection,
+  getBranchPrefix,
   getSelectedSpans,
   parseSelection,
 } from "../timelineEventNodes";
@@ -135,6 +136,7 @@ export function useTranscriptTimeline(
       includeUtility,
       regionIndex: parsed?.regionIndex ?? null,
       showBranches,
+      branchPrefix: getBranchPrefix(state.rows, state.selected),
     });
     return {
       selectedEvents: collected.events,

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -171,7 +171,8 @@ export function useTranscriptTimeline(
 
   const hasTimeline =
     timeline.root.content.length > 0 &&
-    timeline.root.content.some((item) => item.type === "span");
+    (timeline.root.content.some((item) => item.type === "span") ||
+      timeline.root.branches.length > 0);
 
   return {
     timeline,

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -19,6 +19,7 @@ import {
 import type { Event, ServerTimeline } from "../../../types/api-types";
 import type { MinimapSelection } from "../components/TimelineMinimap";
 import {
+  collectBranchWithContext,
   collectRawEvents,
   computeMinimapSelection,
   getBranchPrefix,
@@ -70,6 +71,8 @@ interface TranscriptTimelineResult {
   setActiveTimeline: (index: number) => void;
   /** Map from row key → number of compaction regions (only for rows with compactions). */
   regionCounts: ReadonlyMap<string, number>;
+  /** Event ID to scroll to when a branch is selected (the branch separator). Null for non-branch selections. */
+  branchScrollTarget: string | null;
 }
 
 export function useTranscriptTimeline(
@@ -126,12 +129,40 @@ export function useTranscriptTimeline(
     [visibleRows, timeMapping, markerConfig.depth, markerConfig.kinds]
   );
 
-  const { selectedEvents, sourceSpans } = useMemo(() => {
+  const { selectedEvents, sourceSpans, branchScrollTarget } = useMemo(() => {
     const parsed = parseSelection(state.selected);
     const spans = getSelectedSpans(state.rows, state.selected);
     if (spans.length === 0) {
-      return { selectedEvents: events, sourceSpans: emptySourceSpans };
+      return {
+        selectedEvents: events,
+        sourceSpans: emptySourceSpans,
+        branchScrollTarget: null as string | null,
+      };
     }
+
+    // Detect branch row selection — show parent context up to fork point
+    const rowKey = parsed?.rowKey ?? "";
+    const row = state.rows.find((r) => r.key === rowKey);
+    if (row?.branch && spans.length === 1) {
+      const branchSpan = spans[0]!;
+      const collected = collectBranchWithContext(
+        state.rows,
+        rowKey,
+        branchSpan,
+        {
+          includeUtility,
+          showBranches,
+          branchPrefix: getBranchPrefix(state.rows, state.selected),
+        }
+      );
+      return {
+        selectedEvents: collected.events,
+        sourceSpans: collected.sourceSpans,
+        branchScrollTarget: branchSpan.id,
+      };
+    }
+
+    // Non-branch: existing behavior
     const collected = collectRawEvents(spans, {
       includeUtility,
       regionIndex: parsed?.regionIndex ?? null,
@@ -141,6 +172,7 @@ export function useTranscriptTimeline(
     return {
       selectedEvents: collected.events,
       sourceSpans: collected.sourceSpans,
+      branchScrollTarget: null as string | null,
     };
   }, [events, state.rows, state.selected, includeUtility, showBranches]);
 
@@ -190,5 +222,6 @@ export function useTranscriptTimeline(
     activeTimelineIndex,
     setActiveTimeline,
     regionCounts,
+    branchScrollTarget,
   };
 }

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -23,6 +23,7 @@ import {
   collectRawEvents,
   computeMinimapSelection,
   getBranchPrefix,
+  getParentKeyFromBranch,
   getSelectedSpans,
   parseSelection,
 } from "../timelineEventNodes";
@@ -43,6 +44,7 @@ import {
 } from "./useTimeline";
 
 const emptySourceSpans: ReadonlyMap<string, TimelineSpan> = new Map();
+const emptyHighlightedKeys: ReadonlyMap<string, number> = new Map();
 
 interface TranscriptTimelineResult {
   /** The built Timeline. Always present (even for root-only timelines). */
@@ -73,6 +75,11 @@ interface TranscriptTimelineResult {
   regionCounts: ReadonlyMap<string, number>;
   /** Event ID to scroll to when a branch is selected (the branch separator). Null for non-branch selections. */
   branchScrollTarget: string | null;
+  /** Row key → highlight clip percentage (0–100) within the bar area.
+   *  The selected branch row clips at 100; ancestor rows clip at the
+   *  fork marker's percentage position so only the pre-fork portion
+   *  of the bar is highlighted. */
+  highlightedKeys: ReadonlyMap<string, number>;
 }
 
 export function useTranscriptTimeline(
@@ -203,6 +210,48 @@ export function useTranscriptTimeline(
     return counts;
   }, [state.rows]);
 
+  // Compute highlighted rows with clip percentages when a branch is selected.
+  // The selected branch clips at 100% (full bar). Each ancestor clips at the
+  // fork marker's percentage so only the pre-fork portion is highlighted.
+  const highlightedKeys = useMemo(() => {
+    const parsed = parseSelection(state.selected);
+    const rowKey = parsed?.rowKey ?? "";
+    const row = state.rows.find((r) => r.key === rowKey);
+    if (!row?.branch) return emptyHighlightedKeys;
+
+    // Build a layout lookup by key for marker position queries.
+    const layoutByKey = new Map<string, RowLayout>();
+    for (const layout of layouts) {
+      layoutByKey.set(layout.key, layout);
+    }
+
+    const keys = new Map<string, number>();
+    // The selected branch itself highlights at 100%.
+    keys.set(rowKey, 100);
+
+    // Walk up ancestors, clipping each at its fork marker position.
+    let childKey = rowKey;
+    while (true) {
+      const parentKey = getParentKeyFromBranch(childKey);
+      if (!parentKey) break;
+
+      // Extract the forkedAt UUID from the child branch key.
+      const branchMatch = /\/branch-([^/]*)-\d+$/.exec(childKey);
+      const forkedAt = branchMatch?.[1] ?? "";
+
+      // Find the fork marker on the parent layout.
+      const parentLayout = layoutByKey.get(parentKey);
+      const forkMarker = parentLayout?.markers.find(
+        (m) => m.kind === "branch" && m.reference === forkedAt
+      );
+
+      // Clip at the fork marker's position, or 100% if not found.
+      keys.set(parentKey, forkMarker?.left ?? 100);
+      childKey = parentKey;
+    }
+    return keys;
+  }, [state.selected, state.rows, layouts]);
+
   const hasTimeline =
     timeline.root.content.length > 0 &&
     (timeline.root.content.some((item) => item.type === "span") ||
@@ -223,5 +272,6 @@ export function useTranscriptTimeline(
     setActiveTimeline,
     regionCounts,
     branchScrollTarget,
+    highlightedKeys,
   };
 }

--- a/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTranscriptTimeline.ts
@@ -235,14 +235,14 @@ export function useTranscriptTimeline(
       const parentKey = getParentKeyFromBranch(childKey);
       if (!parentKey) break;
 
-      // Extract the forkedAt UUID from the child branch key.
+      // Extract the branchedFrom identifier from the child branch key.
       const branchMatch = /\/branch-([^/]*)-\d+$/.exec(childKey);
-      const forkedAt = branchMatch?.[1] ?? "";
+      const branchedFrom = branchMatch?.[1] ?? "";
 
       // Find the fork marker on the parent layout.
       const parentLayout = layoutByKey.get(parentKey);
       const forkMarker = parentLayout?.markers.find(
-        (m) => m.kind === "branch" && m.reference === forkedAt
+        (m) => m.kind === "branch" && m.reference === branchedFrom
       );
 
       // Clip at the fork marker's position, or 100% if not found.

--- a/apps/scout/src/app/timeline/syntheticNodes.ts
+++ b/apps/scout/src/app/timeline/syntheticNodes.ts
@@ -1526,7 +1526,7 @@ function branchesSingleFork(): TimelineScenario {
         1,
         2,
         800,
-        undefined,
+        "model-call-5",
         "model-call-5"
       ),
       code,
@@ -1697,7 +1697,7 @@ function branchesMultipleForks(): TimelineScenario {
         1,
         2,
         600,
-        undefined,
+        "model-call-3",
         "model-call-3"
       ),
       code,
@@ -1706,7 +1706,7 @@ function branchesMultipleForks(): TimelineScenario {
         28,
         29,
         400,
-        undefined,
+        "model-call-10",
         "model-call-10"
       ),
       test,

--- a/apps/scout/src/app/timeline/timelineEventNodes.test.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import { TimelineEvent } from "../../components/transcript/timeline";
-import type { CompactionEvent, InfoEvent } from "../../types/api-types";
+import type { CompactionEvent, Event, InfoEvent } from "../../types/api-types";
 
-import { ts } from "./testHelpers";
+import { getScenarioRoot, S11A_BRANCHES, ts } from "./testHelpers";
 import {
   buildSelectionKey,
+  collectBranchWithContext,
   computeCompactionRegions,
+  getParentKeyFromBranch,
   parseSelection,
 } from "./timelineEventNodes";
+import { computeFlatSwimlaneRows } from "./utils/swimlaneRows";
 
 // =============================================================================
 // Test helpers
@@ -261,5 +264,170 @@ describe("computeCompactionRegions", () => {
         }
       }
     }
+  });
+});
+
+// =============================================================================
+// getParentKeyFromBranch
+// =============================================================================
+
+describe("getParentKeyFromBranch", () => {
+  it("extracts parent key from a branch key", () => {
+    expect(getParentKeyFromBranch("main/build/branch-uuid-1")).toBe(
+      "main/build"
+    );
+  });
+
+  it("returns null for a non-branch key", () => {
+    expect(getParentKeyFromBranch("main/build")).toBeNull();
+  });
+
+  it("returns null for a bare key", () => {
+    expect(getParentKeyFromBranch("build")).toBeNull();
+  });
+
+  it("handles nested branch keys", () => {
+    expect(getParentKeyFromBranch("root/branch-abc-1/branch-def-2")).toBe(
+      "root/branch-abc-1"
+    );
+  });
+
+  it("handles branch key with complex branchedFrom UUID", () => {
+    expect(
+      getParentKeyFromBranch(
+        "solvers/agent/branch-550e8400-e29b-41d4-a716-446655440000-1"
+      )
+    ).toBe("solvers/agent");
+  });
+});
+
+// =============================================================================
+// collectBranchWithContext
+// =============================================================================
+
+describe("collectBranchWithContext", () => {
+  // Build rows from S11A scenario once — shared across tests.
+  const root = getScenarioRoot(S11A_BRANCHES);
+  const rows = computeFlatSwimlaneRows(root, { showBranches: true });
+
+  // The build row is the parent, branches are its children.
+  // Branch key pattern: "parentKey/branch-{branchedFrom}-{index}"
+  // In S11A, build is at "transcript/build" and branches fork at "model-call-5".
+  const buildRow = rows.find((r) => r.key === "transcript/build");
+  const branch1Key = "transcript/build/branch-model-call-5-1";
+  const branch1Row = rows.find((r) => r.key === branch1Key);
+
+  it("finds the expected build and branch rows", () => {
+    expect(buildRow).toBeDefined();
+    expect(branch1Row).toBeDefined();
+    expect(branch1Row!.branch).toBe(true);
+  });
+
+  it("includes parent events before the branch separator", () => {
+    const branch1Span = branch1Row!.spans[0]!;
+    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
+    expect(span).toBeDefined();
+
+    const result = collectBranchWithContext(rows, branch1Key, span!, {
+      includeUtility: false,
+      showBranches: false,
+      branchPrefix: "",
+    });
+
+    // The parent (build) has a model event with uuid "model-call-5" as first content.
+    // collectContentUpToFork should emit it, then stop.
+    // The first event in the stream should be from the build span's content.
+    const eventTypes = result.events.map((e: Event) => e.event);
+
+    // Should start with parent model event (the fork point)
+    expect(eventTypes[0]).toBe("model");
+    expect((result.events[0] as { uuid: string | null }).uuid).toBe(
+      "model-call-5"
+    );
+  });
+
+  it("includes a branch separator with spanType 'branch'", () => {
+    const branch1Span = branch1Row!.spans[0]!;
+    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
+
+    const result = collectBranchWithContext(rows, branch1Key, span!, {
+      includeUtility: false,
+      showBranches: false,
+      branchPrefix: "",
+    });
+
+    // Find the branch separator — a span_begin with type "branch"
+    const separatorIndex = result.events.findIndex(
+      (e: Event) => e.event === "span_begin" && e.type === "branch"
+    );
+    expect(separatorIndex).toBeGreaterThan(0);
+
+    // The separator should come after parent events and before branch content
+    const separator = result.events[separatorIndex]!;
+    expect(separator.event).toBe("span_begin");
+    if (separator.event === "span_begin") {
+      expect(separator.span_id).toBe(span!.id);
+    }
+  });
+
+  it("includes branch content after the separator", () => {
+    const branch1Span = branch1Row!.spans[0]!;
+    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
+
+    const result = collectBranchWithContext(rows, branch1Key, span!, {
+      includeUtility: false,
+      showBranches: false,
+      branchPrefix: "",
+    });
+
+    // Find the branch separator
+    const separatorIndex = result.events.findIndex(
+      (e: Event) => e.event === "span_begin" && e.type === "branch"
+    );
+
+    // After the separator + its end, we should have branch content.
+    // Branch 1 content includes agent spans (branch1-refactor, branch1-validate).
+    // These are agent spans so they emit as collapsed begin/end pairs.
+    const afterSeparator = result.events.slice(separatorIndex + 1);
+    const spanBegins = afterSeparator.filter(
+      (e: Event) => e.event === "span_begin"
+    );
+    // Should have at least the two agent spans from branch 1
+    expect(spanBegins.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("records source spans for the branch separator", () => {
+    const branch1Span = branch1Row!.spans[0]!;
+    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
+
+    const result = collectBranchWithContext(rows, branch1Key, span!, {
+      includeUtility: false,
+      showBranches: false,
+      branchPrefix: "",
+    });
+
+    // The branch span should be in sourceSpans for rendering as AgentCardView
+    expect(result.sourceSpans.has(span!.id)).toBe(true);
+  });
+
+  it("fork event is the last parent event before separator", () => {
+    const branch1Span = branch1Row!.spans[0]!;
+    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
+
+    const result = collectBranchWithContext(rows, branch1Key, span!, {
+      includeUtility: false,
+      showBranches: false,
+      branchPrefix: "",
+    });
+
+    // Find the branch separator index
+    const separatorIndex = result.events.findIndex(
+      (e: Event) => e.event === "span_begin" && e.type === "branch"
+    );
+
+    // The event just before the separator should be the fork event
+    const forkEvent = result.events[separatorIndex - 1];
+    expect(forkEvent).toBeDefined();
+    expect((forkEvent as { uuid: string | null }).uuid).toBe("model-call-5");
   });
 });

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -298,14 +298,9 @@ export function collectRawEvents(
       sourceSpans,
       agentSpanId,
       includeUtility,
-      showBranches
+      showBranches,
+      span.branches.length > 0 ? span.branches : undefined
     );
-
-    // Emit branches from the root span (collectFromContent only sees
-    // branches on nested spans it encounters in the content array).
-    if (showBranches) {
-      emitBranchSpans(span, events, sourceSpans);
-    }
   } else {
     // Multiple spans: wrap each in span_begin/span_end so the event tree
     // groups them, matching the drilled-in container behavior.
@@ -323,45 +318,45 @@ export function collectRawEvents(
 }
 
 /**
- * Emit each branch on a span as an empty span_begin/span_end pair (like
- * agents). Content is accessed by selecting the branch swimlane row.
+ * Emit a single branch as an empty span_begin/span_end pair (like agents).
+ * Content is accessed by selecting the branch swimlane row.
  */
-function emitBranchSpans(
-  span: TimelineSpan,
+function emitBranchSpan(
+  branch: TimelineSpan,
+  index: number,
   out: Event[],
-  sourceSpans: Map<string, TimelineSpan>
+  sourceSpans: Map<string, TimelineSpan>,
+  parentSpanId?: string | null
 ): void {
-  for (let i = 0; i < span.branches.length; i++) {
-    const branchSpan = createBranchSpan(span.branches[i]!, i + 1);
-    sourceSpans.set(branchSpan.id, branchSpan);
+  const branchSpan = createBranchSpan(branch, index + 1);
+  sourceSpans.set(branchSpan.id, branchSpan);
 
-    const branchBegin: SpanBeginEvent = {
-      event: "span_begin",
-      name: branchSpan.name,
-      id: branchSpan.id,
-      span_id: branchSpan.id,
-      type: branchSpan.spanType,
-      timestamp: branchSpan.startTime().toISOString(),
-      parent_id: null,
-      pending: false,
-      working_start: 0,
-      uuid: branchSpan.id,
-      metadata: null,
-    };
-    out.push(branchBegin);
+  const branchBegin: SpanBeginEvent = {
+    event: "span_begin",
+    name: branchSpan.name,
+    id: branchSpan.id,
+    span_id: branchSpan.id,
+    type: branchSpan.spanType,
+    timestamp: branchSpan.startTime().toISOString(),
+    parent_id: parentSpanId ?? null,
+    pending: false,
+    working_start: 0,
+    uuid: branchSpan.id,
+    metadata: null,
+  };
+  out.push(branchBegin);
 
-    const branchEnd: SpanEndEvent = {
-      event: "span_end",
-      id: `${branchSpan.id}-end`,
-      span_id: branchSpan.id,
-      timestamp: branchSpan.endTime().toISOString(),
-      pending: false,
-      working_start: 0,
-      uuid: null,
-      metadata: null,
-    };
-    out.push(branchEnd);
-  }
+  const branchEnd: SpanEndEvent = {
+    event: "span_end",
+    id: `${branchSpan.id}-end`,
+    span_id: branchSpan.id,
+    timestamp: branchSpan.endTime().toISOString(),
+    pending: false,
+    working_start: 0,
+    uuid: null,
+    metadata: null,
+  };
+  out.push(branchEnd);
 }
 
 function collectFromContent(
@@ -370,11 +365,29 @@ function collectFromContent(
   sourceSpans: Map<string, TimelineSpan>,
   skipAgentSpanId?: string,
   includeUtility: boolean = false,
-  showBranches: boolean = false
+  showBranches: boolean = false,
+  branches?: ReadonlyArray<TimelineSpan>
 ): void {
   // Track agent tool_call_ids whose results are shown on the AgentCard,
   // so we can filter them from the next model event's input.
   const pendingToolCallIds = new Set<string>();
+
+  // Build a lookup from branchedFrom UUID → branches for inline emission.
+  // Branches whose branchedFrom doesn't match any event are emitted at the end.
+  const branchByBranchedFrom = new Map<string, TimelineSpan[]>();
+  if (branches) {
+    for (const branch of branches) {
+      if (branch.branchedFrom) {
+        const existing = branchByBranchedFrom.get(branch.branchedFrom);
+        if (existing) {
+          existing.push(branch);
+        } else {
+          branchByBranchedFrom.set(branch.branchedFrom, [branch]);
+        }
+      }
+    }
+  }
+  const emittedBranchedFroms = new Set<string>();
 
   for (const item of content) {
     if (item.type === "event") {
@@ -414,12 +427,31 @@ function collectFromContent(
             } as unknown as Event;
             out.push(patched);
             pendingToolCallIds.clear();
+            // Emit branches forked at this event after the event itself
+            emitInlineBranches(
+              item,
+              branchByBranchedFrom,
+              branches ?? [],
+              emittedBranchedFroms,
+              out,
+              sourceSpans
+            );
             continue;
           }
         }
       }
 
       out.push(item.event);
+
+      // Emit branches forked at this event immediately after it
+      emitInlineBranches(
+        item,
+        branchByBranchedFrom,
+        branches ?? [],
+        emittedBranchedFroms,
+        out,
+        sourceSpans
+      );
     } else if (!includeUtility && item.utility) {
       // Skip utility spans — internal model calls (e.g. file path extraction)
       // that should not appear in the event tree or outline.
@@ -450,19 +482,17 @@ function collectFromContent(
           pendingToolCallIds.add(item.id.slice(6));
         }
       } else {
-        // Non-agent spans: recurse into child content
+        // Non-agent spans: recurse into child content, passing their
+        // own branches so they emit inline at the correct fork point.
         collectFromContent(
           item.content,
           out,
           sourceSpans,
           undefined,
           includeUtility,
-          showBranches
+          showBranches,
+          item.branches.length > 0 ? item.branches : undefined
         );
-
-        if (showBranches) {
-          emitBranchSpans(item, out, sourceSpans);
-        }
       }
 
       // Emit synthetic span_end
@@ -479,6 +509,49 @@ function collectFromContent(
       out.push(endEvent);
     }
   }
+
+  // Emit any branches whose branchedFrom didn't match any event in this content
+  // (fallback to end, preserving previous behavior for unresolvable forks).
+  if (branches) {
+    for (const branch of branches) {
+      const branchedFrom = branch.branchedFrom ?? "";
+      if (!emittedBranchedFroms.has(branchedFrom)) {
+        emitBranchSpan(branch, branches.indexOf(branch), out, sourceSpans);
+      }
+    }
+  }
+}
+
+/**
+ * Emit branches inline after their fork point event.
+ */
+function emitInlineBranches(
+  item: TimelineEvent,
+  branchByBranchedFrom: ReadonlyMap<string, TimelineSpan[]>,
+  allBranches: ReadonlyArray<TimelineSpan>,
+  emittedBranchedFroms: Set<string>,
+  out: Event[],
+  sourceSpans: Map<string, TimelineSpan>
+): void {
+  const uuid = item.event.uuid;
+  if (!uuid) return;
+  const forkedBranches = branchByBranchedFrom.get(uuid);
+  if (!forkedBranches) return;
+  // Use the fork event's span_id as the branch's parent so treeifyEvents
+  // nests the branch inside the same span as the fork event.
+  const parentSpanId = (item.event as { span_id?: string | null }).span_id;
+  for (const branch of forkedBranches) {
+    // Use the branch's position in the full branches array for the display index
+    const globalIndex = allBranches.indexOf(branch);
+    emitBranchSpan(
+      branch,
+      globalIndex >= 0 ? globalIndex : 0,
+      out,
+      sourceSpans,
+      parentSpanId
+    );
+  }
+  emittedBranchedFroms.add(uuid);
 }
 
 // =============================================================================

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -578,6 +578,249 @@ function emitInlineBranches(
 }
 
 // =============================================================================
+// Branch context collection
+// =============================================================================
+
+/**
+ * Derives the parent row key from a branch row key.
+ *
+ * Branch keys follow the pattern `"parentKey/branch-{branchedFrom}-{index}"`.
+ * Returns null if the key doesn't contain a branch segment.
+ */
+export function getParentKeyFromBranch(branchKey: string): string | null {
+  const match = /^(.+)\/branch-[^/]+$/.exec(branchKey);
+  return match ? match[1]! : null;
+}
+
+/** A link in the ancestor chain: a span and the fork UUID where the next level branches. */
+interface AncestorLink {
+  span: TimelineSpan;
+  forkUuid: string;
+}
+
+/**
+ * Builds the ancestor chain from a branch row up to the outermost non-branch row.
+ *
+ * Returns links ordered outermost ancestor → innermost parent, each paired
+ * with the fork UUID where the next level (or the target branch) branches off.
+ */
+function buildAncestorChain(
+  rows: SwimlaneRow[],
+  branchRowKey: string
+): AncestorLink[] {
+  const chain: AncestorLink[] = [];
+  let currentKey = branchRowKey;
+
+  while (true) {
+    const parentKey = getParentKeyFromBranch(currentKey);
+    if (!parentKey) break;
+
+    const parentRow = rows.find((r) => r.key === parentKey);
+    if (!parentRow || parentRow.spans.length === 0) break;
+
+    // Get the parent's TimelineSpan
+    const firstSpan = parentRow.spans[0]!;
+    const parentSpan = isSingleSpan(firstSpan)
+      ? firstSpan.agent
+      : getAgents(firstSpan)[0];
+    if (!parentSpan) break;
+
+    // Get the child branch's forkedAt UUID
+    const childRow = rows.find((r) => r.key === currentKey);
+    if (!childRow || childRow.spans.length === 0) break;
+    const childFirstSpan = childRow.spans[0]!;
+    const childSpan = isSingleSpan(childFirstSpan)
+      ? childFirstSpan.agent
+      : getAgents(childFirstSpan)[0];
+    if (!childSpan?.branchedFrom) break;
+
+    chain.unshift({ span: parentSpan, forkUuid: childSpan.branchedFrom });
+
+    currentKey = parentKey;
+    // Keep walking if the parent is also a branch
+    if (!parentRow.branch) break;
+  }
+
+  return chain;
+}
+
+/**
+ * Collects events from a span's content, stopping after the event whose
+ * UUID matches `forkUuid` (inclusive — the fork event is the last parent
+ * event before the branch point).
+ *
+ * Returns true if the fork event was found, false otherwise.
+ */
+function collectContentUpToFork(
+  content: ReadonlyArray<TimelineEvent | TimelineSpan>,
+  forkUuid: string,
+  out: Event[],
+  sourceSpans: Map<string, TimelineSpan>,
+  includeUtility: boolean
+): boolean {
+  for (const item of content) {
+    if (item.type === "event") {
+      out.push(item.event);
+      if (item.event.uuid === forkUuid) {
+        return true;
+      }
+    } else if (!includeUtility && item.utility) {
+      continue;
+    } else if (item.spanType === "agent") {
+      // Agent spans: emit collapsed begin/end pair
+      const beginEvent: SpanBeginEvent = {
+        event: "span_begin",
+        name: item.name,
+        id: item.id,
+        span_id: item.id,
+        type: item.spanType,
+        timestamp: item.startTime().toISOString(),
+        parent_id: null,
+        pending: false,
+        working_start: 0,
+        uuid: item.id,
+        metadata: null,
+      };
+      out.push(beginEvent);
+      sourceSpans.set(item.id, item);
+      const endEvent: SpanEndEvent = {
+        event: "span_end",
+        id: `${item.id}-end`,
+        span_id: item.id,
+        timestamp: item.endTime().toISOString(),
+        pending: false,
+        working_start: 0,
+        uuid: null,
+        metadata: null,
+      };
+      out.push(endEvent);
+    } else {
+      // Non-agent span: recurse into content, checking for fork
+      const beginEvent: SpanBeginEvent = {
+        event: "span_begin",
+        name: item.name,
+        id: item.id,
+        span_id: item.id,
+        type: item.spanType,
+        timestamp: item.startTime().toISOString(),
+        parent_id: null,
+        pending: false,
+        working_start: 0,
+        uuid: item.id,
+        metadata: null,
+      };
+      out.push(beginEvent);
+
+      const found = collectContentUpToFork(
+        item.content,
+        forkUuid,
+        out,
+        sourceSpans,
+        includeUtility
+      );
+
+      const endEvent: SpanEndEvent = {
+        event: "span_end",
+        id: `${item.id}-end`,
+        span_id: item.id,
+        timestamp: item.endTime().toISOString(),
+        pending: false,
+        working_start: 0,
+        uuid: null,
+        metadata: null,
+      };
+      out.push(endEvent);
+
+      if (found) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Collects events for a branch with full ancestor context.
+ *
+ * The resulting event stream contains:
+ * 1. Ancestor events from the root down to each fork point
+ * 2. A branch separator (AgentCardView) at each fork
+ * 3. The branch's own events
+ *
+ * For nested branches (Branch 1.1), the full chain is included:
+ * root events → fork → Branch 1 events → fork → Branch 1.1 events.
+ */
+export function collectBranchWithContext(
+  rows: SwimlaneRow[],
+  branchRowKey: string,
+  branchSpan: TimelineSpan,
+  options: {
+    includeUtility: boolean;
+    showBranches: boolean;
+    branchPrefix: string;
+  }
+): CollectedEvents {
+  const events: Event[] = [];
+  const sourceSpans = new Map<string, TimelineSpan>();
+
+  const ancestorChain = buildAncestorChain(rows, branchRowKey);
+
+  // Emit each ancestor's content up to its fork point
+  for (const ancestor of ancestorChain) {
+    collectContentUpToFork(
+      ancestor.span.content,
+      ancestor.forkUuid,
+      events,
+      sourceSpans,
+      options.includeUtility
+    );
+  }
+
+  // Emit the branch separator (renders as AgentCardView).
+  // branchSpan is already a createBranchSpan result with the correct name,
+  // so emit directly rather than calling emitBranchSpan (which would
+  // double-apply createBranchSpan and produce "Branch Branch 1").
+  sourceSpans.set(branchSpan.id, branchSpan);
+  const branchBegin: SpanBeginEvent = {
+    event: "span_begin",
+    name: branchSpan.name,
+    id: branchSpan.id,
+    span_id: branchSpan.id,
+    type: branchSpan.spanType,
+    timestamp: branchSpan.startTime().toISOString(),
+    parent_id: null,
+    pending: false,
+    working_start: 0,
+    uuid: branchSpan.id,
+    metadata: null,
+  };
+  events.push(branchBegin);
+  const branchEnd: SpanEndEvent = {
+    event: "span_end",
+    id: `${branchSpan.id}-end`,
+    span_id: branchSpan.id,
+    timestamp: branchSpan.endTime().toISOString(),
+    pending: false,
+    working_start: 0,
+    uuid: null,
+    metadata: null,
+  };
+  events.push(branchEnd);
+
+  // Emit the branch's own content
+  collectFromContent(
+    branchSpan.content,
+    events,
+    sourceSpans,
+    undefined,
+    options.includeUtility,
+    options.showBranches,
+    branchSpan.branches.length > 0 ? branchSpan.branches : undefined,
+    options.branchPrefix
+  );
+
+  return { events, sourceSpans };
+}
+
+// =============================================================================
 // Span select key lookup
 // =============================================================================
 

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -625,7 +625,7 @@ function buildAncestorChain(
       : getAgents(firstSpan)[0];
     if (!parentSpan) break;
 
-    // Get the child branch's forkedAt UUID
+    // Get the child branch's branchedFrom identifier
     const childRow = rows.find((r) => r.key === currentKey);
     if (!childRow || childRow.spans.length === 0) break;
     const childFirstSpan = childRow.spans[0]!;

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -20,7 +20,7 @@ import type {
 } from "../../types/api-types";
 
 import type { MinimapSelection } from "./components/TimelineMinimap";
-import { computeTimeEnvelope } from "./utils/swimlaneLayout";
+
 import {
   getAgents,
   isSingleSpan,
@@ -217,15 +217,23 @@ export function computeMinimapSelection(
   if (allAgents.length === 1) {
     const agent = allAgents[0]!;
     return {
-      startTime: agent.startTime(),
-      endTime: agent.endTime(),
-      totalTokens: agent.totalTokens(),
+      startTime: agent.startTime(false),
+      endTime: agent.endTime(false),
+      totalTokens: agent.totalTokens(false),
     };
   }
 
-  const envelope = computeTimeEnvelope(allAgents);
-  const tokens = allAgents.reduce((sum, a) => sum + a.totalTokens(), 0);
-  return { ...envelope, totalTokens: tokens };
+  // Compute envelope with includeBranches=false so each agent contributes
+  // only its own time range
+  let envStart = allAgents[0]!.startTime(false);
+  let envEnd = allAgents[0]!.endTime(false);
+  for (let i = 1; i < allAgents.length; i++) {
+    const a = allAgents[i]!;
+    if (a.startTime(false) < envStart) envStart = a.startTime(false);
+    if (a.endTime(false) > envEnd) envEnd = a.endTime(false);
+  }
+  const tokens = allAgents.reduce((sum, a) => sum + a.totalTokens(false), 0);
+  return { startTime: envStart, endTime: envEnd, totalTokens: tokens };
 }
 
 // =============================================================================

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -561,20 +561,23 @@ function emitInlineBranches(
   sourceSpans: Map<string, TimelineSpan>,
   branchPrefix: string = ""
 ): void {
-  const uuid = item.event.uuid;
-  if (!uuid) return;
-  const forkedBranches = branchByBranchedFrom.get(uuid);
-  if (!forkedBranches) return;
-  // Use the fork event's span_id as the branch's parent so treeifyEvents
-  // nests the branch inside the same span as the fork event.
-  const parentSpanId = (item.event as { span_id?: string | null }).span_id;
-  for (const branch of forkedBranches) {
-    // Use the branch's position in the full branches array for the display label
-    const globalIndex = allBranches.indexOf(branch);
-    const label = `${branchPrefix}${(globalIndex >= 0 ? globalIndex : 0) + 1}`;
-    emitBranchSpan(branch, label, out, sourceSpans, parentSpanId);
+  // branchByBranchedFrom is keyed by message ID. Find entries where
+  // this event produced or carries the matching message ID.
+  for (const [messageId, forkedBranches] of branchByBranchedFrom) {
+    if (emittedBranchedFroms.has(messageId)) continue;
+    if (!item.matchesMessageId(messageId)) continue;
+
+    // Use the fork event's span_id as the branch's parent so treeifyEvents
+    // nests the branch inside the same span as the fork event.
+    const parentSpanId = (item.event as { span_id?: string | null }).span_id;
+    for (const branch of forkedBranches) {
+      // Use the branch's position in the full branches array for the display label
+      const globalIndex = allBranches.indexOf(branch);
+      const label = `${branchPrefix}${(globalIndex >= 0 ? globalIndex : 0) + 1}`;
+      emitBranchSpan(branch, label, out, sourceSpans, parentSpanId);
+    }
+    emittedBranchedFroms.add(messageId);
   }
-  emittedBranchedFroms.add(uuid);
 }
 
 // =============================================================================
@@ -592,10 +595,10 @@ export function getParentKeyFromBranch(branchKey: string): string | null {
   return match ? match[1]! : null;
 }
 
-/** A link in the ancestor chain: a span and the fork UUID where the next level branches. */
+/** A link in the ancestor chain: a span and the fork message ID where the next level branches. */
 interface AncestorLink {
   span: TimelineSpan;
-  forkUuid: string;
+  forkMessageId: string;
 }
 
 /**
@@ -634,7 +637,7 @@ function buildAncestorChain(
       : getAgents(childFirstSpan)[0];
     if (!childSpan?.branchedFrom) break;
 
-    chain.unshift({ span: parentSpan, forkUuid: childSpan.branchedFrom });
+    chain.unshift({ span: parentSpan, forkMessageId: childSpan.branchedFrom });
 
     currentKey = parentKey;
     // Keep walking if the parent is also a branch
@@ -646,14 +649,14 @@ function buildAncestorChain(
 
 /**
  * Collects events from a span's content, stopping after the event whose
- * UUID matches `forkUuid` (inclusive — the fork event is the last parent
- * event before the branch point).
+ * message ID matches `forkMessageId` (inclusive — the fork event is the
+ * last parent event before the branch point).
  *
  * Returns true if the fork event was found, false otherwise.
  */
 function collectContentUpToFork(
   content: ReadonlyArray<TimelineEvent | TimelineSpan>,
-  forkUuid: string,
+  forkMessageId: string,
   out: Event[],
   sourceSpans: Map<string, TimelineSpan>,
   includeUtility: boolean
@@ -661,7 +664,7 @@ function collectContentUpToFork(
   for (const item of content) {
     if (item.type === "event") {
       out.push(item.event);
-      if (item.event.uuid === forkUuid) {
+      if (item.matchesMessageId(forkMessageId)) {
         return true;
       }
     } else if (!includeUtility && item.utility) {
@@ -713,7 +716,7 @@ function collectContentUpToFork(
 
       const found = collectContentUpToFork(
         item.content,
-        forkUuid,
+        forkMessageId,
         out,
         sourceSpans,
         includeUtility
@@ -767,7 +770,7 @@ export function collectBranchWithContext(
   for (const ancestor of ancestorChain) {
     collectContentUpToFork(
       ancestor.span.content,
-      ancestor.forkUuid,
+      ancestor.forkMessageId,
       events,
       sourceSpans,
       options.includeUtility

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -20,7 +20,6 @@ import type {
 } from "../../types/api-types";
 
 import type { MinimapSelection } from "./components/TimelineMinimap";
-
 import {
   getAgents,
   isSingleSpan,

--- a/apps/scout/src/app/timeline/timelineEventNodes.ts
+++ b/apps/scout/src/app/timeline/timelineEventNodes.ts
@@ -108,6 +108,24 @@ function findRowByKey(
   return rows.find((r) => r.key === key);
 }
 
+/**
+ * Derive the branch prefix for nested branches from a selected row.
+ *
+ * If the row is a branch named "Branch 1", returns "1." so nested branches
+ * become "Branch 1.1", "Branch 1.2", etc. Returns "" for non-branch rows.
+ */
+export function getBranchPrefix(
+  rows: SwimlaneRow[],
+  selected: string | null
+): string {
+  const parsed = parseSelection(selected);
+  if (!parsed) return "";
+  const row = findRowByKey(rows, parsed.rowKey);
+  if (!row?.branch) return "";
+  const match = /^Branch (\S+)$/i.exec(row.name);
+  return match ? `${match[1]}.` : "";
+}
+
 // =============================================================================
 // Selected spans
 // =============================================================================
@@ -269,11 +287,13 @@ export function collectRawEvents(
     includeUtility?: boolean;
     regionIndex?: number | null;
     showBranches?: boolean;
+    branchPrefix?: string;
   }
 ): CollectedEvents {
   const includeUtility = options?.includeUtility ?? false;
   const regionIndex = options?.regionIndex ?? null;
   const showBranches = options?.showBranches ?? false;
+  const branchPrefix = options?.branchPrefix ?? "";
   const events: Event[] = [];
   const sourceSpans = new Map<string, TimelineSpan>();
   if (spans.length === 1) {
@@ -299,7 +319,8 @@ export function collectRawEvents(
       agentSpanId,
       includeUtility,
       showBranches,
-      span.branches.length > 0 ? span.branches : undefined
+      span.branches.length > 0 ? span.branches : undefined,
+      branchPrefix
     );
   } else {
     // Multiple spans: wrap each in span_begin/span_end so the event tree
@@ -311,7 +332,9 @@ export function collectRawEvents(
       sourceSpans,
       undefined,
       includeUtility,
-      showBranches
+      showBranches,
+      undefined,
+      branchPrefix
     );
   }
   return { events, sourceSpans };
@@ -323,12 +346,12 @@ export function collectRawEvents(
  */
 function emitBranchSpan(
   branch: TimelineSpan,
-  index: number,
+  label: string,
   out: Event[],
   sourceSpans: Map<string, TimelineSpan>,
   parentSpanId?: string | null
 ): void {
-  const branchSpan = createBranchSpan(branch, index + 1);
+  const branchSpan = createBranchSpan(branch, label);
   sourceSpans.set(branchSpan.id, branchSpan);
 
   const branchBegin: SpanBeginEvent = {
@@ -366,7 +389,8 @@ function collectFromContent(
   skipAgentSpanId?: string,
   includeUtility: boolean = false,
   showBranches: boolean = false,
-  branches?: ReadonlyArray<TimelineSpan>
+  branches?: ReadonlyArray<TimelineSpan>,
+  branchPrefix: string = ""
 ): void {
   // Track agent tool_call_ids whose results are shown on the AgentCard,
   // so we can filter them from the next model event's input.
@@ -434,7 +458,8 @@ function collectFromContent(
               branches ?? [],
               emittedBranchedFroms,
               out,
-              sourceSpans
+              sourceSpans,
+              branchPrefix
             );
             continue;
           }
@@ -450,7 +475,8 @@ function collectFromContent(
         branches ?? [],
         emittedBranchedFroms,
         out,
-        sourceSpans
+        sourceSpans,
+        branchPrefix
       );
     } else if (!includeUtility && item.utility) {
       // Skip utility spans — internal model calls (e.g. file path extraction)
@@ -516,7 +542,8 @@ function collectFromContent(
     for (const branch of branches) {
       const branchedFrom = branch.branchedFrom ?? "";
       if (!emittedBranchedFroms.has(branchedFrom)) {
-        emitBranchSpan(branch, branches.indexOf(branch), out, sourceSpans);
+        const label = `${branchPrefix}${branches.indexOf(branch) + 1}`;
+        emitBranchSpan(branch, label, out, sourceSpans);
       }
     }
   }
@@ -531,7 +558,8 @@ function emitInlineBranches(
   allBranches: ReadonlyArray<TimelineSpan>,
   emittedBranchedFroms: Set<string>,
   out: Event[],
-  sourceSpans: Map<string, TimelineSpan>
+  sourceSpans: Map<string, TimelineSpan>,
+  branchPrefix: string = ""
 ): void {
   const uuid = item.event.uuid;
   if (!uuid) return;
@@ -541,15 +569,10 @@ function emitInlineBranches(
   // nests the branch inside the same span as the fork event.
   const parentSpanId = (item.event as { span_id?: string | null }).span_id;
   for (const branch of forkedBranches) {
-    // Use the branch's position in the full branches array for the display index
+    // Use the branch's position in the full branches array for the display label
     const globalIndex = allBranches.indexOf(branch);
-    emitBranchSpan(
-      branch,
-      globalIndex >= 0 ? globalIndex : 0,
-      out,
-      sourceSpans,
-      parentSpanId
-    );
+    const label = `${branchPrefix}${(globalIndex >= 0 ? globalIndex : 0) + 1}`;
+    emitBranchSpan(branch, label, out, sourceSpans, parentSpanId);
   }
   emittedBranchedFroms.add(uuid);
 }

--- a/apps/scout/src/app/timeline/utils/markers.test.ts
+++ b/apps/scout/src/app/timeline/utils/markers.test.ts
@@ -43,7 +43,12 @@ const NULL_CONFIG = {} as ModelEvent["config"];
 
 function makeModelEventNode(
   startSec: number,
-  options?: { error?: string; outputError?: string; uuid?: string }
+  options?: {
+    error?: string;
+    outputError?: string;
+    uuid?: string;
+    messageId?: string;
+  }
 ): TimelineEvent {
   const event: ModelEvent = {
     event: "model",
@@ -54,7 +59,14 @@ function makeModelEventNode(
     tool_choice: "auto",
     config: NULL_CONFIG,
     output: {
-      choices: [],
+      choices: options?.messageId
+        ? ([
+            {
+              message: { id: options.messageId },
+              stop_reason: "stop",
+            },
+          ] as ModelEvent["output"]["choices"])
+        : [],
       completion: "",
       error: options?.outputError ?? null,
       metadata: null,
@@ -341,9 +353,9 @@ describe("collectMarkers", () => {
   // ---------------------------------------------------------------------------
   describe("branch markers", () => {
     it("creates branch markers positioned at fork point event time", () => {
-      const event1 = makeModelEventNode(0, { uuid: "evt-1" });
-      const event2 = makeModelEventNode(5, { uuid: "evt-2" });
-      const branch = makeBranchObj("evt-1", [makeModelEventNode(2)], 2, 4);
+      const event1 = makeModelEventNode(0, { messageId: "msg-1" });
+      const event2 = makeModelEventNode(5, { messageId: "msg-2" });
+      const branch = makeBranchObj("msg-1", [makeModelEventNode(2)], 2, 4);
 
       const parent = makeSpan("Root", 0, 20, 1000, [event1, event2], {
         branches: [branch],
@@ -354,7 +366,7 @@ describe("collectMarkers", () => {
       expect(markers).toHaveLength(1);
       expect(markers[0]!.kind).toBe("branch");
       expect(markers[0]!.timestamp).toEqual(ts(0)); // fork event's timestamp
-      expect(markers[0]!.reference).toBe("evt-1");
+      expect(markers[0]!.reference).toBe("msg-1");
     });
 
     it("falls back to branch start time when branchedFrom UUID is not found", () => {

--- a/apps/scout/src/app/timeline/utils/markers.test.ts
+++ b/apps/scout/src/app/timeline/utils/markers.test.ts
@@ -340,7 +340,7 @@ describe("collectMarkers", () => {
   // Branch markers
   // ---------------------------------------------------------------------------
   describe("branch markers", () => {
-    it("creates branch markers positioned at branch start time", () => {
+    it("creates branch markers positioned at fork point event time", () => {
       const event1 = makeModelEventNode(0, { uuid: "evt-1" });
       const event2 = makeModelEventNode(5, { uuid: "evt-2" });
       const branch = makeBranchObj("evt-1", [makeModelEventNode(2)], 2, 4);
@@ -353,7 +353,7 @@ describe("collectMarkers", () => {
 
       expect(markers).toHaveLength(1);
       expect(markers[0]!.kind).toBe("branch");
-      expect(markers[0]!.timestamp).toEqual(ts(2)); // branch's startTime
+      expect(markers[0]!.timestamp).toEqual(ts(0)); // fork event's timestamp
       expect(markers[0]!.reference).toBe("evt-1");
     });
 
@@ -400,7 +400,7 @@ describe("collectMarkers", () => {
 
       const markers = collectMarkers(buildSpan!, "direct");
 
-      // Each branch gets its own marker positioned at its startTime
+      // Each branch gets its own marker positioned at the fork point event
       const branchMarkers = markers.filter((m) => m.kind === "branch");
       expect(branchMarkers).toHaveLength(2);
       expect(branchMarkers[0]!.reference).toBe("model-call-5");
@@ -447,7 +447,7 @@ describe("collectMarkers", () => {
       const markers = collectMarkers(parent, "direct");
 
       expect(markers).toHaveLength(3);
-      expect(markers[0]!.kind).toBe("branch"); // ts(6) — branch.startTime
+      expect(markers[0]!.kind).toBe("branch"); // ts(5) — fork event timestamp
       expect(markers[1]!.kind).toBe("error"); // ts(15)
       expect(markers[2]!.kind).toBe("compaction"); // ts(25)
     });

--- a/apps/scout/src/app/timeline/utils/markers.ts
+++ b/apps/scout/src/app/timeline/utils/markers.ts
@@ -191,9 +191,9 @@ function addEventMarker(
 /**
  * Collects branch markers from a span's branches.
  *
- * Emits one marker per branch, positioned at the branch's start time so that
- * markers align with branch swimlane bars. Clicking a branch marker toggles
- * the showBranches display option.
+ * Emits one marker per branch, positioned at the fork point event in the
+ * parent span (resolved via the branch's `branchedFrom` identifier).
+ * Clicking a branch marker toggles the showBranches display option.
  */
 function collectBranchMarkers(
   node: TimelineSpan,
@@ -202,11 +202,31 @@ function collectBranchMarkers(
   for (const branch of node.branches) {
     markers.push({
       kind: "branch",
-      timestamp: branch.startTime(),
+      timestamp: resolveForkTimestamp(node, branch),
       reference: branch.branchedFrom ?? "",
       tooltip: branchTooltip([branch]),
     });
   }
+}
+
+/**
+ * Resolves the fork point timestamp from the parent span's content.
+ *
+ * Searches direct events in the parent for a message ID matching
+ * `branch.branchedFrom`. Falls back to `branch.startTime()` when
+ * branchedFrom is missing or not found.
+ */
+function resolveForkTimestamp(
+  parent: TimelineSpan,
+  branch: TimelineSpan
+): Date {
+  if (!branch.branchedFrom) return branch.startTime();
+  for (const item of parent.content) {
+    if (item.type === "event" && item.event.uuid === branch.branchedFrom) {
+      return item.startTime();
+    }
+  }
+  return branch.startTime();
 }
 
 /**

--- a/apps/scout/src/app/timeline/utils/markers.ts
+++ b/apps/scout/src/app/timeline/utils/markers.ts
@@ -217,7 +217,7 @@ function collectBranchMarkers(
  * Falls back to `branch.startTime()` when branchedFrom is missing or
  * no matching event is found.
  */
-function resolveForkTimestamp(
+export function resolveForkTimestamp(
   parent: TimelineSpan,
   branch: TimelineSpan
 ): Date {

--- a/apps/scout/src/app/timeline/utils/markers.ts
+++ b/apps/scout/src/app/timeline/utils/markers.ts
@@ -212,9 +212,10 @@ function collectBranchMarkers(
 /**
  * Resolves the fork point timestamp from the parent span's content.
  *
- * Searches direct events in the parent for a message ID matching
- * `branch.branchedFrom`. Falls back to `branch.startTime()` when
- * branchedFrom is missing or not found.
+ * `branch.branchedFrom` is a message ID (not an event UUID). Searches
+ * parent events for one that produced or carries this message ID.
+ * Falls back to `branch.startTime()` when branchedFrom is missing or
+ * no matching event is found.
  */
 function resolveForkTimestamp(
   parent: TimelineSpan,
@@ -222,7 +223,7 @@ function resolveForkTimestamp(
 ): Date {
   if (!branch.branchedFrom) return branch.startTime();
   for (const item of parent.content) {
-    if (item.type === "event" && item.event.uuid === branch.branchedFrom) {
+    if (item.type === "event" && item.matchesMessageId(branch.branchedFrom)) {
       return item.startTime();
     }
   }

--- a/apps/scout/src/app/timeline/utils/swimlaneLayout.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneLayout.ts
@@ -185,8 +185,8 @@ export function computeRowLayouts(
     const spans = row.spans.map((rowSpan): PositionedSpan => {
       if (isSingleSpan(rowSpan)) {
         const bar = computeBarFromMapping(
-          rowSpan.agent.startTime(),
-          rowSpan.agent.endTime(),
+          rowSpan.agent.startTime(false),
+          rowSpan.agent.endTime(false),
           mapping
         );
         return {
@@ -199,13 +199,16 @@ export function computeRowLayouts(
       }
 
       // ParallelSpan: envelope from earliest start to latest end
+      // Use includeBranches=false so each agent contributes only its own time range
       const agents = rowSpan.agents;
-      const envelope = computeTimeEnvelope(agents);
-      const bar = computeBarFromMapping(
-        envelope.startTime,
-        envelope.endTime,
-        mapping
-      );
+      let envStart = agents[0]!.startTime(false);
+      let envEnd = agents[0]!.endTime(false);
+      for (let i = 1; i < agents.length; i++) {
+        const a = agents[i]!;
+        if (a.startTime(false) < envStart) envStart = a.startTime(false);
+        if (a.endTime(false) > envEnd) envEnd = a.endTime(false);
+      }
+      const bar = computeBarFromMapping(envStart, envEnd, mapping);
       return {
         bar,
         drillable: false,
@@ -359,7 +362,7 @@ function printSpan(span: TimelineSpan, depth: number, lines: string[]): void {
     .map(([t, n]) => (n > 1 ? `${t}×${n}` : t))
     .join(", ");
   lines.push(
-    `${indent}span "${span.name}" [${childEvents.length} events (${eventSummary}), ${childSpans.length} child spans, ${span.totalTokens()} tokens]${flagStr}`
+    `${indent}span "${span.name}" [${childEvents.length} events (${eventSummary}), ${childSpans.length} child spans, ${span.totalTokens(false)} tokens]${flagStr}`
   );
   for (const child of childSpans) {
     printSpan(child, depth + 1, lines);

--- a/apps/scout/src/app/timeline/utils/swimlaneLayout.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneLayout.ts
@@ -176,10 +176,12 @@ export function computeRowLayouts(
   rows: SwimlaneRow[],
   mapping: TimeMapping,
   markerDepth: MarkerDepth,
-  markerKinds?: MarkerKind[]
+  markerKinds?: MarkerKind[],
+  branchMappings?: ReadonlyMap<string, TimeMapping>
 ): RowLayout[] {
   return rows.map((row) => {
     const isParent = row.depth === 0;
+    const rowMapping = branchMappings?.get(row.key) ?? mapping;
 
     // Position each RowSpan
     const spans = row.spans.map((rowSpan): PositionedSpan => {
@@ -187,7 +189,7 @@ export function computeRowLayouts(
         const bar = computeBarFromMapping(
           rowSpan.agent.startTime(false),
           rowSpan.agent.endTime(false),
-          mapping
+          rowMapping
         );
         return {
           bar,
@@ -208,7 +210,7 @@ export function computeRowLayouts(
         if (a.startTime(false) < envStart) envStart = a.startTime(false);
         if (a.endTime(false) > envEnd) envEnd = a.endTime(false);
       }
-      const bar = computeBarFromMapping(envStart, envEnd, mapping);
+      const bar = computeBarFromMapping(envStart, envEnd, rowMapping);
       return {
         bar,
         drillable: false,
@@ -219,7 +221,7 @@ export function computeRowLayouts(
     });
 
     // Collect markers for this row, optionally filtering by kind
-    const allMarkers = collectRowMarkers(row, markerDepth, mapping);
+    const allMarkers = collectRowMarkers(row, markerDepth, rowMapping);
     const markers = markerKinds
       ? allMarkers.filter((m) => markerKinds.includes(m.kind))
       : allMarkers;

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -60,6 +60,8 @@ export interface SwimlaneRow {
   endTime: Date;
   /** True when this row represents a timeline branch. */
   branch?: boolean;
+  /** For branch rows: the branchedFrom message ID (fork point identifier). */
+  branchedFrom?: string;
 }
 
 // =============================================================================
@@ -559,6 +561,7 @@ function flattenChildren(
           startTime: branchSpan.startTime(false),
           endTime: branchSpan.endTime(false),
           branch: true,
+          branchedFrom: branch.branchedFrom ?? undefined,
         });
         // Recurse into branch content for nested agents.
         // Pass the current label as prefix so nested branches get

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -492,10 +492,35 @@ function flattenChildren(
 
   // Emit branch rows when enabled. Each branch becomes a child row of the
   // node that owns it, with its own bar and optional nested children.
+  // Branches are sorted so that the latest fork point comes first — this
+  // prevents branch connector lines from crossing each other.
   if (showBranches) {
     for (const node of nodes) {
-      for (let i = 0; i < node.branches.length; i++) {
-        const branch = node.branches[i]!;
+      // Build fork position index from parent content so we can sort
+      // branches by where their fork event appears (latest first).
+      const forkIndex = new Map<string, number>();
+      for (let ci = 0; ci < node.content.length; ci++) {
+        const item = node.content[ci]!;
+        if (item.type === "event" && item.event.uuid) {
+          forkIndex.set(item.event.uuid, ci);
+        }
+      }
+
+      // Sort branches: latest fork first (descending by content index).
+      const sorted = node.branches
+        .map((branch, origIndex) => ({ branch, origIndex }))
+        .sort((a, b) => {
+          const ai = a.branch.forkedAt
+            ? (forkIndex.get(a.branch.forkedAt) ?? -1)
+            : -1;
+          const bi = b.branch.forkedAt
+            ? (forkIndex.get(b.branch.forkedAt) ?? -1)
+            : -1;
+          return bi - ai;
+        });
+
+      for (let i = 0; i < sorted.length; i++) {
+        const { branch } = sorted[i]!;
         const label = `${branchPrefix}${i + 1}`;
         const branchSpan = createBranchSpan(branch, label);
         const branchKey = `${parentKey}/branch-${branch.branchedFrom}-${i + 1}`;

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -510,11 +510,11 @@ function flattenChildren(
       const sorted = node.branches
         .map((branch, origIndex) => ({ branch, origIndex }))
         .sort((a, b) => {
-          const ai = a.branch.forkedAt
-            ? (forkIndex.get(a.branch.forkedAt) ?? -1)
+          const ai = a.branch.branchedFrom
+            ? (forkIndex.get(a.branch.branchedFrom) ?? -1)
             : -1;
-          const bi = b.branch.forkedAt
-            ? (forkIndex.get(b.branch.forkedAt) ?? -1)
+          const bi = b.branch.branchedFrom
+            ? (forkIndex.get(b.branch.branchedFrom) ?? -1)
             : -1;
           return bi - ai;
         });

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -355,7 +355,8 @@ function flattenChildren(
   parentDepth: number,
   parentKey: string,
   includeUtility: boolean,
-  showBranches: boolean
+  showBranches: boolean,
+  branchPrefix: string = ""
 ): SwimlaneRow[] {
   // Collect child spans, optionally filtering utility agents
   const children: TimelineSpan[] = [];
@@ -495,7 +496,8 @@ function flattenChildren(
     for (const node of nodes) {
       for (let i = 0; i < node.branches.length; i++) {
         const branch = node.branches[i]!;
-        const branchSpan = createBranchSpan(branch, i + 1);
+        const label = `${branchPrefix}${i + 1}`;
+        const branchSpan = createBranchSpan(branch, label);
         const branchKey = `${parentKey}/branch-${branch.branchedFrom}-${i + 1}`;
         result.push({
           key: branchKey,
@@ -507,14 +509,17 @@ function flattenChildren(
           endTime: branchSpan.endTime(),
           branch: true,
         });
-        // Recurse into branch content for nested agents
+        // Recurse into branch content for nested agents.
+        // Pass the current label as prefix so nested branches get
+        // hierarchical names (e.g. "Branch 1.1", "Branch 1.2").
         result.push(
           ...flattenChildren(
             [branchSpan],
             depth,
             branchKey,
             includeUtility,
-            showBranches
+            showBranches,
+            `${label}.`
           )
         );
       }

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -29,8 +29,8 @@ export function compareByTime(
 /** Compare TimelineSpans by start time, with end time as tiebreaker. */
 function compareSpansByTime(a: TimelineSpan, b: TimelineSpan): number {
   return (
-    a.startTime().getTime() - b.startTime().getTime() ||
-    a.endTime().getTime() - b.endTime().getTime()
+    a.startTime(false).getTime() - b.startTime(false).getTime() ||
+    a.endTime(false).getTime() - b.endTime(false).getTime()
   );
 }
 
@@ -209,9 +209,9 @@ function buildParentRow(node: TimelineSpan): SwimlaneRow {
     name: node.name,
     depth: 0,
     spans: [{ agent: node }],
-    totalTokens: node.totalTokens(),
-    startTime: node.startTime(),
-    endTime: node.endTime(),
+    totalTokens: node.totalTokens(false),
+    startTime: node.startTime(false),
+    endTime: node.endTime(false),
   };
 }
 
@@ -258,13 +258,18 @@ function buildRowFromGroup(
   );
 
   // Compute aggregated time range and tokens
-  const startTime = first.startTime();
+  const startTime = first.startTime(false);
   const endTime = sorted.reduce(
     (latest, span) =>
-      span.endTime().getTime() > latest.getTime() ? span.endTime() : latest,
-    first.endTime()
+      span.endTime(false).getTime() > latest.getTime()
+        ? span.endTime(false)
+        : latest,
+    first.endTime(false)
   );
-  const totalTokens = sorted.reduce((sum, span) => sum + span.totalTokens(), 0);
+  const totalTokens = sorted.reduce(
+    (sum, span) => sum + span.totalTokens(false),
+    0
+  );
 
   const key = parentKey
     ? `${parentKey}/${displayName.toLowerCase()}`
@@ -382,7 +387,7 @@ function flattenChildren(
     const hasParallel = clusters.some((c) => c.length > 1);
     // Earliest start across the whole name group — used for sorting so
     // that all entries from the same agent name stay together.
-    const groupStartTime = sorted[0]!.startTime();
+    const groupStartTime = sorted[0]!.startTime(false);
 
     if (!hasParallel) {
       // All non-overlapping (iterative): one row with one bar per cluster
@@ -390,16 +395,18 @@ function flattenChildren(
       const first = sorted[0]!;
       const endTime = sorted.reduce(
         (latest, s) =>
-          s.endTime().getTime() > latest.getTime() ? s.endTime() : latest,
-        first.endTime()
+          s.endTime(false).getTime() > latest.getTime()
+            ? s.endTime(false)
+            : latest,
+        first.endTime(false)
       );
       entries.push({
         displayName,
         key: `${parentKey}/${baseName}`,
         spans: sorted,
         rowSpans,
-        totalTokens: sorted.reduce((sum, s) => sum + s.totalTokens(), 0),
-        startTime: first.startTime(),
+        totalTokens: sorted.reduce((sum, s) => sum + s.totalTokens(false), 0),
+        startTime: first.startTime(false),
         endTime,
         groupStartTime,
         laneIndex: -1,
@@ -416,16 +423,21 @@ function flattenChildren(
         const first = laneSpans[0]!;
         const endTime = laneSpans.reduce(
           (latest, s) =>
-            s.endTime().getTime() > latest.getTime() ? s.endTime() : latest,
-          first.endTime()
+            s.endTime(false).getTime() > latest.getTime()
+              ? s.endTime(false)
+              : latest,
+          first.endTime(false)
         );
         entries.push({
           displayName,
           key: `${parentKey}/${baseName}`,
           spans: laneSpans,
           rowSpans,
-          totalTokens: laneSpans.reduce((sum, s) => sum + s.totalTokens(), 0),
-          startTime: first.startTime(),
+          totalTokens: laneSpans.reduce(
+            (sum, s) => sum + s.totalTokens(false),
+            0
+          ),
+          startTime: first.startTime(false),
           endTime,
           groupStartTime,
           laneIndex: -1,
@@ -438,16 +450,21 @@ function flattenChildren(
           const first = laneSpans[0]!;
           const endTime = laneSpans.reduce(
             (latest, s) =>
-              s.endTime().getTime() > latest.getTime() ? s.endTime() : latest,
-            first.endTime()
+              s.endTime(false).getTime() > latest.getTime()
+                ? s.endTime(false)
+                : latest,
+            first.endTime(false)
           );
           entries.push({
             displayName: `${displayName} ${i + 1}`,
             key: `${parentKey}/${baseName}-${i + 1}`,
             spans: laneSpans,
             rowSpans,
-            totalTokens: laneSpans.reduce((sum, s) => sum + s.totalTokens(), 0),
-            startTime: first.startTime(),
+            totalTokens: laneSpans.reduce(
+              (sum, s) => sum + s.totalTokens(false),
+              0
+            ),
+            startTime: first.startTime(false),
             endTime,
             groupStartTime,
             laneIndex: i,
@@ -538,9 +555,9 @@ function flattenChildren(
           name: branchSpan.name,
           depth,
           spans: [{ agent: branchSpan }],
-          totalTokens: branchSpan.totalTokens(),
-          startTime: branchSpan.startTime(),
-          endTime: branchSpan.endTime(),
+          totalTokens: branchSpan.totalTokens(false),
+          startTime: branchSpan.startTime(false),
+          endTime: branchSpan.endTime(false),
           branch: true,
         });
         // Recurse into branch content for nested agents.

--- a/apps/scout/src/app/timeline/utils/swimlaneRows.ts
+++ b/apps/scout/src/app/timeline/utils/swimlaneRows.ts
@@ -498,11 +498,20 @@ function flattenChildren(
     for (const node of nodes) {
       // Build fork position index from parent content so we can sort
       // branches by where their fork event appears (latest first).
-      const forkIndex = new Map<string, number>();
-      for (let ci = 0; ci < node.content.length; ci++) {
-        const item = node.content[ci]!;
-        if (item.type === "event" && item.event.uuid) {
-          forkIndex.set(item.event.uuid, ci);
+      // branchedFrom is a message ID, so we resolve each branch's
+      // fork point by scanning content events for a message ID match.
+      const forkPositions = new Map<string, number>();
+      for (const branch of node.branches) {
+        if (!branch.branchedFrom) continue;
+        for (let ci = 0; ci < node.content.length; ci++) {
+          const item = node.content[ci]!;
+          if (
+            item.type === "event" &&
+            item.matchesMessageId(branch.branchedFrom)
+          ) {
+            forkPositions.set(branch.branchedFrom, ci);
+            break;
+          }
         }
       }
 
@@ -511,10 +520,10 @@ function flattenChildren(
         .map((branch, origIndex) => ({ branch, origIndex }))
         .sort((a, b) => {
           const ai = a.branch.branchedFrom
-            ? (forkIndex.get(a.branch.branchedFrom) ?? -1)
+            ? (forkPositions.get(a.branch.branchedFrom) ?? -1)
             : -1;
           const bi = b.branch.branchedFrom
-            ? (forkIndex.get(b.branch.branchedFrom) ?? -1)
+            ? (forkPositions.get(b.branch.branchedFrom) ?? -1)
             : -1;
           return bi - ai;
         });

--- a/apps/scout/src/app/timeline/utils/timeMapping.ts
+++ b/apps/scout/src/app/timeline/utils/timeMapping.ts
@@ -102,29 +102,49 @@ export function createIdentityMapping(
 }
 
 /**
+ * Compute the full view range of a node, including branches recursively.
+ *
+ * The span's own startTime/endTime cover only direct content. Branches
+ * (and their nested branches) may extend beyond that range. The view
+ * range is the recursive union of the span's time range and all branch
+ * time ranges, giving the full time extent needed by the swimlane
+ * visualization.
+ */
+function computeViewRange(node: TimelineSpan): { start: Date; end: Date } {
+  // startTime()/endTime() with default includeBranches=true already covers
+  // branches, so we just use them directly.
+  return { start: node.startTime(), end: node.endTime() };
+}
+
+/**
  * Computes a TimeMapping for a timeline node.
+ *
+ * The mapping covers the full view range (content + branches) so that
+ * branch rows render at correct positions within the swimlane.
  *
  * If the node has no idle time (idleTime === 0), returns an identity mapping
  * with zero overhead. Otherwise, detects gaps between content items and
  * compresses them into small fixed-width regions.
  */
 export function computeTimeMapping(node: TimelineSpan): TimeMapping {
+  const { start: viewStart, end: viewEnd } = computeViewRange(node);
+
   // Fast exit: no idle time means no gaps to compress
   if (node.idleTime() === 0) {
-    return createIdentityMapping(node.startTime(), node.endTime());
+    return createIdentityMapping(viewStart, viewEnd);
   }
 
-  const nodeStartMs = node.startTime().getTime();
-  const nodeEndMs = node.endTime().getTime();
+  const nodeStartMs = viewStart.getTime();
+  const nodeEndMs = viewEnd.getTime();
   const nodeRange = nodeEndMs - nodeStartMs;
   if (nodeRange <= 0) {
-    return createIdentityMapping(node.startTime(), node.endTime());
+    return createIdentityMapping(viewStart, viewEnd);
   }
 
   // Extract time intervals from content items
   const intervals = extractIntervals(node.content);
   if (intervals.length === 0) {
-    return createIdentityMapping(node.startTime(), node.endTime());
+    return createIdentityMapping(viewStart, viewEnd);
   }
 
   // Merge overlapping intervals into active regions
@@ -133,7 +153,7 @@ export function computeTimeMapping(node: TimelineSpan): TimeMapping {
   // Find compressible gaps between active regions and node boundaries
   const rawGaps = findGaps(nodeStartMs, nodeEndMs, activeRegions);
   if (rawGaps.length === 0) {
-    return createIdentityMapping(node.startTime(), node.endTime());
+    return createIdentityMapping(viewStart, viewEnd);
   }
 
   // Allocate percentages: gaps get fixed small widths, active regions share the rest

--- a/apps/scout/src/app/timeline/utils/timeMapping.ts
+++ b/apps/scout/src/app/timeline/utils/timeMapping.ts
@@ -301,6 +301,44 @@ export function computeTimeMapping(node: TimelineSpan): TimeMapping {
 }
 
 /**
+ * Creates a shifted time mapping for a branch row in fork-relative mode.
+ *
+ * The branch's wall-clock range [branchStart, branchEnd] is linearly remapped
+ * so that it starts at `forkPercent` in the timeline's percentage space. The
+ * branch's width is proportional to its duration relative to the parent's total
+ * time range, preserving visual duration proportionality.
+ *
+ * @param branchStart  Branch content start time
+ * @param branchEnd    Branch content end time
+ * @param forkPercent  The fork marker's percentage position on the parent row (0-100)
+ * @param parentTotalRangeMs  The parent timeline's total time range in milliseconds
+ */
+export function createShiftedMapping(
+  branchStart: Date,
+  branchEnd: Date,
+  forkPercent: number,
+  parentTotalRangeMs: number
+): TimeMapping {
+  const startMs = branchStart.getTime();
+  const endMs = branchEnd.getTime();
+  const branchDurationMs = endMs - startMs;
+
+  // Scale factor: branch width as a percentage, proportional to parent range
+  const scaleFactor =
+    parentTotalRangeMs > 0 ? (branchDurationMs / parentTotalRangeMs) * 100 : 0;
+
+  return {
+    toPercent(timestamp: Date): number {
+      if (branchDurationMs <= 0) return forkPercent;
+      const t = (timestamp.getTime() - startMs) / branchDurationMs;
+      return Math.max(0, Math.min(100, forkPercent + t * scaleFactor));
+    },
+    hasCompression: false,
+    gaps: [],
+  };
+}
+
+/**
  * Compute active time (seconds) within [startMs, endMs] by subtracting
  * overlapping gap durations from the mapping.
  */

--- a/apps/scout/src/app/timeline/utils/timeMapping.ts
+++ b/apps/scout/src/app/timeline/utils/timeMapping.ts
@@ -111,9 +111,37 @@ export function createIdentityMapping(
  * visualization.
  */
 function computeViewRange(node: TimelineSpan): { start: Date; end: Date } {
-  // startTime()/endTime() with default includeBranches=true already covers
-  // branches, so we just use them directly.
-  return { start: node.startTime(), end: node.endTime() };
+  // The view range must tightly envelope all bar positions. Since bars use
+  // includeBranches=false, we compute the envelope from content-only times
+  // of the node itself plus its branches (which get their own bar rows).
+  // This ensures the timeline fills its full width without empty margins.
+  const items: TimelineSpan[] = [node];
+  collectBranches(node, items);
+  let start = items[0]!.startTime(false);
+  let end = items[0]!.endTime(false);
+  for (let i = 1; i < items.length; i++) {
+    const s = items[i]!;
+    // Skip empty spans whose startTime(false) returns epoch (no content)
+    if (s.content.length === 0) continue;
+    const st = s.startTime(false);
+    const et = s.endTime(false);
+    if (st < start) start = st;
+    if (et > end) end = et;
+  }
+  return { start, end };
+}
+
+/** Recursively collect all branch spans for view range computation. */
+function collectBranches(node: TimelineSpan, out: TimelineSpan[]): void {
+  for (const branch of node.branches) {
+    out.push(branch);
+    collectBranches(branch, out);
+  }
+  for (const item of node.content) {
+    if (item.type === "span") {
+      collectBranches(item, out);
+    }
+  }
 }
 
 /**
@@ -141,8 +169,9 @@ export function computeTimeMapping(node: TimelineSpan): TimeMapping {
     return createIdentityMapping(viewStart, viewEnd);
   }
 
-  // Extract time intervals from content items
-  const intervals = extractIntervals(node.content);
+  // Extract time intervals from content items and branches so that branch
+  // activity is treated as active time (not compressed as a gap).
+  const intervals = extractIntervals([...node.content, ...node.branches]);
   if (intervals.length === 0) {
     return createIdentityMapping(viewStart, viewEnd);
   }

--- a/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
+++ b/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
@@ -7,6 +7,7 @@ import {
 import { useStore } from "../../../state/store";
 
 export const kDefaultExcludedEventTypes: EventTypeValue[] = [
+  "branch",
   "sample_init",
   "sandbox",
   "state",

--- a/apps/scout/src/components/transcript/AgentCardView.module.css
+++ b/apps/scout/src/components/transcript/AgentCardView.module.css
@@ -10,6 +10,14 @@
   background-color: var(--bs-secondary-bg-subtle);
 }
 
+.branchCard {
+  cursor: default;
+}
+
+.branchCard:hover {
+  background-color: var(--bs-secondary-bg);
+}
+
 .utilityCard {
   background-color: var(--bs-body-bg);
   border-style: dashed;

--- a/apps/scout/src/components/transcript/AgentCardView.tsx
+++ b/apps/scout/src/components/transcript/AgentCardView.tsx
@@ -44,8 +44,13 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
 
   return (
     <div
-      className={clsx(styles.card, isUtility && styles.utilityCard, className)}
-      onClick={handleClick}
+      className={clsx(
+        styles.card,
+        isUtility && styles.utilityCard,
+        isBranch && styles.branchCard,
+        className
+      )}
+      onClick={isBranch ? undefined : handleClick}
     >
       <div className={clsx(styles.header, "text-size-small")}>
         <i className={clsx(iconClass, styles.icon, "text-style-secondary")} />
@@ -62,13 +67,15 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
         <div className={clsx(styles.meta, "text-style-secondary")}>
           {tokens} &middot; {duration}
         </div>
-        <i
-          className={clsx(
-            ApplicationIcons.chevron.right,
-            styles.disclosure,
-            "text-style-secondary"
-          )}
-        />
+        {!isBranch && (
+          <i
+            className={clsx(
+              ApplicationIcons.chevron.right,
+              styles.disclosure,
+              "text-style-secondary"
+            )}
+          />
+        )}
       </div>
       {!isUtility && span.description && (
         <div className={clsx(styles.description, "text-size-small")}>

--- a/apps/scout/src/components/transcript/outline/OutlineRow.module.css
+++ b/apps/scout/src/components/transcript/outline/OutlineRow.module.css
@@ -1,21 +1,9 @@
 .eventRow {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 0.7em 1fr;
   column-gap: 0.25em;
   cursor: pointer;
   padding-left: 0.7em;
-}
-
-.eventRow.withToggles {
-  grid-template-columns: 0.7em 1fr;
-}
-
-.eventRow.withIcons {
-  grid-template-columns: 1em 1fr;
-}
-
-.eventRow.withToggles.withIcons {
-  grid-template-columns: 0.7em 1em 1fr;
 }
 
 .eventRow.selected {
@@ -45,10 +33,11 @@
 }
 
 .iconSlot {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   opacity: 0.5;
+  margin-right: 0.3em;
 }
 
 .eventRow.selected .iconSlot {

--- a/apps/scout/src/components/transcript/outline/OutlineRow.tsx
+++ b/apps/scout/src/components/transcript/outline/OutlineRow.tsx
@@ -22,10 +22,6 @@ export interface OutlineRowProps {
   onSelect?: (nodeId: string) => void;
   /** Called when a URL isn't available but the user clicks to navigate to an event. */
   onNavigateToEvent?: (eventId: string) => void;
-  /** Depths that have at least one toggle chevron. Controls column reservation per-depth. */
-  depthsWithToggles?: ReadonlySet<number>;
-  /** Depths that have at least one icon. Controls column reservation per-depth. */
-  depthsWithIcons?: ReadonlySet<number>;
 }
 
 export const OutlineRow: FC<OutlineRowProps> = ({
@@ -36,8 +32,6 @@ export const OutlineRow: FC<OutlineRowProps> = ({
   getEventUrl,
   onSelect,
   onNavigateToEvent,
-  depthsWithToggles,
-  depthsWithIcons,
 }) => {
   const [collapsed, setCollapsed] = useCollapseTranscriptEvent(
     collapseScope,
@@ -48,11 +42,10 @@ export const OutlineRow: FC<OutlineRowProps> = ({
 
   const ref = useRef(null);
 
-  const hasToggle = depthsWithToggles?.has(node.depth) ?? false;
-  const hasIcon = depthsWithIcons?.has(node.depth) ?? false;
-
   // Generate URL for deep linking to this event
   const eventUrl = getEventUrl?.(node.id);
+
+  const labelText = parsePackageName(labelForNode(node)).module;
 
   return (
     <>
@@ -60,43 +53,41 @@ export const OutlineRow: FC<OutlineRowProps> = ({
         className={clsx(
           styles.eventRow,
           "text-size-smaller",
-          selected ? styles.selected : "",
-          hasToggle && styles.withToggles,
-          hasIcon && styles.withIcons
+          selected ? styles.selected : ""
         )}
-        style={{ paddingLeft: `${node.depth * 0.4}em` }}
+        style={{ paddingLeft: `${node.depth * 0.75}em` }}
         data-unsearchable={true}
         onClick={() => {
           onSelect?.(node.id);
           onNavigateToEvent?.(node.id);
         }}
       >
-        {hasToggle && (
-          <div
-            className={clsx(styles.toggle)}
-            onClick={() => {
+        <div
+          className={styles.toggle}
+          onClick={() => {
+            if (node.children.length > 0) {
               setCollapsed(!collapsed);
-            }}
-          >
-            {toggle ? <i className={clsx(toggle)} /> : undefined}
-          </div>
-        )}
-        {hasIcon && (
-          <div className={styles.iconSlot}>
-            {icon ? <i className={clsx(icon)} /> : undefined}
-          </div>
-        )}
+            }
+          }}
+        >
+          {toggle ? <i className={clsx(toggle)} /> : undefined}
+        </div>
         <div
           className={clsx(styles.label)}
           data-depth={node.depth}
           title={tooltipForNode(node)}
         >
+          {icon && (
+            <span className={styles.iconSlot}>
+              <i className={clsx(icon)} />
+            </span>
+          )}
           {eventUrl ? (
             <Link to={eventUrl} className={clsx(styles.eventLink)} ref={ref}>
-              {parsePackageName(labelForNode(node)).module}
+              {labelText}
             </Link>
           ) : (
-            <span ref={ref}>{parsePackageName(labelForNode(node)).module}</span>
+            <span ref={ref}>{labelText}</span>
           )}
           {running ? (
             <PulsingDots

--- a/apps/scout/src/components/transcript/outline/TranscriptOutline.tsx
+++ b/apps/scout/src/components/transcript/outline/TranscriptOutline.tsx
@@ -17,7 +17,7 @@ import { kSandboxSignalName } from "../transform/fixups";
 import { flatTree } from "../transform/flatten";
 import { EventNode, kTranscriptOutlineCollapseScope } from "../types";
 
-import { iconForNode, OutlineRow } from "./OutlineRow";
+import { OutlineRow } from "./OutlineRow";
 import styles from "./TranscriptOutline.module.css";
 import {
   collapseScoring,
@@ -172,35 +172,13 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
     return collapseScoring(collapseTurns(makeTurns(nodeList)));
   }, [eventNodes, collapsedEvents, defaultCollapsedIds]);
 
-  const depthsWithToggles = useMemo(() => {
-    const s = new Set<number>();
-    for (const n of outlineNodeList) {
-      if (n.children.length > 0) s.add(n.depth);
-    }
-    return s;
-  }, [outlineNodeList]);
-
-  const depthsWithIcons = useMemo(() => {
-    const s = new Set<number>();
-    for (const n of outlineNodeList) {
-      if (iconForNode(n) !== undefined) s.add(n.depth);
-    }
-    return s;
-  }, [outlineNodeList]);
-
   const hasOutlineNodes = outlineNodeList.length > 0;
   useEffect(() => {
     onHasNodesChange?.(hasOutlineNodes);
   }, [hasOutlineNodes, onHasNodesChange]);
 
   // Measure the ideal width for the outline column from label text
-  const outlineWidth = useOutlineWidth(
-    outlineNodeList,
-    undefined,
-    agentName,
-    depthsWithToggles,
-    depthsWithIcons
-  );
+  const outlineWidth = useOutlineWidth(outlineNodeList, undefined, agentName);
   useEffect(() => {
     onWidthChange?.(outlineWidth);
   }, [outlineWidth, onWidthChange]);
@@ -282,8 +260,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
             getEventUrl={getEventUrl}
             onSelect={handleOutlineSelect}
             onNavigateToEvent={onNavigateToEvent}
-            depthsWithToggles={depthsWithToggles}
-            depthsWithIcons={depthsWithIcons}
           />
         );
       }
@@ -295,8 +271,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
       getEventUrl,
       handleOutlineSelect,
       onNavigateToEvent,
-      depthsWithToggles,
-      depthsWithIcons,
     ]
   );
 

--- a/apps/scout/src/components/transcript/outline/tree-visitors.test.ts
+++ b/apps/scout/src/components/transcript/outline/tree-visitors.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+
+import type { EventType } from "../types";
+import { EventNode } from "../types";
+
+import { collapseScoring, collapseTurns, makeTurns } from "./tree-visitors";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Minimal event stub — tree-visitors only inspect `event.event` and a few
+ *  metadata fields (`working_start`, `timestamp`, `span_id`). We satisfy
+ *  the type system with a cast at this one boundary so every test can use
+ *  concise factory functions. */
+function evt(type: string, overrides?: Record<string, unknown>): EventType {
+  return {
+    event: type,
+    working_start: 0,
+    timestamp: "2025-01-01T00:00:00Z",
+    span_id: null,
+    pending: false,
+    uuid: null,
+    metadata: null,
+    ...overrides,
+  } as unknown as EventType;
+}
+
+function node(type: string, id?: string, depth = 0): EventNode {
+  return new EventNode(id ?? type, evt(type), depth);
+}
+
+function ids(nodes: EventNode[]): string[] {
+  return nodes.map((n) => n.id);
+}
+
+function childIds(n: EventNode): string[] {
+  return n.children.map((c) => c.id);
+}
+
+// =============================================================================
+// makeTurns
+// =============================================================================
+
+describe("makeTurns", () => {
+  it("wraps model + tools into a single turn", () => {
+    const nodes = [node("model", "m1"), node("tool", "t1"), node("tool", "t2")];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.event.event).toBe("span_begin");
+    expect((result[0]!.event as { type: string }).type).toBe("turn");
+    expect((result[0]!.event as { name: string }).name).toBe("turn 1");
+    expect(childIds(result[0]!)).toEqual(["m1", "t1", "t2"]);
+  });
+
+  it("creates separate turns for back-to-back model events", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("model", "m2"),
+      node("tool", "t1"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(2);
+    expect((result[0]!.event as { name: string }).name).toBe("turn 1");
+    expect(childIds(result[0]!)).toEqual(["m1"]);
+    expect((result[1]!.event as { name: string }).name).toBe("turn 2");
+    expect(childIds(result[1]!)).toEqual(["m2", "t1"]);
+  });
+
+  it("emits a turn for a lone model event (no tools)", () => {
+    const nodes = [node("model", "m1")];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]!.event as { name: string }).name).toBe("turn 1");
+    expect(childIds(result[0]!)).toEqual(["m1"]);
+  });
+
+  it("passes through non-turn events unchanged", () => {
+    const nodes = [
+      node("span_begin", "sb1"),
+      node("model", "m1"),
+      node("tool", "t1"),
+      node("score", "s1"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]!.id).toBe("sb1");
+    expect(result[0]!.event.event).toBe("span_begin");
+    expect((result[1]!.event as { name: string }).name).toBe("turn 1");
+    expect(result[2]!.id).toBe("s1");
+    expect(result[2]!.event.event).toBe("score");
+  });
+
+  it("creates multiple turns for alternating model/tool pairs", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("tool", "t1"),
+      node("model", "m2"),
+      node("tool", "t2"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(2);
+    expect(childIds(result[0]!)).toEqual(["m1", "t1"]);
+    expect(childIds(result[1]!)).toEqual(["m2", "t2"]);
+  });
+
+  it("emits trailing model without tools as a turn", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("tool", "t1"),
+      node("model", "m2"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(2);
+    expect(childIds(result[0]!)).toEqual(["m1", "t1"]);
+    expect((result[1]!.event as { name: string }).name).toBe("turn 2");
+    expect(childIds(result[1]!)).toEqual(["m2"]);
+  });
+
+  it("handles three consecutive model events", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("model", "m2"),
+      node("model", "m3"),
+      node("tool", "t1"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(3);
+    expect(childIds(result[0]!)).toEqual(["m1"]);
+    expect(childIds(result[1]!)).toEqual(["m2"]);
+    expect(childIds(result[2]!)).toEqual(["m3", "t1"]);
+  });
+
+  it("handles five consecutive model events", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("model", "m2"),
+      node("model", "m3"),
+      node("model", "m4"),
+      node("model", "m5"),
+    ];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect((result[i]!.event as { name: string }).name).toBe(`turn ${i + 1}`);
+      expect(childIds(result[i]!)).toEqual([`m${i + 1}`]);
+    }
+  });
+
+  it("flushes pending model-only turn before a non-turn event", () => {
+    const nodes = [node("model", "m1"), node("span_begin", "sb1")];
+    const result = makeTurns(nodes);
+
+    expect(result).toHaveLength(2);
+    expect((result[0]!.event as { name: string }).name).toBe("turn 1");
+    expect(childIds(result[0]!)).toEqual(["m1"]);
+    expect(result[1]!.id).toBe("sb1");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(makeTurns([])).toEqual([]);
+  });
+
+  it("returns non-turn events as-is when no model events exist", () => {
+    const nodes = [node("span_begin", "sb1"), node("score", "s1")];
+    const result = makeTurns(nodes);
+    expect(ids(result)).toEqual(["sb1", "s1"]);
+  });
+});
+
+// =============================================================================
+// collapseTurns
+// =============================================================================
+
+describe("collapseTurns", () => {
+  /** Create a synthetic turn node matching what makeTurns produces. */
+  function turnNode(id: string, depth = 0): EventNode {
+    return new EventNode(
+      id,
+      evt("span_begin", { type: "turn", name: `turn ${id}` }),
+      depth
+    );
+  }
+
+  it("collapses consecutive turns into a single 'N turns' node", () => {
+    const nodes = [turnNode("t1"), turnNode("t2"), turnNode("t3")];
+    const result = collapseTurns(nodes);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]!.event as { name: string }).name).toBe("3 turns");
+    expect((result[0]!.event as { type: string }).type).toBe("turns");
+  });
+
+  it("labels a single turn as '1 turn'", () => {
+    const nodes = [turnNode("t1")];
+    const result = collapseTurns(nodes);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]!.event as { name: string }).name).toBe("1 turn");
+  });
+
+  it("splits groups when a non-turn event appears", () => {
+    const nodes = [
+      turnNode("t1"),
+      turnNode("t2"),
+      node("score", "s1"),
+      turnNode("t3"),
+    ];
+    const result = collapseTurns(nodes);
+
+    expect(result).toHaveLength(3);
+    expect((result[0]!.event as { name: string }).name).toBe("2 turns");
+    expect(result[1]!.id).toBe("s1");
+    expect((result[2]!.event as { name: string }).name).toBe("1 turn");
+  });
+
+  it("splits groups at different depths", () => {
+    const shallow = turnNode("t1", 0);
+    const deep = turnNode("t2", 1);
+    const result = collapseTurns([shallow, deep]);
+
+    expect(result).toHaveLength(2);
+    expect((result[0]!.event as { name: string }).name).toBe("1 turn");
+    expect((result[1]!.event as { name: string }).name).toBe("1 turn");
+  });
+
+  it("passes through non-turn events unchanged", () => {
+    const nodes = [node("span_begin", "sb1"), node("score", "s1")];
+    const result = collapseTurns(nodes);
+    expect(ids(result)).toEqual(["sb1", "s1"]);
+  });
+});
+
+// =============================================================================
+// collapseScoring
+// =============================================================================
+
+describe("collapseScoring", () => {
+  it("collapses consecutive score events into a single 'scoring' node", () => {
+    const nodes = [node("score", "s1"), node("score", "s2")];
+    const result = collapseScoring(nodes);
+
+    expect(result).toHaveLength(1);
+    expect((result[0]!.event as { name: string }).name).toBe("scoring");
+    expect((result[0]!.event as { type: string }).type).toBe("scorings");
+  });
+
+  it("splits groups when a non-score event appears", () => {
+    const nodes = [
+      node("score", "s1"),
+      node("model", "m1"),
+      node("score", "s2"),
+    ];
+    const result = collapseScoring(nodes);
+
+    expect(result).toHaveLength(3);
+    expect((result[0]!.event as { name: string }).name).toBe("scoring");
+    expect(result[1]!.id).toBe("m1");
+    expect((result[2]!.event as { name: string }).name).toBe("scoring");
+  });
+
+  it("passes through non-score events unchanged", () => {
+    const nodes = [node("model", "m1"), node("tool", "t1")];
+    const result = collapseScoring(nodes);
+    expect(ids(result)).toEqual(["m1", "t1"]);
+  });
+});
+
+// =============================================================================
+// Full pipeline: makeTurns → collapseTurns → collapseScoring
+// =============================================================================
+
+describe("full pipeline", () => {
+  it("processes a typical agent transcript", () => {
+    const nodes = [
+      node("span_begin", "agent"),
+      node("model", "m1"),
+      node("tool", "t1"),
+      node("tool", "t2"),
+      node("model", "m2"),
+      node("tool", "t3"),
+      node("model", "m3"),
+      node("tool", "t4"),
+      node("score", "s1"),
+      node("score", "s2"),
+    ];
+
+    const result = collapseScoring(collapseTurns(makeTurns(nodes)));
+
+    // agent span + collapsed turns + collapsed scoring
+    expect(result).toHaveLength(3);
+    expect(result[0]!.id).toBe("agent");
+    expect((result[1]!.event as { name: string }).name).toBe("3 turns");
+    expect((result[2]!.event as { name: string }).name).toBe("scoring");
+  });
+
+  it("handles back-to-back models in the full pipeline", () => {
+    const nodes = [
+      node("model", "m1"),
+      node("model", "m2"),
+      node("model", "m3"),
+      node("tool", "t1"),
+      node("score", "s1"),
+    ];
+
+    const result = collapseScoring(collapseTurns(makeTurns(nodes)));
+
+    // 3 turns (collapsed) + scoring
+    expect(result).toHaveLength(2);
+    expect((result[0]!.event as { name: string }).name).toBe("3 turns");
+    expect((result[1]!.event as { name: string }).name).toBe("scoring");
+  });
+});

--- a/apps/scout/src/components/transcript/outline/tree-visitors.ts
+++ b/apps/scout/src/components/transcript/outline/tree-visitors.ts
@@ -101,21 +101,18 @@ export const makeTurns = (eventNodes: EventNode[]): EventNode[] => {
 
   for (const node of eventNodes) {
     if (node.event.event === "model") {
-      if (modelNode !== null && toolNodes.length === 0) {
-        // back to back model calls are considered a single turn
-        makeTurn(true);
-      } else {
-        makeTurn();
-        modelNode = node;
-      }
+      // Every model event starts a new turn. Flush the pending turn first
+      // (force=true so model-only turns without tools still emit).
+      makeTurn(true);
+      modelNode = node;
     } else if (node.event.event === "tool") {
       toolNodes.push(node);
     } else {
-      makeTurn();
+      makeTurn(true);
       results.push(node);
     }
   }
-  makeTurn();
+  makeTurn(true);
 
   return results;
 };

--- a/apps/scout/src/components/transcript/outline/useOutlineWidth.ts
+++ b/apps/scout/src/components/transcript/outline/useOutlineWidth.ts
@@ -4,6 +4,7 @@ import { parsePackageName } from "@tsmono/util";
 
 import { EventNode } from "../types";
 
+import { iconForNode } from "./OutlineRow";
 import rowStyles from "./OutlineRow.module.css";
 import outlineStyles from "./TranscriptOutline.module.css";
 
@@ -50,9 +51,7 @@ function getOrCreateMeasureRoot(): HTMLDivElement {
 export function useOutlineWidth(
   outlineNodes: EventNode[],
   _font?: string,
-  agentName?: string,
-  depthsWithToggles?: ReadonlySet<number>,
-  depthsWithIcons?: ReadonlySet<number>
+  agentName?: string
 ): number {
   return useMemo(() => {
     if (outlineNodes.length === 0 && !agentName) return kMinWidth;
@@ -83,42 +82,40 @@ export function useOutlineWidth(
     }
 
     // ── Rows ────────────────────────────────────────────────────────────
+    // Every row uses the same uniform 2-column grid (toggle + label).
     // We measure at font-weight 800 (the selected-row weight) so the column
     // is wide enough for any row to be selected without clipping.
     for (const node of outlineNodes) {
       const row = document.createElement("div");
-
-      const hasToggle = depthsWithToggles?.has(node.depth) ?? false;
-      const hasIcon = depthsWithIcons?.has(node.depth) ?? false;
-
-      const classes = [rowStyles.eventRow ?? "", "text-size-smaller"];
-      if (hasToggle) classes.push(rowStyles.withToggles ?? "");
-      if (hasIcon) classes.push(rowStyles.withIcons ?? "");
-      row.className = classes.join(" ");
-      row.style.paddingLeft = `${node.depth * 0.4}em`;
+      row.className = [rowStyles.eventRow ?? "", "text-size-smaller"].join(" ");
+      row.style.paddingLeft = `${node.depth * 0.75}em`;
       row.style.fontWeight = "800";
 
-      // Toggle column placeholder (empty — just reserves space)
-      if (hasToggle) {
-        const toggle = document.createElement("div");
-        toggle.className = rowStyles.toggle ?? "";
-        row.appendChild(toggle);
-      }
+      // Toggle column placeholder (always present)
+      const toggle = document.createElement("div");
+      toggle.className = rowStyles.toggle ?? "";
+      row.appendChild(toggle);
 
-      // Icon column placeholder
-      if (hasIcon) {
-        const icon = document.createElement("div");
-        icon.className = rowStyles.iconSlot ?? "";
-        row.appendChild(icon);
-      }
-
-      // Label column — use `white-space: nowrap; width: max-content` so it
-      // doesn't collapse into the 1fr minimum.
+      // Label column — includes inline icon when present.
       const label = document.createElement("div");
       label.className = rowStyles.label ?? "";
       label.style.overflow = "visible";
       label.style.width = "max-content";
-      label.textContent = parsePackageName(labelForOutlineNode(node)).module;
+
+      // Inline icon placeholder (mirrors the real component)
+      if (iconForNode(node) !== undefined) {
+        const iconSpan = document.createElement("span");
+        iconSpan.className = rowStyles.iconSlot ?? "";
+        // Approximate icon width via a placeholder character
+        iconSpan.innerHTML = "&#x25C6;";
+        label.appendChild(iconSpan);
+      }
+
+      label.appendChild(
+        document.createTextNode(
+          parsePackageName(labelForOutlineNode(node)).module
+        )
+      );
       row.appendChild(label);
 
       root.appendChild(row);
@@ -129,7 +126,7 @@ export function useOutlineWidth(
     const width = root.getBoundingClientRect().width;
 
     return Math.min(kMaxWidth, Math.max(kMinWidth, Math.ceil(width)));
-  }, [outlineNodes, agentName, depthsWithToggles, depthsWithIcons]);
+  }, [outlineNodes, agentName]);
 }
 
 /**

--- a/apps/scout/src/components/transcript/timeline.ts
+++ b/apps/scout/src/components/transcript/timeline.ts
@@ -423,6 +423,12 @@ function createTimelineSpan(
   description?: string,
   branchedFrom: string | null = null
 ): TimelineSpan {
+  if (content.length === 0) {
+    throw new Error(
+      `createTimelineSpan called with empty content for span "${name}" (id=${id}). ` +
+        "Callers must guard against empty content before calling the factory."
+    );
+  }
   return new TimelineSpan({
     id,
     name: name.toLowerCase(),

--- a/apps/scout/src/components/transcript/timeline.ts
+++ b/apps/scout/src/components/transcript/timeline.ts
@@ -266,11 +266,8 @@ export function convertServerTimeline(
   events: Event[]
 ): Timeline {
   const lookup = buildEventLookup(events);
-  return {
-    name: server.name,
-    description: server.description,
-    root: convertServerSpan(server.root, lookup),
-  };
+  const root = convertServerSpan(server.root, lookup);
+  return { name: server.name, description: server.description, root };
 }
 
 function convertServerContentItem(
@@ -303,7 +300,9 @@ function convertServerSpan(
   const content = server.content
     .map((item) => convertServerContentItem(item, lookup))
     .filter((item): item is TimelineEvent | TimelineSpan => item !== null);
-  const branches = server.branches.map((b) => convertServerSpan(b, lookup));
+  const branches = server.branches
+    .map((b) => convertServerSpan(b, lookup))
+    .filter((b) => b.content.length > 0);
 
   return new TimelineSpan({
     id: server.id,

--- a/apps/scout/src/components/transcript/timeline.ts
+++ b/apps/scout/src/components/transcript/timeline.ts
@@ -77,6 +77,28 @@ export class TimelineEvent {
   idleTime(): number {
     return 0;
   }
+
+  /**
+   * Returns true if this event produced or carries the given message ID.
+   *
+   * `branchedFrom` is a message ID (not an event UUID). It may match:
+   * 1. A model event's output message ID (`output.choices[0].message.id`)
+   * 2. A tool event's message ID (`message_id`)
+   *
+   * This is used to locate the fork point for branches.
+   */
+  matchesMessageId(messageId: string): boolean {
+    const e = this.event;
+    if (e.event === "model") {
+      const outMsg = (e as Record<string, unknown>).output as
+        | { choices?: Array<{ message?: { id?: string } }> }
+        | undefined;
+      if (outMsg?.choices?.[0]?.message?.id === messageId) return true;
+    } else if (e.event === "tool") {
+      if ((e as Record<string, unknown>).message_id === messageId) return true;
+    }
+    return false;
+  }
 }
 
 /**

--- a/apps/scout/src/components/transcript/timeline.ts
+++ b/apps/scout/src/components/transcript/timeline.ts
@@ -162,12 +162,12 @@ export class TimelineSpan {
  */
 export function createBranchSpan(
   branch: TimelineSpan,
-  index: number
+  label: string
 ): TimelineSpan {
-  const label = deriveBranchLabel(branch, index);
+  const name = deriveBranchLabel(branch, label);
   return new TimelineSpan({
     id: branch.id,
-    name: label,
+    name,
     spanType: "branch",
     content: branch.content,
     branches: branch.branches,
@@ -179,11 +179,11 @@ export function createBranchSpan(
   });
 }
 
-function deriveBranchLabel(branch: TimelineSpan, index: number): string {
+function deriveBranchLabel(branch: TimelineSpan, label: string): string {
   for (const item of branch.content) {
     if (item.type === "span") return item.name;
   }
-  return `Branch ${index}`;
+  return `Branch ${label}`;
 }
 
 /**

--- a/apps/scout/src/components/transcript/transform/transform.ts
+++ b/apps/scout/src/components/transcript/transform/transform.ts
@@ -76,6 +76,12 @@ export const transformTree = (roots: EventNode[]): EventNode[] => {
 const transformers = () => {
   const treeNodeTransformers: TreeNodeTransformer[] = [
     {
+      name: "unwrap_main",
+      matches: (node) =>
+        node.event.event === SPAN_BEGIN && node.event.type === "main",
+      process: unwrapNode,
+    },
+    {
       name: "unwrap_tools",
       matches: (node) =>
         node.event.event === SPAN_BEGIN && node.event.type === TYPE_TOOL,
@@ -192,6 +198,13 @@ const elevateChildNode = (
   // and more importantly we drive children / transcripts using the tree structure itself
   // and notes rather than the event.events itself)
   return targetNode as EventNode;
+};
+
+const unwrapNode = (node: EventNode): EventNode[] => {
+  return node.children.map((child) => {
+    child.depth = node.depth;
+    return child;
+  });
 };
 
 const skipFirstChildNode = (node: EventNode): EventNode => {


### PR DESCRIPTION
## Summary

- **Full branch visualization** for timeline swimlanes — branches rendered as child rows with L-shaped connectors to fork points, selectable to view branch event context alongside pre-fork parent events
- **Fork-relative positioning mode** — branch bars align to their fork marker position instead of wall-clock time, making fork→branch relationships immediately visible (on by default)
- **Branch event context** — selecting a branch shows parent events up to the fork point followed by branch events, with highlighted ancestor bars clipped at the fork position

## Details

### Branch swimlane rendering (`swimlaneRows.ts`, `TimelineSwimLanes.tsx`)
- Branch rows as children of their parent span, toggled via "Branches" in View Options
- Sorted by fork position (latest first) to prevent connector line crossings
- Diamond glyph markers on parent rows at fork points
- L-shaped SVG connectors from fork markers to branch bar starts

### Fork-relative positioning (`timeMapping.ts`, `swimlaneLayout.ts`, `useTranscriptTimeline.ts`)
- `createShiftedMapping()` remaps branch wall-clock ranges to start at the fork marker's percent position
- Preserves duration proportionality relative to parent's total range
- Nested branches compose naturally (each shifted relative to parent's mapping)
- Toggleable via "Fork-relative branches" checkbox; defaults on when branches visible

### Branch selection & context (`timelineEventNodes.ts`, `useTranscriptTimeline.ts`)
- `collectBranchWithContext()` walks ancestor chain to build pre-fork event context
- Ancestor swimlane bars highlight with clip at fork marker position
- Branch separator (`AgentCardView`) marks the transition in the event list
- `branchScrollTarget` auto-scrolls to branch separator on selection

### Other improvements
- Outline row indentation refined for deeper nesting (`OutlineRow.tsx`, `useOutlineWidth.ts`)
- Adaptive outline column width based on content
- Back-to-back model events create proper turn boundaries (`contentItems.ts`)
- Branch events hidden by default (shown via branch selection)

## Files changed (27 files, +1649 / -293)

**Core pipeline:** `timeMapping.ts`, `swimlaneLayout.ts`, `swimlaneRows.ts`, `markers.ts`
**Hooks:** `useTimeline.ts`, `useTimelineConfig.ts`, `useTranscriptTimeline.ts`
**Components:** `TimelineSwimLanes.tsx`, `TimelineEventsView.tsx`, `TimelineOptionsPopover.tsx`, `TimelineMinimap.tsx`, `AgentCardView.tsx`
**Event handling:** `timelineEventNodes.ts`, `contentItems.ts`, `syntheticNodes.ts`
**Outline:** `OutlineRow.tsx`, `TranscriptOutline.tsx`, `tree-visitors.ts`, `useOutlineWidth.ts`
**Types:** `timeline.ts`
**Tests:** `timelineEventNodes.test.ts`, `markers.test.ts`, `tree-visitors.test.ts`

## Test plan

- [x] `pnpm check` passes (typecheck, lint, format)
- [x] `pnpm build` succeeds
- [x] `pnpm test` — all 518 tests pass
- [x] Manual: open a transcript with branches, verify branch rows with connectors
- [x] Manual: toggle fork-relative mode, verify branch bars shift to fork positions
- [x] Manual: select a branch row, verify ancestor context + highlight clipping
- [x] Manual: test with nested branches
- [x] Manual: verify minimap stays in wall-clock mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)