### PR TITLE
Chat transcript rendering improvements

### DIFF
--- a/packages/inspect-components/src/chat/ChatMessage.tsx
+++ b/packages/inspect-components/src/chat/ChatMessage.tsx
@@ -84,7 +84,11 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
         >
           <div>
             {message.role}
-            {message.role === "tool" ? `: ${message.function}` : ""}
+            {message.role === "tool"
+              ? message.function
+                ? `: ${message.function}`
+                : ""
+              : ""}
             {linkingEnabled && messageUrl ? (
               <CopyButton
                 icon={linkIcon}

--- a/packages/inspect-components/src/chat/ChatMessageRow.module.css
+++ b/packages/inspect-components/src/chat/ChatMessageRow.module.css
@@ -1,7 +1,6 @@
 .grid {
   display: grid;
   grid-template-columns: max-content auto;
-  column-gap: 0.4rem;
   row-gap: 0;
   margin-bottom: 0.75rem;
 }
@@ -40,6 +39,7 @@
 
 .label {
   padding-top: 0.7rem;
+  margin-left: 0.4em;
 }
 
 .highlight {

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -6,6 +6,7 @@ import type { ChatMessageTool } from "@tsmono/inspect-common/types";
 import { ChatMessage } from "./ChatMessage";
 import styles from "./ChatMessageRow.module.css";
 import { Message, ResolvedMessage } from "./messages";
+import { ToolCallErrorView } from "./tools/ToolCallErrorView";
 import { resolveToolInput, substituteToolCallContent } from "./tools/tool";
 import { ToolCallView } from "./tools/ToolCallView";
 import {
@@ -97,6 +98,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
     const toolMessages = resolvedMessage.toolMessages || [];
     let idx = 0;
     for (const tool_call of resolvedMessage.message.tool_calls) {
+      
       // Extract tool input
       const { name, input, description, functionCall, contentType } =
         resolveToolInput(tool_call.function, tool_call.arguments);
@@ -147,6 +149,21 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
           />
         );
       }
+
+      // If the tool call errored, render a dedicated error view as its own
+      // row (with an empty label) so it visually attaches to the tool call.
+      if (toolMessage?.error) {
+        if (useLabels) {
+          viewLabels.push(undefined);
+        }
+        views.push(
+          <ToolCallErrorView
+            key={`tool-call-${idx}-error`}
+            error={toolMessage.error}
+          />
+        );
+      }
+
       idx++;
     }
   }
@@ -217,14 +234,11 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
 };
 
 const resolveToolMessage = (toolMessage?: ChatMessageTool): ContentTool[] => {
-  if (!toolMessage) {
+  if (!toolMessage || toolMessage.error) {
     return [];
   }
 
-  const content =
-    toolMessage.error !== null && toolMessage.error
-      ? toolMessage.error.message
-      : toolMessage.content;
+  const content = toolMessage.content;
   if (typeof content === "string") {
     return [
       {

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -38,9 +38,9 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
   className,
   display,
   labels,
+  maxLabelLength,
   linking,
   tools,
-  maxLabelLength,
 }) => {
   const highlightUserMessage = display?.highlightUserMessage ?? true;
   const showLabels = labels?.show ?? true;
@@ -67,14 +67,9 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
     hasToolCalls && !hasVisibleContent(resolvedMessage.message);
 
   const rowLabel = useLabels
-    ? (() => {
-        const number = index + 1;
-        const maxlabelLen = maxLabelLength ?? 3;
-        return labelValues && resolvedMessage.message.id
-          ? labelValues[resolvedMessage.message.id] ||
-              "\u00A0".repeat(maxlabelLen * 2)
-          : String(number) || undefined;
-      })()
+    ? labelValues && resolvedMessage.message.id
+      ? labelValues[resolvedMessage.message.id]
+      : String(index + 1)
     : undefined;
 
   if (!skipChatMessage) {
@@ -171,6 +166,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
                     styles.number,
                     styles.label
                   )}
+                  style={{ minWidth: `${maxLabelLength ?? 3}ch` }}
                 >
                   {label}
                 </div>

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -6,8 +6,8 @@ import type { ChatMessageTool } from "@tsmono/inspect-common/types";
 import { ChatMessage } from "./ChatMessage";
 import styles from "./ChatMessageRow.module.css";
 import { Message, ResolvedMessage } from "./messages";
-import { ToolCallErrorView } from "./tools/ToolCallErrorView";
 import { resolveToolInput, substituteToolCallContent } from "./tools/tool";
+import { ToolCallErrorView } from "./tools/ToolCallErrorView";
 import { ToolCallView } from "./tools/ToolCallView";
 import {
   ChatViewDisplayOptions,
@@ -98,7 +98,6 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
     const toolMessages = resolvedMessage.toolMessages || [];
     let idx = 0;
     for (const tool_call of resolvedMessage.message.tool_calls) {
-      
       // Extract tool input
       const { name, input, description, functionCall, contentType } =
         resolveToolInput(tool_call.function, tool_call.arguments);

--- a/packages/inspect-components/src/chat/index.ts
+++ b/packages/inspect-components/src/chat/index.ts
@@ -27,6 +27,7 @@ export {
 // Components
 export type { ToolCallViewProps } from "./tools/ToolCallView";
 export { ToolCallView } from "./tools/ToolCallView";
+export { ToolCallErrorView } from "./tools/ToolCallErrorView";
 export { ToolOutput } from "./tools/ToolOutput";
 export { MessageContent, isMessageContent } from "./MessageContent";
 export type { MessagesContext } from "./MessageContents";

--- a/packages/inspect-components/src/chat/tools/ToolCallErrorView.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolCallErrorView.module.css
@@ -1,0 +1,19 @@
+.error {
+  color: var(--bs-danger);
+  background-color: rgba(var(--bs-danger-rgb), 0.06);
+  padding: 0.5em 0.7em;
+  border-radius: var(--bs-border-radius);
+  font-family: var(--bs-font-monospace);
+  overflow-wrap: anywhere;
+  margin: 0.5em 0;
+}
+
+.type {
+  font-weight: 600;
+  margin-bottom: 0.25em;
+  text-transform: capitalize;
+}
+
+.message {
+  white-space: pre-wrap;
+}

--- a/packages/inspect-components/src/chat/tools/ToolCallErrorView.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallErrorView.tsx
@@ -1,0 +1,22 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+import type { ToolCallError } from "@tsmono/inspect-common/types";
+
+import styles from "./ToolCallErrorView.module.css";
+
+interface ToolCallErrorViewProps {
+  error: ToolCallError;
+  className?: string | string[];
+}
+
+export const ToolCallErrorView: FC<ToolCallErrorViewProps> = ({
+  error,
+  className,
+}) => {
+  return (
+    <div className={clsx(styles.error, "text-size-smallest", className)}>
+      <div className={styles.message}>{error.message}</div>
+    </div>
+  );
+};

--- a/packages/inspect-components/src/chat/tools/ToolCallView.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.tsx
@@ -188,9 +188,9 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
         >
           <MessageContent contents={normalizedContent} context={context} />
         </ExpandablePanel>
-      ) : (
+      ) : hasContent ? (
         <MessageContent contents={normalizedContent} context={context} />
-      )}
+      ) : null}
     </div>
   );
 };

