### PR TITLE
Fix message ordering in running-sample Messages tab

### DIFF
--- a/apps/inspect/src/app/samples/messagesFromEvents.test.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.test.ts
@@ -1,20 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
 
 import { messagesFromEvents } from "./messagesFromEvents";
 
 const makeModelEvent = (opts: {
   error?: string;
+  input?: ChatMessage[];
   inputId?: string;
   outputId?: string;
 }): Event =>
   ({
     event: "model",
     error: opts.error ?? null,
-    input: opts.inputId
-      ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
-      : [],
+    input:
+      opts.input ??
+      (opts.inputId
+        ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
+        : []),
     output: {
       choices: [
         {
@@ -28,6 +31,23 @@ const makeModelEvent = (opts: {
       ],
     },
   }) as unknown as Event;
+
+const userMsg = (id: string): ChatMessage =>
+  ({ id, role: "user", content: "u", source: null }) as unknown as ChatMessage;
+const assistantMsg = (id: string): ChatMessage =>
+  ({
+    id,
+    role: "assistant",
+    content: "a",
+    source: "generate",
+  }) as unknown as ChatMessage;
+const toolMsg = (id: string): ChatMessage =>
+  ({
+    id,
+    role: "tool",
+    content: "t",
+    source: null,
+  }) as unknown as ChatMessage;
 
 describe("messagesFromEvents", () => {
   it("returns messages from successful model events", () => {
@@ -51,5 +71,164 @@ describe("messagesFromEvents", () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]!.id).toBe("msg-1");
     expect(messages[1]!.id).toBe("msg-2");
+  });
+
+  it("includes the latest event's output when not yet folded into a later input", () => {
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1")],
+        outputId: "a1",
+      }),
+    ];
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("returns [] for an empty event stream", () => {
+    expect(messagesFromEvents([])).toEqual([]);
+  });
+
+  it("returns [] when every model event has an error", () => {
+    const events = [
+      makeModelEvent({
+        error: "429 rate limit",
+        inputId: "msg-1",
+        outputId: "msg-err-1",
+      }),
+      makeModelEvent({
+        error: "500 server error",
+        inputId: "msg-1",
+        outputId: "msg-err-2",
+      }),
+    ];
+    expect(messagesFromEvents(events)).toEqual([]);
+  });
+
+  it("interleaves tool results with their assistants when a later event folds them in", () => {
+    // Multiple model events produce tool-calling assistants without their
+    // tool results yet folded into subsequent inputs. A late event finally
+    // arrives with all the tool results interleaved. Each tool result must
+    // slot in immediately after the assistant whose call it answered.
+    const events = [
+      makeModelEvent({ input: [userMsg("u1")], outputId: "a1" }),
+      makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1"), assistantMsg("a2")],
+        outputId: "a3",
+      }),
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          assistantMsg("a1"),
+          toolMsg("t1"),
+          assistantMsg("a2"),
+          toolMsg("t2"),
+          assistantMsg("a3"),
+          toolMsg("t3"),
+        ],
+        outputId: "a4",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "t1",
+      "a2",
+      "t2",
+      "a3",
+      "t3",
+      "a4",
+    ]);
+  });
+
+  it("preserves pre-compaction messages when later inputs are compacted", () => {
+    // After compaction the next model event's input is a shortened summary
+    // view that omits earlier messages. Those earlier messages must still
+    // be visible, with the new compaction summary slotted in after them.
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2"), assistantMsg("a1")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [userMsg("summary"), assistantMsg("a2")],
+        outputId: "a3",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "u2",
+      "a1",
+      "a2",
+      "summary",
+      "a3",
+    ]);
+  });
+
+  it("ignores duplicate ids within a single event's input", () => {
+    // A duplicate input id would otherwise re-anchor the cursor backwards
+    // and corrupt the ordering of subsequent new messages in the same walk.
+    const events = [
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          assistantMsg("a1"),
+          userMsg("u1"),
+          toolMsg("t1"),
+        ],
+        outputId: "a2",
+      }),
+    ];
+    expect(messagesFromEvents(events).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "t1",
+      "a2",
+    ]);
+  });
+
+  it("places intermediate-output assistants between their event's neighbors", () => {
+    // Two events share the same input, the second produces an extra
+    // assistant. A later event has new tool/user messages folded in.
+    // The intermediate assistant slots between its event's last input
+    // anchor (u2) and its successor in the next event's input.
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2")],
+        outputId: "a1",
+      }),
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          userMsg("u2"),
+          assistantMsg("a1"),
+          toolMsg("t1"),
+          userMsg("u3"),
+        ],
+        outputId: "a3",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "u2",
+      "a1",
+      "t1",
+      "u3",
+      "a2",
+      "a3",
+    ]);
   });
 });

