### PR TITLE
Fix timeline error markers flagging every model and tool event

### DIFF
--- a/packages/inspect-components/src/transcript/timeline/markers.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/markers.test.ts
@@ -183,9 +183,12 @@ describe("isErrorEvent", () => {
     expect(isErrorEvent(node.event)).toBe(true);
   });
 
-  it("returns true for ModelEvent with output.error", () => {
+  it("returns false for ModelEvent with only output.error", () => {
+    // output.error is a soft-refusal/content-filter channel that the
+    // transcript's ModelEventView does not render, so it must not produce
+    // an error marker on its own.
     const node = makeModelEventNode(0, { outputError: "API error" });
-    expect(isErrorEvent(node.event)).toBe(true);
+    expect(isErrorEvent(node.event)).toBe(false);
   });
 
   it("returns false for ModelEvent without error", () => {

--- a/packages/inspect-components/src/transcript/timeline/markers.ts
+++ b/packages/inspect-components/src/transcript/timeline/markers.ts
@@ -45,15 +45,25 @@ export const defaultMarkerConfig: MarkerConfig = {
  * Returns true if the event is an error event.
  *
  * An event is an error if:
- * - It's a ToolEvent with `.error !== null`
- * - It's a ModelEvent with `.error !== null` or `.output.error !== null`
+ * - It's a ToolEvent with a non-null `.error`
+ * - It's a ModelEvent with a non-null `.error`
+ *
+ * Noneable fields are stripped during serialization (`exclude_none=True`), so
+ * `null`/missing both manifest as `undefined` at runtime — hence the `!= null`
+ * check. See packages/inspect-common/src/types/index.ts.
+ *
+ * Note: `ModelOutput.error` (a soft-refusal/content-filter channel populated
+ * by some providers without raising) is intentionally excluded — the
+ * transcript's ModelEventView only renders `event.error`, so flagging on
+ * `output.error` produces markers that navigate to a card with no visible
+ * error.
  */
 export function isErrorEvent(event: Event): boolean {
   if (event.event === "tool") {
-    return event.error !== null;
+    return event.error != null;
   }
   if (event.event === "model") {
-    return event.error !== null || event.output.error !== null;
+    return event.error != null;
   }
   return false;
 }
@@ -75,9 +85,7 @@ function errorTooltip(event: Event): string {
   }
   if (event.event === "model") {
     const msg =
-      (typeof event.error === "string" ? event.error : null) ??
-      (typeof event.output.error === "string" ? event.output.error : null) ??
-      "Unknown error";
+      (typeof event.error === "string" ? event.error : null) ?? "Unknown error";
     return `Error (${event.model}): ${msg}`;
   }
   return "Error";


### PR DESCRIPTION
## Summary

`isErrorEvent` used `event.error !== null`, but inspect_ai serializes Pydantic models with `exclude_none=True` — noneable fields are stripped from JSON and arrive as `undefined` at runtime. `undefined !== null` is `true`, so every model and tool event was flagged as an error. The timeline lit up with markers and clicking one landed on a card with no visible error.

- Switched the model and tool branches in `isErrorEvent` to `!= null`, which treats `null` and `undefined` identically — the standard pattern for these noneable fields. See the comment in `packages/inspect-common/src/types/index.ts` documenting this convention.
- Dropped `output.error` from the model branch. It's a narrow soft-refusal / content-filter channel (populated by Anthropic without raising — see `_providers/anthropic.py`), and `ModelEventView` doesn't render it, so a marker for it navigates to a card that shows nothing.
- Flipped the `output.error`-only test to assert `false` and added a comment explaining the deliberate behavior.

Fixes #140

## Test plan

- [x] `pnpm --filter @tsmono/inspect-components test` — 242/242 pass
- [x] `pnpm --filter @tsmono/inspect-components typecheck` — clean
- [x] `pnpm --filter @tsmono/inspect-components lint` — clean
- [x] Reload an `.eval` log in the viewer and enable error markers; confirm only events with a real `event.error` produce markers, and clicking one lands on a card with the error visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)