--- a/packages/inspect-components/src/chat/tools/ToolTitle.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolTitle.module.css
@@ -5,6 +5,7 @@
 
 .toolTitle {
   color: unset !important;
+  overflow-wrap: anywhere;
 }
 
 .description {

--- a/packages/inspect-components/src/transcript/ModelEventView.module.css
+++ b/packages/inspect-components/src/transcript/ModelEventView.module.css
@@ -68,17 +68,19 @@
 
 .toolConfig {
   display: grid;
-  grid-template-columns: max-content auto;
+  grid-template-columns: max-content minmax(0, auto);
   column-gap: 1em;
   row-gap: 0.5em;
   padding-top: 0.5em;
+  overflow-wrap: anywhere;
 }
 
 .toolChoice {
   border-top: solid var(--bs-light-border-subtle) 1px;
   display: grid;
-  grid-template-columns: max-content auto;
+  grid-template-columns: max-content minmax(0, auto);
   column-gap: 1em;
   margin-top: 0.5em;
   padding-top: 0.5em;
+  overflow-wrap: anywhere;
 }

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -11,7 +11,11 @@ import type {
 import { ChatView } from "@tsmono/inspect-components/chat";
 import { MetaDataGrid } from "@tsmono/inspect-components/content";
 import { ModelUsagePanel } from "@tsmono/inspect-components/usage";
-import { ExpandablePanel, MarkdownDiv, PulsingDots } from "@tsmono/react/components";
+import {
+  ExpandablePanel,
+  MarkdownDiv,
+  PulsingDots,
+} from "@tsmono/react/components";
 import { usePrismHighlight } from "@tsmono/react/hooks";
 
 import { EventPanel } from "./event/EventPanel";
@@ -294,7 +298,7 @@ const ToolsConfig: FC<ToolConfigProps> = ({ tools, toolChoice }) => {
           {tool.name}
         </div>
         <ExpandablePanel id={`config-${tool.name}-${idx}`} collapse={true}>
-        <MarkdownDiv markdown={tool.description}/>
+          <MarkdownDiv markdown={tool.description} />
         </ExpandablePanel>
       </Fragment>
     );

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -53,45 +53,62 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   // For any user messages which immediately preceded this model call, including a
   // panel and display those user messages (exclude tool_call messages as they
   // are already shown in the tool call above)
-  const userMessages: ChatMessage[] = [];
+  const userMessages = useMemo<ChatMessage[]>(() => {
+    const result: ChatMessage[] = [];
 
-  // When agent tool results have been filtered from input (shown on AgentCard
-  // instead), the trailing assistant message is the previous model call's output
-  // — just show it without crawling backward through system/user messages.
-  const agentResultsFiltered = !!(event as Record<string, unknown>)
-    .agentResultsFiltered;
+    // When agent tool results have been filtered from input (shown on AgentCard
+    // instead), the trailing assistant message is the previous model call's output
+    // — just show it without crawling backward through system/user messages.
+    const agentResultsFiltered = !!(event as Record<string, unknown>)
+      .agentResultsFiltered;
 
-  if (!agentResultsFiltered) {
-    // if there is an assistant message immediately before then include this
-    // (as it could be an assistant compaction message)
-    let offset: number | undefined = undefined;
-    const lastMessage = event.input.at(-1);
-    if (lastMessage?.role === "assistant") {
-      userMessages.push(lastMessage);
-      offset = -1;
-    }
+    if (!agentResultsFiltered) {
+      // if there is an assistant message immediately before then include this
+      // (as it could be an assistant compaction message)
+      let offset: number | undefined = undefined;
+      const lastMessage = event.input.at(-1);
+      if (lastMessage?.role === "assistant") {
+        result.push(lastMessage);
+        offset = -1;
+      }
 
-    for (const msg of event.input.slice(offset).reverse()) {
-      if (
-        (msg.role === "user" && !msg.tool_call_id) ||
-        msg.role === "system" ||
-        // If the client doesn't support tool events, then tools messages are allowed to be displayed
-        // in this view, since no tool events will be shown.
-        (context?.hasToolEvents === false && msg.role === "tool")
-      ) {
-        userMessages.unshift(msg);
-      } else {
-        break;
+      for (const msg of event.input.slice(offset).reverse()) {
+        if (
+          (msg.role === "user" && !msg.tool_call_id) ||
+          msg.role === "system" ||
+          // If the client doesn't support tool events, then tools messages are allowed to be displayed
+          // in this view, since no tool events will be shown.
+          (context?.hasToolEvents === false && msg.role === "tool")
+        ) {
+          result.unshift(msg);
+        } else {
+          break;
+        }
       }
     }
-  }
+
+    return result;
+  }, [event, context?.hasToolEvents]);
 
   const hasHiddenMessages = event.input.length > userMessages.length;
   const [showAllMessages, setShowAllMessages] = useState(false);
 
-  const summaryMessages = showAllMessages
-    ? [...event.input, ...(outputMessages || [])]
-    : [...userMessages, ...(outputMessages || [])];
+  const summaryMessages = useMemo(
+    () =>
+      showAllMessages
+        ? [...event.input, ...(outputMessages || [])]
+        : [...userMessages, ...(outputMessages || [])],
+    [showAllMessages, event.input, outputMessages, userMessages]
+  );
+
+  // Only enable labels for the Summary when at least one visible message has
+  // a matching entry — otherwise every row reserves an empty label column.
+  const summaryLabels = useMemo(() => {
+    const map = context?.messageLabels;
+    if (!map) return { show: false } as const;
+    const hasAny = summaryMessages.some((m) => !!m.id && !!map[m.id]);
+    return hasAny ? { messageLabels: map } : ({ show: false } as const);
+  }, [context?.messageLabels, summaryMessages]);
 
   const panelTitle = event.role
     ? `Model Call (${event.role}): ${event.model}`
@@ -142,11 +159,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
             callStyle: showToolCalls ? "complete" : "omit",
             collapseToolMessages: context?.hasToolEvents !== false,
           }}
-          labels={
-            context?.messageLabels
-              ? { messageLabels: context.messageLabels }
-              : { show: false }
-          }
+          labels={summaryLabels}
         />
         {event.error ? (
           <EventSection title="Error">

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -11,7 +11,7 @@ import type {
 import { ChatView } from "@tsmono/inspect-components/chat";
 import { MetaDataGrid } from "@tsmono/inspect-components/content";
 import { ModelUsagePanel } from "@tsmono/inspect-components/usage";
-import { PulsingDots } from "@tsmono/react/components";
+import { ExpandablePanel, MarkdownDiv, PulsingDots } from "@tsmono/react/components";
 import { usePrismHighlight } from "@tsmono/react/hooks";
 
 import { EventPanel } from "./event/EventPanel";
@@ -293,7 +293,9 @@ const ToolsConfig: FC<ToolConfigProps> = ({ tools, toolChoice }) => {
         <div className={clsx("text-style-label", "text-style-secondary")}>
           {tool.name}
         </div>
-        <div>{tool.description}</div>
+        <ExpandablePanel id={`config-${tool.name}-${idx}`} collapse={true}>
+        <MarkdownDiv markdown={tool.description}/>
+        </ExpandablePanel>
       </Fragment>
     );
   });

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -78,7 +78,8 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event.events]);
 
-  const title = `Tool: ${resolvedView?.title || name}`;
+  const displayName = resolvedView?.title || name;
+  const title = displayName ? `Tool: ${displayName}` : "Tool";
 
   const turnLabel = context?.turnInfo
     ? `turn ${context.turnInfo.turnNumber}/${context.turnInfo.totalTurns}`

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -10,6 +10,7 @@ import {
   ChatView,
   resolveToolInput,
   substituteToolCallContent,
+  ToolCallErrorView,
   ToolCallView,
 } from "@tsmono/inspect-components/chat";
 import { PulsingDots } from "@tsmono/react/components";
@@ -107,10 +108,12 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
           input={input}
           description={description}
           contentType={contentType}
-          output={event.error?.message || event.result || ""}
+          output={event.error ? "" : event.result || ""}
           mode="compact"
           view={resolvedView}
         />
+
+        {event.error ? <ToolCallErrorView error={event.error} /> : null}
 
         {lastModelNode ? (
           <ChatView


### PR DESCRIPTION
### Summary
A batch of UI fixes and enhancements for how chat messages, tool calls, and model events render in the transcript view.

### Changes

- Tool configuration rendering — render tool descriptions as markdown and wrap them in an expandable panel to cap height (fixes #120)
- Tool call error rendering — new dedicated ToolCallErrorView component with its own styling (fixes #113)
- Tool content wrapping — force wrapping for long tool content/titles so it no longer overflows (fixes #112, #115, #117)
- Model event view — refactored layout with improved label spacing and more consistent positioning of unlabeled messages (fixes #111, #118)
- Formatting cleanup