### PR TITLE
Sample Viewing Improvements

### DIFF
--- a/apps/inspect/e2e/timeline.spec.ts
+++ b/apps/inspect/e2e/timeline.spec.ts
@@ -89,6 +89,7 @@ function makeServerSpan(
     branched_from: null,
     description: null,
     utility: false,
+    tool_invoked: false,
     agent_result: null,
     outline: null,
     ...overrides,

--- a/apps/inspect/src/app/App.css
+++ b/apps/inspect/src/app/App.css
@@ -22,7 +22,6 @@ li > ul {
 .tab-tools > * {
   flex: 0 1 auto;
   height: 1.5rem;
-  margin-left: 0.5rem;
 }
 
 .tab-tools > input {

--- a/apps/inspect/src/app/samples/SampleSummaryView.tsx
+++ b/apps/inspect/src/app/samples/SampleSummaryView.tsx
@@ -20,7 +20,7 @@ import { SampleErrorView } from "./error/SampleErrorView";
 import styles from "./SampleSummaryView.module.css";
 import { isCancelled } from "./status/sampleStatus";
 
-const kMaxCellTextLength = 256;
+const kMaxCellTextLength = 128;
 interface SampleSummaryViewProps {
   parent_id: string;
   sample: SampleSummary | EvalSample;
@@ -130,6 +130,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
       />
     ),
     size: `minmax(auto, 5fr)`,
+    clamp: true
   });
 
   if (fields.target) {

--- a/apps/inspect/src/app/samples/SampleSummaryView.tsx
+++ b/apps/inspect/src/app/samples/SampleSummaryView.tsx
@@ -130,7 +130,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
       />
     ),
     size: `minmax(auto, 5fr)`,
-    clamp: true
+    clamp: true,
   });
 
   if (fields.target) {

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -194,11 +194,7 @@ export function createSamplePolling(
       if (
         shouldFinalizeStreamingSample(
           sampleDataResponse,
-          hasCompletedLogSummary(
-            store.getState(),
-            summary.id,
-            summary.epoch
-          )
+          hasCompletedLogSummary(store.getState(), summary.id, summary.epoch)
         )
       ) {
         return await loadCompletedSample(

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -80,10 +80,12 @@ export function createSamplePolling(
       return;
     }
 
-    // Stop any existing polling first
+    // Stop any existing polling first (this also aborts the previous
+    // controller so any in-flight callback for the prior session bails
+    // out instead of mutating state for the new session).
     if (currentPolling) {
       log.debug(`Resetting existing polling`);
-      currentPolling.stop();
+      stopPolling();
 
       // Clear any current running events
       store.getState().sampleActions.setRunningEvents([]);
@@ -91,7 +93,11 @@ export function createSamplePolling(
 
     // Always reset the polling state when starting new polling
     resetPollingState(pollingState);
-    abortController = new AbortController();
+    // Capture the controller in a local so this callback always checks
+    // its own session's signal — even if `abortController` is later
+    // reassigned by a subsequent startPolling call.
+    const localAbort = new AbortController();
+    abortController = localAbort;
 
     // Create the polling callback
     log.debug(`Polling sample: ${summary.id}-${summary.epoch}`);
@@ -109,7 +115,7 @@ export function createSamplePolling(
         throw new Error("Required API get_log_sample_data is undefined.");
       }
 
-      if (abortController.signal.aborted) {
+      if (localAbort.signal.aborted) {
         return false;
       }
 
@@ -128,7 +134,7 @@ export function createSamplePolling(
         callPoolId !== kNoId ? callPoolId : undefined
       );
 
-      if (abortController.signal.aborted) {
+      if (localAbort.signal.aborted) {
         return false;
       }
 
@@ -154,6 +160,12 @@ export function createSamplePolling(
               summary.epoch
             );
 
+            // If the user navigated away while we were fetching, don't
+            // overwrite the new sample's state with this stale result.
+            if (localAbort.signal.aborted) {
+              return false;
+            }
+
             if (sample) {
               const migratedSample = resolveSample(sample);
 
@@ -169,12 +181,15 @@ export function createSamplePolling(
               sampleActions.setRunningEvents([]);
             }
           } catch (e) {
+            if (localAbort.signal.aborted) {
+              return false;
+            }
             sampleActions.setSampleError(e as Error);
             sampleActions.setSampleStatus("error");
             sampleActions.setRunningEvents([]);
           }
         } else {
-          if (state.sample.sampleStatus === "streaming") {
+          if (store.getState().sample.sampleStatus === "streaming") {
             sampleActions.setSampleStatus("ok");
           }
           sampleActions.setRunningEvents([]);
@@ -186,7 +201,7 @@ export function createSamplePolling(
         sampleDataResponse?.status === "OK" &&
         sampleDataResponse.sampleData
       ) {
-        if (abortController.signal.aborted) {
+        if (localAbort.signal.aborted) {
           return false;
         }
         sampleActions.setSampleStatus("streaming");
@@ -251,6 +266,12 @@ export function createSamplePolling(
 
   // Stop polling
   const stopPolling = () => {
+    // Abort the in-flight callback (if any) so it bails out at its
+    // next abort check instead of mutating state for a sample the
+    // user has navigated away from.
+    if (abortController) {
+      abortController.abort();
+    }
     if (currentPolling) {
       currentPolling.stop();
       currentPolling = null;

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -54,7 +54,7 @@ export function createSamplePolling(
   let currentPolling: ReturnType<typeof createPolling> | null = null;
 
   // handle aborts
-  let abortController: AbortController;
+  let abortController: AbortController | undefined;
 
   // The inintial polling state
   const pollingState: PollingState = {
@@ -82,11 +82,14 @@ export function createSamplePolling(
       return;
     }
 
-    // Stop any existing polling first (this also aborts the previous
-    // controller so any in-flight callback for the prior session bails
-    // out instead of mutating state for the new session).
-    if (currentPolling) {
-      log.debug(`Resetting existing polling`);
+    // Stop any existing or completing session first. A previous session may
+    // have already stopped its timer while still awaiting a terminal sample
+    // fetch, so we also key off the abort controller here.
+    if (
+      currentPolling ||
+      (abortController && !abortController.signal.aborted)
+    ) {
+      log.debug(`Resetting existing polling session`);
       stopPolling();
 
       // Clear any current running events

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -8,11 +8,13 @@ import {
 } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
+import { sampleIdsEqual } from "../app/shared/sample";
 import { Event } from "../app/types";
 import {
   ClientAPI,
   EventData,
   SampleData,
+  SampleDataResponse,
   SampleSummary,
 } from "../client/api/types";
 import { resolveAttachments } from "../utils/attachments";
@@ -119,6 +121,51 @@ export function createSamplePolling(
         return false;
       }
 
+      const loadCompletedSample = async (message: string) => {
+        // A 404 from the server means that this sample has been flushed to the
+        // main eval file. We also take the same path when the log summary says
+        // the sample is complete but the buffer only returns empty deltas.
+        stopPollingTimer();
+
+        try {
+          log.debug(message);
+          const sample = await api.get_log_sample(
+            logFile,
+            summary.id,
+            summary.epoch
+          );
+
+          // If the user navigated away while we were fetching, don't overwrite
+          // the new sample's state with this stale result.
+          if (localAbort.signal.aborted) {
+            return false;
+          }
+
+          if (sample) {
+            const migratedSample = resolveSample(sample);
+
+            sampleActions.setSelectedSample(migratedSample, logFile);
+            sampleActions.setSampleStatus("ok");
+            sampleActions.setRunningEvents([]);
+          } else {
+            sampleActions.setSampleStatus("error");
+            sampleActions.setSampleError(
+              new Error("Unable to load sample - an unknown error occurred")
+            );
+            sampleActions.setRunningEvents([]);
+          }
+        } catch (e) {
+          if (localAbort.signal.aborted) {
+            return false;
+          }
+          sampleActions.setSampleError(e as Error);
+          sampleActions.setSampleStatus("error");
+          sampleActions.setRunningEvents([]);
+        }
+
+        return false;
+      };
+
       // Fetch sample data
       const eventId = pollingState.eventId;
       const attachmentId = pollingState.attachmentId;
@@ -139,62 +186,24 @@ export function createSamplePolling(
       }
 
       if (sampleDataResponse?.status === "NotFound") {
-        // A 404 from the server means that this sample
-        // has been flushed to the main eval file, no events
-        // are available and we should retrieve the data from the
-        // sample file itself.
+        return await loadCompletedSample(
+          `LOADING COMPLETED SAMPLE AFTER FLUSH: ${summary.id}-${summary.epoch}`
+        );
+      }
 
-        // Stop polling since we now have the complete sample
-        stopPolling();
-
-        // Also fetch a fresh sample and clear the runnning Events
-        // (if there were ever running events)
-        if (state.sample.runningEvents.length > 0) {
-          try {
-            log.debug(
-              `LOADING COMPLETED SAMPLE AFTER FLUSH: ${summary.id}-${summary.epoch}`
-            );
-            const sample = await api.get_log_sample(
-              logFile,
-              summary.id,
-              summary.epoch
-            );
-
-            // If the user navigated away while we were fetching, don't
-            // overwrite the new sample's state with this stale result.
-            if (localAbort.signal.aborted) {
-              return false;
-            }
-
-            if (sample) {
-              const migratedSample = resolveSample(sample);
-
-              // Update the store with the completed sample
-              sampleActions.setSelectedSample(migratedSample, logFile);
-              sampleActions.setSampleStatus("ok");
-              sampleActions.setRunningEvents([]);
-            } else {
-              sampleActions.setSampleStatus("error");
-              sampleActions.setSampleError(
-                new Error("Unable to load sample - an unknown error occurred")
-              );
-              sampleActions.setRunningEvents([]);
-            }
-          } catch (e) {
-            if (localAbort.signal.aborted) {
-              return false;
-            }
-            sampleActions.setSampleError(e as Error);
-            sampleActions.setSampleStatus("error");
-            sampleActions.setRunningEvents([]);
-          }
-        } else {
-          if (store.getState().sample.sampleStatus === "streaming") {
-            sampleActions.setSampleStatus("ok");
-          }
-          sampleActions.setRunningEvents([]);
-        }
-        return false;
+      if (
+        shouldFinalizeStreamingSample(
+          sampleDataResponse,
+          hasCompletedLogSummary(
+            store.getState(),
+            summary.id,
+            summary.epoch
+          )
+        )
+      ) {
+        return await loadCompletedSample(
+          `LOADING COMPLETED SAMPLE AFTER SUMMARY UPDATE: ${summary.id}-${summary.epoch}`
+        );
       }
 
       if (
@@ -272,6 +281,10 @@ export function createSamplePolling(
     if (abortController) {
       abortController.abort();
     }
+    stopPollingTimer();
+  };
+
+  const stopPollingTimer = () => {
     if (currentPolling) {
       currentPolling.stop();
       currentPolling = null;
@@ -292,6 +305,47 @@ export function createSamplePolling(
     cleanup,
   };
 }
+
+const hasCompletedLogSummary = (
+  state: StoreState,
+  sampleId: string | number,
+  sampleEpoch: number
+) => {
+  return state.log.selectedLogDetails?.sampleSummaries.some(
+    (sampleSummary) =>
+      sampleIdsEqual(sampleSummary.id, sampleId) &&
+      sampleSummary.epoch === sampleEpoch &&
+      sampleSummary.completed !== false
+  );
+};
+
+export const hasSampleDataUpdates = (sampleData?: SampleData) => {
+  if (!sampleData) {
+    return false;
+  }
+
+  return (
+    sampleData.events.length > 0 ||
+    sampleData.attachments.length > 0 ||
+    sampleData.message_pool.length > 0 ||
+    sampleData.call_pool.length > 0
+  );
+};
+
+export const shouldFinalizeStreamingSample = (
+  sampleDataResponse: SampleDataResponse | undefined,
+  completedInLog: boolean | undefined
+) => {
+  if (!completedInLog || !sampleDataResponse) {
+    return false;
+  }
+
+  return (
+    sampleDataResponse.status === "NotModified" ||
+    (sampleDataResponse.status === "OK" &&
+      !hasSampleDataUpdates(sampleDataResponse.sampleData))
+  );
+};
 
 const resetPollingState = (state: PollingState) => {
   state.eventId = kNoId;

--- a/apps/inspect/src/state/utils.ts
+++ b/apps/inspect/src/state/utils.ts
@@ -14,11 +14,10 @@ export const mergeSampleSummaries = (
   const uniquePendingSamples = pendingSamples
     .filter((sample) => !existingSampleIds.has(`${sample.id}-${sample.epoch}`))
     .map((sample) => {
-      // Pass through the server's completed status. Samples start with
-      // completed=false and transition to completed=true when they finish.
-      // This allows the UI to detect completion (e.g. stop showing progress
-      // indicators) even while the sample is still in the pending buffer.
-      return { ...sample, completed: sample.completed ?? false };
+      // Pending-buffer samples are not necessarily in the .eval ZIP yet,
+      // even if their work has completed. Keep them on the streaming path
+      // until they appear in the log summaries.
+      return { ...sample, completed: false };
     });
 
   // Combine and return all samples

--- a/apps/inspect/src/tests/state/samplePolling.test.ts
+++ b/apps/inspect/src/tests/state/samplePolling.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { StoreApi, UseBoundStore } from "zustand";
+
+import { EvalSample } from "@tsmono/inspect-common/types";
 
 import { SampleDataResponse } from "../../client/api/types";
 import {
+  createSamplePolling,
   hasSampleDataUpdates,
   shouldFinalizeStreamingSample,
 } from "../../state/samplePolling";
+import { StoreState } from "../../state/store";
 
 describe("samplePolling helpers", () => {
   it("treats empty sample-data payloads as no-op updates", () => {
@@ -65,3 +70,92 @@ describe("samplePolling helpers", () => {
     expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
   });
 });
+
+describe("createSamplePolling", () => {
+  it("aborts a stale completion fetch when a new polling session starts", async () => {
+    const staleSampleDeferred = deferred<EvalSample | undefined>();
+    const getLogSampleData = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "NotFound",
+      } satisfies SampleDataResponse)
+      .mockImplementation(() => new Promise(() => {}));
+    const getLogSample = vi.fn().mockReturnValue(staleSampleDeferred.promise);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: {
+        runningEvents: [],
+      },
+      sampleActions,
+      log: {
+        selectedLogDetails: {
+          sampleSummaries: [],
+        },
+      },
+    } as unknown as StoreState;
+
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+
+    polling.startPolling("log.json", createSummary("sample-1"));
+    await flushPromises();
+
+    expect(getLogSample).toHaveBeenCalledWith("log.json", "sample-1", 1);
+
+    polling.startPolling("log.json", createSummary("sample-2"));
+
+    staleSampleDeferred.resolve(createEvalSample("sample-1"));
+    await flushPromises();
+
+    expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
+    expect(sampleActions.setSampleStatus).not.toHaveBeenCalledWith("ok");
+  });
+});
+
+const createSummary = (id: string) =>
+  ({
+    id,
+    epoch: 1,
+  }) as any;
+
+const createEvalSample = (id: string) =>
+  ({
+    id,
+    epoch: 1,
+    events: [],
+    messages: [],
+    metadata: {},
+    store: {},
+    attachments: {},
+    scores: null,
+    input: null,
+    target: null,
+  }) as unknown as EvalSample;
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};

--- a/apps/inspect/src/tests/state/samplePolling.test.ts
+++ b/apps/inspect/src/tests/state/samplePolling.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { SampleDataResponse } from "../../client/api/types";
+import {
+  hasSampleDataUpdates,
+  shouldFinalizeStreamingSample,
+} from "../../state/samplePolling";
+
+describe("samplePolling helpers", () => {
+  it("treats empty sample-data payloads as no-op updates", () => {
+    expect(
+      hasSampleDataUpdates({
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      })
+    ).toBe(false);
+  });
+
+  it("detects sample-data deltas across all streamed collections", () => {
+    expect(
+      hasSampleDataUpdates({
+        events: [],
+        attachments: [
+          {
+            id: 1,
+            sample_id: "sample-1",
+            epoch: 1,
+            hash: "hash-1",
+            content: "content",
+          },
+        ],
+        message_pool: [],
+        call_pool: [],
+      })
+    ).toBe(true);
+  });
+
+  it("finalizes streaming when the sample is complete in the log and only empty deltas remain", () => {
+    const response: SampleDataResponse = {
+      status: "OK",
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    };
+
+    expect(shouldFinalizeStreamingSample(response, true)).toBe(true);
+  });
+
+  it("keeps streaming when the sample is still incomplete in the log", () => {
+    const response: SampleDataResponse = {
+      status: "OK",
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    };
+
+    expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
+  });
+});

--- a/apps/inspect/src/tests/state/utils.test.ts
+++ b/apps/inspect/src/tests/state/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+
+import { SampleSummary } from "../../client/api/types";
+import { mergeSampleSummaries } from "../../state/utils";
+
+describe("mergeSampleSummaries", () => {
+  test("keeps pending-only completed samples on the streaming path", () => {
+    const result = mergeSampleSummaries(
+      [],
+      [createSampleSummary({ completed: true })]
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].completed).toBe(false);
+  });
+
+  test("prefers log summaries over pending summaries for the same sample", () => {
+    const logSummary = createSampleSummary({
+      input: "from log",
+      completed: true,
+    });
+    const pendingSummary = createSampleSummary({
+      input: "from pending",
+      completed: false,
+    });
+
+    expect(mergeSampleSummaries([logSummary], [pendingSummary])).toEqual([
+      logSummary,
+    ]);
+  });
+});
+
+const createSampleSummary = (
+  overrides: Partial<SampleSummary> = {}
+): SampleSummary => ({
+  id: "it_has_begun (hard)",
+  epoch: 1,
+  input: "input",
+  target: "target",
+  scores: null,
+  ...overrides,
+});

--- a/packages/inspect-components/src/transcript/timeline/core.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.test.ts
@@ -78,6 +78,7 @@ function makeServerSpan(
     branched_from: null,
     description: null,
     utility: false,
+    tool_invoked: false,
     agent_result: null,
     outline: null,
     ...overrides,

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -67,6 +67,7 @@ function makeServerSpan(
     branched_from: null,
     description: null,
     utility: false,
+    tool_invoked: false,
     agent_result: null,
     outline: null,
     ...overrides,

--- a/packages/react/src/components/TabSet.module.css
+++ b/packages/react/src/components/TabSet.module.css
@@ -40,14 +40,20 @@
   margin-right: 0.5em;
 }
 
+.tabSpacer {
+  flex: 1 1 0;
+  min-width: 0;
+  list-style: none;
+}
+
 .tabTools {
   flex-basis: auto;
-  margin-left: auto;
   display: flex;
   align-items: center;
   justify-content: end;
   flex-wrap: wrap;
   row-gap: 0.3rem;
+  column-gap: 0.5rem;
 }
 
 .tabStyle {
@@ -57,7 +63,6 @@
 
 .tabTools > * {
   flex: 0 1 auto;
-  margin-left: 0.5rem;
 }
 
 .tabTools input {

--- a/packages/react/src/components/TabSet.tsx
+++ b/packages/react/src/components/TabSet.tsx
@@ -82,7 +82,12 @@ export const TabSet: FC<TabSetProps> = ({
             className={clsx(tabControlsClassName)}
           />
         ))}
-        {tools && <TabTools tools={tools} />}
+        {tools && (
+          <Fragment>
+            <li className={moduleStyles.tabSpacer} aria-hidden="true" />
+            <TabTools tools={tools} />
+          </Fragment>
+        )}
       </ul>
       <TabPanels id={id} tabs={validTabs} className={tabPanelsClassName} />
     </Fragment>


### PR DESCRIPTION
1) Improve rendering of sample at narrow widths
- constraint input / answer to 3 lines
- improve tool button layout at constrained widths (wrapping)

2) Improve running sample behavior
- more carefully check completion state before switching from 'streaming' to 'completed modes
- ensure if you are watching a sample, we switch from streaming to completed when the sample completes

3) race conditions
- prevent terminal completion fetches from aborting themselves
- abort stale in-flight completion work when a new sample polling session starts

fixes #148, #149 