### PR TITLE
Add tags, % completed, sample errors, and error columns to log list

### DIFF
--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -150,6 +150,20 @@ export const LogListGrid: FC<LogListGridProps> = ({
         }
       }
 
+      // Percent of samples completed
+      let percentCompleted: number | undefined;
+      const total = details?.results?.total_samples;
+      const completed = details?.results?.completed_samples;
+      if (total && total > 0 && completed !== undefined) {
+        percentCompleted = (completed / total) * 100;
+      }
+
+      // Count of sample errors
+      let sampleErrors: number | undefined;
+      if (details?.sampleSummaries) {
+        sampleErrors = details.sampleSummaries.filter((s) => s.error).length;
+      }
+
       const row: LogListRow = {
         id: item.id,
         name: item.name,
@@ -181,6 +195,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
         taskArgs,
         taskArgsRaw: details?.eval?.task_args ?? undefined,
         tags: details?.tags,
+        percentCompleted,
+        sampleErrors,
+        errorMessage: details?.error?.message,
       };
 
       // Add individual scorer columns from results

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -1,5 +1,6 @@
 import type {
   CellMouseDownEvent,
+  ColDef,
   GridColumnsChangedEvent,
   IRowNode,
   ModelUpdatedEvent,
@@ -213,18 +214,6 @@ export const LogListGrid: FC<LogListGridProps> = ({
         }
       }
 
-      // Pre-compute searchable text for fast Cmd+F search
-      row.searchText = [
-        row.name,
-        row.task,
-        row.model,
-        row.id,
-        ...(row.tags ?? []),
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-
       return row;
     });
   }, [items, logDetails]);
@@ -340,7 +329,15 @@ export const LogListGrid: FC<LogListGridProps> = ({
     resizeGridColumns();
   }, [columns, resizeGridColumns]);
 
-  // Find functionality - uses pre-computed searchText for O(1) lookup per row
+  // Find functionality - searches across the currently visible columns.
+  // Formatted cell values are cached per (data, columns) so only keystrokes
+  // after a data/visibility change pay the formatter cost.
+  const searchCacheRef = useRef<{
+    data: LogListRow[] | null;
+    columns: ColDef<LogListRow>[] | null;
+    cache: Map<string, string>;
+  }>({ data: null, columns: null, cache: new Map() });
+
   const performSearch = useCallback(
     (term: string) => {
       const api = gridRef.current?.api;
@@ -349,13 +346,36 @@ export const LogListGrid: FC<LogListGridProps> = ({
         setCurrentMatchIndex(0);
         return;
       }
+
+      // Rebuild cache if data or visible columns changed since last search
+      const cached = searchCacheRef.current;
+      let cache = cached.cache;
+      if (cached.data !== data || cached.columns !== columns) {
+        cache = new Map();
+        const displayedColumns = api.getAllDisplayedColumns();
+        api.forEachNode((node) => {
+          if (!node.data) return;
+          const parts: string[] = [];
+          for (const col of displayedColumns) {
+            const value = api.getCellValue({
+              rowNode: node,
+              colKey: col,
+              useFormatter: true,
+            });
+            if (value) parts.push(String(value));
+          }
+          cache.set(node.data.id, parts.join(" ").toLowerCase());
+        });
+        searchCacheRef.current = { data, columns, cache };
+      }
+
       const lowerTerm = term.toLowerCase();
       const foundIds: string[] = [];
       api.forEachNode((node) => {
-        const rowData = node.data;
-        if (!rowData?.searchText) return;
-        if (rowData.searchText.includes(lowerTerm)) {
-          foundIds.push(rowData.id);
+        if (!node.data) return;
+        const text = cache.get(node.data.id);
+        if (text && text.includes(lowerTerm)) {
+          foundIds.push(node.data.id);
         }
       });
       setMatchIds(foundIds);
@@ -369,7 +389,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         }
       }
     },
-    [gridRef]
+    [data, columns, gridRef]
   );
 
   const goToMatch = useCallback(

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -180,6 +180,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         taskFile: details?.eval?.task_file ?? undefined,
         taskArgs,
         taskArgsRaw: details?.eval?.task_args ?? undefined,
+        tags: details?.tags,
       };
 
       // Add individual scorer columns from results
