### PR TITLE
Fix routing to selected tab

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { ChatViewVirtualList } from "@tsmono/inspect-components/chat";
@@ -108,12 +108,6 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const selectedTab = useStore((state) => state.app.tabs.sample);
   const setSelectedTab = useStore((state) => state.appActions.setSampleTab);
 
-  // Get sample tab from URL if available
-  const { sampleTabId } = useParams<{ sampleTabId?: string }>();
-
-  // Use sampleTabId from URL if available, otherwise use the one from state
-  const effectiveSelectedTab = sampleTabId || selectedTab;
-
   // Navigation hook for URL updates
   const navigate = useNavigate();
 
@@ -159,7 +153,11 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     logPath: urlLogPath,
     id: urlSampleId,
     epoch: urlEpoch,
+    sampleTabId,
   } = useLogOrSampleRouteParams();
+
+  // Use sampleTabId from parsed route if available, otherwise use the one from state
+  const effectiveSelectedTab = sampleTabId || selectedTab;
 
   // Focus the panel when it loads
   useEffect(() => {
@@ -353,7 +351,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     );
   }
 
-  if (selectedTab === kSampleTranscriptTabId) {
+  if (effectiveSelectedTab === kSampleTranscriptTabId) {
     const label = isNoneFilter
       ? "None"
       : isDebugFilter


### PR DESCRIPTION
When viewing a sample, you can click on tabs like MESSAGES and SCORING to take you to URLs ending in `/messages` and `/scoring`. However if you reload the page, you'll be taken back to the TRANSCRIPT tab. I found out about this [on Slack](https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1775344198803779?thread_ts=1775309523.074139&cid=C0805HJTK8U) from @tadamcz.

`useLogOrSampleRouteParams` correctly parses `sampleTabId` and fixes the issue.

I started to add a test but ran into ESM issues. I think once we're using Vitest (#44), we can add a test more easily. 