### PR TITLE
feat: stream deduplicated message pools during in-progress evals

### DIFF
--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -356,7 +356,9 @@ export const clientApi = (
     id: string | number,
     epoch: number,
     last_event?: number,
-    last_attachment?: number
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
   ): Promise<SampleDataResponse | undefined> => {
     if (!api.eval_log_sample_data) {
       throw new Error("API doesn't supported streamed sample data");
@@ -366,7 +368,9 @@ export const clientApi = (
       id,
       epoch,
       last_event,
-      last_attachment
+      last_attachment,
+      last_message_pool,
+      last_call_pool
     );
   };
 

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -2,6 +2,7 @@ import type {
   ApprovalEvent,
   AttachmentData,
   BranchEvent,
+  CallPoolData,
   CompactionEvent,
   ErrorEvent,
   EvalError,
@@ -20,6 +21,7 @@ import type {
   LogHandle,
   LogInfo,
   LogUpdate,
+  MessagePoolData,
   ModelEvent,
   SampleInitEvent,
   SampleLimitEvent,
@@ -39,21 +41,7 @@ import {
   EvalSampleTarget,
 } from "../../@types/extraInspect";
 
-export interface MessagePoolData {
-  id: number;
-  sample_id: string;
-  epoch: number;
-  msg_id: string;
-  data: string;
-}
-
-export interface CallPoolData {
-  id: number;
-  sample_id: string;
-  epoch: number;
-  hash: string;
-  data: string;
-}
+export type { CallPoolData, MessagePoolData };
 
 // Hand-coded — references the local EventData with typed event union
 export interface SampleData {

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -39,10 +39,28 @@ import {
   EvalSampleTarget,
 } from "../../@types/extraInspect";
 
+export interface MessagePoolData {
+  id: number;
+  sample_id: string;
+  epoch: number;
+  msg_id: string;
+  data: string;
+}
+
+export interface CallPoolData {
+  id: number;
+  sample_id: string;
+  epoch: number;
+  hash: string;
+  data: string;
+}
+
 // Hand-coded — references the local EventData with typed event union
 export interface SampleData {
   events: EventData[];
   attachments: AttachmentData[];
+  message_pool: MessagePoolData[];
+  call_pool: CallPoolData[];
 }
 
 export type ProgressCallback = (
@@ -188,7 +206,9 @@ export interface LogViewAPI {
     id: string | number,
     epoch: number,
     last_event?: number,
-    last_attachment?: number
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
   ) => Promise<SampleDataResponse | undefined>;
 }
 
@@ -233,7 +253,9 @@ export interface ClientAPI {
     id: string | number,
     epoch: number,
     last_event?: number,
-    last_attachment?: number
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
   ) => Promise<SampleDataResponse | undefined>;
 
   // Events

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -298,7 +298,9 @@ export function viewServerApi(
     id: string | number,
     epoch: number,
     last_event?: number,
-    last_attachment?: number
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
   ): Promise<SampleDataResponse | undefined> => {
     const params = new URLSearchParams();
     params.append("log", log_file);
@@ -310,6 +312,14 @@ export function viewServerApi(
 
     if (last_attachment !== undefined) {
       params.append("after-attachment-id", String(last_attachment));
+    }
+
+    if (last_message_pool !== undefined) {
+      params.append("after-message-pool-id", String(last_message_pool));
+    }
+
+    if (last_call_pool !== undefined) {
+      params.append("after-call-pool-id", String(last_call_pool));
     }
 
     const request: Request<SampleDataResponse> = {

--- a/apps/inspect/src/client/api/vscode/api-vscode.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.ts
@@ -165,7 +165,9 @@ async function eval_log_sample_data(
   id: string | number,
   epoch: number,
   last_event?: number,
-  last_attachment?: number
+  last_attachment?: number,
+  last_message_pool?: number,
+  last_call_pool?: number
 ): Promise<SampleDataResponse | undefined> {
   const response = await vscodeClient(kMethodSampleData, [
     log_file,
@@ -173,6 +175,8 @@ async function eval_log_sample_data(
     epoch,
     last_event,
     last_attachment,
+    last_message_pool,
+    last_call_pool,
   ]);
   if (response) {
     if (response === kNotModifiedSignal) {

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -298,10 +298,7 @@ function processMessagePool(
   sampleData: SampleData,
   pollingState: PollingState
 ) {
-  if (!sampleData.message_pool?.length) return;
-  log.debug(
-    `Processing ${sampleData.message_pool.length} message pool entries`
-  );
+  if (!sampleData.message_pool.length) return;
   for (const entry of sampleData.message_pool) {
     pollingState.messagePool.push(JSON.parse(entry.data) as ChatMessage);
     pollingState.messagePoolId = Math.max(pollingState.messagePoolId, entry.id);
@@ -309,8 +306,7 @@ function processMessagePool(
 }
 
 function processCallPool(sampleData: SampleData, pollingState: PollingState) {
-  if (!sampleData.call_pool?.length) return;
-  log.debug(`Processing ${sampleData.call_pool.length} call pool entries`);
+  if (!sampleData.call_pool.length) return;
   for (const entry of sampleData.call_pool) {
     pollingState.callPool.push(JSON.parse(entry.data) as JsonValue);
     pollingState.callPoolId = Math.max(pollingState.callPoolId, entry.id);
@@ -334,7 +330,7 @@ function processEvents(
     const existingIndex = pollingState.eventMapping[eventData.event_id];
 
     // Resolve attachments within this event
-    let resolvedEvent = resolveAttachments<Event>(
+    const withAttachments = resolveAttachments<Event>(
       eventData.event,
       pollingState.attachments,
       (attachmentId: string) => {
@@ -356,12 +352,12 @@ function processEvents(
     );
 
     // Resolve pool refs for model events
-    resolvedEvent = resolvePoolRefs(resolvedEvent, pollingState);
+    const withPoolRefs = resolvePoolRefs(withAttachments, pollingState);
 
     // Resolve attachments again after pool expansion, since pool entries
     // may contain attachment:// URIs that weren't visible before expansion.
-    resolvedEvent = resolveAttachments<Event>(
-      resolvedEvent,
+    const resolvedEvent = resolveAttachments<Event>(
+      withPoolRefs,
       pollingState.attachments
     );
 
@@ -387,44 +383,39 @@ function expandRefs<T>(refs: [number, number][], pool: T[]): T[] {
 }
 
 function resolvePoolRefs(event: Event, pollingState: PollingState): Event {
-  const ev = event as ModelEvent;
-  if (ev.event !== "model") return event;
+  if (event.event !== "model") return event;
 
-  let resolved = ev;
+  const withInput =
+    Array.isArray(event.input_refs) && pollingState.messagePool.length > 0
+      ? {
+          ...event,
+          input: expandRefs(
+            event.input_refs,
+            pollingState.messagePool
+          ) satisfies ModelEvent["input"],
+          input_refs: null,
+        }
+      : event;
 
-  if (
-    Array.isArray(resolved.input_refs) &&
-    pollingState.messagePool.length > 0
-  ) {
-    resolved = {
-      ...resolved,
-      input: expandRefs(
-        resolved.input_refs as [number, number][],
-        pollingState.messagePool
-      ) as ModelEvent["input"],
-      input_refs: null,
-    };
+  if (!withInput.call || !Array.isArray(withInput.call.call_refs)) {
+    return withInput;
   }
 
-  if (resolved.call && Array.isArray(resolved.call.call_refs)) {
-    const msgKey = (resolved.call.call_key as string) || "messages";
-    const request = { ...resolved.call.request };
-    request[msgKey] = expandRefs(
-      resolved.call.call_refs as [number, number][],
-      pollingState.callPool
-    );
-    resolved = {
-      ...resolved,
-      call: {
-        ...resolved.call,
-        request,
-        call_refs: null,
-        call_key: null,
-      },
-    };
-  }
-
-  return resolved;
+  const msgKey = (withInput.call.call_key as string) || "messages";
+  const request = { ...withInput.call.request };
+  request[msgKey] = expandRefs(
+    withInput.call.call_refs,
+    pollingState.callPool
+  );
+  return {
+    ...withInput,
+    call: {
+      ...withInput.call,
+      request,
+      call_refs: null,
+      call_key: null,
+    },
+  };
 }
 
 const findMaxId = (

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -1,6 +1,11 @@
 import { StoreApi, UseBoundStore } from "zustand";
 
-import { AttachmentData } from "@tsmono/inspect-common/types";
+import {
+  AttachmentData,
+  ChatMessage,
+  JsonValue,
+  ModelEvent,
+} from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import { Event } from "../app/types";
@@ -29,8 +34,12 @@ const kPollingMaxRetries = 10;
 interface PollingState {
   eventId: number;
   attachmentId: number;
+  messagePoolId: number;
+  callPoolId: number;
 
   attachments: Record<string, string>;
+  messagePool: ChatMessage[];
+  callPool: JsonValue[];
 
   eventMapping: Record<string, number>;
   events: Event[];
@@ -49,9 +58,13 @@ export function createSamplePolling(
   const pollingState: PollingState = {
     eventId: kNoId,
     attachmentId: kNoId,
+    messagePoolId: kNoId,
+    callPoolId: kNoId,
 
     eventMapping: {},
     attachments: {},
+    messagePool: [],
+    callPool: [],
     events: [],
   };
 
@@ -103,12 +116,16 @@ export function createSamplePolling(
       // Fetch sample data
       const eventId = pollingState.eventId;
       const attachmentId = pollingState.attachmentId;
+      const messagePoolId = pollingState.messagePoolId;
+      const callPoolId = pollingState.callPoolId;
       const sampleDataResponse = await api.get_log_sample_data(
         logFile,
         summary.id,
         summary.epoch,
         eventId,
-        attachmentId
+        attachmentId,
+        messagePoolId !== kNoId ? messagePoolId : undefined,
+        callPoolId !== kNoId ? callPoolId : undefined
       );
 
       if (abortController.signal.aborted) {
@@ -177,6 +194,10 @@ export function createSamplePolling(
         if (sampleDataResponse.sampleData) {
           // Process attachments
           processAttachments(sampleDataResponse.sampleData, pollingState);
+
+          // Process pool entries (must come before events so refs can be resolved)
+          processMessagePool(sampleDataResponse.sampleData, pollingState);
+          processCallPool(sampleDataResponse.sampleData, pollingState);
 
           // Process events
           const processedEvents = processEvents(
@@ -254,8 +275,12 @@ export function createSamplePolling(
 const resetPollingState = (state: PollingState) => {
   state.eventId = kNoId;
   state.attachmentId = kNoId;
+  state.messagePoolId = kNoId;
+  state.callPoolId = kNoId;
   state.eventMapping = {};
   state.attachments = {};
+  state.messagePool = [];
+  state.callPool = [];
   state.events = [];
 };
 
@@ -267,6 +292,31 @@ function processAttachments(
   Object.values(sampleData.attachments).forEach((v) => {
     pollingState.attachments[v.hash] = v.content;
   });
+}
+
+function processMessagePool(
+  sampleData: SampleData,
+  pollingState: PollingState
+) {
+  if (!sampleData.message_pool?.length) return;
+  log.debug(
+    `Processing ${sampleData.message_pool.length} message pool entries`
+  );
+  for (const entry of sampleData.message_pool) {
+    pollingState.messagePool.push(
+      JSON.parse(entry.data) as ChatMessage
+    );
+    pollingState.messagePoolId = Math.max(pollingState.messagePoolId, entry.id);
+  }
+}
+
+function processCallPool(sampleData: SampleData, pollingState: PollingState) {
+  if (!sampleData.call_pool?.length) return;
+  log.debug(`Processing ${sampleData.call_pool.length} call pool entries`);
+  for (const entry of sampleData.call_pool) {
+    pollingState.callPool.push(JSON.parse(entry.data) as JsonValue);
+    pollingState.callPoolId = Math.max(pollingState.callPoolId, entry.id);
+  }
 }
 
 function processEvents(
@@ -286,7 +336,7 @@ function processEvents(
     const existingIndex = pollingState.eventMapping[eventData.event_id];
 
     // Resolve attachments within this event
-    const resolvedEvent = resolveAttachments<Event>(
+    let resolvedEvent = resolveAttachments<Event>(
       eventData.event,
       pollingState.attachments,
       (attachmentId: string) => {
@@ -307,7 +357,17 @@ function processEvents(
       }
     );
 
-    if (existingIndex) {
+    // Resolve pool refs for model events
+    resolvedEvent = resolvePoolRefs(resolvedEvent, pollingState);
+
+    // Resolve attachments again after pool expansion, since pool entries
+    // may contain attachment:// URIs that weren't visible before expansion.
+    resolvedEvent = resolveAttachments<Event>(
+      resolvedEvent,
+      pollingState.attachments
+    );
+
+    if (existingIndex !== undefined) {
       // There is an existing event in the stream, replace it
       log.debug(`Replace event ${existingIndex}`);
       pollingState.events[existingIndex] = resolvedEvent;
@@ -322,6 +382,51 @@ function processEvents(
     }
   }
   return true;
+}
+
+function expandRefs<T>(refs: [number, number][], pool: T[]): T[] {
+  return refs.flatMap(([start, end]) => pool.slice(start, end));
+}
+
+function resolvePoolRefs(event: Event, pollingState: PollingState): Event {
+  const ev = event as ModelEvent;
+  if (ev.event !== "model") return event;
+
+  let resolved = ev;
+
+  if (
+    Array.isArray(resolved.input_refs) &&
+    pollingState.messagePool.length > 0
+  ) {
+    resolved = {
+      ...resolved,
+      input: expandRefs(
+        resolved.input_refs as [number, number][],
+        pollingState.messagePool
+      ) as ModelEvent["input"],
+      input_refs: null,
+    };
+  }
+
+  if (resolved.call && Array.isArray(resolved.call.call_refs)) {
+    const msgKey = (resolved.call.call_key as string) || "messages";
+    const request = { ...resolved.call.request };
+    request[msgKey] = expandRefs(
+      resolved.call.call_refs as [number, number][],
+      pollingState.callPool
+    );
+    resolved = {
+      ...resolved,
+      call: {
+        ...resolved.call,
+        request,
+        call_refs: null,
+        call_key: null,
+      },
+    };
+  }
+
+  return resolved;
 }
 
 const findMaxId = (

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -303,9 +303,7 @@ function processMessagePool(
     `Processing ${sampleData.message_pool.length} message pool entries`
   );
   for (const entry of sampleData.message_pool) {
-    pollingState.messagePool.push(
-      JSON.parse(entry.data) as ChatMessage
-    );
+    pollingState.messagePool.push(JSON.parse(entry.data) as ChatMessage);
     pollingState.messagePoolId = Math.max(pollingState.messagePoolId, entry.id);
   }
 }

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -403,10 +403,7 @@ function resolvePoolRefs(event: Event, pollingState: PollingState): Event {
 
   const msgKey = (withInput.call.call_key as string) || "messages";
   const request = { ...withInput.call.request };
-  request[msgKey] = expandRefs(
-    withInput.call.call_refs,
-    pollingState.callPool
-  );
+  request[msgKey] = expandRefs(withInput.call.call_refs, pollingState.callPool);
   return {
     ...withInput,
     call: {

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -520,6 +520,19 @@ export interface components {
                 [key: string]: string;
             };
         };
+        /** CallPoolData */
+        CallPoolData: {
+            /** Data */
+            data: string;
+            /** Epoch */
+            epoch: number;
+            /** Hash */
+            hash: string;
+            /** Id */
+            id: number;
+            /** Sample Id */
+            sample_id: string;
+        };
         /**
          * ChatCompletionChoice
          * @description Choice generated for completion.
@@ -1919,6 +1932,19 @@ export interface components {
             /** Content */
             content: components["schemas"]["Logprob"][];
         };
+        /** MessagePoolData */
+        MessagePoolData: {
+            /** Data */
+            data: string;
+            /** Epoch */
+            epoch: number;
+            /** Id */
+            id: number;
+            /** Msg Id */
+            msg_id: string;
+            /** Sample Id */
+            sample_id: string;
+        };
         /**
          * MetadataEdit
          * @description Edit action for metadata.
@@ -2169,8 +2195,18 @@ export interface components {
         SampleData: {
             /** Attachments */
             attachments: components["schemas"]["AttachmentData"][];
+            /**
+             * Call Pool
+             * @default []
+             */
+            call_pool: components["schemas"]["CallPoolData"][];
             /** Events */
             events: components["schemas"]["EventData"][];
+            /**
+             * Message Pool
+             * @default []
+             */
+            message_pool: components["schemas"]["MessagePoolData"][];
         };
         /**
          * SampleInitEvent
@@ -3362,6 +3398,8 @@ export interface operations {
                 epoch: number;
                 "last-event-id"?: number | null;
                 "after-attachment-id"?: number | null;
+                "after-message-pool-id"?: number | null;
+                "after-call-pool-id"?: number | null;
             };
             header?: never;
             path?: never;

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -121,6 +121,7 @@ export type ApproverPolicyConfig = S["ApproverPolicyConfig"];
 
 // Server response types
 export type AttachmentData = S["AttachmentData"];
+export type CallPoolData = S["CallPoolData"];
 export type EventData = S["EventData"];
 export type EvalSampleSummary = S["EvalSampleSummary"];
 export type LogDirResponse = S["LogDirResponse"];
@@ -136,6 +137,7 @@ export type TaskDisplayMetric = S["TaskDisplayMetric"];
 export type JsonChange = S["JsonChange"];
 export type JsonValue = S["JsonValue"];
 export type LogUpdate = S["LogUpdate"];
+export type MessagePoolData = S["MessagePoolData"];
 export type LoggingMessage = S["LoggingMessage"];
 export type MetadataEdit = S["MetadataEdit"];
 export type TagsEdit = S["TagsEdit"];


### PR DESCRIPTION
## Summary

- Add `message_pool` and `call_pool` fields to `SampleData` and pool cursor parameters to all API layers (view-server, vscode, client-api)
- Accumulate pool entries in `samplePolling` across polling iterations and resolve condensed `ModelEvent` input/call refs client-side during live streaming
- Fix `existingIndex === 0` falsy check bug in event replacement

Companion PR to https://github.com/UKGovernmentBEIS/inspect_ai/pull/3375 which adds the Python-side buffer pool dedup and server endpoints.

## Test plan

Tested with https://github.com/UKGovernmentBEIS/inspect_ai/pull/3375