### PR TITLE
Loudly warn when `pnpm watch` is run outside context of a submodule mount.

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -7,7 +7,10 @@ import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
-import { findPythonRepoRoot } from "../../tooling/python-repo/index.js";
+import {
+  findPythonRepoRoot,
+  warnIfWatchingWithoutSubmodule,
+} from "../../tooling/python-repo/index.js";
 
 import getVersionInfo from "./scripts/get-version.js";
 
@@ -104,7 +107,11 @@ export default defineConfig(({ mode }) => {
     // App build configuration
     return {
       ...baseConfig,
-      plugins: [...baseConfig.plugins, copyToPythonRepo()],
+      plugins: [
+        ...baseConfig.plugins,
+        warnIfWatchingWithoutSubmodule("inspect_ai"),
+        copyToPythonRepo(),
+      ],
       mode: "development",
       base: "",
       server: {

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -7,7 +7,10 @@ import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
-import { findPythonRepoRoot } from "../../tooling/python-repo/index.js";
+import {
+  findPythonRepoRoot,
+  warnIfWatchingWithoutSubmodule,
+} from "../../tooling/python-repo/index.js";
 
 function copyToPythonRepo(): Plugin {
   return {
@@ -84,7 +87,11 @@ export default defineConfig(({ mode }) => {
     // App build configuration
     return {
       ...baseConfig,
-      plugins: [...baseConfig.plugins, copyToPythonRepo()],
+      plugins: [
+        ...baseConfig.plugins,
+        warnIfWatchingWithoutSubmodule("inspect_scout"),
+        copyToPythonRepo(),
+      ],
       base: "",
       server: {
         proxy: {

--- a/tooling/python-repo/index.js
+++ b/tooling/python-repo/index.js
@@ -11,6 +11,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import pc from "picocolors";
 
 /**
  * Walk up from startDir looking for a directory containing the given marker file.
@@ -69,4 +70,23 @@ export function requirePythonRepoRoot(packageName) {
     );
   }
   return root;
+}
+
+/**
+ * Vite plugin that warns when watch mode is active outside a submodule mount.
+ *
+ * @param {string} packageName - Expected `name` value in pyproject.toml.
+ * @returns {import("vite").Plugin}
+ */
+export function warnIfWatchingWithoutSubmodule(packageName) {
+  return {
+    name: "warn-no-submodule-watch",
+    configResolved(config) {
+      if (!config.build.watch) return;
+      if (findPythonRepoRoot(packageName)) return;
+      console.log(
+        `\n${pc.red(pc.bold("⚠  pnpm watch outside a submodule mount has no effect!"))}\n${pc.red(`   dist will not be copied — mount ts-mono at src/${packageName}/_view/ts-mono/`)}\n`,
+      );
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Add red/bold warning when `pnpm watch` is run without a submodule mount (dist copy has no effect in that context)
- Centralize the Vite plugin in `tooling/python-repo/index.js` alongside existing submodule detection helpers