### PR TITLE
fix: break infinite re-render loop in bulk collapse/expand

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -22,6 +22,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -407,8 +408,16 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   // Bulk collapse/expand
   // ---------------------------------------------------------------------------
 
-  const onSetTranscriptCollapsed = collapseState?.onSetTranscriptCollapsed;
+  const onSetTranscriptCollapsedRef = useRef(
+    collapseState?.onSetTranscriptCollapsed
+  );
   useEffect(() => {
+    onSetTranscriptCollapsedRef.current =
+      collapseState?.onSetTranscriptCollapsed;
+  });
+
+  useEffect(() => {
+    const onSetTranscriptCollapsed = onSetTranscriptCollapsedRef.current;
     if (events.length <= 0 || !bulkCollapse || !onSetTranscriptCollapsed) {
       return;
     }
@@ -421,13 +430,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
       const allCollapsibleIds = collectAllCollapsibleIds(eventNodes);
       onSetTranscriptCollapsed(allCollapsibleIds);
     }
-  }, [
-    defaultCollapsedIds,
-    eventNodes,
-    bulkCollapse,
-    onSetTranscriptCollapsed,
-    events.length,
-  ]);
+  }, [defaultCollapsedIds, eventNodes, bulkCollapse, events.length]);
 
   // ---------------------------------------------------------------------------
   // Outline auto-hide


### PR DESCRIPTION
## Summary

When pressing the collapse button in the transcript tab, you entered an infinite loop resulting in React error #185 (maximum update depth exceeded).

- Root cause: `onSetTranscriptCollapsed` callback was included in the `useEffect` dependency array, but calling it updates `collapsedEvents` in the Zustand store, which causes `collapseState` to recalculate via `useMemo`, creating a new callback reference, which re-triggers the effect — infinite loop
- Fix: use a `useRef` to hold the `onSetTranscriptCollapsed` callback, breaking the circular dependency

## Test plan

- [x] Verified locally that clicking Collapse no longer causes React error #185
- [x] Verified that Collapse collapses all collapsible sections (step, span_begin, tool, subtask)
- [x] Verified that Expand restores sections to their default collapsed state
- [x] Run existing tests