### PR TITLE
Fix post-migration regressions

### DIFF
--- a/apps/inspect/src/app/App.css
+++ b/apps/inspect/src/app/App.css
@@ -180,6 +180,7 @@ body[class^="vscode-"] {
   --bs-card-bg: var(--vscode-editor-background);
   --bs-table-bg: var(--vscode-editor-background);
   --bs-light-bg-subtle: var(--vscode-sideBar-background);
+  --bs-tertiary-bg: var(--vscode-list-hoverBackground);
   --bs-light-border-subtle: var(--vscode-editorHoverWidget-border);
   --bs-body-color: var(--vscode-editor-foreground);
   --bs-table-color: var(--vscode-editor-foreground);

--- a/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
@@ -41,7 +41,15 @@ export const ModelTab: FC<ModelTabProps> = ({
 }) => {
   return (
     <div style={{ width: "100%" }}>
-      <div style={{ padding: "0.5em 1em 0 1em", width: "100%" }}>
+      <div
+        style={{
+          padding: "0.5em 1em 0 1em",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem",
+        }}
+      >
         {evalSpec ? <ModelCard evalSpec={evalSpec} /> : undefined}
         {evalStatus !== "started" &&
           evalStats?.model_usage &&

--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -113,7 +113,15 @@ export const TaskTab: FC<TaskTabProps> = ({
 
   return (
     <div style={{ width: "100%" }}>
-      <div style={{ padding: "0.5em 1em 0 1em", width: "100%" }}>
+      <div
+        style={{
+          padding: "0.5em 1em 0 1em",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.75rem",
+        }}
+      >
         <Card>
           <CardHeader label="Task Info" />
           <CardBody id={"task-card-config"}>

--- a/apps/inspect/src/app/samples/InlineSampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/InlineSampleDisplay.tsx
@@ -2,8 +2,10 @@ import clsx from "clsx";
 import { FC, useRef } from "react";
 
 import { ErrorPanel, StickyScrollProvider } from "@tsmono/react/components";
+import { useStatefulScrollPosition } from "@tsmono/react/hooks";
 
 import { useSampleData } from "../../state/hooks";
+import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
 import { usePollSample } from "../../state/usePollSample";
 
@@ -43,8 +45,11 @@ export const InlineSampleComponent: FC<InlineSampleDisplayProps> = ({
       ? sampleData.downloadProgress.complete / sampleData.downloadProgress.total
       : undefined;
 
-  // Scroll ref
+  // Scroll ref — key by active tab so each tab restores independently
   const scrollRef = useRef<HTMLDivElement>(null);
+  const sampleTab = useStore((state) => state.app.tabs.sample);
+  useStatefulScrollPosition(scrollRef, `inline-sample-scroller-${sampleTab}`);
+
   return (
     <div className={clsx(className, styles.container)}>
       <div className={clsx(styles.scroller)} ref={scrollRef}>

--- a/apps/inspect/src/app/samples/SampleDisplay.module.css
+++ b/apps/inspect/src/app/samples/SampleDisplay.module.css
@@ -15,11 +15,8 @@
 
 .metadataPanel {
   display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: 1em;
-  padding-left: 0;
-  margin-top: 0.5em;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .padded {

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -538,7 +538,13 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
               selected={effectiveSelectedTab === kSampleMetdataTabId}
             >
               {sampleMetadatas.length > 0 ? (
-                <div className={clsx(styles.padded, styles.fullWidth)}>
+                <div
+                  className={clsx(
+                    styles.padded,
+                    styles.fullWidth,
+                    styles.metadataPanel
+                  )}
+                >
                   {sampleMetadatas}
                 </div>
               ) : (

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -156,6 +156,14 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     sampleTabId,
   } = useLogOrSampleRouteParams();
 
+  // Reset tab to default when this sample view unmounts
+  const clearSampleTab = useStore((state) => state.appActions.clearSampleTab);
+  useEffect(() => {
+    return () => {
+      clearSampleTab();
+    };
+  }, [clearSampleTab]);
+
   // Use sampleTabId from parsed route if available, otherwise use the one from state
   const effectiveSelectedTab = sampleTabId || selectedTab;
 

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -30,7 +30,7 @@ import {
   ToolButton,
   ToolDropdownButton,
 } from "@tsmono/react/components";
-import { isVscode } from "@tsmono/util";
+import { isHostedEnvironment, isVscode } from "@tsmono/util";
 
 import { Events } from "../../@types/extraInspect";
 import { SampleSummary } from "../../client/api/types";
@@ -506,7 +506,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                   formatDateTime,
                 }}
                 linking={{
-                  enabled: true,
+                  enabled: isHostedEnvironment(),
                   getUrl: getMessageUrl,
                 }}
                 onNativeFindChanged={setNativeFind}

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -23,7 +23,10 @@ import {
   TranscriptVirtualList,
 } from "@tsmono/inspect-components/transcript";
 import { NoContentsPanel, StickyScroll } from "@tsmono/react/components";
-import { useCollapsedState } from "@tsmono/react/hooks";
+import {
+  useCollapsedState,
+  useListKeyboardNavigation,
+} from "@tsmono/react/hooks";
 
 import { Events } from "../../../@types/extraInspect";
 import { useStore } from "../../../state/store";
@@ -198,38 +201,11 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
 
   const listHandle = useRef<VirtuosoHandle | null>(null);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey) {
-        if (event.key === "ArrowUp") {
-          listHandle.current?.scrollToIndex({ index: 0, align: "center" });
-          event.preventDefault();
-        } else if (event.key === "ArrowDown") {
-          listHandle.current?.scrollToIndex({
-            index: Math.max(flattenedNodes.length - 5, 0),
-            align: "center",
-            behavior: "auto",
-          });
-
-          // This is needed to allow measurement to complete before finding
-          // the last item to scroll to it properly. The timing isn't magical sadly
-          // it is just a heuristic.
-          setTimeout(() => {
-            listHandle.current?.scrollToIndex({
-              index: Math.max(flattenedNodes.length - 1, 0),
-              align: "end",
-              behavior: "auto",
-            });
-          }, 250);
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [flattenedNodes]);
+  useListKeyboardNavigation({
+    listHandle,
+    scrollRef,
+    itemCount: flattenedNodes.length,
+  });
 
   if (sampleStatus === "loading" && flattenedNodes.length === 0) {
     return undefined;

--- a/apps/scout/src/app/App.css
+++ b/apps/scout/src/app/App.css
@@ -328,6 +328,7 @@ body[class^="vscode-"] {
   --bs-border-radius-lg: 0;
   --bs-body-bg: var(--vscode-editor-background);
   --bs-secondary-bg-subtle: var(--vscode-editorHoverWidget-background);
+  --bs-tertiary-bg: var(--vscode-list-hoverBackground);
   --bs-primary-text-emphasis: var(--vscode-editorLink-activeForeground);
   --bs-card-bg: var(--vscode-editor-background);
   --bs-table-bg: var(--vscode-editor-background);

--- a/apps/scout/src/app/App.css
+++ b/apps/scout/src/app/App.css
@@ -350,6 +350,7 @@ body[class^="vscode-"] {
   --bs-link-hover-color: var(--vscode-textLink-activeForeground);
   --bs-secondary: var(--vscode-breadcrumb-foreground);
   --bs-secondary-bg: var(--vscode-list-inactiveSelectionBackground);
+  --bs-tertiary-bg: var(--vscode-list-hoverBackground);
   --bs-border-color: var(--vscode-editorGroup-border);
   --bs-card-border-color: var(--vscode-editorGroup-border);
   --bs-warning-bg-subtle: var(--vscode-inputValidation-warningBackground);

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -384,6 +384,14 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
   const scrubberProgress = useScrubberProgress(listKey);
 
   const getVisibleRange = useStore((state) => state.getVisibleRange);
+  const storeSetVisibleRange = useStore((state) => state.setVisibleRange);
+
+  const handleRangeChanged = useCallback(
+    (range: { startIndex: number; endIndex: number; totalCount: number }) => {
+      storeSetVisibleRange(listKey, range);
+    },
+    [storeSetVisibleRange, listKey]
+  );
 
   const handleScrub = useCallback(
     (progress: number) => {
@@ -706,6 +714,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
               turnMap={turnMap}
               getEventUrl={getEventUrl}
               linkingEnabled={linkingEnabled}
+              onRangeChanged={handleRangeChanged}
             />
           ) : (
             <NoContentsPanel text="No events match the current filter" />

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -25,6 +25,8 @@ import {
 } from "@tsmono/react/components";
 
 import { ApplicationIcons } from "../../components/icons";
+import { isHostedEnvironment } from "@tsmono/util";
+
 import { getValidationParam, updateValidationParam } from "../../router/url";
 import { useStore } from "../../state/store";
 import { Transcript } from "../../types/api-types";
@@ -307,7 +309,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
         className={styles.chatList}
         scrollRef={activeScrollRef}
         linking={{
-          enabled: true,
+          enabled: isHostedEnvironment(),
           getUrl: getFullMessageUrl,
         }}
       />
@@ -340,7 +342,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
         headroomHidden={headroomHidden}
         onHeadroomResetAnchor={onHeadroomResetAnchor}
         getEventUrl={getFullEventUrl}
-        linkingEnabled={true}
+        linkingEnabled={isHostedEnvironment()}
       />
       <TranscriptFilterPopover
         showing={transcriptFilterShowing}

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -23,10 +23,9 @@ import {
   ToolButton,
   ToolDropdownButton,
 } from "@tsmono/react/components";
-
-import { ApplicationIcons } from "../../components/icons";
 import { isHostedEnvironment } from "@tsmono/util";
 
+import { ApplicationIcons } from "../../components/icons";
 import { getValidationParam, updateValidationParam } from "../../router/url";
 import { useStore } from "../../state/store";
 import { Transcript } from "../../types/api-types";

--- a/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
+++ b/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
@@ -4,7 +4,6 @@ import {
   forwardRef,
   ReactNode,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -27,6 +26,7 @@ import type {
   EventType,
 } from "@tsmono/inspect-components/transcript";
 import { StickyScrollProvider } from "@tsmono/react/components";
+import { useListKeyboardNavigation } from "@tsmono/react/hooks";
 
 import { useStore } from "../../state/store";
 
@@ -176,46 +176,11 @@ export const TranscriptViewNodes = forwardRef<
     scrollToIndex,
   ]);
 
-  // Cmd/Ctrl+Arrow keyboard shortcuts to jump to top/bottom of the event list.
-  // Uses a two-stage scroll for ArrowDown: first jump near the end so Virtuoso
-  // measures those items, then scroll to the very last item after a short delay.
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey) {
-        if (event.key === "ArrowUp") {
-          listHandle.current?.scrollToIndex({ index: 0, align: "center" });
-          event.preventDefault();
-        } else if (event.key === "ArrowDown") {
-          listHandle.current?.scrollToIndex({
-            index: Math.max(flattenedNodes.length - 5, 0),
-            align: "center",
-          });
-
-          // Allow Virtuoso to measure the near-bottom items before
-          // scrolling to the true last item.
-          setTimeout(() => {
-            listHandle.current?.scrollToIndex({
-              index: flattenedNodes.length - 1,
-              align: "end",
-            });
-          }, 250);
-          event.preventDefault();
-        }
-      }
-    };
-
-    const scrollElement = scrollRef?.current;
-    if (scrollElement) {
-      scrollElement.addEventListener("keydown", handleKeyDown);
-      if (!scrollElement.hasAttribute("tabIndex")) {
-        scrollElement.setAttribute("tabIndex", "0");
-      }
-
-      return () => {
-        scrollElement.removeEventListener("keydown", handleKeyDown);
-      };
-    }
-  }, [scrollRef, flattenedNodes, listHandle]);
+  useListKeyboardNavigation({
+    listHandle,
+    scrollRef,
+    itemCount: flattenedNodes.length,
+  });
 
   return (
     <StickyScrollProvider value={scrollRef ?? null}>

--- a/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
+++ b/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
@@ -48,6 +48,11 @@ interface TranscriptViewNodesProps {
   turnMap?: Map<string, { turnNumber: number; totalTurns: number }>;
   getEventUrl?: (eventId: string) => string | undefined;
   linkingEnabled?: boolean;
+  onRangeChanged?: (range: {
+    startIndex: number;
+    endIndex: number;
+    totalCount: number;
+  }) => void;
 }
 
 export interface TranscriptViewNodesHandle {
@@ -74,6 +79,7 @@ export const TranscriptViewNodes = forwardRef<
     turnMap,
     getEventUrl,
     linkingEnabled,
+    onRangeChanged,
   },
   ref
 ) {
@@ -209,6 +215,7 @@ export const TranscriptViewNodes = forwardRef<
           getCollapsed={getCollapsed}
           getEventUrl={getEventUrl}
           linkingEnabled={linkingEnabled}
+          onRangeChanged={onRangeChanged}
         />
       </div>
     </StickyScrollProvider>

--- a/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
+++ b/apps/scout/src/components/transcript/TranscriptViewNodes.tsx
@@ -154,9 +154,13 @@ export const TranscriptViewNodes = forwardRef<
           behavior: "auto",
           offset: offsetTop ? -offsetTop : undefined,
         });
+      } else {
+        // Non-virtual fallback: find the DOM element and scroll it into view
+        const el = scrollRef?.current?.querySelector(`[id="${eventId}"]`);
+        el?.scrollIntoView({ block: "start", behavior: "auto" });
       }
     },
-    [flattenedNodes, offsetTop]
+    [flattenedNodes, offsetTop, scrollRef]
   );
 
   const scrollToIndex = useCallback(

--- a/apps/scout/src/components/transcript/timeline.ts
+++ b/apps/scout/src/components/transcript/timeline.ts
@@ -297,10 +297,10 @@ function convertServerSpan(
   server: ServerTimelineSpan,
   lookup: Map<string, Event>
 ): TimelineSpan {
-  const content = server.content
+  const content = (server.content ?? [])
     .map((item) => convertServerContentItem(item, lookup))
     .filter((item): item is TimelineEvent | TimelineSpan => item !== null);
-  const branches = server.branches
+  const branches = (server.branches ?? [])
     .map((b) => convertServerSpan(b, lookup))
     .filter((b) => b.content.length > 0);
 

--- a/apps/scout/src/router/url.ts
+++ b/apps/scout/src/router/url.ts
@@ -288,14 +288,6 @@ export const updateColumnsParam = (
   return newParams;
 };
 
-export const isHostedEnvironment = () => {
-  return (
-    location.hostname !== "localhost" &&
-    location.hostname !== "127.0.0.1" &&
-    location.protocol !== "vscode-webview:"
-  );
-};
-
 /**
  * Opens a route in a new browser tab.
  * Handles the hash router URL format.

--- a/packages/inspect-components/src/chat/ChatMessageRow.module.css
+++ b/packages/inspect-components/src/chat/ChatMessageRow.module.css
@@ -3,6 +3,7 @@
   grid-template-columns: max-content auto;
   column-gap: 0.4rem;
   row-gap: 0;
+  margin-bottom: 0.75rem;
 }
 
 .number {
@@ -46,7 +47,7 @@
 }
 
 .bottomMargin {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .codeCompact {

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -13,6 +13,7 @@ import { ContextProp, ItemProps, VirtuosoHandle } from "react-virtuoso";
 
 import type { ChatMessage } from "@tsmono/inspect-common/types";
 import { LiveVirtualList } from "@tsmono/react/components";
+import { useListKeyboardNavigation } from "@tsmono/react/hooks";
 
 import { ChatMessageRow } from "./ChatMessageRow";
 import { ChatView } from "./ChatView";
@@ -69,59 +70,11 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
       onNativeFindChanged?.(!useVirtuoso);
     }, [onNativeFindChanged, useVirtuoso]);
 
-    useEffect(() => {
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.metaKey || event.ctrlKey) {
-          if (event.key === "ArrowUp") {
-            if (useVirtuoso) {
-              listHandle.current?.scrollToIndex({
-                index: 0,
-                align: "center",
-              });
-            } else {
-              scrollRef?.current?.scrollTo({ top: 0, behavior: "instant" });
-            }
-            event.preventDefault();
-          } else if (event.key === "ArrowDown") {
-            if (useVirtuoso) {
-              listHandle.current?.scrollToIndex({
-                index: Math.max(messages.length - 5, 0),
-                align: "center",
-              });
-
-              // This is needed to allow measurement to complete before finding
-              // the last item to scroll to it properly. The timing isn't magical sadly
-              // it is just a heuristic.
-              setTimeout(() => {
-                listHandle.current?.scrollToIndex({
-                  index: messages.length - 1,
-                  align: "end",
-                });
-              }, 250);
-            } else {
-              scrollRef?.current?.scrollTo({
-                top: scrollRef.current.scrollHeight,
-                behavior: "instant",
-              });
-            }
-            event.preventDefault();
-          }
-        }
-      };
-
-      const scrollElement = scrollRef?.current;
-      if (scrollElement) {
-        scrollElement.addEventListener("keydown", handleKeyDown);
-        // Make the element focusable so it can receive keyboard events
-        if (!scrollElement.hasAttribute("tabIndex")) {
-          scrollElement.setAttribute("tabIndex", "0");
-        }
-
-        return () => {
-          scrollElement.removeEventListener("keydown", handleKeyDown);
-        };
-      }
-    }, [scrollRef, messages, useVirtuoso]);
+    useListKeyboardNavigation({
+      listHandle,
+      scrollRef,
+      itemCount: messages.length,
+    });
 
     if (!useVirtuoso) {
       return (

--- a/packages/inspect-components/src/transcript/TranscriptVirtualList.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualList.tsx
@@ -62,6 +62,11 @@ interface TranscriptVirtualListProps extends EventPanelCallbacks {
     node: EventNode,
     className?: string | string[]
   ) => ReactNode;
+  onRangeChanged?: (range: {
+    startIndex: number;
+    endIndex: number;
+    totalCount: number;
+  }) => void;
 }
 
 /**
@@ -87,6 +92,7 @@ const TranscriptVirtualListInner: FC<TranscriptVirtualListProps> = (props) => {
       getCollapsed={props.getCollapsed}
       getEventUrl={props.getEventUrl}
       linkingEnabled={props.linkingEnabled}
+      onRangeChanged={props.onRangeChanged}
     />
   );
 };

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -36,6 +36,11 @@ interface TranscriptVirtualListComponentProps extends EventPanelCallbacks {
     node: EventNode,
     className?: string | string[]
   ) => ReactNode;
+  onRangeChanged?: (range: {
+    startIndex: number;
+    endIndex: number;
+    totalCount: number;
+  }) => void;
 }
 
 /**
@@ -61,6 +66,7 @@ export const TranscriptVirtualListComponent: FC<
   getCollapsed,
   getEventUrl,
   linkingEnabled,
+  onRangeChanged,
 }) => {
   const useVirtualization =
     !disableVirtualization && (running || eventNodes.length > 100);
@@ -220,6 +226,7 @@ export const TranscriptVirtualListComponent: FC<
         live={running}
         animation={!!running}
         itemSearchText={eventSearchText}
+        onRangeChanged={onRangeChanged}
       />
     );
   } else {

--- a/packages/inspect-components/src/transcript/outline/tree-visitors.ts
+++ b/packages/inspect-components/src/transcript/outline/tree-visitors.ts
@@ -112,7 +112,10 @@ export const makeTurns = (eventNodes: EventNode[]): EventNode[] => {
       modelNode = node;
     } else if (node.event.event === "tool") {
       toolNodes.push(node);
-    } else if (modelNode !== null && kTurnPassthroughEvents.has(node.event.event)) {
+    } else if (
+      modelNode !== null &&
+      kTurnPassthroughEvents.has(node.event.event)
+    ) {
       // Absorb logger/info events into the current turn
       toolNodes.push(node);
     } else {

--- a/packages/inspect-components/src/transcript/outline/tree-visitors.ts
+++ b/packages/inspect-components/src/transcript/outline/tree-visitors.ts
@@ -100,6 +100,10 @@ export const makeTurns = (eventNodes: EventNode[]): EventNode[] => {
     toolNodes.length = 0;
   };
 
+  // Events that can appear between model and tool events without
+  // breaking the turn (e.g. logging, informational events).
+  const kTurnPassthroughEvents = new Set(["logger", "info"]);
+
   for (const node of eventNodes) {
     if (node.event.event === "model") {
       // Every model event starts a new turn. Flush the pending turn first
@@ -107,6 +111,9 @@ export const makeTurns = (eventNodes: EventNode[]): EventNode[] => {
       makeTurn(true);
       modelNode = node;
     } else if (node.event.event === "tool") {
+      toolNodes.push(node);
+    } else if (modelNode !== null && kTurnPassthroughEvents.has(node.event.event)) {
+      // Absorb logger/info events into the current turn
       toolNodes.push(node);
     } else {
       makeTurn(true);

--- a/packages/react/src/components/LiveVirtualList.tsx
+++ b/packages/react/src/components/LiveVirtualList.tsx
@@ -60,6 +60,13 @@ interface LiveVirtualListProps<T> {
   // If not provided, will use JSON.stringify as fallback
   // Return a string or array of strings to search within
   itemSearchText?: (item: T) => string | string[];
+
+  // Called when the visible range changes (includes totalCount from data)
+  onRangeChanged?: (range: {
+    startIndex: number;
+    endIndex: number;
+    totalCount: number;
+  }) => void;
 }
 
 /**
@@ -78,6 +85,7 @@ export const LiveVirtualList = <T,>({
   offsetTop,
   components,
   itemSearchText,
+  onRangeChanged,
   animation = true,
 }: LiveVirtualListProps<T>) => {
   // The list handle and list state management
@@ -454,6 +462,10 @@ export const LiveVirtualList = <T,>({
       isScrolling={handleScrollingChange}
       rangeChanged={(range) => {
         setVisibleRange(range);
+        onRangeChanged?.({
+          ...range,
+          totalCount: data.length,
+        });
       }}
       skipAnimationFrameInResizeObserver={true}
       restoreStateFrom={getRestoreState()}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -17,3 +17,4 @@ export * from "./useVirtuosoState";
 export * from "./useRafThrottle";
 export * from "./useScrollTrack";
 export * from "./useRevokableUrls";
+export * from "./useListKeyboardNavigation";

--- a/packages/react/src/hooks/useListKeyboardNavigation.ts
+++ b/packages/react/src/hooks/useListKeyboardNavigation.ts
@@ -1,0 +1,66 @@
+import { RefObject, useEffect } from "react";
+import { VirtuosoHandle } from "react-virtuoso";
+
+interface ListKeyboardNavigationOptions {
+  /** Virtuoso list handle — used when the list is virtualized. */
+  listHandle: RefObject<VirtuosoHandle | null>;
+  /** Scroll container — used as fallback when the list is not virtualized. */
+  scrollRef?: RefObject<HTMLDivElement | null>;
+  /** Total number of items in the list. */
+  itemCount: number;
+}
+
+/**
+ * Registers Cmd/Ctrl+ArrowUp/Down keyboard shortcuts on `document` to jump
+ * to the top or bottom of a virtualized (or plain-DOM) list.
+ *
+ * When the Virtuoso handle is available it delegates to `scrollToIndex`;
+ * otherwise it falls back to `scrollTo` on the scroll container.
+ */
+export function useListKeyboardNavigation({
+  listHandle,
+  scrollRef,
+  itemCount,
+}: ListKeyboardNavigationOptions): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        if (listHandle.current) {
+          listHandle.current.scrollToIndex({ index: 0, align: "center" });
+        } else {
+          scrollRef?.current?.scrollTo({ top: 0, behavior: "instant" });
+        }
+      } else if (event.key === "ArrowDown") {
+        event.preventDefault();
+        if (listHandle.current) {
+          listHandle.current.scrollToIndex({
+            index: Math.max(itemCount - 5, 0),
+            align: "center",
+          });
+
+          // Virtuoso needs to measure the near-bottom items before it can
+          // accurately scroll to the very last item.
+          setTimeout(() => {
+            listHandle.current?.scrollToIndex({
+              index: Math.max(itemCount - 1, 0),
+              align: "end",
+            });
+          }, 250);
+        } else {
+          const el = scrollRef?.current;
+          if (el) {
+            el.scrollTo({ top: el.scrollHeight, behavior: "instant" });
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [listHandle, scrollRef, itemCount]);
+}

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -86,7 +86,7 @@ export function useStatefulScrollPosition<
 
       if (!tryRestoreScroll()) {
         let attempts = 0;
-        const maxAttempts = 5;
+        const maxAttempts = 20;
 
         const pollForRender = () => {
           if (tryRestoreScroll() || attempts >= maxAttempts) {
@@ -99,10 +99,10 @@ export function useStatefulScrollPosition<
           }
 
           attempts++;
-          setTimeout(pollForRender, 1000);
+          setTimeout(pollForRender, 100);
         };
 
-        setTimeout(pollForRender, 1000);
+        setTimeout(pollForRender, 100);
       }
     }
 

--- a/packages/util/src/vscode.ts
+++ b/packages/util/src/vscode.ts
@@ -47,3 +47,15 @@ export const isVscode = () => {
     })
   );
 };
+
+/**
+ * Returns true when the app is running in a hosted (non-local) environment
+ * — i.e. not localhost, not 127.0.0.1, and not inside a VS Code webview.
+ */
+export const isHostedEnvironment = () => {
+  return (
+    location.hostname !== "localhost" &&
+    location.hostname !== "127.0.0.1" &&
+    location.protocol !== "vscode-webview:"
+  );
+};


### PR DESCRIPTION
## Summary
- **Runtime crash**: guard against undefined `server.branches`/`server.content` in older transcripts
- **Scroll restoration**: add `useStatefulScrollPosition` for non-virtual sample lists in VSCode, with per-tab keying and faster polling (100ms × 20)
- **Link affordances**: consolidate `isHostedEnvironment()` into `@tsmono/util` and use it in Scout (chat/transcript) and Inspect (chat) so links only show in hosted deployments
- **Turn counting**: absorb logger/info events into turns in `makeTurns` instead of breaking them
- **Outline navigation**: add non-virtual fallback (`scrollIntoView`) to `scrollToEvent` in `TranscriptViewNodes`
- **VSCode theme**: override `--bs-tertiary-bg` with `--vscode-list-hoverBackground`
- **Minimap scrubber**: thread `onRangeChanged` from `LiveVirtualList` through to `TimelineEventsView` so `state.visibleRanges` is populated and the scrubber updates during scroll
- **Misc**: card spacing, message spacing, clear selected sample on unmount, keyboard navigation hook

## Test plan
- [x] Open a transcript in Scout on localhost — verify no link icons appear
- [x] Open a transcript in VSCode — verify scroll position restores on tab switch
- [x] Check transcript outline turn numbering ignores logger/info events
- [x] Click outline items in Scout — events panel scrolls correctly
- [x] Scroll the events list — minimap scrubber tracks scroll position
- [x] Verify VSCode theme colors look correct (tertiary bg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)