### PR TITLE
Bump speech-rule-engine to 4.1.4 (fixes @xmldom/xmldom vuln)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
       "seroval-plugins": ">=1.4.1",
       "postcss-url>minimatch": "^3.1.3",
       "@microsoft/api-extractor": "^7.57.6",
-      "rollup": "^4.59.0",
-      "@xmldom/xmldom": "^0.9.10"
+      "rollup": "^4.59.0"
     }
   },
   "manypkg": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "seroval-plugins": ">=1.4.1",
       "postcss-url>minimatch": "^3.1.3",
       "@microsoft/api-extractor": "^7.57.6",
-      "rollup": "^4.59.0"
+      "rollup": "^4.59.0",
+      "@xmldom/xmldom": "^0.9.10"
     }
   },
   "manypkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ overrides:
   postcss-url>minimatch: ^3.1.3
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
-  '@xmldom/xmldom': ^0.9.10
 
 importers:
 
@@ -4460,8 +4459,8 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
-  speech-rule-engine@4.1.3:
-    resolution: {integrity: sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==}
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
     hasBin: true
 
   sprintf-js@1.0.3:
@@ -8012,7 +8011,7 @@ snapshots:
       esm: 3.2.25
       mhchemparser: 4.2.1
       mj-context-menu: 0.6.1
-      speech-rule-engine: 4.1.3
+      speech-rule-engine: 4.1.4
 
   mathxyjax3@0.8.3: {}
 
@@ -8702,7 +8701,7 @@ snapshots:
   source-map@0.7.6:
     optional: true
 
-  speech-rule-engine@4.1.3:
+  speech-rule-engine@4.1.4:
     dependencies:
       '@xmldom/xmldom': 0.9.10
       commander: 13.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   postcss-url>minimatch: ^3.1.3
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
+  '@xmldom/xmldom': ^0.9.10
 
 importers:
 
@@ -2434,10 +2435,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xmldom/xmldom@0.9.9':
-    resolution: {integrity: sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==}
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6527,7 +6527,7 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xmldom/xmldom@0.9.9': {}
+  '@xmldom/xmldom@0.9.10': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -8704,7 +8704,7 @@ snapshots:
 
   speech-rule-engine@4.1.3:
     dependencies:
-      '@xmldom/xmldom': 0.9.9
+      '@xmldom/xmldom': 0.9.10
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 


### PR DESCRIPTION
## Summary
- `@xmldom/xmldom@0.9.9` had a vuln; `0.9.10` fixed it.
- It entered the tree via `mathjax-full@3.2.2` → `speech-rule-engine@4.1.3` (which pinned `@xmldom/xmldom` to **exact** `0.9.9`, blocking transitive resolution).
- `speech-rule-engine@4.1.4` ([SRE #864](https://github.com/Speech-Rule-Engine/speech-rule-engine/issues/864)) was released and depends on `@xmldom/xmldom@0.9.10`.
- `mathjax-full` already allows `^4.0.6`, so the lockfile was just stale — `pnpm update -r speech-rule-engine` re-resolved to `4.1.4`. No override needed.

## Test plan
- [ ] `pnpm install` clean
- [ ] `pnpm why @xmldom/xmldom -r` shows `0.9.10` everywhere
- [ ] `pnpm build` / `pnpm test` pass