### PR TITLE
Task list per-scope filter/sort + samples Tokens/Duration columns

### DIFF
--- a/apps/inspect/e2e/log-list-filters.spec.ts
+++ b/apps/inspect/e2e/log-list-filters.spec.ts
@@ -18,8 +18,8 @@
  * Tests drive AG-Grid via column-header sort clicks and via setFilterModel
  * through a dev-only window hook on LogListGrid (`__inspectGridApi`).
  */
-import { http, HttpResponse } from "msw";
 import type { Page } from "@playwright/test";
+import { http, HttpResponse } from "msw";
 
 import { expect, test } from "./fixtures/app";
 import {
@@ -87,9 +87,7 @@ function setupHandlers(
   network: Parameters<Parameters<typeof test>[2]>[0]["network"]
 ) {
   network.use(
-    http.get("*/api/log-dir", () =>
-      HttpResponse.json({ log_dir: LOG_DIR })
-    ),
+    http.get("*/api/log-dir", () => HttpResponse.json({ log_dir: LOG_DIR })),
     http.get("*/api/logs", () =>
       HttpResponse.json({ log_dir: LOG_DIR, files: LOG_FILES })
     ),

--- a/apps/inspect/e2e/log-list-filters.spec.ts
+++ b/apps/inspect/e2e/log-list-filters.spec.ts
@@ -1,0 +1,458 @@
+/**
+ * E2E tests for log-list filter / column-ordering scope behavior.
+ *
+ * Each scope (Tasks segment vs Folders segment, individual folders, etc.)
+ * keeps its own filter+sort independently in the store. Switching scopes
+ * shows that scope's own state; switching back restores what was there.
+ *
+ * Issue #136: Originally filed because Tasks and Folders shared a single
+ * gridState slot — applying a sort in one bled into the other. Now each
+ * scope has its own slot, so:
+ *   - Tasks ↔ Folders round-trip preserves each side's state independently.
+ *   - Drilling into a fresh subfolder shows a clean grid (that scope has
+ *     no prior state).
+ *
+ * Issue #137: Navigating into a log and pressing back must PRESERVE the
+ * filter and ordering on the task list (same scope round-trip).
+ *
+ * Tests drive AG-Grid via column-header sort clicks and via setFilterModel
+ * through a dev-only window hook on LogListGrid (`__inspectGridApi`).
+ */
+import { http, HttpResponse } from "msw";
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures/app";
+import {
+  createEvalLog,
+  createEvalSample,
+  createLogDetails,
+} from "./fixtures/test-data";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const LOG_DIR = "/home/test/logs";
+
+const LOG_FILES = [
+  {
+    name: `${LOG_DIR}/2025-01-15T10-00-00_task-alpha_abc123.eval`,
+    task: "task-alpha",
+    task_id: "task-alpha",
+  },
+  {
+    name: `${LOG_DIR}/2025-01-15T10-05-00_task-beta_def456.eval`,
+    task: "task-beta",
+    task_id: "task-beta",
+  },
+  {
+    name: `${LOG_DIR}/subdir/2025-01-15T10-10-00_task-gamma_ghi789.eval`,
+    task: "task-gamma",
+    task_id: "task-gamma",
+  },
+];
+
+const LOG_HEADERS = LOG_FILES.map((f, i) => ({
+  eval_id: `eval-${i}`,
+  run_id: `run-${i}`,
+  task: f.task,
+  task_id: f.task_id,
+  task_version: 1,
+  model: "claude-sonnet-4-5-20250929",
+  status: "success",
+  started_at: "2025-01-15T10:00:00Z",
+  completed_at: "2025-01-15T10:05:00Z",
+}));
+
+function makeSampleLog(taskName: string) {
+  const sample = createEvalSample({
+    id: 1,
+    epoch: 1,
+    messages: [
+      { role: "user", content: `Input for ${taskName}`, source: "input" },
+      {
+        role: "assistant",
+        content: `Response for ${taskName}`,
+        source: "generate",
+      },
+    ],
+  });
+  return createEvalLog({
+    samples: [sample],
+    eval: { task: taskName, task_id: taskName },
+  });
+}
+
+function setupHandlers(
+  network: Parameters<Parameters<typeof test>[2]>[0]["network"]
+) {
+  network.use(
+    http.get("*/api/log-dir", () =>
+      HttpResponse.json({ log_dir: LOG_DIR })
+    ),
+    http.get("*/api/logs", () =>
+      HttpResponse.json({ log_dir: LOG_DIR, files: LOG_FILES })
+    ),
+    http.get("*/api/log-files*", () =>
+      HttpResponse.json({ files: LOG_FILES, response_type: "full" })
+    ),
+    http.get("*/api/log-headers*", () => HttpResponse.json(LOG_HEADERS)),
+    http.get("*/api/logs/:file", ({ params }) => {
+      const file = decodeURIComponent(params.file as string);
+      const match = LOG_FILES.find(
+        (f) => f.name === file || file.endsWith(f.name)
+      );
+      return HttpResponse.json(makeSampleLog(match?.task ?? "unknown"));
+    }),
+    http.get("*/api/log-details/:file", ({ params }) => {
+      const file = decodeURIComponent(params.file as string);
+      const match = LOG_FILES.find(
+        (f) => f.name === file || file.endsWith(f.name)
+      );
+      return HttpResponse.json(
+        createLogDetails(makeSampleLog(match?.task ?? "unknown"))
+      );
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function segmentButton(page: Page, name: string) {
+  return page.getByRole("button", { name });
+}
+
+function gridCell(page: Page, text: string) {
+  return page.locator(".ag-cell").filter({ hasText: text }).first();
+}
+
+function taskColumnHeader(page: Page) {
+  return page.locator('.ag-header-cell[col-id="task"]').first();
+}
+
+function resetFiltersButton(page: Page) {
+  return page.getByRole("button", { name: "Reset Filters" });
+}
+
+/**
+ * Apply a "task contains <value>" filter via the dev-only window hook.
+ * LogListGrid stashes its api on window.__inspectGridApi when running in
+ * vite dev / Playwright (DEV mode); production builds drop the branch.
+ */
+async function applyTaskFilter(page: Page, value: string) {
+  await page.waitForFunction(() => {
+    return (
+      (window as unknown as { __inspectGridApi?: unknown }).__inspectGridApi !==
+      undefined
+    );
+  });
+  await page.evaluate((filterValue: string) => {
+    const api = (
+      window as unknown as {
+        __inspectGridApi: {
+          setFilterModel: (m: unknown) => void;
+          onFilterChanged?: () => void;
+        };
+      }
+    ).__inspectGridApi;
+    api.setFilterModel({
+      task: { filterType: "text", type: "contains", filter: filterValue },
+    });
+  }, value);
+  await expect(resetFiltersButton(page)).toBeVisible();
+}
+
+async function waitForGrid(page: Page) {
+  await expect(page.locator(".ag-root-wrapper")).toBeVisible();
+  await expect(gridCell(page, "task-alpha")).toBeVisible();
+}
+
+async function sortByTaskDesc(page: Page) {
+  const header = taskColumnHeader(page);
+  // Two clicks on Balham theme: asc, then desc.
+  await header.click();
+  await expect(header).toHaveAttribute("aria-sort", "ascending");
+  await header.click();
+  await expect(header).toHaveAttribute("aria-sort", "descending");
+}
+
+async function expectSortedDesc(page: Page) {
+  await expect(taskColumnHeader(page)).toHaveAttribute(
+    "aria-sort",
+    "descending"
+  );
+}
+
+async function expectNoSort(page: Page) {
+  await expect(taskColumnHeader(page)).toHaveAttribute("aria-sort", "none");
+}
+
+// ---------------------------------------------------------------------------
+// Per-scope state — each scope (Tasks/Folders segment, each folder)
+// keeps its filter+sort independently.
+// ---------------------------------------------------------------------------
+
+test.describe("Per-scope filter and ordering", () => {
+  test("Tasks segment's sort doesn't leak into Folders segment", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await segmentButton(page, "Folders").click();
+    await expect(page).toHaveURL(/#\/logs/);
+    await waitForGrid(page);
+    // Folders has its own (empty) state — Tasks' sort doesn't bleed in.
+    await expectNoSort(page);
+  });
+
+  test("Tasks segment's filter doesn't leak into Folders segment", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await applyTaskFilter(page, "alpha");
+
+    await segmentButton(page, "Folders").click();
+    await expect(page).toHaveURL(/#\/logs/);
+    await waitForGrid(page);
+    await expect(resetFiltersButton(page)).toBeHidden();
+  });
+
+  test("Tasks ↔ Folders round-trip restores Tasks' sort", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await segmentButton(page, "Folders").click();
+    await expect(page).toHaveURL(/#\/logs/);
+    await waitForGrid(page);
+    await expectNoSort(page);
+
+    await segmentButton(page, "Tasks").click();
+    await expect(page).toHaveURL(/#\/tasks/);
+    await waitForGrid(page);
+    // Tasks' sort is restored — independent of Folders' state.
+    await expectSortedDesc(page);
+  });
+
+  test("Tasks ↔ Folders round-trip restores Tasks' filter", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await applyTaskFilter(page, "alpha");
+
+    await segmentButton(page, "Folders").click();
+    await expect(page).toHaveURL(/#\/logs/);
+    await waitForGrid(page);
+    await expect(resetFiltersButton(page)).toBeHidden();
+
+    await segmentButton(page, "Tasks").click();
+    await expect(page).toHaveURL(/#\/tasks/);
+    await waitForGrid(page);
+    await expect(resetFiltersButton(page)).toBeVisible();
+  });
+
+  test("Drilling into a fresh folder shows a clean grid", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/#/logs");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await gridCell(page, "subdir").click();
+    await expect(page).toHaveURL(/#\/logs\/subdir/);
+    await expect(gridCell(page, "task-gamma")).toBeVisible();
+    // The subdir scope has no prior state — clean grid.
+    await expectNoSort(page);
+  });
+
+  test("Each folder remembers its own filter independently", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/#/logs");
+    await waitForGrid(page);
+
+    // Apply filter at the root folder.
+    await applyTaskFilter(page, "subdir");
+    await expect(resetFiltersButton(page)).toBeVisible();
+
+    // Drill into subdir — its own scope, no filter.
+    await gridCell(page, "subdir").click();
+    await expect(page).toHaveURL(/#\/logs\/subdir/);
+    await expect(gridCell(page, "task-gamma")).toBeVisible();
+    await expect(resetFiltersButton(page)).toBeHidden();
+  });
+});
+
+test.describe("Tasks ↔ Samples round-trip preserves ordering", () => {
+  // Samples is a different surface, not a different log-list scope. Like
+  // going to a log and back, this round-trip should leave the task list's
+  // sort untouched.
+  test("Tasks → Samples → Tasks preserves column ordering", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await segmentButton(page, "Samples").click();
+    await expect(page).toHaveURL(/#\/samples/);
+
+    await segmentButton(page, "Tasks").click();
+    await expect(page).toHaveURL(/#\/tasks/);
+    await waitForGrid(page);
+    await expectSortedDesc(page);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #137 — navigating into a log and back MUST preserve ordering
+// ---------------------------------------------------------------------------
+
+test.describe("#137 – Back from a log preserves ordering", () => {
+  test("Tasks → log → back preserves column ordering", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/tasks\/.+\.eval/);
+
+    await page.goBack();
+    // goto("/") landed on the index route — back returns to that bare URL
+    // (no /#/tasks suffix). Wait until it looks like the task list again.
+    await waitForGrid(page);
+    await expectSortedDesc(page);
+  });
+
+  test("Folders → log → back preserves column ordering", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/#/logs");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/logs\/.+\.eval/);
+
+    await page.goBack();
+    await page.waitForURL(/#\/logs\/?$/);
+    await waitForGrid(page);
+    await expectSortedDesc(page);
+  });
+
+  test("Tasks → log → back preserves filter", async ({ page, network }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await applyTaskFilter(page, "alpha");
+
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/tasks\/.+\.eval/);
+
+    await page.goBack();
+    await waitForGrid(page);
+    await expect(resetFiltersButton(page)).toBeVisible();
+  });
+
+  test("Folders → log → back preserves filter", async ({ page, network }) => {
+    setupHandlers(network);
+    await page.goto("/#/logs");
+    await waitForGrid(page);
+
+    await applyTaskFilter(page, "alpha");
+
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/logs\/.+\.eval/);
+
+    await page.goBack();
+    await page.waitForURL(/#\/logs\/?$/);
+    await waitForGrid(page);
+    await expect(resetFiltersButton(page)).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression — adjacent behaviors that must keep working both before and
+// after the fix.
+// ---------------------------------------------------------------------------
+
+test.describe("Regression — adjacent behaviors", () => {
+  test("Sort indicator appears after clicking a column header", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    const header = taskColumnHeader(page);
+    await header.click();
+    await expect(header).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  test("Cycling sort to none removes the indicator", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    const header = taskColumnHeader(page);
+    await header.click(); // asc
+    await header.click(); // desc
+    await header.click(); // none
+    await expectNoSort(page);
+  });
+
+  test("Sorted column still navigates into a log on row click", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await sortByTaskDesc(page);
+
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/tasks\/.+\.eval/);
+  });
+});

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -76,6 +76,15 @@ export const LogsPanel: FC<LogsPanelProps> = ({
 
   const currentDir = join(logPath || "", logDir);
 
+  // Identifies the current data scope for the log list. Each scope keeps
+  // its own filter/sort independently in the store: Tasks at the root and
+  // Folders at the root are distinct scopes, so toggling between them
+  // restores each side's state instead of clearing. Folder drill-down is
+  // a different scope (different dir), so each folder also remembers its
+  // own state. `undefined` until logDir hydrates so we never write under
+  // a half-initialized scope.
+  const scopeKey = logDir === undefined ? undefined : `${mode}::${currentDir}`;
+
   useFlowServerData(logPath || "");
   const flowData = useStore((state) => state.logs.flow);
 
@@ -419,6 +428,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
           <LogListGrid
             items={logItems}
             currentPath={currentDir}
+            scopeKey={scopeKey}
             gridRef={gridRef}
             mode={mode}
           />

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -2,6 +2,7 @@ import type {
   CellMouseDownEvent,
   ColDef,
   GridColumnsChangedEvent,
+  GridReadyEvent,
   IRowNode,
   ModelUpdatedEvent,
   RowClickedEvent,
@@ -45,6 +46,11 @@ import { LogListRow } from "./columns/types";
 interface LogListGridProps {
   items: Array<FileLogItem | FolderLogItem | PendingTaskItem>;
   currentPath?: string;
+  // Identifies the data scope of the current view (mode + directory).
+  // Reset of filter+sort is keyed on this — same scope across renders
+  // means "preserve gridState"; a change means "fresh grid". `undefined`
+  // means logDir is still hydrating and we shouldn't compare yet.
+  scopeKey?: string;
   gridRef?: RefObject<AgGridReact<LogListRow> | null>;
   mode?: LogListMode;
 }
@@ -52,16 +58,13 @@ interface LogListGridProps {
 export const LogListGrid: FC<LogListGridProps> = ({
   items,
   currentPath,
+  scopeKey,
   gridRef: externalGridRef,
   mode = "logs",
 }) => {
-  const {
-    gridState,
-    setGridState,
-    setFilteredCount,
-    previousLogPath,
-    setPreviousLogPath,
-  } = useLogsListing();
+  const { gridStateByScope, setGridState, setFilteredCount } =
+    useLogsListing();
+  const gridState = scopeKey ? gridStateByScope[scopeKey] : undefined;
 
   const { loadLogOverviews, loadAllLogOverviews } = useLogs();
 
@@ -109,20 +112,13 @@ export const LogListGrid: FC<LogListGridProps> = ({
   );
   const { columns } = useLogListColumns(mode, scopePrefix, scoresViewMode);
 
-  const initialGridState = useMemo(() => {
-    if (previousLogPath !== undefined && previousLogPath !== currentPath) {
-      const result = { ...gridState };
-      delete result.filter;
-      return result;
-    }
-    return gridState;
-  }, [currentPath, gridState, previousLogPath]);
-
-  useEffect(() => {
-    if (currentPath !== previousLogPath) {
-      setPreviousLogPath(currentPath);
-    }
-  }, [currentPath, previousLogPath, setPreviousLogPath]);
+  // Each scope (mode + dir) has its own gridState in the store, so the
+  // initial state is just the entry for the current scope. Switching to a
+  // different scope hits a different key — typically `undefined` if the
+  // scope hasn't been visited yet, which lets AG-Grid initialise with
+  // column defaults. The `key={scopeKey}` on AgGridReact remounts the
+  // grid on scope change so this initial state is actually re-applied.
+  const initialGridState = gridState;
 
   useEffect(() => {
     gridContainerRef.current?.focus();
@@ -326,6 +322,15 @@ export const LogListGrid: FC<LogListGridProps> = ({
     loadHeaders();
   }, [logFiles, loadLogOverviews, setWatchedLogs, logPreviews]);
 
+  // Dev-only test hook: expose AG-Grid api so Playwright tests can drive
+  // filter/sort programmatically. Vite strips this branch in production.
+  const handleGridReady = useCallback((e: GridReadyEvent<LogListRow>) => {
+    if (import.meta.env.DEV) {
+      (window as unknown as { __inspectGridApi?: unknown }).__inspectGridApi =
+        e.api;
+    }
+  }, []);
+
   const handleSortChanged = useCallback(async () => {
     await loadAllLogOverviews();
     setWatchedLogs(logFiles);
@@ -490,6 +495,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
       )}
       <div ref={gridContainerRef} className={styles.gridContainer} tabIndex={0}>
         <AgGridReact<LogListRow>
+          // Remount on scope change so filter/sort/column state get a clean
+          // slate. AG-Grid's `initialState` is one-shot at mount, so a key
+          // change is the cleanest way to reset everything declaratively.
+          key={scopeKey ?? "pending"}
           ref={gridRef}
           rowData={data}
           animateRows={false}
@@ -519,8 +528,13 @@ export const LogListGrid: FC<LogListGridProps> = ({
           initialState={initialGridState}
           suppressCellFocus={true}
           onStateUpdated={(e: StateUpdatedEvent<LogListRow>) => {
-            setGridState(e.state);
+            // Don't write under an unhydrated scope — we'd lose track of
+            // which scope this state belongs to.
+            if (scopeKey !== undefined) {
+              setGridState(scopeKey, e.state);
+            }
           }}
+          onGridReady={handleGridReady}
           onRowClicked={handleRowClick}
           onCellMouseDown={handleCellMouseDown}
           onSortChanged={handleSortChanged}

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -62,8 +62,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
   gridRef: externalGridRef,
   mode = "logs",
 }) => {
-  const { gridStateByScope, setGridState, setFilteredCount } =
-    useLogsListing();
+  const { gridStateByScope, setGridState, setFilteredCount } = useLogsListing();
   const gridState = scopeKey ? gridStateByScope[scopeKey] : undefined;
 
   const { loadLogOverviews, loadAllLogOverviews } = useLogs();

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -175,6 +175,17 @@ export const SamplesPanel: FC = () => {
 
     Object.entries(logDetailsInPath).forEach(([logFile, logDetail]) => {
       logDetail.sampleSummaries.forEach((sampleSummary) => {
+        let tokens: number | undefined;
+        if (sampleSummary.model_usage) {
+          const usages = Object.values(sampleSummary.model_usage);
+          if (usages.length > 0) {
+            tokens = 0;
+            for (const usage of usages) {
+              tokens += usage.total_tokens ?? 0;
+            }
+          }
+        }
+
         const row: SampleRow = {
           logFile,
           created: logDetail.eval.created,
@@ -191,6 +202,8 @@ export const SamplesPanel: FC = () => {
           limit: sampleSummary.limit,
           retries: sampleSummary.retries,
           completed: sampleSummary.completed || false,
+          tokens,
+          duration: sampleSummary.total_time ?? undefined,
           displayIndex: displayIndex++,
         };
 

--- a/apps/inspect/src/app/samples-panel/samples-grid/hooks.tsx
+++ b/apps/inspect/src/app/samples-panel/samples-grid/hooks.tsx
@@ -6,16 +6,18 @@ import {
 } from "ag-grid-community";
 import { useEffect, useMemo } from "react";
 
-import { filename } from "@tsmono/util";
+import { filename, formatNumber } from "@tsmono/util";
 
 import { LogDetails } from "../../../client/api/types";
 import { useStore } from "../../../state/store";
-import { formatDateTime } from "../../../utils/format";
+import { formatDateTime, formatTime } from "../../../utils/format";
 import styles from "../../shared/gridCells.module.css";
 import { comparators } from "../../shared/gridComparators";
 import { getFieldKey } from "../../shared/gridUtils";
 
 import { SampleRow } from "./types";
+
+const EmptyCell = () => <div>-</div>;
 
 export const useSampleColumns = (logDetails: Record<string, LogDetails>) => {
   const optionalColumnsHaveAnyData: Record<string, boolean> = useMemo(() => {
@@ -177,6 +179,48 @@ export const useSampleColumns = (logDetails: Record<string, LogDetails>) => {
         filter: true,
         resizable: true,
         cellStyle: { overflow: "hidden", textOverflow: "ellipsis" },
+      },
+      {
+        field: "tokens",
+        headerName: "Tokens",
+        initialWidth: 100,
+        minWidth: 60,
+        maxWidth: 140,
+        sortable: true,
+        filter: "agNumberColumnFilter",
+        resizable: true,
+        cellRenderer: (params: ICellRendererParams<SampleRow>) => {
+          if (params.value === undefined || params.value === null) {
+            return <EmptyCell />;
+          }
+          return <div>{formatNumber(params.value)}</div>;
+        },
+      },
+      {
+        field: "duration",
+        headerName: "Duration",
+        initialWidth: 120,
+        minWidth: 70,
+        maxWidth: 160,
+        sortable: true,
+        filter: "agNumberColumnFilter",
+        resizable: true,
+        valueFormatter: (params: ValueFormatterParams<SampleRow>) => {
+          if (params.value === undefined || params.value === null) return "";
+          return formatTime(params.value);
+        },
+        cellRenderer: (params: ICellRendererParams<SampleRow>) => {
+          if (params.value === undefined || params.value === null) {
+            return <EmptyCell />;
+          }
+          return <div>{formatTime(params.value)}</div>;
+        },
+        tooltipValueGetter: (params) => {
+          if (params.value === undefined || params.value === null) {
+            return undefined;
+          }
+          return formatTime(params.value);
+        },
       },
     ];
 

--- a/apps/inspect/src/app/samples-panel/samples-grid/types.ts
+++ b/apps/inspect/src/app/samples-panel/samples-grid/types.ts
@@ -16,5 +16,9 @@ export interface SampleRow {
   limit?: string;
   retries?: number;
   completed?: boolean;
+  // Total tokens across all model usages for this sample.
+  tokens?: number;
+  // Sample duration in seconds (total_time from the summary).
+  duration?: number;
   [key: string]: any; // For dynamic score columns
 }

--- a/apps/inspect/src/app/types.ts
+++ b/apps/inspect/src/app/types.ts
@@ -106,8 +106,10 @@ export interface LogsListing {
   filteredCount?: number;
   watchedLogs?: LogHandle[];
   selectedRowIndex?: number | null;
-  gridState?: GridState;
-  previousLogPath?: string;
+  // AG-Grid state stored independently per scope (Tasks vs Folders, each
+  // folder, etc.). Switching between scopes loads that scope's own state;
+  // switching back restores it. Keyed by `${mode}::${currentDir}`.
+  gridStateByScope: Record<string, GridState>;
   columnVisibility: Record<string, boolean>;
 }
 

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -23,6 +23,7 @@ import type {
   LogUpdate,
   MessagePoolData,
   ModelEvent,
+  ModelUsage,
   SampleInitEvent,
   SampleLimitEvent,
   SandboxEvent,
@@ -109,6 +110,13 @@ export interface SampleSummary {
   metadata?: Record<string, any>;
   completed?: boolean;
   retries?: number;
+  // Per-sample timing and token usage; populated by Inspect's Python
+  // EvalSampleSummary.summary() and serialized into summaries.json.
+  model_usage?: Record<string, ModelUsage>;
+  started_at?: string | null;
+  completed_at?: string | null;
+  total_time?: number | null;
+  working_time?: number | null;
 }
 
 // Hand-coded — generated EventData.event is JsonValue, losing the

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -487,26 +487,20 @@ export const useLogsListing = () => {
     (state) => state.logsActions.setFilteredCount
   );
 
-  const gridState = useStore((state) => state.logs.listing.gridState);
+  const gridStateByScope = useStore(
+    (state) => state.logs.listing.gridStateByScope
+  );
   const setGridState = useStore((state) => state.logsActions.setLogsGridState);
   const clearGridState = useStore(
     (state) => state.logsActions.clearLogsGridState
-  );
-  const previousLogPath = useStore(
-    (state) => state.logs.listing.previousLogPath
-  );
-  const setPreviousLogPath = useStore(
-    (state) => state.logsActions.setPreviousLogsPath
   );
 
   return {
     filteredCount,
     setFilteredCount,
-    gridState,
+    gridStateByScope,
     setGridState,
     clearGridState,
-    previousLogPath,
-    setPreviousLogPath,
   };
 };
 

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -50,9 +50,8 @@ export interface LogsSlice {
     clearWatchedLogs: () => void;
     setSelectedRowIndex: (index: number | null) => void;
 
-    setLogsGridState: (gridState: GridState | undefined) => void;
-    clearLogsGridState: () => void;
-    setPreviousLogsPath: (path: string | undefined) => void;
+    setLogsGridState: (scope: string, gridState: GridState) => void;
+    clearLogsGridState: (scope?: string) => void;
     setLogsColumnVisibility: (visibility: Record<string, boolean>) => void;
 
     setGridState: (gridState: GridState) => void;
@@ -73,6 +72,7 @@ const initialState: LogsState = {
   selectedLogFile: undefined as string | undefined,
   listing: {
     columnVisibility: {},
+    gridStateByScope: {},
   },
   pendingRequests: new Map<string, Promise<EvalHeader | null>>(),
   dbStats: {
@@ -102,8 +102,9 @@ export const createLogsSlice = (
           if (logDir !== state.logs.logDir) {
             state.logs.logDir = logDir;
             state.logs.samplesListState.gridState = undefined;
-            state.logs.listing.gridState = undefined;
-            state.logs.listing.previousLogPath = undefined;
+            // Persisted scopes referenced the old logDir's paths and are
+            // no longer meaningful; drop them so a new logDir starts fresh.
+            state.logs.listing.gridStateByScope = {};
           }
         });
       },
@@ -405,19 +406,18 @@ export const createLogsSlice = (
           state.logs.listing.selectedRowIndex = index;
         });
       },
-      setLogsGridState: (gridState: GridState | undefined) => {
+      setLogsGridState: (scope: string, gridState: GridState) => {
         set((state) => {
-          state.logs.listing.gridState = gridState;
+          state.logs.listing.gridStateByScope[scope] = gridState;
         });
       },
-      clearLogsGridState: () => {
+      clearLogsGridState: (scope?: string) => {
         set((state) => {
-          state.logs.listing.gridState = undefined;
-        });
-      },
-      setPreviousLogsPath: (path: string | undefined) => {
-        set((state) => {
-          state.logs.listing.previousLogPath = path;
+          if (scope === undefined) {
+            state.logs.listing.gridStateByScope = {};
+          } else {
+            delete state.logs.listing.gridStateByScope[scope];
+          }
         });
       },
       setLogsColumnVisibility: (visibility: Record<string, boolean>) => {

--- a/apps/inspect/src/state/store.ts
+++ b/apps/inspect/src/state/store.ts
@@ -177,7 +177,7 @@ export const initializeStore = (
               logs: state.logs,
               sample: state.sample,
             }) as unknown as StoreState,
-          version: 1,
+          version: 3,
           onRehydrateStorage: (state: StoreState) => {
             return (hydrationState, error) => {
               handleRehydrate(state);


### PR DESCRIPTION
## Summary

Two related changes to the inspect log viewer:

### 1. Task list: per-scope filter and sort (closes #136 and #137)

Each scope (Tasks segment vs Folders segment, individual folders, etc.) now keeps its own AG-Grid state independently in the store. Switching scopes shows that scope's own state; switching back restores what was there.

The previous single-slot approach with a path-based reset misfired in two ways:
- Tasks and Folders shared one slot, so toggling segments left the prior side's filter/sort in place (#136).
- On back-from-log, a stale `previousLogPath` comparison could strip the filter from the persisted gridState before AG-Grid read it (#137).

State is now keyed by `${mode}::${currentDir}` and lives in `logs.listing.gridStateByScope`. AG-Grid is remounted on scope change via `key={scopeKey}` so the per-scope `initialState` actually applies.

New e2e suite `apps/inspect/e2e/log-list-filters.spec.ts` covers:
- Per-scope independence (Tasks↔Folders don't bleed, each folder remembers its own state)
- Tasks↔Folders round-trip restores state on each side
- Tasks↔Samples and back-from-log preserve state
- Sort interaction regressions

### 2. Samples list: Tokens and Duration columns

Added Tokens and Duration columns to the samples grid, visible by default and present in the column chooser. Tokens sums `total_tokens` across the sample's `model_usage` map; Duration reads `total_time` from the summary.

The TS `SampleSummary` type is extended to expose `model_usage`, `total_time`, `working_time`, `started_at`, `completed_at` — these are already populated by Inspect's Python `EvalSampleSummary` and serialized into `summaries.json`, so no Python-side change is needed. Older logs (pre-April 2025, before `EvalSampleSummary`) render the existing empty-cell dash for these fields.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 178 unit tests pass
- [x] `pnpm e2e` — 54 e2e tests pass (incl. 14 new in `log-list-filters.spec.ts`)
- [x] Manual: apply filter/sort in Tasks, switch to Folders, verify Folders is clean; switch back, verify Tasks state restored
- [x] Manual: apply filter, click into a log, press back, verify filter preserved
- [x] Manual: open a sample list with a recent log, verify Tokens and Duration populate; toggle them off in the column chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)