### PR TITLE
fix: enable reference popovers for sample scan results

### DIFF
--- a/apps/inspect/src/app/samples/scans/SampleScansSidebar.tsx
+++ b/apps/inspect/src/app/samples/scans/SampleScansSidebar.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { FC, useMemo } from "react";
 
-import type { Score } from "@tsmono/inspect-common/types";
+import type { Event, Score } from "@tsmono/inspect-common/types";
 import {
   inferValueType,
   ScannerResultDetailView,
@@ -16,10 +16,12 @@ import { useEvalSpec } from "../../../state/hooks";
 
 import { SampleScannerPicker } from "./SampleScannerPicker";
 import styles from "./SampleScansSidebar.module.css";
+import { buildScanReferencePreviews } from "./scanReferencePreviews";
 import { buildScoreMarkdownRefs, MakeCiteUrl } from "./scanReferences";
 
 interface SampleScansSidebarProps {
   scores: Record<string, Score>;
+  events?: readonly Event[] | null;
   makeCiteUrl: MakeCiteUrl;
   selected: string;
   onSelectedChange: (scanner: string) => void;
@@ -27,6 +29,7 @@ interface SampleScansSidebarProps {
 
 export const SampleScansSidebar: FC<SampleScansSidebarProps> = ({
   scores,
+  events,
   makeCiteUrl,
   selected,
   onSelectedChange,
@@ -34,9 +37,19 @@ export const SampleScansSidebar: FC<SampleScansSidebarProps> = ({
   const scanners = Object.keys(scores);
   const score: Score | undefined = selected ? scores[selected] : undefined;
 
+  const previewTable = useMemo(
+    () => buildScanReferencePreviews(events ?? undefined),
+    [events]
+  );
+
   const references = useMemo(
-    () => buildScoreMarkdownRefs(score?.metadata ?? null, makeCiteUrl),
-    [score?.metadata, makeCiteUrl]
+    () =>
+      buildScoreMarkdownRefs(
+        score?.metadata ?? null,
+        makeCiteUrl,
+        previewTable
+      ),
+    [score?.metadata, makeCiteUrl, previewTable]
   );
 
   const viewer = useEvalSpec()?.viewer;
@@ -74,7 +87,6 @@ export const SampleScansSidebar: FC<SampleScansSidebarProps> = ({
       <ScannerResultDetailView
         data={data}
         references={references}
-        options={{ previewRefsOnHover: false }}
         config={config}
       />
     </div>

--- a/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
+++ b/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
@@ -1,0 +1,78 @@
+import { FC, ReactNode } from "react";
+
+import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
+import { ChatView } from "@tsmono/inspect-components/chat";
+import {
+  TranscriptViewNodes,
+  useEventNodes,
+} from "@tsmono/inspect-components/transcript";
+
+// Shared empty map so the preview component doesn't re-render on reference
+// equality changes.
+const EMPTY_COLLAPSE: Record<string, boolean> = {};
+const noopCollapse = () => {};
+
+const TranscriptPreview: FC<{ id: string; events: Event[] }> = ({
+  id,
+  events,
+}) => {
+  const { eventNodes, defaultCollapsedIds } = useEventNodes(events, false);
+  return (
+    <TranscriptViewNodes
+      id={id}
+      eventNodes={eventNodes}
+      defaultCollapsedIds={defaultCollapsedIds}
+      collapsedTranscript={EMPTY_COLLAPSE}
+      onCollapseTranscript={noopCollapse}
+    />
+  );
+};
+
+/**
+ * Walk events and build a lookup of reference id → preview renderer.
+ *
+ * Scanner references can point to either an event uuid or a message id.
+ * Event previews render the event inline via a transcript view; message
+ * previews render the message inline via a chat view. Messages can live
+ * inside ModelEvent input/output, so those are harvested here too.
+ */
+export function buildScanReferencePreviews(
+  events: readonly Event[] | undefined
+): Record<string, () => ReactNode> {
+  if (!events || events.length === 0) return {};
+  const table: Record<string, () => ReactNode> = {};
+
+  const addMessage = (msg: ChatMessage | null | undefined) => {
+    if (!msg?.id || table[msg.id]) return;
+    const captured = msg;
+    table[msg.id] = () => (
+      <ChatView
+        id={`ref-preview-${captured.id}`}
+        messages={[captured]}
+        labels={{ show: false }}
+        tools={{ collapseToolMessages: false }}
+      />
+    );
+  };
+
+  for (const event of events) {
+    if (event.uuid && !table[event.uuid]) {
+      const captured = event;
+      table[event.uuid] = () => (
+        <TranscriptPreview
+          id={`ref-preview-${captured.uuid}`}
+          events={[captured]}
+        />
+      );
+    }
+
+    if (event.event === "model") {
+      for (const msg of event.input ?? []) addMessage(msg);
+      for (const choice of event.output?.choices ?? []) {
+        addMessage(choice.message);
+      }
+    }
+  }
+
+  return table;
+}

--- a/apps/inspect/src/app/samples/scans/scanReferences.ts
+++ b/apps/inspect/src/app/samples/scans/scanReferences.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { ReactNode, useCallback } from "react";
 
 import type { Event } from "@tsmono/inspect-common/types";
 import type { MarkdownReference } from "@tsmono/react/components";
@@ -65,12 +65,14 @@ export function findEventForMessage(
 
 export function buildScoreMarkdownRefs(
   metadata: Metadata,
-  makeUrl: (id: string, type: ScannerRefType) => string | undefined
+  makeUrl: (id: string, type: ScannerRefType) => string | undefined,
+  previewTable?: Record<string, () => ReactNode>
 ): MarkdownReference[] {
   return readScannerReferences(metadata).map((ref) => ({
     id: ref.id,
     cite: ref.cite,
     citeUrl: makeUrl(ref.id, ref.type),
+    citePreview: previewTable?.[ref.id],
   }));
 }
 

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -431,6 +431,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
               content: (
                 <SampleScansSidebar
                   scores={scores}
+                  events={events}
                   makeCiteUrl={makeCiteUrl}
                   selected={selectedScanner}
                   onSelectedChange={setSelectedScanner}

--- a/packages/react/src/components/MarkdownDivWithReferences.tsx
+++ b/packages/react/src/components/MarkdownDivWithReferences.tsx
@@ -103,7 +103,9 @@ export const MarkdownDivWithReferences = forwardRef<
       [ref, markdown, postProcess, style, omitMedia, omitMath, handleLinkClick]
     );
 
-    // Attach event handlers to reference links after render
+    // Use event delegation so handlers work even when cite links are injected
+    // asynchronously (MarkdownDiv renders via an async queue, so the initial
+    // DOM has no cite links — a per-link attach would miss them entirely).
     useEffect(() => {
       const container = containerRef.current;
       if (!container) {
@@ -115,67 +117,52 @@ export const MarkdownDivWithReferences = forwardRef<
         return;
       }
 
-      // Find all cite links
-      const citeLinks = container.querySelectorAll<HTMLElement>(
-        `.${styles.cite}`
-      );
+      const citeSelector = `.${styles.cite}`;
 
-      const handleMouseEnter = (e: MouseEvent): void => {
-        // Identify the ref
-        const el = e.currentTarget as HTMLElement;
+      const findCiteLink = (target: EventTarget | null): HTMLElement | null => {
+        if (!(target instanceof Element)) return null;
+        return target.closest<HTMLElement>(citeSelector);
+      };
+
+      // mouseover bubbles (mouseenter doesn't) — we filter to transitions
+      // into the cite link by checking relatedTarget.
+      const handleMouseOver = (e: MouseEvent): void => {
+        const el = findCiteLink(e.target);
+        if (!el) return;
+        const related = e.relatedTarget;
+        if (related instanceof Node && el.contains(related)) return;
+
         const id = el.getAttribute("data-ref-id");
-        if (!id) {
-          return;
-        }
+        if (!id) return;
         const r = refMap.get(id);
-        if (!r) {
-          return;
-        }
+        if (!r || !r.citePreview) return;
 
-        if (!r.citePreview) {
-          return;
-        }
-
-        // Just set which cite we're tracking
-        // PopOver will handle all show/hide logic including hover delays
+        // PopOver handles show/hide logic including hover delays.
         setPositionEl(el);
         setCurrentRef(r);
         setVisibleKey(popoverKey(r));
       };
 
       const handleClick = (e: MouseEvent): void => {
-        // Cancel the popover if one is pending or showing
+        if (!findCiteLink(e.target)) return;
+
+        // Cancel the popover if one is pending or showing.
         clearVisibleKey();
         setCurrentRef(null);
         setPositionEl(null);
 
-        // Stop propagation to prevent parent Link components from handling the click
+        // Stop propagation to prevent parent Link components from handling.
         e.stopPropagation();
       };
 
-      // Mouse handling to activate the popover
-      const cleanup: Array<() => void> = [];
-      citeLinks.forEach((link) => {
-        link.addEventListener("mouseenter", handleMouseEnter);
-        link.addEventListener("click", handleClick);
+      container.addEventListener("mouseover", handleMouseOver);
+      container.addEventListener("click", handleClick);
 
-        cleanup.push(() => {
-          link.removeEventListener("mouseenter", handleMouseEnter);
-          link.removeEventListener("click", handleClick);
-        });
-      });
-
-      // Cleanup all handlers
       return () => {
-        cleanup.forEach((fn) => fn());
+        container.removeEventListener("mouseover", handleMouseOver);
+        container.removeEventListener("click", handleClick);
       };
-    }, [
-      markdown,
-      refMap,
-      options?.previewRefsOnHover,
-      setVisibleKey,
-      clearVisibleKey,
-    ]);
+    }, [refMap, options?.previewRefsOnHover, setVisibleKey, clearVisibleKey]);
 
     const key = currentRef
       ? popoverKey(currentRef)
@@ -197,8 +184,9 @@ export const MarkdownDivWithReferences = forwardRef<
               }
             }}
             placement="auto"
-            hoverDelay={400}
+            hoverDelay={1000}
             showArrow={true}
+            styles={{ maxHeight: "70vh", overflowY: "auto" }}
           >
             {(currentRef.citePreview && currentRef.citePreview()) || (
               <NoContentsPanel text="No preview available." />


### PR DESCRIPTION
## Summary
- Thread sample events into `SampleScansSidebar` so scanner reference links can render inline previews — `ChatView` for message refs, `TranscriptView` for event refs — and drop the `previewRefsOnHover: false` opt-out.
- Switch `MarkdownDivWithReferences` to event delegation so hover handlers survive the async markdown render queue. The previous per-link attach ran once on mount, before cite links existed in the DOM, which is why popovers didn't display until something forced a re-render.
- Give the preview popover a viewport-based `maxHeight` and `overflow-y: auto` so long conversations scroll rather than clip.

Fixes #102

## Test plan
- [x] Open a sample with scanner results whose explanation contains cite refs (e.g. `[M1]`, `[E2]`)
- [x] Hover a cite on first load — popover appears after the hover delay, without needing a prior click
- [x] Preview for a message ref shows the message via `ChatView` (no label column)
- [x] Preview for an event ref shows the event transcript
- [x] Long previews scroll vertically inside the popover
- [x] Clicking a cite still navigates to the referenced event/message and dismisses the popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)