### PR TITLE
Stop defining and using types that are already part of `inspect-common/types`.

### DIFF
--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -18,7 +18,6 @@ import {
   isMessageInput,
   isMessagesInput,
   isTranscriptInput,
-  MessageType,
 } from "../types";
 
 import styles from "./ScannerResultHeader.module.css";
@@ -183,7 +182,7 @@ const transcriptCols = (
   return cols;
 };
 
-const messageCols = (message: MessageType, status?: Status) => {
+const messageCols = (message: ChatMessage, status?: Status) => {
   const cols: Column[] = [
     {
       label: "Message ID",

--- a/apps/scout/src/app/types.ts
+++ b/apps/scout/src/app/types.ts
@@ -1,9 +1,5 @@
 import type {
   ChatMessage,
-  ChatMessageAssistant,
-  ChatMessageSystem,
-  ChatMessageTool,
-  ChatMessageUser,
   Event,
   JsonValue,
   ModelUsage,
@@ -11,8 +7,6 @@ import type {
 import type { EventType } from "@tsmono/inspect-components/transcript";
 
 import { ScannerInputResponse, Transcript } from "../types/api-types";
-
-export type InputType = ScannerInputResponse["input_type"];
 
 export interface ScanResultSummary {
   // Basic Info
@@ -26,7 +20,7 @@ export interface ScanResultSummary {
   timestamp?: string;
 
   // Input
-  inputType: InputType;
+  inputType: ScannerInputResponse["input_type"];
 
   // Refs
   eventReferences: ScanResultReference[];
@@ -38,7 +32,7 @@ export interface ScanResultSummary {
 
   // Value
   value: string | boolean | number | null | unknown[] | object;
-  valueType: ValueType;
+  valueType: ScanResultValueType;
 
   // Scan metadata
   scanError?: string;
@@ -92,12 +86,6 @@ export interface ScanResultReference {
   cite?: string;
 }
 
-export type MessageType =
-  | ChatMessageSystem
-  | ChatMessageUser
-  | ChatMessageAssistant
-  | ChatMessageTool;
-
 export interface SortColumn {
   column: string;
   direction: "asc" | "desc";
@@ -118,7 +106,7 @@ export type ResultGroup =
   | "model"
   | "none";
 
-export type ValueType =
+export type ScanResultValueType =
   | "boolean"
   | "number"
   | "string"
@@ -180,7 +168,7 @@ export function isMessageInput(
   input: ScannerInputResponse
 ): input is ScannerInputResponse & {
   inputType: "message";
-  input: MessageType;
+  input: ChatMessage;
 } {
   return input.input_type === "message";
 }

--- a/apps/scout/src/app/utils/arrow.ts
+++ b/apps/scout/src/app/utils/arrow.ts
@@ -3,13 +3,13 @@ import JSON5 from "json5";
 
 import { asyncJsonParse } from "@tsmono/util";
 
-import { ScanResultReference, ValueType } from "../types";
+import { ScanResultReference, ScanResultValueType } from "../types";
 
 interface Result {
   uuid?: string | null;
   label?: string | null;
   value: unknown;
-  type?: ValueType | null;
+  type?: ScanResultValueType | null;
   answer?: string | null;
   explanation?: string | null;
   metadata?: Record<string, unknown> | null;
@@ -333,7 +333,7 @@ async function createSyntheticRows(
   }
 }
 
-function inferType(value: unknown): ValueType {
+function inferType(value: unknown): ScanResultValueType {
   if (typeof value === "boolean") {
     return "boolean";
   } else if (typeof value === "number") {

--- a/apps/scout/src/app/utils/arrowHelpers.ts
+++ b/apps/scout/src/app/utils/arrowHelpers.ts
@@ -11,12 +11,13 @@ import {
   ScanResultData,
   ScanResultReference,
   ScanResultSummary,
+  ScanResultValueType,
 } from "../types";
 
 export const parseScanResultData = async (
   filtered: ColumnTable
 ): Promise<ScanResultData> => {
-  const valueType = filtered.get("value_type", 0) as ValueType;
+  const valueType = filtered.get("value_type", 0) as ScanResultValueType;
 
   const transcript_agent_args_raw = getOptionalColumn<string>(
     filtered,
@@ -209,7 +210,7 @@ export const parseScanResultSummaries = async (
     rowData.map(async (row) => {
       const r = row as Record<string, unknown>;
 
-      const valueType = r.value_type as ValueType;
+      const valueType = r.value_type as ScanResultValueType;
 
       // Note that validation_result and validation_target will always a JSON deserializable string as of Jan 7 2026, but prior to this it could be stored as a boolean directly. This conditionality deals with that.
       const [
@@ -300,11 +301,10 @@ const tryParseJson = async <T>(text: unknown): Promise<T> => {
   }
 };
 
-type ValueType = "string" | "number" | "boolean" | "null" | "array" | "object";
 
 const parseSimpleValue = (
   val: unknown,
-  valueType: ValueType
+  valueType: ScanResultValueType
 ): Promise<
   string | number | boolean | null | unknown[] | object | undefined
 > =>

--- a/apps/scout/src/app/utils/arrowHelpers.ts
+++ b/apps/scout/src/app/utils/arrowHelpers.ts
@@ -301,7 +301,6 @@ const tryParseJson = async <T>(text: unknown): Promise<T> => {
   }
 };
 
-
 const parseSimpleValue = (
   val: unknown,
   valueType: ScanResultValueType


### PR DESCRIPTION
## Summary
- Rename `ValueType` → `ScanResultValueType` for clarity
- Delete duplicate local `ValueType` definition in `arrowHelpers.ts` (now imports from `types.ts`)
- Remove unused `InputType` and `MessageType` exports