### PR TITLE
Rename Copy/Download Transcript to Messages

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -326,7 +326,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
             }, 1250);
           }
         },
-        Transcript: () => {
+        Messages: () => {
           if (sample?.messages) {
             navigator.clipboard.writeText(messagesToStr(sample.messages));
             setIcon(ApplicationIcons.confirm);
@@ -353,9 +353,9 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
               JSON.stringify(sample, null, 2)
             );
           },
-          Transcript: () => {
+          Messages: () => {
             api.download_file(
-              `${sampleId}-transcript.txt`,
+              `${sampleId}-messages.txt`,
               messagesToStr(sample.messages ?? [])
             );
           },


### PR DESCRIPTION
### What is the current behavior? (You can also link to an open issue here)

The Copy > Transcript button actually copies Messages. Same with Download > Transcript.

### What is the new behavior?

- The buttons are now called Copy/Download > Messages

### Does this PR introduce a breaking change?

No.

### Other information:

I will probably also add a PR for a Copy/Download Transcript button, but that might be a larger refactor to avoid introducing a lot of new code that needs to be maintained.