### PR TITLE
Use generated types from OpenAPI spec

### DIFF
--- a/apps/inspect/src/app/log-list/LogItem.ts
+++ b/apps/inspect/src/app/log-list/LogItem.ts
@@ -1,4 +1,6 @@
-import { LogHandle, LogPreview } from "../../client/api/types";
+import { LogHandle } from "@tsmono/inspect-common";
+
+import { LogPreview } from "../../client/api/types";
 
 export interface LogItem {
   id: string;

--- a/apps/inspect/src/app/log-list/grid/columns/types.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/types.ts
@@ -1,4 +1,4 @@
-import { LogHandle } from "../../../../client/api/types";
+import { LogHandle } from "@tsmono/inspect-common";
 
 export interface LogListRow {
   id: string;

--- a/apps/inspect/src/app/types.ts
+++ b/apps/inspect/src/app/types.ts
@@ -3,15 +3,20 @@ import { StateSnapshot } from "react-virtuoso";
 
 import {
   ApprovalEvent,
+  AttachmentData,
   BranchEvent,
   CompactionEvent,
   ContentDocument,
   ContentImage,
   ContentText,
+  ErrorEvent,
   EvalSample,
   EvalSet,
+  EventData,
   InfoEvent,
+  InputEvent,
   LoggerEvent,
+  LogHandle,
   ModelEvent,
   SampleInitEvent,
   SampleLimitEvent,
@@ -25,11 +30,8 @@ import {
 } from "@tsmono/inspect-common/types";
 
 import {
-  AttachmentData,
   EvalHeader,
-  EventData,
   LogDetails,
-  LogHandle,
   LogPreview,
   PendingSamples,
   SampleSummary,

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -313,7 +313,7 @@ export const clientApi = (
     } else {
       const logRoot = await api.get_log_root();
       return {
-        files: (logRoot?.logs || []).map((log) => ({ ...log, size: 0 })),
+        files: logRoot?.logs || [],
         response_type: "full",
       };
     }

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -1,4 +1,4 @@
-import { EvalSample } from "@tsmono/inspect-common/types";
+import { EvalSample, LogFilesResponse } from "@tsmono/inspect-common/types";
 
 import { sampleIdsEqual } from "../../app/shared/sample";
 import { encodePathParts } from "../../utils/uri";
@@ -13,7 +13,6 @@ import {
   ClientAPI,
   LogContents,
   LogDetails,
-  LogFilesResponse,
   LogPreview,
   LogRoot,
   LogViewAPI,
@@ -314,7 +313,7 @@ export const clientApi = (
     } else {
       const logRoot = await api.get_log_root();
       return {
-        files: logRoot?.logs || [],
+        files: (logRoot?.logs || []).map((log) => ({ ...log, size: 0 })),
         response_type: "full",
       };
     }

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -1,7 +1,9 @@
-import {
+import type {
   ApprovalEvent,
+  AttachmentData,
   BranchEvent,
   CompactionEvent,
+  ErrorEvent,
   EvalError,
   EvalLog,
   EvalMetric,
@@ -12,7 +14,11 @@ import {
   EvalSpec,
   EvalStats,
   InfoEvent,
+  InputEvent,
+  LogFilesResponse,
   LoggerEvent,
+  LogHandle,
+  LogInfo,
   LogUpdate,
   ModelEvent,
   SampleInitEvent,
@@ -33,6 +39,12 @@ import {
   EvalSampleTarget,
 } from "../../@types/extraInspect";
 
+// Hand-coded — references the local EventData with typed event union
+export interface SampleData {
+  events: EventData[];
+  attachments: AttachmentData[];
+}
+
 export type ProgressCallback = (
   bytesLoaded: number,
   bytesTotal: number
@@ -52,11 +64,6 @@ export interface LogDetails {
   sampleSummaries: SampleSummary[];
 }
 
-export interface LogFilesResponse {
-  files: LogHandle[];
-  response_type: "incremental" | "full";
-}
-
 export interface PendingSampleResponse {
   pendingSamples?: PendingSamples;
   status: "NotModified" | "NotFound" | "OK";
@@ -67,6 +74,8 @@ export interface SampleDataResponse {
   status: "NotModified" | "NotFound" | "OK";
 }
 
+// Client-side types — looser than generated server types because they're
+// also constructed locally (from URL params, manifests, etc.)
 export interface RunningMetric {
   scorer: string;
   name: string;
@@ -82,11 +91,22 @@ export interface PendingSamples {
   etag?: string;
 }
 
-export interface SampleData {
-  events: EventData[];
-  attachments: AttachmentData[];
+export interface SampleSummary {
+  uuid?: string;
+  id: number | string;
+  epoch: number;
+  input: EvalSample["input"];
+  target: EvalSampleTarget;
+  scores: EvalSampleScore | null | undefined;
+  error?: string;
+  limit?: string;
+  metadata?: Record<string, any>;
+  completed?: boolean;
+  retries?: number;
 }
 
+// Hand-coded — generated EventData.event is JsonValue, losing the
+// discriminated union that the client relies on for type-safe event handling.
 export interface EventData {
   id: number;
   event_id: string;
@@ -112,28 +132,6 @@ export interface EventData {
     | SubtaskEvent;
 }
 
-export interface AttachmentData {
-  id: number;
-  sample_id: string;
-  epoch: number;
-  hash: string;
-  content: string;
-}
-
-export interface SampleSummary {
-  uuid?: string;
-  id: number | string;
-  epoch: number;
-  input: EvalSample["input"];
-  target: EvalSampleTarget;
-  scores: EvalSampleScore | null | undefined;
-  error?: string;
-  limit?: string;
-  metadata?: Record<string, any>;
-  completed?: boolean;
-  retries?: number;
-}
-
 export interface BasicSampleData {
   id: number | string;
   epoch: number;
@@ -147,11 +145,6 @@ export interface Capabilities {
   webWorkers: boolean;
   streamSamples: boolean;
   streamSampleData: boolean;
-}
-
-export interface LogInfo {
-  size: number;
-  direct_url?: string;
 }
 
 export interface LogViewAPI {
@@ -306,13 +299,6 @@ export interface LogRoot {
   logs: LogHandle[];
   log_dir?: string;
   abs_log_dir?: string;
-}
-
-export interface LogHandle {
-  name: string;
-  task?: string;
-  task_id?: string;
-  mtime?: number;
 }
 
 export interface LogContents {

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -1,3 +1,5 @@
+import { LogInfo } from "@tsmono/inspect-common/types";
+
 import { EvalScores } from "../../../@types/extraInspect";
 import { asyncJsonParse } from "../../../utils/json-worker";
 import { download_file } from "../shared/api-shared";
@@ -5,7 +7,6 @@ import {
   Capabilities,
   EvalHeader,
   LogContents,
-  LogInfo,
   LogPreview,
   LogViewAPI,
   PendingSampleResponse,

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -8,7 +8,9 @@
  * - log_details: stores complete results from get_log_info() including samples (LogDetails)
  */
 
-import { LogDetails, LogHandle, LogPreview, SampleSummary } from "../api/types";
+import { LogHandle } from "@tsmono/inspect-common";
+
+import { LogDetails, LogPreview, SampleSummary } from "../api/types";
 
 import { createDatabaseService, DatabaseService } from "./service";
 
@@ -121,11 +123,13 @@ describe("Database Service", () => {
       const testLogRoot: LogHandle[] = [
         {
           name: "/test/logs/eval1.json",
+
           task: "test-task-1",
           task_id: "task1",
         },
         {
           name: "/test/logs/eval2.json",
+
           task: "test-task-2",
           task_id: "task2",
         },
@@ -144,13 +148,13 @@ describe("Database Service", () => {
     });
 
     test("should update existing cached log files", async () => {
-      const initialFiles = [
+      const initialFiles: LogHandle[] = [
         { name: "/test/logs/eval1.json", task: "initial-task" },
       ];
       await databaseService.writeLogs(initialFiles);
 
       // Update with new data
-      const updatedFiles = [
+      const updatedFiles: LogHandle[] = [
         { name: "/test/logs/eval1.json", task: "updated-task" },
         { name: "/test/logs/eval2.json", task: "additional-task" },
       ];
@@ -172,7 +176,7 @@ describe("Database Service", () => {
         createTestLogSummary({ eval_id: "eval-1", task: "task-1" }),
         createTestLogSummary({ eval_id: "eval-2", task: "task-2" }),
       ];
-      const logHandles = [
+      const logHandles: LogHandle[] = [
         { name: "/test/logs/eval1.json" },
         { name: "/test/logs/eval2.json" },
       ];

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -8,9 +8,9 @@ export interface LogHandleRecord {
   id?: number;
   file_path: string;
   file_name: string;
-  task?: string;
-  task_id?: string;
-  mtime?: number;
+  task?: string | null;
+  task_id?: string | null;
+  mtime?: number | null;
   cached_at: string;
 }
 

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -1,9 +1,10 @@
+import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
-import { LogDetails, LogHandle, LogPreview, SampleSummary } from "../api/types";
+import { LogDetails, LogPreview, SampleSummary } from "../api/types";
 
 import { DatabaseManager } from "./manager";
-import { AppDatabase } from "./schema";
+import { AppDatabase, LogHandleRecord } from "./schema";
 
 const log = createLogger("DatabaseService");
 
@@ -80,7 +81,7 @@ export class DatabaseService {
       existingRecords.map((r) => [r.file_path, r.id])
     );
 
-    const records = logs.map((file) => ({
+    const records = logs.map<LogHandleRecord>((file) => ({
       id: existingByPath.get(file.name),
       file_path: file.name,
       file_name: file.name.split("/").pop() || file.name,
@@ -105,15 +106,11 @@ export class DatabaseService {
       // Sort by mtime if available, otherwise by id (insertion order)
       let files = await db.logs.toArray();
 
-      // Sort by mtime (descending) if present, otherwise maintain insertion order
+      // Sort by mtime (descending) if present, otherwise maintain insertion order.
+      // Note: != null (not !==) catches both null and undefined.
       files.sort((a, b) => {
-        if (a.mtime !== undefined && b.mtime !== undefined) {
-          return b.mtime - a.mtime;
-        }
-        // If mtime is not available, maintain insertion order (ascending by id)
-        if (a.id !== undefined && b.id !== undefined) {
-          return a.id - b.id;
-        }
+        if (a.mtime != null && b.mtime != null) return b.mtime - a.mtime;
+        if (a.id != null && b.id != null) return a.id - b.id;
         return 0;
       });
 

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -12,8 +12,6 @@ export type {
   ClientAPI,
   LogViewAPI,
   LogRoot,
-  LogHandle,
-  LogFilesResponse,
   LogContents,
   LogPreview,
   PendingSampleResponse,
@@ -21,7 +19,11 @@ export type {
 } from "./client/api/types";
 
 // Log types
-export type { EvalSet } from "@tsmono/inspect-common/types";
+export type {
+  EvalSet,
+  LogHandle,
+  LogFilesResponse,
+} from "@tsmono/inspect-common/types";
 
 // State Store
 export { initializeStore } from "./state/store";

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect } from "react";
 
+import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
-
-import { LogHandle } from "../client/api/types";
 
 import { clientEventsService } from "./clientEventsService";
 import { useLogs } from "./hooks";

--- a/apps/inspect/src/state/clientEventsService.ts
+++ b/apps/inspect/src/state/clientEventsService.ts
@@ -1,6 +1,6 @@
+import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
-import { LogHandle } from "../client/api/types";
 import { createPolling } from "../utils/polling";
 
 const log = createLogger("Client-Events-Service");

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import { EvalSample, EvalSpec } from "@tsmono/inspect-common/types";
+import { EvalSample, EvalSpec, LogHandle } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import { EvalLogStatus, Events } from "../@types/extraInspect";
@@ -10,7 +10,7 @@ import {
 } from "../app/samples/descriptor/samplesDescriptor";
 import { filterSamples } from "../app/samples/sample-tools/filters";
 import { sampleIdsEqual } from "../app/shared/sample";
-import { LogHandle, SampleSummary } from "../client/api/types";
+import { SampleSummary } from "../client/api/types";
 import { prettyDirUri } from "../utils/uri";
 
 import { getAvailableScorers, getDefaultScorer } from "./scoring";

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -1,15 +1,10 @@
 import { GridState } from "ag-grid-community";
 
-import { EvalSet } from "@tsmono/inspect-common/types";
+import { EvalSet, LogHandle } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import { DisplayedSample, LogsState } from "../app/types";
-import {
-  EvalHeader,
-  LogDetails,
-  LogHandle,
-  LogPreview,
-} from "../client/api/types";
+import { EvalHeader, LogDetails, LogPreview } from "../client/api/types";
 import { DatabaseService } from "../client/database";
 import { isUri, join } from "../utils/uri";
 

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -1,10 +1,10 @@
 import { StoreApi, UseBoundStore } from "zustand";
 
+import { AttachmentData } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import { Event } from "../app/types";
 import {
-  AttachmentData,
   ClientAPI,
   EventData,
   SampleData,

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -1,11 +1,7 @@
+import { LogHandle } from "@tsmono/inspect-common";
 import { throttle } from "@tsmono/util";
 
-import {
-  ClientAPI,
-  LogDetails,
-  LogHandle,
-  LogPreview,
-} from "../../client/api/types";
+import { ClientAPI, LogDetails, LogPreview } from "../../client/api/types";
 import { DatabaseService } from "../../client/database";
 import { WorkPriority, WorkQueue } from "../../utils/workQueue";
 

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -55,23 +55,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/eval-log": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Eval Log */
-        get: operations["_eval_log_eval_log_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/eval-set": {
         parameters: {
             query?: never;
@@ -80,7 +63,7 @@ export interface paths {
             cookie?: never;
         };
         /** Eval Set */
-        get: operations["_eval_set_eval_set_get"];
+        get: operations["eval_set_eval_set_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -98,6 +81,261 @@ export interface paths {
         };
         /** Event */
         get: operations["_event_event_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Events */
+        get: operations["api_events_events_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/flow": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Flow */
+        get: operations["flow_flow_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-bytes/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Bytes */
+        get: operations["api_log_bytes_log_bytes__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-delete/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Delete */
+        get: operations["api_log_delete_log_delete__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-dir": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Dir */
+        get: operations["api_log_dir_log_dir_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-download/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Download */
+        get: operations["api_log_download_log_download__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Files */
+        get: operations["api_log_files_log_files_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-headers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Headers */
+        get: operations["api_log_headers_log_headers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-info/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Info */
+        get: operations["api_log_info_log_info__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-message": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Message */
+        get: operations["api_log_message_log_message_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/log-size/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log Size */
+        get: operations["api_log_size_log_size__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Logs */
+        get: operations["api_logs_logs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logs/{log}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Log */
+        get: operations["api_log_logs__log__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pending-sample-data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Sample Events */
+        get: operations["api_sample_events_pending_sample_data_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pending-samples": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Api Pending Samples */
+        get: operations["api_pending_samples_pending_samples_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -200,6 +438,19 @@ export interface components {
             tools: string | string[];
         } & {
             [key: string]: unknown;
+        };
+        /** AttachmentData */
+        AttachmentData: {
+            /** Content */
+            content: string;
+            /** Epoch */
+            epoch: number;
+            /** Hash */
+            hash: string;
+            /** Id */
+            id: number;
+            /** Sample Id */
+            sample_id: string;
         };
         /**
          * BatchConfig
@@ -1059,6 +1310,61 @@ export interface components {
             };
         };
         /**
+         * EvalSampleSummary
+         * @description Summary information (including scoring) for a sample.
+         */
+        EvalSampleSummary: {
+            /** Choices */
+            choices?: string[] | null;
+            /**
+             * Completed
+             * @default false
+             */
+            completed: boolean;
+            /** Completed At */
+            completed_at?: string | null;
+            /** Epoch */
+            epoch: number;
+            /** Error */
+            error?: string | null;
+            /** Id */
+            id: number | string;
+            /** Input */
+            input: string | (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[];
+            /** Limit */
+            limit?: string | null;
+            /** Message Count */
+            message_count?: number | null;
+            /** Metadata */
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Model Usage */
+            model_usage: {
+                [key: string]: components["schemas"]["ModelUsage"];
+            };
+            /** Retries */
+            retries?: number | null;
+            /** Role Usage */
+            role_usage: {
+                [key: string]: components["schemas"]["ModelUsage"];
+            };
+            /** Scores */
+            scores?: {
+                [key: string]: components["schemas"]["Score"];
+            } | null;
+            /** Started At */
+            started_at?: string | null;
+            /** Target */
+            target: string | string[];
+            /** Total Time */
+            total_time?: number | null;
+            /** Uuid */
+            uuid?: string | null;
+            /** Working Time */
+            working_time?: number | null;
+        };
+        /**
          * EvalScore
          * @description Score for evaluation task.
          */
@@ -1243,6 +1549,21 @@ export interface components {
         };
         /** Event */
         Event: components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"];
+        /** EventData */
+        EventData: {
+            /** Epoch */
+            epoch: number;
+            /** Event */
+            event: {
+                [key: string]: components["schemas"]["JsonValue"];
+            };
+            /** Event Id */
+            event_id: string;
+            /** Id */
+            id: number;
+            /** Sample Id */
+            sample_id: string;
+        };
         /**
          * EventsData
          * @description Pooled data extracted by condense_events / condense_sample.
@@ -1331,6 +1652,11 @@ export interface components {
             top_p?: number | null;
             /** Verbosity */
             verbosity?: ("low" | "medium" | "high") | null;
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
         };
         /**
          * ImageOutput
@@ -1421,21 +1747,9 @@ export interface components {
             description?: string | null;
             /** Enum */
             enum?: unknown[] | null;
-            /** Examples */
-            examples?: unknown[] | null;
             /** Format */
             format?: string | null;
             items?: components["schemas"]["JSONSchema"] | null;
-            /** Maxlength */
-            maxLength?: number | null;
-            /** Maximum */
-            maximum?: number | null;
-            /** Minlength */
-            minLength?: number | null;
-            /** Minimum */
-            minimum?: number | null;
-            /** Pattern */
-            pattern?: string | null;
             /** Properties */
             properties?: {
                 [key: string]: components["schemas"]["JSONSchema"];
@@ -1463,6 +1777,46 @@ export interface components {
             value: components["schemas"]["JsonValue"];
         };
         JsonValue: JsonValue;
+        /** LogDirResponse */
+        LogDirResponse: {
+            /** Log Dir */
+            log_dir: string;
+        };
+        /** LogFilesResponse */
+        LogFilesResponse: {
+            /** Files */
+            files: components["schemas"]["LogHandle"][];
+            /**
+             * Response Type
+             * @enum {string}
+             */
+            response_type: "incremental" | "full";
+        };
+        /** LogHandle */
+        LogHandle: {
+            /** Mtime */
+            mtime?: number | null;
+            /** Name */
+            name: string;
+            /** Task */
+            task?: string | null;
+            /** Task Id */
+            task_id?: string | null;
+        };
+        /** LogInfo */
+        LogInfo: {
+            /** Direct Url */
+            direct_url?: string | null;
+            /** Size */
+            size: number;
+        };
+        /** LogListingResponse */
+        LogListingResponse: {
+            /** Files */
+            files: components["schemas"]["LogHandle"][];
+            /** Log Dir */
+            log_dir: string;
+        };
         /**
          * LogUpdate
          * @description A group of edits that share provenance.
@@ -1799,6 +2153,13 @@ export interface components {
             /** Target */
             target: string | string[];
         };
+        /** SampleData */
+        SampleData: {
+            /** Attachments */
+            attachments: components["schemas"]["AttachmentData"][];
+            /** Events */
+            events: components["schemas"]["EventData"][];
+        };
         /**
          * SampleInitEvent
          * @description Beginning of processing a Sample.
@@ -1861,6 +2222,17 @@ export interface components {
             uuid?: string | null;
             /** Working Start */
             working_start: number;
+        };
+        /** Samples */
+        Samples: {
+            /** Etag */
+            etag: string;
+            /** Metrics */
+            metrics: components["schemas"]["TaskDisplayMetric"][];
+            /** Refresh */
+            refresh: number;
+            /** Samples */
+            samples: components["schemas"]["EvalSampleSummary"][];
         };
         /**
          * SandboxEnvironmentSpec
@@ -2254,6 +2626,21 @@ export interface components {
              */
             type: "tags";
         };
+        /** TaskDisplayMetric */
+        TaskDisplayMetric: {
+            /** Name */
+            name: string;
+            /** Params */
+            params?: {
+                [key: string]: unknown;
+            } | null;
+            /** Reducer */
+            reducer?: string | null;
+            /** Scorer */
+            scorer: string;
+            /** Value */
+            value: number | null;
+        };
         /**
          * Timeline
          * @description A named timeline view over a transcript.
@@ -2537,6 +2924,19 @@ export interface components {
             /** Url */
             url: string;
         };
+        /** ValidationError */
+        ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -2606,29 +3006,12 @@ export interface operations {
             };
         };
     };
-    _eval_log_eval_log_get: {
+    eval_set_eval_set_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EvalLog"];
-                };
+            query?: {
+                log_dir?: string;
+                dir?: string;
             };
-        };
-    };
-    _eval_set_eval_set_get: {
-        parameters: {
-            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -2641,7 +3024,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["EvalSet"];
+                    "application/json": components["schemas"]["EvalSet"] | null;
                 };
             };
         };
@@ -2662,6 +3045,347 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Event"];
+                };
+            };
+        };
+    };
+    api_events_events_get: {
+        parameters: {
+            query?: {
+                last_eval_time?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
+                };
+            };
+        };
+    };
+    flow_flow_get: {
+        parameters: {
+            query?: {
+                log_dir?: string;
+                dir?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    api_log_bytes_log_bytes__log__get: {
+        parameters: {
+            query: {
+                start: number;
+                end: number;
+            };
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    api_log_delete_log_delete__log__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
+                };
+            };
+        };
+    };
+    api_log_dir_log_dir_get: {
+        parameters: {
+            query?: {
+                log_dir?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogDirResponse"];
+                };
+            };
+        };
+    };
+    api_log_download_log_download__log__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    api_log_files_log_files_get: {
+        parameters: {
+            query?: {
+                log_dir?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogFilesResponse"];
+                };
+            };
+        };
+    };
+    api_log_headers_log_headers_get: {
+        parameters: {
+            query?: {
+                file?: string[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalLog"][];
+                };
+            };
+        };
+    };
+    api_log_info_log_info__log__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogInfo"];
+                };
+            };
+        };
+    };
+    api_log_message_log_message_get: {
+        parameters: {
+            query: {
+                log_file: string;
+                message: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    api_log_size_log_size__log__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": number;
+                };
+            };
+        };
+    };
+    api_logs_logs_get: {
+        parameters: {
+            query?: {
+                log_dir?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogListingResponse"];
+                };
+            };
+        };
+    };
+    api_log_logs__log__get: {
+        parameters: {
+            query?: {
+                "header-only"?: string | null;
+            };
+            header?: never;
+            path: {
+                log: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalLog"];
+                };
+            };
+        };
+    };
+    api_sample_events_pending_sample_data_get: {
+        parameters: {
+            query: {
+                log: string;
+                id: string;
+                epoch: number;
+                "last-event-id"?: number | null;
+                "after-attachment-id"?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SampleData"];
+                };
+            };
+        };
+    };
+    api_pending_samples_pending_samples_get: {
+        parameters: {
+            query: {
+                log: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Samples"];
                 };
             };
         };

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1747,9 +1747,21 @@ export interface components {
             description?: string | null;
             /** Enum */
             enum?: unknown[] | null;
+            /** Examples */
+            examples?: unknown[] | null;
             /** Format */
             format?: string | null;
             items?: components["schemas"]["JSONSchema"] | null;
+            /** Maxlength */
+            maxLength?: number | null;
+            /** Maximum */
+            maximum?: number | null;
+            /** Minlength */
+            minLength?: number | null;
+            /** Minimum */
+            minimum?: number | null;
+            /** Pattern */
+            pattern?: string | null;
             /** Properties */
             properties?: {
                 [key: string]: components["schemas"]["JSONSchema"];

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -119,6 +119,19 @@ export type JSONSchema = S["JSONSchema"];
 export type ApprovalPolicyConfig = S["ApprovalPolicyConfig"];
 export type ApproverPolicyConfig = S["ApproverPolicyConfig"];
 
+// Server response types
+export type AttachmentData = S["AttachmentData"];
+export type EventData = S["EventData"];
+export type EvalSampleSummary = S["EvalSampleSummary"];
+export type LogDirResponse = S["LogDirResponse"];
+export type LogHandle = S["LogHandle"];
+export type LogFilesResponse = S["LogFilesResponse"];
+export type LogInfo = S["LogInfo"];
+export type LogListingResponse = S["LogListingResponse"];
+export type SampleData = S["SampleData"];
+export type Samples = S["Samples"];
+export type TaskDisplayMetric = S["TaskDisplayMetric"];
+
 // Other types
 export type JsonChange = S["JsonChange"];
 export type JsonValue = S["JsonValue"];


### PR DESCRIPTION
## Summary
- Replace hand-coded TypeScript types with generated equivalents from the OpenAPI spec where possible
- Import `LogHandle`, `LogFilesResponse`, `LogInfo`, `AttachmentData`, and other server response types directly from `@tsmono/inspect-common/types` instead of manually defining them
- Fix pre-existing bug: `InputEvent`/`ErrorEvent` in `app/types.ts` were resolving to DOM globals instead of inspect event types
- Add `size` field to `LogHandle` (always sent by server, was missing from hand-coded type)
- Update database schema and test fixtures to match

Types that remain hand-coded (intentionally):
- `EventData` — generated version loses the discriminated event union (becomes `JsonValue`)
- `SampleSummary`, `PendingSamples`, `RunningMetric` — constructed client-side with incomplete data, looser than server types
- Client-only types (`LogDetails`, `LogPreview`, `Capabilities`, API interfaces, etc.)