### PR TITLE
Improved retry error display

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.module.css
+++ b/apps/inspect/src/app/samples/SampleDisplay.module.css
@@ -61,3 +61,11 @@
 .overflowVisible {
   overflow-y: visible;
 }
+
+.retriedErrors {
+  margin: 0.5rem;
+  min-width: 0;
+  overflow: hidden;
+  align-self: stretch;
+  flex: 1;
+}

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -43,6 +43,7 @@ import {
   kSampleJsonTabId,
   kSampleMessagesTabId,
   kSampleMetdataTabId,
+  kSampleRetriesTabId,
   kSampleScoringTabId,
   kSampleTranscriptTabId,
 } from "../../constants";
@@ -66,6 +67,7 @@ import {
 import { messagesFromEvents } from "./messagesFromEvents";
 import styles from "./SampleDisplay.module.css";
 import { SampleJSONView } from "./SampleJSONView";
+import { SampleRetriedErrors } from "./SampleRetriedErrors";
 import { SampleSummaryView } from "./SampleSummaryView";
 import { SampleScoresView } from "./scores/SampleScoresView";
 import { useTranscriptFilter } from "./transcript/hooks";
@@ -558,12 +560,11 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 <NoContentsPanel text="No sample metadata available" />
               )}
             </TabPanel>
-            {sample?.error ||
-            (sample?.error_retries && sample?.error_retries.length > 0) ? (
+            {sample?.error && (
               <TabPanel
                 id={kSampleErrorTabId}
                 className="sample-tab"
-                title="Errors"
+                title="Error"
                 onSelected={onSelectedTab}
                 selected={effectiveSelectedTab === kSampleErrorTabId}
               >
@@ -583,26 +584,28 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                       </CardBody>
                     </Card>
                   ) : undefined}
-                  {sample.error_retries?.map((retry, index) => {
-                    return (
-                      <Card key={`sample-retry-error-${index}`}>
-                        <CardHeader label={`Attempt ${index + 1}`} />
-                        <CardBody>
-                          <ANSIDisplay
-                            output={retry.traceback_ansi}
-                            className={clsx("text-size-small", styles.ansi)}
-                            style={{
-                              fontSize: "clamp(0.3rem, 1.1vw, 0.8rem)",
-                              margin: "0.5em 0",
-                            }}
-                          />
-                        </CardBody>
-                      </Card>
-                    );
-                  })}
+                </div>
+              </TabPanel>
+            )}
+
+            {sample?.error_retries && sample.error_retries.length > 0 ? (
+              <TabPanel
+                id={kSampleRetriesTabId}
+                className="sample-tab"
+                title="Retries"
+                onSelected={onSelectedTab}
+                selected={effectiveSelectedTab === kSampleRetriesTabId}
+              >
+                <div className={styles.retriedErrors}>
+                  <SampleRetriedErrors
+                    id={sample.uuid || String(sample.id)}
+                    retries={sample.error_retries}
+                    scrollRef={scrollRef}
+                  />
                 </div>
               </TabPanel>
             ) : null}