@@ -196,7 +197,13 @@ export const LogListGrid: FC<LogListGridProps> = ({
       }
 
       // Pre-compute searchable text for fast Cmd+F search
-      row.searchText = [row.name, row.task, row.model, row.id]
+      row.searchText = [
+        row.name,
+        row.task,
+        row.model,
+        row.id,
+        ...(row.tags ?? []),
+      ]
         .filter(Boolean)
         .join(" ")
         .toLowerCase();

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -510,8 +510,7 @@ export const useLogListColumns = (
           if (!msg) return "";
           return msg.split("\n")[0];
         },
-        tooltipValueGetter: (params) =>
-          params.data?.errorMessage || undefined,
+        tooltipValueGetter: (params) => params.data?.errorMessage || undefined,
         cellRenderer: (params: ICellRendererParams<LogListRow>) => {
           if (!params.value) return <EmptyCell />;
           return <div className={styles.nameCell}>{params.value}</div>;

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -197,6 +197,14 @@ export const useLogListColumns = (
         sortable: true,
         filter: true,
         resizable: true,
+        tooltipValueGetter: (params) => {
+          const item = params.data;
+          if (!item) return undefined;
+          if (item.status === "error" && item.errorMessage) {
+            return item.errorMessage;
+          }
+          return item.status || undefined;
+        },
         cellRenderer: (params: ICellRendererParams<LogListRow>) => {
           const item = params.data;
           if (!item) return null;
@@ -453,6 +461,62 @@ export const useLogListColumns = (
           return <div className={styles.nameCell}>{params.value}</div>;
         },
       },
+      {
+        field: "percentCompleted",
+        headerName: "% Completed",
+        initialWidth: 110,
+        minWidth: 80,
+        maxWidth: 140,
+        sortable: true,
+        filter: "agNumberColumnFilter",
+        resizable: true,
+        valueFormatter: (params) => {
+          if (params.value === undefined || params.value === null) return "";
+          return `${formatPrettyDecimal(params.value)}%`;
+        },
+        cellRenderer: (params: ICellRendererParams<LogListRow>) => {
+          if (params.value === undefined || params.value === null) {
+            return <EmptyCell />;
+          }
+          return <div>{formatPrettyDecimal(params.value)}%</div>;
+        },
+      },
+      {
+        field: "sampleErrors",
+        headerName: "Sample Errors",
+        initialWidth: 110,
+        minWidth: 60,
+        maxWidth: 140,
+        sortable: true,
+        filter: "agNumberColumnFilter",
+        resizable: true,
+        cellRenderer: (params: ICellRendererParams<LogListRow>) => {
+          if (params.value === undefined || params.value === null) {
+            return <EmptyCell />;
+          }
+          return <div>{formatNumber(params.value)}</div>;
+        },
+      },
+      {
+        field: "errorMessage",
+        headerName: "Error",
+        initialWidth: 300,
+        minWidth: 100,
+        sortable: true,
+        filter: true,
+        resizable: true,
+        valueGetter: (params) => {
+          const msg = params.data?.errorMessage;
+          if (!msg) return "";
+          return msg.split("\n")[0];
+        },
+        tooltipValueGetter: (params) =>
+          params.data?.errorMessage || undefined,
+        cellRenderer: (params: ICellRendererParams<LogListRow>) => {
+          if (!params.value) return <EmptyCell />;
+          return <div className={styles.nameCell}>{params.value}</div>;
+        },
+      },
     ];
 
     // Add scorer columns (currently only showing when we detect them)
@@ -521,8 +585,11 @@ export const useLogListColumns = (
         "completedAt",
         "totalSamples",
         "completedSamples",
+        "percentCompleted",
+        "sampleErrors",
         "totalTokens",
         "duration",
+        "errorMessage",
         "name",
         "sandbox",
         "taskFile",
@@ -572,6 +639,10 @@ export const useLogListColumns = (
       hidden.add("sandbox");
       hidden.add("taskFile");
     }
+    // New columns default to hidden in both views
+    hidden.add("percentCompleted");
+    hidden.add("sampleErrors");
+    hidden.add("errorMessage");
     return hidden;
   }, [mode]);
 

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -434,6 +434,25 @@ export const useLogListColumns = (
         },
         tooltipComponent: PreformattedTooltip,
       },
