### PR TITLE
Collapse the LogView title bar on scroll

### DIFF
--- a/apps/inspect/src/app/log-view/LogView.module.css
+++ b/apps/inspect/src/app/log-view/LogView.module.css
@@ -15,7 +15,7 @@
   flex-wrap: nowrap;
   padding: 0.5rem 0.5rem 0.5rem 0.5rem;
   border-bottom: solid 1px var(--bs-border-color);
-  background: var(--bs-light);
+  background: var(--bs-light-bg-subtle);
 }
 
 .tabs {

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -4,11 +4,14 @@ import {
   FC,
   Fragment,
   MouseEvent,
+  RefObject,
   useCallback,
+  useMemo,
   useRef,
 } from "react";
 
 import { EmptyPanel, TabPanel, TabSet } from "@tsmono/react/components";
+import { useScrollDirection } from "@tsmono/react/hooks";
 
 import { useEvalSpec, useRefreshLog } from "../../state/hooks";
 import { useStore } from "../../state/store";
@@ -77,6 +80,20 @@ export const LogView: FC = () => {
     json: jsonTabConfig,
   };
 
+  const scrollRefs = useMemo(() => {
+    const refs: RefObject<HTMLElement | null>[] = [];
+    for (const key of Object.keys(tabs)) {
+      const ref = tabs[key].scrollRef;
+      if (ref) refs.push(ref as RefObject<HTMLElement | null>);
+    }
+    return refs;
+    // The set of tab refs is stable within a session — recompute only when
+    // the tab keys change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [Object.keys(tabs).join(",")]);
+
+  const { hidden: titleCollapsed } = useScrollDirection(scrollRefs);
+
   const selectedTab = useStore((state) => state.app.tabs.workspace);
   const setSelectedTab = useStore((state) => state.appActions.setWorkspaceTab);
 
@@ -120,6 +137,7 @@ export const LogView: FC = () => {
           runningMetrics={runningMetrics}
           evalStats={selectedLogDetails?.stats}
           status={selectedLogDetails?.status}
+          collapsed={titleCollapsed}
         />
         <div ref={divRef} className={clsx("workspace", styles.workspace)}>
           <div className={clsx("log-detail", styles.tabContainer)}>
@@ -141,7 +159,7 @@ export const LogView: FC = () => {
                     onSelected={onSelected}
                     selected={selectedTab === tab.id}
                     scrollable={!!tab.scrollable}
-                    scrollRef={tab.scrollRef}
+                    scrollRef={tab.scrollable ? tab.scrollRef : undefined}
                     className={clsx(tab.className)}
                     style={{ height: tab.scrollable ? "100%" : undefined }}
                   >

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -1,5 +1,5 @@
 import type { AgGridReact } from "ag-grid-react";
-import { FC, Fragment, useEffect, useMemo, useRef } from "react";
+import { FC, Fragment, RefObject, useEffect, useMemo, useRef } from "react";
 
 import { NoContentsPanel, ToolButton } from "@tsmono/react/components";
 
@@ -31,14 +31,22 @@ export const useSamplesTabConfig = (
   const samplesDescriptor = useSampleDescriptor();
   const streamSamples = useStore((state) => state.capabilities.streamSamples);
 
+  // Single ref exposed to the parent so cross-tab UI (title-view
+  // collapse-on-scroll) can listen to scrolling inside this tab. Only one of
+  // `InlineSampleDisplay` or `SampleList` is mounted at a time, so they
+  // share this ref.
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
   return useMemo(() => {
     return {
       id: kLogViewSamplesTabId,
       scrollable: false,
+      scrollRef,
       label: totalSampleCount > 1 ? "Samples" : "Sample",
       component: SamplesTab,
       componentProps: {
         running: evalStatus === "started",
+        scrollRef,
       },
       tools: () =>
         !samplesDescriptor
@@ -69,9 +77,10 @@ export const useSamplesTabConfig = (
 interface SamplesTabProps {
   // Required props
   running: boolean;
+  scrollRef?: RefObject<HTMLDivElement | null>;
 }
 
-export const SamplesTab: FC<SamplesTabProps> = ({ running }) => {
+export const SamplesTab: FC<SamplesTabProps> = ({ running, scrollRef }) => {
   const sampleSummaries = useFilteredSamples();
   const selectedLogDetails = useStore((state) => state.log.selectedLogDetails);
   const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
@@ -137,6 +146,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({ running }) => {
             showActivity={
               sampleStatus === "loading" || sampleStatus === "streaming"
             }
+            scrollRef={scrollRef}
           />
         ) : undefined}
         {samplesDescriptor && totalSampleCount > 1 ? (
@@ -146,6 +156,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({ running }) => {
             earlyStopping={selectedLogDetails?.results?.early_stopping}
             totalItemCount={evalSampleCount}
             running={running}
+            scrollRef={scrollRef}
           />
         ) : undefined}
       </Fragment>

--- a/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.module.css
+++ b/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.module.css
@@ -1,0 +1,79 @@
+.container {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  min-height: 1.75rem;
+}
+
+.left {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.task {
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+.model {
+  opacity: 0.75;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.right {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.inlineMetrics {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.inlineMetric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.inlineMetricLabel {
+  opacity: 0.7;
+}
+
+.inlineMetricValue {
+  font-weight: 600;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.statusIcon {
+  font-size: 1em;
+}
+
+.statusCount {
+  opacity: 0.7;
+}
+
+.scoringDetailModal :global(.modal-dialog) {
+  max-width: min(1000px, 90vw);
+}
+
+.scoringDetailModal :global(.modal-content) {
+  width: fit-content;
+  max-width: 100%;
+}

--- a/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.tsx
@@ -1,0 +1,223 @@
+import clsx from "clsx";
+import { FC, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { EvalResults, EvalSpec } from "@tsmono/inspect-common/types";
+import { formatPrettyDecimal } from "@tsmono/util";
+
+import { EvalLogStatus } from "../../../@types/extraInspect";
+import { RunningMetric } from "../../../client/api/types";
+import { LinkButton } from "../../../components/LinkButton";
+import { Modal } from "../../../components/Modal";
+import { kModelNone } from "../../../constants";
+import {
+  expandGroupedMetrics,
+  metricDisplayName,
+  toDisplayScorers,
+} from "../../../scoring/metrics";
+import { groupScorers } from "../../../scoring/scores";
+import { ApplicationIcons } from "../../appearance/icons";
+
+import styles from "./CollapsedTitleBar.module.css";
+import { displayScorersFromRunningMetrics } from "./ResultsPanel";
+import { ScoreAgGrid } from "./ScoreAgGrid";
+
+const kInlineMetricLimit = 2;
+
+interface CollapsedTitleBarProps {
+  evalSpec?: EvalSpec;
+  evalResults?: EvalResults | null;
+  runningMetrics?: RunningMetric[];
+  status?: EvalLogStatus;
+  sampleCount?: number;
+}
+
+export const CollapsedTitleBar: FC<CollapsedTitleBarProps> = ({
+  evalSpec,
+  evalResults,
+  runningMetrics,
+  status,
+  sampleCount,
+}) => {
+  const showMetrics =
+    status === "success" ||
+    (status === "started" && (runningMetrics?.length ?? 0) > 0) ||
+    (status === "error" && evalSpec?.config["continue_on_fail"]);
+
+  const scorers = runningMetrics
+    ? displayScorersFromRunningMetrics(runningMetrics)
+    : toDisplayScorers(evalResults?.scores);
+
+  const expandedScorers = expandGroupedMetrics(scorers ?? []);
+  const totalMetrics = expandedScorers.reduce(
+    (n, s) => n + s.metrics.length,
+    0
+  );
+
+  const modelText = formatModelText(evalSpec);
+
+  return (
+    <div
+      className={clsx("navbar-brand", "navbar-text", "mb-0", styles.container)}
+    >
+      <div className={clsx(styles.left)}>
+        <span
+          id="task-title-collapsed"
+          className={clsx(
+            "task-title",
+            "text-truncate",
+            "text-size-larger",
+            styles.task
+          )}
+          title={evalSpec?.task}
+        >
+          {evalSpec?.task}
+        </span>
+        {modelText ? (
+          <span
+            id="task-model-collapsed"
+            className={clsx(
+              "task-model",
+              "text-truncate",
+              "text-size-small",
+              styles.model
+            )}
+            title={modelText}
+          >
+            ({modelText})
+          </span>
+        ) : null}
+      </div>
+      <div className={clsx(styles.right, "text-size-smaller")}>
+        {showMetrics && totalMetrics > 0 ? (
+          totalMetrics <= kInlineMetricLimit ? (
+            <InlineMetrics scorers={expandedScorers} />
+          ) : (
+            <MetricsLink scorers={expandedScorers} />
+          )
+        ) : (
+          <StatusBadge status={status} sampleCount={sampleCount} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const formatModelText = (evalSpec?: EvalSpec): string | undefined => {
+  if (!evalSpec) return undefined;
+  const roles = evalSpec.model_roles;
+  if (roles && Object.keys(roles).length > 0) {
+    return Object.entries(roles)
+      .map(([role, data]) => `${role}: ${data.model}`)
+      .join(", ");
+  }
+  if (evalSpec.model && evalSpec.model !== kModelNone) {
+    return evalSpec.model;
+  }
+  return undefined;
+};
+
+interface InlineMetricsProps {
+  scorers: ReturnType<typeof expandGroupedMetrics>;
+}
+
+const InlineMetrics: FC<InlineMetricsProps> = ({ scorers }) => {
+  const items: { key: string; label: string; value: string }[] = [];
+  scorers.forEach((scorer, scorerIdx) => {
+    scorer.metrics.forEach((metric, metricIdx) => {
+      items.push({
+        key: `${scorerIdx}-${metricIdx}`,
+        label: metricDisplayName(metric),
+        value:
+          metric.value !== undefined && metric.value !== null
+            ? formatPrettyDecimal(metric.value)
+            : "n/a",
+      });
+    });
+  });
+
+  return (
+    <div className={styles.inlineMetrics}>
+      {items.map((item) => (
+        <span key={item.key} className={styles.inlineMetric}>
+          <span className={clsx("text-style-label", styles.inlineMetricLabel)}>
+            {item.label}
+          </span>
+          <span className={styles.inlineMetricValue}>{item.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+};
+
+interface StatusBadgeProps {
+  status?: EvalLogStatus;
+  sampleCount?: number;
+}
+
+const StatusBadge: FC<StatusBadgeProps> = ({ status, sampleCount }) => {
+  const display = statusDisplay(status);
+  if (!display) return null;
+  const count = sampleCount ?? 0;
+  return (
+    <div className={styles.statusBadge}>
+      <i className={clsx(display.icon, styles.statusIcon)} />
+      <span className="text-style-label">{display.label}</span>
+      {count > 0 ? (
+        <span className={styles.statusCount}>
+          ({count} {count === 1 ? "sample" : "samples"})
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+const statusDisplay = (
+  status?: EvalLogStatus
+): { icon: string; label: string } | undefined => {
+  switch (status) {
+    case "started":
+      return { icon: ApplicationIcons.running, label: "Running" };
+    case "cancelled":
+      return { icon: ApplicationIcons.logging.info, label: "Cancelled" };
+    case "error":
+      return { icon: ApplicationIcons.logging.error, label: "Task Failed" };
+    default:
+      return undefined;
+  }
+};
+
+interface MetricsLinkProps {
+  scorers: ReturnType<typeof expandGroupedMetrics>;
+}
+
+const MetricsLink: FC<MetricsLinkProps> = ({ scorers }) => {
+  const grouped = groupScorers(scorers);
+  const showReducer = scorers.findIndex((s) => !!s.reducer) !== -1;
+
+  // The modal is portaled to <body> so it escapes the title-view collapsing
+  // wrapper (which sets opacity: 0 on whichever slot is hidden). Without the
+  // portal, the modal would inherit that opacity and become invisible while
+  // still capturing pointer events.
+  const [showing, setShowing] = useState(false);
+
+  return (
+    <>
+      <LinkButton text="View metrics…" onClick={() => setShowing(true)} />
+      {createPortal(
+        <Modal
+          id="collapsed-title-bar-metrics"
+          showing={showing}
+          setShowing={setShowing}
+          title="Scoring Detail"
+          overflow="hidden"
+          padded={false}
+          className={styles.scoringDetailModal}
+        >
+          <ScoreAgGrid scoreGroups={grouped} showReducer={showReducer} />
+        </Modal>,
+        document.body
+      )}
+    </>
+  );
+};

--- a/apps/inspect/src/app/log-view/title-view/TitleView.module.css
+++ b/apps/inspect/src/app/log-view/title-view/TitleView.module.css
@@ -52,6 +52,7 @@
   padding: 0;
   position: sticky;
   overflow: hidden;
+  background-color: var(--bs-light-bg-subtle);
 }
 .navbarInnerWrapper {
   display: grid;

--- a/apps/inspect/src/app/log-view/title-view/TitleView.module.css
+++ b/apps/inspect/src/app/log-view/title-view/TitleView.module.css
@@ -47,8 +47,56 @@
 
 .navbarWrapper {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  position: sticky;
+  overflow: hidden;
 }
 .navbarInnerWrapper {
   display: grid;
   grid-template-columns: 1fr auto;
+}
+
+/* Expanded / collapsed slot animation
+ *
+ * Both slots are rendered into a CSS grid with an animated row size:
+ * the active slot's container gets `grid-template-rows: 1fr` and the
+ * inactive slot collapses to `0fr`. Combined with `overflow: hidden`,
+ * this produces a smooth height transition.
+ */
+.expandedSlot,
+.collapsedSlot {
+  width: 100%;
+  display: grid;
+  overflow: hidden;
+  transition: opacity 120ms linear;
+}
+
+.expandedSlot {
+  grid-template-rows: 1fr;
+}
+
+.collapsedSlot {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.collapsed .expandedSlot {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.collapsed .collapsedSlot {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.expandedSlot > .expandedInner,
+.collapsedSlot > * {
+  min-height: 0;
+  overflow: hidden;
 }

--- a/apps/inspect/src/app/log-view/title-view/TitleView.tsx
+++ b/apps/inspect/src/app/log-view/title-view/TitleView.tsx
@@ -12,6 +12,7 @@ import { EvalLogStatus } from "../../../@types/extraInspect";
 import { RunningMetric } from "../../../client/api/types";
 import { useTotalSampleCount } from "../../../state/hooks";
 
+import { CollapsedTitleBar } from "./CollapsedTitleBar";
 import { PrimaryBar } from "./PrimaryBar";
 import { SecondaryBar } from "./SecondaryBar";
 import styles from "./TitleView.module.css";
@@ -23,6 +24,7 @@ interface TitleViewProps {
   evalPlan?: EvalPlan;
   evalStats?: EvalStats;
   status?: EvalLogStatus;
+  collapsed?: boolean;
 }
 
 /**
@@ -35,26 +37,47 @@ export const TitleView: FC<TitleViewProps> = ({
   evalStats,
   status,
   runningMetrics,
+  collapsed,
 }) => {
   const totalSampleCount = useTotalSampleCount();
 
   return (
-    <nav className={clsx("navbar", "sticky-top", styles.navbarWrapper)}>
-      <PrimaryBar
-        evalSpec={evalSpec}
-        evalResults={evalResults}
-        status={status}
-        runningMetrics={runningMetrics}
-        sampleCount={totalSampleCount}
-      />
-      <SecondaryBar
-        evalSpec={evalSpec}
-        evalPlan={evalPlan}
-        evalResults={evalResults}
-        evalStats={evalStats}
-        status={status}
-        sampleCount={totalSampleCount}
-      />
+    <nav
+      className={clsx(
+        "navbar",
+        "sticky-top",
+        styles.navbarWrapper,
+        collapsed ? styles.collapsed : styles.expanded
+      )}
+    >
+      <div className={styles.expandedSlot} aria-hidden={collapsed}>
+        <div className={styles.expandedInner}>
+          <PrimaryBar
+            evalSpec={evalSpec}
+            evalResults={evalResults}
+            status={status}
+            runningMetrics={runningMetrics}
+            sampleCount={totalSampleCount}
+          />
+          <SecondaryBar
+            evalSpec={evalSpec}
+            evalPlan={evalPlan}
+            evalResults={evalResults}
+            evalStats={evalStats}
+            status={status}
+            sampleCount={totalSampleCount}
+          />
+        </div>
+      </div>
+      <div className={styles.collapsedSlot} aria-hidden={!collapsed}>
+        <CollapsedTitleBar
+          evalSpec={evalSpec}
+          evalResults={evalResults}
+          runningMetrics={runningMetrics}
+          status={status}
+          sampleCount={totalSampleCount}
+        />
+      </div>
     </nav>
   );
 };

--- a/apps/inspect/src/app/samples/InlineSampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/InlineSampleDisplay.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, useRef } from "react";
+import { FC, RefObject, useRef } from "react";
 
 import { ErrorPanel, StickyScrollProvider } from "@tsmono/react/components";
 import { useStatefulScrollPosition } from "@tsmono/react/hooks";
@@ -15,6 +15,9 @@ import { SampleDisplay } from "./SampleDisplay";
 interface InlineSampleDisplayProps {
   showActivity?: boolean;
   className?: string | string[];
+  /** Optional ref that receives the inner scroller element so callers can
+   *  hook scroll listeners on the actual scrolling viewport. */
+  scrollRef?: RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -23,18 +26,24 @@ interface InlineSampleDisplayProps {
 export const InlineSampleDisplay: FC<InlineSampleDisplayProps> = ({
   showActivity,
   className,
+  scrollRef,
 }) => {
   // Use shared hooks for loading and polling
   useLoadSample();
   usePollSample();
   return (
-    <InlineSampleComponent showActivity={showActivity} className={className} />
+    <InlineSampleComponent
+      showActivity={showActivity}
+      className={className}
+      scrollRef={scrollRef}
+    />
   );
 };
 
 export const InlineSampleComponent: FC<InlineSampleDisplayProps> = ({
   showActivity,
   className,
+  scrollRef: externalScrollRef,
 }) => {
   const sampleData = useSampleData();
 
@@ -45,8 +54,8 @@ export const InlineSampleComponent: FC<InlineSampleDisplayProps> = ({
       ? sampleData.downloadProgress.complete / sampleData.downloadProgress.total
       : undefined;
 
-  // Scroll ref — key by active tab so each tab restores independently
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const localScrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = externalScrollRef ?? localScrollRef;
   const sampleTab = useStore((state) => state.app.tabs.sample);
   useStatefulScrollPosition(scrollRef, `inline-sample-scroller-${sampleTab}`);
 

--- a/apps/inspect/src/app/samples/list/SampleList.tsx
+++ b/apps/inspect/src/app/samples/list/SampleList.tsx
@@ -48,6 +48,10 @@ interface SampleListProps {
   running: boolean;
   className?: string | string[];
   listHandle: RefObject<AgGridReact<SampleListItem> | null>;
+  /** Optional ref that receives the AgGrid `.ag-body-viewport` DOM element
+   *  once the grid is ready, so callers can hook scroll listeners on the
+   *  actual scrolling viewport. */
+  scrollRef?: RefObject<HTMLDivElement | null>;
 }
 
 const makeSampleRowId = (id: string | number, epoch: number) =>
@@ -61,6 +65,7 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
     running,
     className,
     listHandle,
+    scrollRef,
   } = props;
 
   const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
@@ -336,6 +341,14 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
           suppressCellFocus={true}
           domLayout="normal"
           onBodyScroll={handleBodyScroll}
+          onGridReady={() => {
+            if (scrollRef) {
+              const viewport = gridContainerRef.current?.querySelector(
+                ".ag-body-viewport"
+              ) as HTMLDivElement | null;
+              scrollRef.current = viewport ?? null;
+            }
+          }}
           onFirstDataRendered={() => {
             if (running && followOutputRef.current) {
               listHandle.current?.api?.ensureIndexVisible(


### PR DESCRIPTION
When the user scrolls down inside any tab's scroll viewport, the title bar collapses to a single row showing the task, model (or model_roles), and either inline metrics, a "View metrics…" link, or the run status. Scrolling back up re-expands the bar. Reuses the existing useScrollDirection hook for headroom-style hysteresis.

Fixes #152