### PR TITLE
fix: skip errored model events in Messages tab

### DIFF
--- a/apps/inspect/src/app/samples/messagesFromEvents.test.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { messagesFromEvents } from "./messagesFromEvents";
+
+const makeModelEvent = (opts: {
+  error?: string;
+  inputId?: string;
+  outputId?: string;
+}): Event =>
+  ({
+    event: "model",
+    error: opts.error ?? null,
+    input: opts.inputId
+      ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
+      : [],
+    output: {
+      choices: [
+        {
+          message: {
+            id: opts.outputId ?? null,
+            role: "assistant",
+            content: "response",
+            source: "generate",
+          },
+        },
+      ],
+    },
+  }) as unknown as Event;
+
+describe("messagesFromEvents", () => {
+  it("returns messages from successful model events", () => {
+    const messages = messagesFromEvents([
+      makeModelEvent({ inputId: "msg-1", outputId: "msg-2" }),
+    ]);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.id).toBe("msg-1");
+    expect(messages[1]!.id).toBe("msg-2");
+  });
+
+  it("skips model events with error set", () => {
+    const messages = messagesFromEvents([
+      makeModelEvent({
+        error: "429 rate limit",
+        inputId: "msg-1",
+        outputId: "msg-err",
+      }),
+      makeModelEvent({ inputId: "msg-1", outputId: "msg-2" }),
+    ]);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.id).toBe("msg-1");
+    expect(messages[1]!.id).toBe("msg-2");
+  });
+});

--- a/apps/inspect/src/app/samples/messagesFromEvents.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.ts
@@ -15,6 +15,7 @@ export const messagesFromEvents = (runningEvents: Event[]): ChatMessage[] => {
 
   runningEvents
     .filter((e) => e.event === "model")
+    .filter((e) => !e.error)
     .forEach((e) => {
       for (const m of e.input) {
         const inputMessage = m as


### PR DESCRIPTION
## Summary

Errored model events (e.g. retries) show up as an empty message in the message view:
<img width="855" height="583" alt="image" src="https://github.com/user-attachments/assets/baf8ff7e-9321-4330-8608-076df110a2ee" />

## Changes
- Filter them out with `.filter((e) => !e.error)` before processing
- Added tests for the fix

## Test plan
- [X] Open an eval log with retry errors (rate limits, 500s)
- [X] Verify the Messages tab no longer shows broken/empty entries for failed retries
- [X] Verify successful model messages still render correctly