### PR TITLE
Use filename ordering instead of mtime for retried log deduplication

### DIFF
--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -573,10 +573,7 @@ export const useLogsWithretried = (): LogHandleWithretried[] => {
         const bs = simplifiedStatusForDeduplication(
           logPreviews[b.name]?.status
         );
-        const am = a.mtime ?? 0;
-        const bm = b.mtime ?? 0;
-
-        if (as === bs) return bm - am; // newest on top
+        if (as === bs) return b.name.localeCompare(a.name);
         if (as === "started") return -1;
         if (bs === "started") return 1;
         if (as === "success") return -1;


### PR DESCRIPTION
## Summary

The "Show Retried Logs" toggle groups eval logs by `task_id` and picks one as "current." When multiple logs share the same status, the tiebreaker was file modification time (`mtime`). This is unreliable: copying files, syncing from S3, or extracting from an archive can reset `mtime`, causing an older log to appear as "current" instead of the most recent retry.

Replace the `mtime` tiebreaker with lexicographic comparison of the filename. Eval log filenames always begin with an ISO 8601 creation timestamp (e.g. `2026-04-22T10-30-00+00-00_mytask_abc123.eval`), so lexicographic order matches chronological order. This prefix is hardcoded and unaffected by `INSPECT_EVAL_LOG_FILE_PATTERN`.

## Test plan

- [x] Open the viewer with an eval set containing retried tasks; verify the most recent retry is shown as "current"
- [x] Toggle "Show Retried Logs" and confirm older retries appear in the expected order
- [x] Copy or re-download log files (altering `mtime`) and verify the correct log is still selected as "current"