### PR TITLE
ExpandablePanel: fade out the bottom of truncated content

### DIFF
--- a/packages/react/src/components/ExpandablePanel.module.css
+++ b/packages/react/src/components/ExpandablePanel.module.css
@@ -22,8 +22,25 @@
   font-size: var(--inspect-font-size-base);
 }
 
-.expandableCollapsed {
-  overflow: hidden;
+/* Fade-out at the bottom of truncated content to signal "more below".
+   Applied only when collapsed AND the content overflows.
+
+   The wrapper carries `overflow: hidden` + `max-height` (set inline), so its
+   box matches the visible region — the mask gradient's "bottom" lands on the
+   last visible line rather than on the bottom of the natural-height content
+   (which would sit off-screen).
+
+   We mask the content itself (rather than overlaying a background-color
+   gradient) so the affordance works on any surface, regardless of the
+   panel's bg. The inline-right toggle is a sibling of this wrapper, so it
+   stays fully opaque. */
+.expandableTruncated {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black calc(100% - 3rem),
+    transparent
+  );
+  mask-image: linear-gradient(to bottom, black calc(100% - 3rem), transparent);
 }
 
 .moreToggle {

--- a/packages/react/src/components/ExpandablePanel.tsx
+++ b/packages/react/src/components/ExpandablePanel.tsx
@@ -61,11 +61,15 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
     );
     const contentRef = useResizeObserver(checkOverflow);
 
-    // `overflow: hidden` is only needed when collapsed (to clip to maxHeight).
-    // Leaving it on when expanded would make the panel a "scroll container"
-    // for CSS sticky purposes, trapping the sticky toggle inside the panel
-    // instead of letting it follow the outer viewport/scroll container.
-    const baseStyles: CSSProperties = collapsed
+    // `overflow: hidden` + `maxHeight` live on the inner content wrapper, not
+    // the outer panel. Two reasons:
+    //   1. Keeping it off the panel when expanded prevents the panel from
+    //      becoming a "scroll container" that would trap the sticky toggle.
+    //   2. Putting them on the wrapper means the wrapper's box matches the
+    //      visible (clipped) area, so a `mask-image` gradient on the wrapper
+    //      fades the bottom of the *visible* region — not the bottom of the
+    //      natural-height content (which would sit off-screen).
+    const contentStyles: CSSProperties = collapsed
       ? { overflow: "hidden", maxHeight: `${lines}rem` }
       : {};
 
@@ -96,17 +100,23 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
     return (
       <div className={clsx(styles.outer, className)}>
         <div
-          style={baseStyles}
-          ref={contentRef}
           data-expandable-panel="true"
           className={clsx(
             styles.expandablePanel,
-            collapsed ? styles.expandableCollapsed : undefined,
             border ? styles.expandableBordered : undefined,
             className
           )}
         >
-          {children}
+          <div
+            ref={contentRef}
+            style={contentStyles}
+            className={clsx(
+              styles.expandableContentWrap,
+              collapsed && showToggle ? styles.expandableTruncated : undefined
+            )}
+          >
+            {children}
+          </div>
           {showToggle && layout === "inline-right" && (
             <div className={styles.inlineToggleHolder}>
               <div className={styles.inlineToggleSticky}>


### PR DESCRIPTION
## Summary

When `ExpandablePanel` clips its children, the only affordance was a small "more..." button in the corner — easy to miss in dense transcripts. This PR adds a soft fade-out at the bottom of the visible region as an in-line cue that there's more content below.

- Uses `mask-image` on the content itself rather than a background-color overlay, so the fade is **background-neutral** — it works on any surface (event panels, agent cards, etc.) without callers needing to set a fade color.
- Restructured so `overflow: hidden` + `max-height` live on an inner content wrapper instead of the outer panel. Two reasons: (1) the wrapper's box now matches the visible region, so the mask gradient lands on the last visible line instead of off-screen; (2) the outer panel still has no `overflow` when expanded, preserving the existing sticky-toggle behavior. The inline toggle is a sibling of the masked wrapper, so it stays fully opaque.
- Fade depth is 3rem (~3 lines of body text). Tweak in `ExpandablePanel.module.css` if it feels off.

Fixes #142

## Test plan

- [x] `pnpm --filter @tsmono/react test` — 45/45 pass
- [x] `pnpm --filter @tsmono/react typecheck` — clean
- [x] `pnpm --filter @tsmono/react lint` — clean
- [x] Reload the viewer; confirm long chat messages, model events, and tool outputs show the fade above the "more..." button when collapsed and clipping
- [x] Confirm short content (where `showToggle` is false) renders unmasked
- [x] Confirm expanded panels render at full opacity
- [x] Confirm fade looks correct on different surfaces (event panel, agent card, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)