### PR TITLE
Don’t show double borders (or corners) on root elements of transcript

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.module.css
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.module.css
@@ -18,6 +18,12 @@
   border-top-right-radius: 0;
 }
 
+.depthRoot {
+  border-left: none;
+  border-right: none;
+  border-radius: 0;
+}
+
 .last {
   padding-bottom: 0.8rem;
 }

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -159,6 +159,7 @@ export const TranscriptVirtualListComponent: FC<
       const attachedParentClass = attachedParent
         ? styles.attachedParent
         : undefined;
+      const depthRootClass = item.depth === 0 ? styles.depthRoot : undefined;
 
       const context = contextMap.get(item.id);
       const isLast = index === eventNodes.length - 1;
@@ -182,7 +183,11 @@ export const TranscriptVirtualListComponent: FC<
           <RenderedEventNode
             node={item}
             next={next}
-            className={clsx(attachedParentClass, attachedChildClass)}
+            className={clsx(
+              attachedParentClass,
+              attachedChildClass,
+              depthRootClass
+            )}
             context={context}
             onAutoCollapse={onAutoCollapse}
             renderAgentCard={renderAgentCard}


### PR DESCRIPTION
fixes #127