+      {
+        field: "tags",
+        headerName: "Tags",
+        initialWidth: 80,
+        minWidth: 80,
+        sortable: true,
+        filter: true,
+        resizable: true,
+        valueGetter: (params) => {
+          const tags = params.data?.tags;
+          if (!tags || tags.length === 0) return "";
+          return tags.join(", ");
+        },
+        tooltipValueGetter: (params) => params.value || undefined,
+        cellRenderer: (params: ICellRendererParams<LogListRow>) => {
+          if (!params.value) return <EmptyCell />;
+          return <div className={styles.nameCell}>{params.value}</div>;
+        },
+      },
     ];
 
     // Add scorer columns (currently only showing when we detect them)
@@ -497,6 +516,7 @@ export const useLogListColumns = (
         "task",
         "model",
         "taskArgs",
+        "tags",
         "score",
         "completedAt",
         "totalSamples",

--- a/apps/inspect/src/app/log-list/grid/columns/types.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/types.ts
@@ -24,5 +24,8 @@ export interface LogListRow {
   taskArgs?: string;
   taskArgsRaw?: Record<string, unknown>;
   tags?: string[];
+  percentCompleted?: number;
+  sampleErrors?: number;
+  errorMessage?: string;
   [key: string]: any; // For dynamic score columns
 }

--- a/apps/inspect/src/app/log-list/grid/columns/types.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/types.ts
@@ -23,5 +23,6 @@ export interface LogListRow {
   taskFile?: string;
   taskArgs?: string;
   taskArgsRaw?: Record<string, unknown>;
+  tags?: string[];
   [key: string]: any; // For dynamic score columns
 }

--- a/apps/inspect/src/app/log-list/grid/columns/types.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/types.ts
@@ -13,7 +13,6 @@ export interface LogListRow {
   completedAt?: string;
   itemCount?: number;
   log?: LogHandle;
-  searchText?: string; // Pre-computed searchable text for fast Cmd+F search
   path?: string;
   totalSamples?: number;
   completedSamples?: number;


### PR DESCRIPTION
## Summary
- Adds four new columns to the inspect viewer log list (tasks + folders views): **Tags**, **% Completed**, **Sample Errors**, and **Error** (first line in cell, full message in tooltip). The latter three start hidden.
- Adds a tooltip on the **Status** column that surfaces the error message when a run failed.
- Rewrites Cmd+F search to match against the currently visible columns using their formatted (displayed) values, with a per-row cache keyed on `(data, columns)` so formatter cost is paid once per data/visibility change, not per keystroke.

Fixes https://github.com/meridianlabs-ai/ts-mono/issues/71

## Test plan
- [ ] Open the inspect viewer against a log dir with tags — Tags column visible by default and sortable/filterable.
- [ ] Toggle % Completed, Sample Errors, and Error on via the column menu; verify values populate as log details load.
- [ ] Hover a failed run's status icon — tooltip shows the error message.
- [ ] Hover the Error column cell — tooltip shows the full (possibly multi-line) message.
- [ ] Cmd+F: search matches values from visible columns only; hide a column and its contents are no longer matchable.
- [ ] Cmd+F on formatted values like "1,234" or "85%" still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)