### PR TITLE
fix: size Scoring Detail modal to its content

### DIFF
--- a/apps/inspect/src/app/log-view/title-view/ResultsPanel.module.css
+++ b/apps/inspect/src/app/log-view/title-view/ResultsPanel.module.css
@@ -100,3 +100,15 @@
   align-items: flex-end;
   margin-bottom: 0.35em;
 }
+
+.scoringDetailModal :global(.modal-dialog) {
+  max-width: min(1000px, 90vw);
+}
+
+/* Let the dialog shrink to the grid's natural width instead of always
+   stretching to the max-width. The grid container sizes itself from the
+   sum of column widths; modal-content honours that. */
+.scoringDetailModal :global(.modal-content) {
+  width: fit-content;
+  max-width: 100%;
+}

--- a/apps/inspect/src/app/log-view/title-view/ResultsPanel.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ResultsPanel.tsx
@@ -150,6 +150,7 @@ export const ResultsPanel: FC<ResultsPanelProps> = ({ scorers }) => {
               title={"Scoring Detail"}
               overflow="hidden"
               padded={false}
+              className={styles.scoringDetailModal}
             >
               <ScoreAgGrid scoreGroups={grouped} showReducer={showReducer} />
             </Modal>

--- a/apps/inspect/src/app/log-view/title-view/ScoreAgGrid.module.css
+++ b/apps/inspect/src/app/log-view/title-view/ScoreAgGrid.module.css
@@ -1,5 +1,20 @@
 .gridContainer {
-  width: 100%;
+  max-width: 100%;
   max-height: 60vh;
   overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+/* Breathing room at the edges so values don't sit flush with the modal border
+   (and so the last column doesn't get overlapped by the vertical scroll bar).
+   The extra specificity via `:global(.ag-cell)` / `:global(.ag-header-cell)`
+   is needed to win against ag-grid's built-in theme padding. */
+:global(.ag-cell).firstCell,
+:global(.ag-header-cell).firstHeader {
+  padding-left: 1rem;
+}
+
+:global(.ag-cell).lastCell,
+:global(.ag-header-cell).lastHeader {
+  padding-right: 0.5rem;
 }

--- a/apps/inspect/src/app/log-view/title-view/ScoreAgGrid.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreAgGrid.tsx
@@ -30,7 +30,10 @@ export const ScoreAgGrid: FC<ScoreAgGridProps> = ({
   showReducer,
   className,
 }) => {
-  const { rowData, columnDefs } = useMemo(() => {
+  const kScorerColWidth = 280;
+  const kMetricColWidth = 120;
+
+  const { rowData, columnDefs, naturalWidth } = useMemo(() => {
     const metricNames: string[] = [];
     const metricNameSet = new Set<string>();
     for (const group of scoreGroups) {
@@ -61,14 +64,17 @@ export const ScoreAgGrid: FC<ScoreAgGridProps> = ({
       }
     }
 
+    const lastIdx = metricNames.length - 1;
     const columns: ColDef<ScoreGridRow>[] = [
       {
         headerName: "Scorer",
         field: "scorer",
         sortable: true,
         resizable: true,
-        flex: 1,
-        minWidth: 100,
+        width: kScorerColWidth,
+        minWidth: 150,
+        cellClass: styles.firstCell,
+        headerClass: styles.firstHeader,
         cellRenderer: (params: { data: ScoreGridRow | undefined }) => {
           const data = params.data;
           if (!data) return null;
@@ -84,12 +90,14 @@ export const ScoreAgGrid: FC<ScoreAgGridProps> = ({
         },
       },
       ...metricNames.map(
-        (name): ColDef<ScoreGridRow> => ({
+        (name, i): ColDef<ScoreGridRow> => ({
           headerName: name,
           field: `metric_${name}`,
           sortable: true,
           resizable: true,
-          width: 120,
+          width: kMetricColWidth,
+          cellClass: i === lastIdx ? styles.lastCell : undefined,
+          headerClass: i === lastIdx ? styles.lastHeader : undefined,
           valueFormatter: (params) => {
             if (params.value == null) return "";
             return formatPrettyDecimal(params.value as number);
@@ -99,11 +107,16 @@ export const ScoreAgGrid: FC<ScoreAgGridProps> = ({
       ),
     ];
 
-    return { rowData: rows, columnDefs: columns };
+    const naturalWidth = kScorerColWidth + metricNames.length * kMetricColWidth;
+
+    return { rowData: rows, columnDefs: columns, naturalWidth };
   }, [scoreGroups, showReducer]);
 
   return (
-    <div className={clsx(className, styles.gridContainer)}>
+    <div
+      className={clsx(className, styles.gridContainer)}
+      style={{ width: naturalWidth }}
+    >
       <AgGridReact<ScoreGridRow>
         rowData={rowData}
         columnDefs={columnDefs}


### PR DESCRIPTION
## Summary
- Cap the Scoring Detail dialog at `min(1000px, 90vw)` and let it shrink to the grid's natural width via `width: fit-content` on `.modal-content`, so runs with only a few metrics no longer render in a wide modal with mostly empty space.
- Drop `flex: 1` on the scorer column and use a fixed `width: 280, minWidth: 150`. The grid container sets its width to `scorerWidth + metricCount * 120` so the modal can shrink-wrap to it.
- Add 1rem edge padding on the first/last grid cells and headers so values don't sit flush with the modal border and the vertical scroll bar doesn't overlap the last column. Use `scrollbar-gutter: stable` so the natural width stays consistent whether scroll is active or not.
- The modal max-width override is scoped to this instance via a CSS module class passed through the existing `className` prop — other modals are untouched.

Fixes #104

## Test plan
- [x] Open a run with scanner scores that have few metrics — "All scoring..." modal is narrow, roughly `280 + n * 120` + padding
- [x] Open a run with many metrics — modal caps at 1000px and the grid scrolls horizontally inside it
- [x] On a narrow viewport (<1100px), modal caps at 90vw and scrolls
- [x] Values in the leftmost column aren't flush with the border; vertical scroll bar doesn't overlap the rightmost values
- [x] Long scorer names truncate (or column can be resized) without breaking layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)