+
             <TabPanel
               id={kSampleJsonTabId}
               className={"sample-tab"}

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -1,5 +1,6 @@
 .ansi {
-  margin: 1em 0;
+  margin: 0.5em 0;
+  font-size: clamp(0.3rem, 1.1vw, 0.8rem) !important;
 }
 
 .headerRow {

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -1,0 +1,25 @@
+.ansi {
+  margin: 1em 0;
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.headerControls {
+  display: flex;
+  align-items: center;
+  margin-left: 1rem;
+  gap: 0.5rem;
+}
+
+.card {
+  width: 100%;
+}
+
+.attemptDropdown {
+  padding: 1px 0.25rem;
+}

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -59,10 +59,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   const initialCollapsed = useMemo(() => {
     const ids: Record<string, boolean> = {};
     for (const event of retry.events || []) {
-      if (
-        (event.event === "state" || event.event === "store") &&
-        event.uuid
-      ) {
+      if ((event.event === "state" || event.event === "store") && event.uuid) {
         ids[event.uuid] = true;
       }
     }
@@ -88,7 +85,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
         : Object.keys(initialCollapsed).length > 0
           ? initialCollapsed
           : undefined,
-    [transcriptCollapsed, initialCollapsed],
+    [transcriptCollapsed, initialCollapsed]
   );
 
   const collapseState = useMemo<TranscriptCollapseState>(
@@ -104,7 +101,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
         setBulkCollapse(undefined);
       },
     }),
-    [effectiveCollapsed],
+    [effectiveCollapsed]
   );
 
   return (
@@ -152,8 +149,5 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
 };
 
 const RetryTraceback: FC<{ retry: EvalRetryError }> = ({ retry }) => (
-  <ANSIDisplay
-    output={retry.traceback_ansi}
-    className={styles.ansi}
-  />
+  <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
 );

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,0 +1,102 @@
+import clsx from "clsx";
+import { FC, RefObject, useCallback, useMemo, useState } from "react";
+
+import { EvalRetryError } from "@tsmono/inspect-common";
+import { TranscriptLayout } from "@tsmono/inspect-components/transcript";
+import {
+  ANSIDisplay,
+  Card,
+  CardBody,
+  CardHeader,
+  SegmentedControl,
+  ToolDropdownButton,
+} from "@tsmono/react/components";
+
+import styles from "./SampleRetriedErrors.module.css";
+
+type RetryView = "error" | "events";
+
+const kViewSegments = [
+  { id: "error", label: "Error" },
+  { id: "events", label: "Events" },
+];
+
+interface SampleRetriedErrorsProps {
+  id: string;
+  retries: EvalRetryError[];
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
+  id,
+  retries,
+  scrollRef,
+}) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [view, setView] = useState<RetryView>("error");
+
+  const onSegmentChange = useCallback((segmentId: string) => {
+    setView(segmentId as RetryView);
+  }, []);
+
+  const dropdownItems = useMemo(() => {
+    const items: Record<string, () => void> = {};
+    retries.forEach((_, index) => {
+      items[`Attempt ${index + 1}`] = () => setSelectedIndex(index);
+    });
+    return items;
+  }, [retries]);
+
+  const retry = retries[retries.length === 1 ? 0 : selectedIndex];
+  const hasEvents = !!retry.events?.length;
+
+  return (
+    <Card className={styles.card}>
+      <CardHeader>
+        <div className={styles.headerRow}>
+          <span>Retry Attempts</span>
+          <div className={styles.headerControls}>
+            {retries.length > 1 && (
+              <ToolDropdownButton
+                label={`Attempt ${selectedIndex + 1}`}
+                items={dropdownItems}
+                className={clsx("text-size-smallest", styles.attemptDropdown)}
+              />
+            )}
+            {hasEvents && (
+              <SegmentedControl
+                segments={kViewSegments}
+                selectedId={view}
+                onSegmentChange={onSegmentChange}
+              />
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardBody>
+        {view === "error" ? (
+          <RetryTraceback retry={retry} />
+        ) : (
+          <div className="text-size-small">
+            <TranscriptLayout
+              events={retry.events || []}
+              scrollRef={scrollRef}
+              listId={`sample-error-retries-${id}`}
+            />
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+};
+
+const RetryTraceback: FC<{ retry: EvalRetryError }> = ({ retry }) => (
+  <ANSIDisplay
+    output={retry.traceback_ansi}
+    className={clsx("text-size-small", styles.ansi)}
+    style={{
+      fontSize: "clamp(0.3rem, 1.1vw, 0.8rem)",
+      margin: "0.5em 0",
+    }}
+  />
+);

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -142,6 +142,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
               showSwimlanes={false}
               collapseState={collapseState}
               bulkCollapse={bulkCollapse}
+              eventNodeContext={{ inlineExpansionUX: true }}
             />
           </div>
         )}

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -2,7 +2,10 @@ import clsx from "clsx";
 import { FC, RefObject, useCallback, useMemo, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
-import { TranscriptLayout } from "@tsmono/inspect-components/transcript";
+import {
+  TranscriptCollapseState,
+  TranscriptLayout,
+} from "@tsmono/inspect-components/transcript";
 import {
   ANSIDisplay,
   Card,
@@ -50,6 +53,60 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   const retry = retries[retries.length === 1 ? 0 : selectedIndex];
   const hasEvents = !!retry.events?.length;
 
+  // Pre-seed collapsed state for state/store events so their
+  // collapsibleContent bodies start hidden (matching main transcript
+  // where they're hidden inside collapsed parent containers).
+  const initialCollapsed = useMemo(() => {
+    const ids: Record<string, boolean> = {};
+    for (const event of retry.events || []) {
+      if (
+        (event.event === "state" || event.event === "store") &&
+        event.uuid
+      ) {
+        ids[event.uuid] = true;
+      }
+    }
+    return ids;
+  }, [retry.events]);
+
+  // Lightweight local collapse state for transcript event toggling.
+  // bulkCollapse applies defaults on first render, then clears itself
+  // so user toggles aren't overwritten — mirroring the main transcript pattern.
+  const [transcriptCollapsed, setTranscriptCollapsed] = useState<
+    Record<string, boolean> | undefined
+  >(undefined);
+  const [bulkCollapse, setBulkCollapse] = useState<
+    "collapse" | "expand" | undefined
+  >("expand");
+
+  // Always layer initialCollapsed under the current state so state/store
+  // events default to collapsed. User toggles override via spread order.
+  const effectiveCollapsed = useMemo(
+    () =>
+      transcriptCollapsed
+        ? { ...initialCollapsed, ...transcriptCollapsed }
+        : Object.keys(initialCollapsed).length > 0
+          ? initialCollapsed
+          : undefined,
+    [transcriptCollapsed, initialCollapsed],
+  );
+
+  const collapseState = useMemo<TranscriptCollapseState>(
+    () => ({
+      transcript: effectiveCollapsed,
+      onCollapseTranscript: (nodeId: string, collapsed: boolean) =>
+        setTranscriptCollapsed((prev) => ({
+          ...prev,
+          [nodeId]: collapsed,
+        })),
+      onSetTranscriptCollapsed: (ids: Record<string, boolean>) => {
+        setTranscriptCollapsed(ids);
+        setBulkCollapse(undefined);
+      },
+    }),
+    [effectiveCollapsed],
+  );
+
   return (
     <Card className={styles.card}>
       <CardHeader>
@@ -82,6 +139,9 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
               events={retry.events || []}
               scrollRef={scrollRef}
               listId={`sample-error-retries-${id}`}
+              showSwimlanes={false}
+              collapseState={collapseState}
+              bulkCollapse={bulkCollapse}
             />
           </div>
         )}
@@ -93,10 +153,6 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
 const RetryTraceback: FC<{ retry: EvalRetryError }> = ({ retry }) => (
   <ANSIDisplay
     output={retry.traceback_ansi}
-    className={clsx("text-size-small", styles.ansi)}
-    style={{
-      fontSize: "clamp(0.3rem, 1.1vw, 0.8rem)",
-      margin: "0.5em 0",
-    }}
+    className={styles.ansi}
   />
 );

--- a/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -321,7 +321,7 @@ export const createSamplesDescriptor = (
         10,
         Math.max(
           shape.retriesSize,
-          sample.retries ? String(sample.retries).length : 0
+          sample.retries ? String(sample.retries).length + 2 : 0
         )
       );
       shape.errorSize = Math.min(

--- a/apps/inspect/src/constants.ts
+++ b/apps/inspect/src/constants.ts
@@ -24,6 +24,7 @@ export const kSampleTranscriptTabId = `transcript`;
 export const kSampleScoringTabId = `scoring`;
 export const kSampleMetdataTabId = `metadata`;
 export const kSampleErrorTabId = `error`;
+export const kSampleRetriesTabId = `retries`;
 export const kSampleErrorRetriesTabId = `retry-errors`;
 export const kSampleJsonTabId = `json`;
 
@@ -33,6 +34,7 @@ export const kSampleTabIds = [
   kSampleScoringTabId,
   kSampleMetdataTabId,
   kSampleErrorTabId,
+  kSampleRetriesTabId,
   kSampleErrorRetriesTabId,
   kSampleJsonTabId,
 ];

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1191,6 +1191,20 @@ export interface components {
             total_samples: number;
         };
         /**
+         * EvalRetryError
+         * @description Error from a retried sample attempt.
+         */
+        EvalRetryError: {
+            /** Events */
+            events?: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[] | null;
+            /** Message */
+            message: string;
+            /** Traceback */
+            traceback: string;
+            /** Traceback Ansi */
+            traceback_ansi: string;
+        };
+        /**
          * EvalRevision
          * @description Git revision for evaluation.
          */
@@ -1224,7 +1238,7 @@ export interface components {
             epoch: number;
             error?: components["schemas"]["EvalError"] | null;
             /** Error Retries */
-            error_retries?: components["schemas"]["EvalError"][] | null;
+            error_retries?: components["schemas"]["EvalRetryError"][] | null;
             /** Events */
             events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
             events_data?: components["schemas"]["EventsData"] | null;

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -36,6 +36,7 @@ export type EvalScore = S["EvalScore"];
 export type EvalScorer = S["EvalScorer"];
 export type EvalSpec = S["EvalSpec"];
 export type EvalStats = S["EvalStats"];
+export type EvalRetryError = S["EvalRetryError"];
 
 // Event types
 export type Event = S["Event"];

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -68,7 +68,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
   // The chat message
   views.push(
     <ChatMessage
-      id={`${parentName}-chat-messages`}
+      id={`${parentName}-chat-messages-${index}`}
       message={resolvedMessage.message}
       display={display}
       linking={linking}

--- a/packages/inspect-components/src/transcript/ModelEventView.module.css
+++ b/packages/inspect-components/src/transcript/ModelEventView.module.css
@@ -46,6 +46,26 @@
   margin: 0.5em 0;
 }
 
+.showAllLink {
+  text-align: center;
+  padding: 0.5em 0 0.7em;
+}
+
+.showAllLink a {
+  cursor: pointer;
+  color: var(--bs-secondary-color);
+  text-decoration: none;
+}
+
+.showAllIcon {
+  margin-right: 0.35em;
+}
+
+.showAllLink a:hover {
+  color: var(--bs-body-color);
+  text-decoration: underline;
+}
+
 .toolConfig {
   display: grid;
   grid-template-columns: max-content auto;

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -116,20 +116,24 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       eventCallbacks={eventCallbacks}
     >
       <div data-name="Summary" className={styles.container}>
-        {context?.inlineExpansionUX && hasHiddenMessages && !showAllMessages && (
-          <div className={clsx("text-size-small", styles.showAllLink)}>
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setShowAllMessages(true);
-              }}
-            >
-              <i className={clsx(TranscriptIcons.expand, styles.showAllIcon)} />
-              Show all messages
-            </a>
-          </div>
-        )}
+        {context?.inlineExpansionUX &&
+          hasHiddenMessages &&
+          !showAllMessages && (
+            <div className={clsx("text-size-small", styles.showAllLink)}>
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setShowAllMessages(true);
+                }}
+              >
+                <i
+                  className={clsx(TranscriptIcons.expand, styles.showAllIcon)}
+                />
+                Show all messages
+              </a>
+            </div>
+          )}
         <ChatView
           id={`${eventNode.id}-model-output`}
           messages={summaryMessages}

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, Fragment, useMemo, useRef } from "react";
+import { FC, Fragment, useMemo, useRef, useState } from "react";
 
 import type {
   ChatMessage,
@@ -86,6 +86,13 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     }
   }
 