--- a/apps/inspect/src/app/samples/messagesFromEvents.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.ts
@@ -1,41 +1,58 @@
 import type {
   ChatMessage,
-  ChatMessageAssistant,
-  ChatMessageSystem,
-  ChatMessageTool,
-  ChatMessageUser,
   Event,
+  ModelEvent,
 } from "@tsmono/inspect-common/types";
 
+const isSuccessfulModelEvent = (e: Event): e is ModelEvent =>
+  e.event === "model" && !e.error;
+
 export const messagesFromEvents = (runningEvents: Event[]): ChatMessage[] => {
-  const messages: Map<
-    string,
-    ChatMessageSystem | ChatMessageUser | ChatMessageAssistant | ChatMessageTool
-  > = new Map();
+  const modelEvents = runningEvents.filter(isSuccessfulModelEvent);
 
-  runningEvents
-    .filter((e) => e.event === "model")
-    .filter((e) => !e.error)
-    .forEach((e) => {
-      for (const m of e.input) {
-        const inputMessage = m as
-          | ChatMessageSystem
-          | ChatMessageUser
-          | ChatMessageAssistant
-          | ChatMessageTool;
-        if (inputMessage.id && !messages.has(inputMessage.id)) {
-          messages.set(inputMessage.id, inputMessage);
-        }
-      }
-      const outputMessage = e.output.choices[0].message;
-      if (outputMessage.id) {
-        messages.set(outputMessage.id, outputMessage);
-      }
-    });
+  // Build the conversation list by merging each model event's `input`
+  // (the model's view at that call) in order. Per event: reset a cursor
+  // to the end of the list, then walk its input. Known ids re-anchor
+  // the cursor to their position without re-inserting; new ids splice
+  // at cursor + 1. The output appends at the end of the list (not at
+  // cursor + 1) and dedupes by id.
+  //
+  // The end-of-list cursor default lets an event whose input begins
+  // with unseen messages (e.g. a compaction summary introduced ahead
+  // of any prior anchor) extend the prefix rather than prepend. The
+  // output-at-end rule then keeps the post-compaction assistant after
+  // the summary, not between it and earlier history.
+  const result: ChatMessage[] = [];
+  const positions = new Map<string, number>();
 
-  if (messages.size > 0) {
-    return messages.values().toArray();
-  } else {
-    return [];
+  const insert = (index: number, m: ChatMessage) => {
+    result.splice(index, 0, m);
+    for (const [id, pos] of positions) {
+      if (pos >= index) positions.set(id, pos + 1);
+    }
+    if (m.id) positions.set(m.id, index);
+  };
+
+  for (const e of modelEvents) {
+    let cursor = result.length - 1;
+    const seenInEvent = new Set<string>();
+    for (const m of e.input) {
+      if (!m.id || seenInEvent.has(m.id)) continue;
+      seenInEvent.add(m.id);
+      const known = positions.get(m.id);
+      if (known !== undefined) {
+        cursor = known;
+      } else {
+        cursor += 1;
+        insert(cursor, m);
+      }
+    }
+    const out = e.output.choices[0]?.message;
+    if (out?.id && !positions.has(out.id)) {
+      positions.set(out.id, result.length);
+      result.push(out);
+    }
   }
+
+  return result;
 };


### PR DESCRIPTION
## Summary

While a sample is running, the Messages tab built its list by walking model events in stream order with a `Map<id, message>`. `Map.set` on an existing key keeps the original insertion position, so tool results and follow-up user turns from later events were appended at the end instead of slotting between the assistants that produced them. The bug self-healed once the sample completed and the server-provided `sample.messages` was used instead.

This PR walks model events in order and reconstructs the conversation incrementally. Known messages in each event's `input` anchor a cursor to their position; new messages splice in at `cursor + 1`. Outputs append. The cursor defaults to the end of the list so a fresh first message in an event (e.g. a compaction summary that the post-compaction event introduces ahead of any prior anchor) lands after the existing prefix rather than at the front.

This handles three scenarios:

1. **Original bug — tool results clumped at the end.** When tool results first appear in a later event's `input` interleaved among earlier assistants, they splice immediately after the assistant whose call they answer, not at the end.
2. **Compaction.** Post-compaction events have a shortened `input` that omits earlier messages. Those earlier messages stay visible (they're already in the running list), and the new compaction summary slots in after them.
3. **Intermediate outputs not folded into a later input.** An assistant produced by an event whose output never appears in a subsequent event's `input` lands between its event's last input anchor and the next event's new messages.

## Test plan

- [X] Manual: load a running sample with tool calls and verify Messages tab interleaves assistants/tools/users correctly; verify a compacting sample preserves pre-compaction history.