+  const hasHiddenMessages = event.input.length > userMessages.length;
+  const [showAllMessages, setShowAllMessages] = useState(false);
+
+  const summaryMessages = showAllMessages
+    ? [...event.input, ...(outputMessages || [])]
+    : [...userMessages, ...(outputMessages || [])];
+
   const panelTitle = event.role
     ? `Model Call (${event.role}): ${event.model}`
     : `Model Call: ${event.model}`;
@@ -109,9 +116,23 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       eventCallbacks={eventCallbacks}
     >
       <div data-name="Summary" className={styles.container}>
+        {context?.inlineExpansionUX && hasHiddenMessages && !showAllMessages && (
+          <div className={clsx("text-size-small", styles.showAllLink)}>
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setShowAllMessages(true);
+              }}
+            >
+              <i className={clsx(TranscriptIcons.expand, styles.showAllIcon)} />
+              Show all messages
+            </a>
+          </div>
+        )}
         <ChatView
           id={`${eventNode.id}-model-output`}
-          messages={[...userMessages, ...(outputMessages || [])]}
+          messages={summaryMessages}
           tools={{
             callStyle: showToolCalls ? "complete" : "omit",
             collapseToolMessages: context?.hasToolEvents !== false,

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -59,8 +59,8 @@ import {
 } from "./TranscriptViewNodes";
 import {
   EventNode,
-  type EventNodeContext,
   kCollapsibleEventTypes,
+  type EventNodeContext,
   type TranscriptCollapseState,
 } from "./types";
 

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -59,6 +59,7 @@ import {
 } from "./TranscriptViewNodes";
 import {
   EventNode,
+  type EventNodeContext,
   kCollapsibleEventTypes,
   type TranscriptCollapseState,
 } from "./types";
@@ -129,6 +130,9 @@ export interface TranscriptLayoutProps {
   /** Outline panel configuration. When omitted, the outline column is hidden entirely. */
   outline?: TranscriptLayoutOutlineProps;
 
+  /** Extra context fields merged into every EventNodeContext entry. */
+  eventNodeContext?: Partial<EventNodeContext>;
+
   /** Text shown when no events match the current filter. Pass null to disable empty state. */
   emptyText?: string | null;
   className?: string;
@@ -184,6 +188,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   bulkCollapse,
   collapseState,
   outline,
+  eventNodeContext,
   emptyText = "No events match the current filter",
   className,
 }) => {
@@ -602,6 +607,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
               collapsedTranscript={collapseState?.transcript}
               collapsedOutline={collapseState?.outline}
               onCollapseTranscript={collapseState?.onCollapseTranscript}
+              eventNodeContext={eventNodeContext}
             />
           ) : emptyText !== null ? (
             <NoContentsPanel text={emptyText} />

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
@@ -28,7 +28,7 @@ import {
 import { TranscriptVirtualList } from "./TranscriptVirtualList";
 import { kSandboxSignalName } from "./transform/fixups";
 import { flatTree } from "./transform/flatten";
-import type { EventNode, EventPanelCallbacks } from "./types";
+import type { EventNode, EventNodeContext, EventPanelCallbacks } from "./types";
 
 // =============================================================================
 // Types
@@ -54,6 +54,8 @@ export interface TranscriptViewNodesProps {
   /** Outline collapse state, used only for turn-map computation. */
   collapsedOutline?: Record<string, boolean>;
   onCollapseTranscript?: (nodeId: string, collapsed: boolean) => void;
+  /** Extra context fields merged into every EventNodeContext entry. */
+  eventNodeContext?: Partial<EventNodeContext>;
 }
 
 export interface TranscriptViewNodesHandle {
@@ -87,6 +89,7 @@ export const TranscriptViewNodes = forwardRef<
     collapsedTranscript,
     collapsedOutline,
     onCollapseTranscript,
+    eventNodeContext,
   },
   ref
 ) {
@@ -203,6 +206,7 @@ export const TranscriptViewNodes = forwardRef<
           renderAgentCard={renderAgentCard}
           turnMap={computedTurnMap}
           eventCallbacks={eventCallbacks}
+          eventNodeContext={eventNodeContext}
         />
       </div>
     </StickyScrollProvider>

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -34,6 +34,8 @@ interface TranscriptVirtualListComponentProps {
   onAutoCollapse?: (eventId: string) => void;
   renderAgentCard?: (node: EventNode, className?: string) => ReactNode;
   eventCallbacks?: EventPanelCallbacks;
+  /** Extra context fields merged into every EventNodeContext entry. */
+  eventNodeContext?: Partial<EventNodeContext>;
 }
 
 /**
@@ -56,6 +58,7 @@ export const TranscriptVirtualListComponent: FC<
   onAutoCollapse,
   renderAgentCard,
   eventCallbacks,
+  eventNodeContext,
 }) => {
   const useVirtualization =
     !disableVirtualization && (running || eventNodes.length > 100);
@@ -126,10 +129,10 @@ export const TranscriptVirtualListComponent: FC<
     for (const [i, node] of eventNodes.entries()) {
       const hasToolEvents = hasToolEventsAtCurrentDepth(i);
       const turnInfo = turnMap?.get(node.id);
-      map.set(node.id, { hasToolEvents, turnInfo });
+      map.set(node.id, { hasToolEvents, turnInfo, ...eventNodeContext });
     }
     return map;
-  }, [eventNodes, hasToolEventsAtCurrentDepth, turnMap]);
+  }, [eventNodes, hasToolEventsAtCurrentDepth, turnMap, eventNodeContext]);
 
   const renderRow = useCallback(
     (index: number, item: EventNode, style?: CSSProperties) => {

--- a/packages/inspect-components/src/transcript/icons.ts
+++ b/packages/inspect-components/src/transcript/icons.ts
@@ -16,6 +16,7 @@ export const TranscriptIcons = {
   arrows: {
     right: "bi bi-arrow-right",
   },
+  expand: "bi bi-chevron-up",
   compaction: "bi bi-arrows-collapse-vertical",
   edit: "bi bi-pencil-square",
   error: "bi bi-exclamation-circle-fill",

--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -160,4 +160,6 @@ export type TranscriptState = Record<string, TranscriptEventState>;
 export interface EventNodeContext {
   hasToolEvents?: boolean;
   turnInfo?: { turnNumber: number; totalTurns: number };
+  /** When true, event views should show inline expansion UX element. (e.g. ModelEventView shows a "Show all messages" toggle for expanding filtered input.) */
+  inlineExpansionUX?: boolean;
 }

--- a/packages/react/src/components/AnsiDisplay.module.css
+++ b/packages/react/src/components/AnsiDisplay.module.css
@@ -69,7 +69,6 @@
 }
 
 .ansiDisplayToggle {
-  padding: 0.1rem;
-  padding-left: 0.5rem;
+  padding: 0 0.2rem;
   background-color: var(--bs-body-bg);
 }


### PR DESCRIPTION
Improve retries display by showing each retry attempt, the error traceback, and the events immediately preceding the error.

<img width="865" height="1058" alt="Screenshot 2026-04-14 at 11 34 32 AM" src="https://github.com/user-attachments/assets/7b88a7ce-3545-4c0c-ae68-120d82e08513" />

<img width="865" height="1058" alt="Screenshot 2026-04-14 at 11 34 44 AM" src="https://github.com/user-attachments/assets/490502d8-7f3b-4ca2-b2e0-5c9b0ef971ec" />


