### PR TITLE
fix: transcript copy leaks opaque payloads & dumps full event JSON

### DIFF
--- a/apps/inspect/src/tests/transcript/eventText.test.ts
+++ b/apps/inspect/src/tests/transcript/eventText.test.ts
@@ -371,7 +371,7 @@ describe("eventSearchText", () => {
     expect(texts).toContain("init");
   });
 
-  test("compaction: includes source and serialized event", () => {
+  test("compaction: emits tokens and omits default 'inspect' source", () => {
     const texts = eventSearchText(
       makeNode({
         event: "compaction",
@@ -381,7 +381,22 @@ describe("eventSearchText", () => {
         timestamp: "2024-01-01T00:00:00Z",
       })
     );
-    expect(texts).toContain("inspect");
+    expect(texts).toContain("1000");
+    expect(texts).toContain("500");
+    expect(texts).not.toContain("inspect");
+  });
+
+  test("compaction: includes non-default source", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "compaction",
+        source: "agent",
+        tokens_before: 1000,
+        tokens_after: 500,
+        timestamp: "2024-01-01T00:00:00Z",
+      })
+    );
+    expect(texts).toContain("agent");
   });
 
   test("unknown event: returns empty array", () => {

--- a/packages/inspect-components/src/chat/messagesToStr.test.ts
+++ b/packages/inspect-components/src/chat/messagesToStr.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ChatMessageAssistant,
+  ContentReasoning,
+} from "@tsmono/inspect-common/types";
+
+import { messagesToStr } from "./messagesToStr";
+
+const reasoningMsg = (r: Partial<ContentReasoning>): ChatMessageAssistant => ({
+  role: "assistant",
+  source: "generate",
+  content: [
+    {
+      type: "reasoning",
+      reasoning: "",
+      redacted: false,
+      ...r,
+    },
+  ],
+});
+
+describe("messagesToStr — reasoning content", () => {
+  it("uses summary when redacted (Anthropic ≥4, OpenAI encrypted)", () => {
+    const out = messagesToStr([
+      reasoningMsg({
+        reasoning: "OPAQUE_SIGNATURE_BLOB",
+        summary: "Reading the instructions.",
+        redacted: true,
+      }),
+    ]);
+    expect(out).toContain("Reading the instructions.");
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+
+  it("falls back to summary when reasoning is empty (OpenAI summary-only)", () => {
+    const out = messagesToStr([
+      reasoningMsg({
+        reasoning: "",
+        summary: "Step-by-step plan.",
+        redacted: false,
+      }),
+    ]);
+    expect(out).toContain("Step-by-step plan.");
+  });
+
+  it("uses reasoning when present and not redacted (Anthropic 3.7, plaintext providers)", () => {
+    const out = messagesToStr([
+      reasoningMsg({
+        reasoning: "Full chain of thought.",
+        summary: null,
+        redacted: false,
+      }),
+    ]);
+    expect(out).toContain("Full chain of thought.");
+  });
+
+  it("returns empty think block when redacted and no summary", () => {
+    const out = messagesToStr([
+      reasoningMsg({
+        reasoning: "OPAQUE_SIGNATURE_BLOB",
+        summary: null,
+        redacted: true,
+      }),
+    ]);
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+    expect(out).toContain("ASSISTANT:");
+    expect(out).not.toContain("<think>");
+  });
+
+  it("emits no think block when redacted and summary is empty string", () => {
+    const out = messagesToStr([
+      reasoningMsg({
+        reasoning: "OPAQUE_SIGNATURE_BLOB",
+        summary: "",
+        redacted: true,
+      }),
+    ]);
+    expect(out).not.toContain("<think>");
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+});

--- a/packages/inspect-components/src/chat/messagesToStr.ts
+++ b/packages/inspect-components/src/chat/messagesToStr.ts
@@ -106,11 +106,13 @@ const textFromContent = (
       if (excludeReasoning) {
         return null;
       }
-      const reasoning = content.redacted ? content.summary : content.reasoning;
-      if (!reasoning) {
+      const text = content.redacted
+        ? content.summary
+        : content.reasoning || content.summary;
+      if (!text) {
         return null;
       }
-      return `\n<think>${reasoning}</think>`;
+      return `\n<think>${text}</think>`;
     }
 
     case "tool_use": {

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ContentReasoning,
+  ModelEvent,
+} from "@tsmono/inspect-common/types";
+
+import { eventsToStr } from "./eventText";
+
+const reasoning = (r: Partial<ContentReasoning>): ContentReasoning => ({
+  type: "reasoning",
+  reasoning: "",
+  redacted: false,
+  ...r,
+});
+
+const modelEventWith = (
+  content: ModelEvent["output"]["choices"][number]["message"]["content"]
+): ModelEvent =>
+  ({
+    event: "model",
+    uuid: "u",
+    span_id: null,
+    timestamp: "2026-04-29T00:00:00Z",
+    working_start: 0,
+    pending: false,
+    model: "test/model",
+    role: null,
+    input: [],
+    tools: [],
+    tool_choice: null,
+    config: {},
+    output: {
+      model: "test/model",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content,
+            source: "generate",
+          },
+          stop_reason: "stop",
+        },
+      ],
+      usage: null,
+    },
+    error: null,
+    cache: null,
+    call: null,
+    completed: null,
+    working_time: null,
+    style: null,
+    metadata: null,
+  }) as unknown as ModelEvent;
+
+describe("eventsToStr — reasoning content", () => {
+  it("uses summary when redacted (Anthropic ≥4, OpenAI encrypted)", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        reasoning({
+          reasoning: "OPAQUE_SIGNATURE_BLOB",
+          summary: "Reading the instructions.",
+          redacted: true,
+        }),
+      ]),
+    ]);
+    expect(out).toContain("Reading the instructions.");
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+
+  it("falls back to summary when reasoning is empty", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        reasoning({
+          reasoning: "",
+          summary: "Step-by-step plan.",
+          redacted: false,
+        }),
+      ]),
+    ]);
+    expect(out).toContain("Step-by-step plan.");
+  });
+
+  it("uses reasoning when present and not redacted", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        reasoning({
+          reasoning: "Full chain of thought.",
+          summary: null,
+          redacted: false,
+        }),
+      ]),
+    ]);
+    expect(out).toContain("Full chain of thought.");
+  });
+
+  it("emits no reasoning text when redacted and no summary (signature must not leak)", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        reasoning({
+          reasoning: "OPAQUE_SIGNATURE_BLOB",
+          summary: null,
+          redacted: true,
+        }),
+      ]),
+    ]);
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+
+  it("emits no reasoning text when redacted and summary is empty string", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        reasoning({
+          reasoning: "OPAQUE_SIGNATURE_BLOB",
+          summary: "",
+          redacted: true,
+        }),
+      ]),
+    ]);
+    expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+});

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import type {
+  CompactionEvent,
+  ContentImage,
   ContentReasoning,
+  ContentToolUse,
   ModelEvent,
+  ToolEvent,
 } from "@tsmono/inspect-common/types";
 
 import { eventsToStr } from "./eventText";
@@ -118,5 +122,221 @@ describe("eventsToStr — reasoning content", () => {
       ]),
     ]);
     expect(out).not.toContain("OPAQUE_SIGNATURE_BLOB");
+  });
+});
+
+describe("eventsToStr — tool_use content", () => {
+  it("includes result and error text for tool_use blocks", () => {
+    const toolUse: ContentToolUse = {
+      type: "tool_use",
+      id: "tu-1",
+      name: "search",
+      arguments: '{"q":"hi"}',
+      result: "Found 3 hits",
+      error: "rate-limited",
+      caller: { type: "direct" },
+    } as unknown as ContentToolUse;
+    const out = eventsToStr([modelEventWith([toolUse])]);
+    expect(out).toContain("search");
+    expect(out).toContain("Found 3 hits");
+    expect(out).toContain("rate-limited");
+  });
+});
+
+describe("eventsToStr — multimodal content placeholders", () => {
+  const data = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA_LONG_BLOB_";
+  const image: ContentImage = {
+    type: "image",
+    image: data,
+    detail: null,
+  } as unknown as ContentImage;
+
+  it("emits <image /> placeholder, no base64 leak", () => {
+    const out = eventsToStr([modelEventWith([image])]);
+    expect(out).toContain("<image />");
+    expect(out).not.toContain("_LONG_BLOB_");
+  });
+
+  it("emits placeholders for audio/video/data/document", () => {
+    const out = eventsToStr([
+      modelEventWith([
+        { type: "audio", audio: "data:audio/mp3;base64,_AUDIO_BLOB_" } as never,
+        { type: "video", video: "data:video/mp4;base64,_VIDEO_BLOB_" } as never,
+        { type: "data", data: { huge: "_DATA_BLOB_" } } as never,
+        { type: "document", document: "_DOC_BLOB_" } as never,
+      ]),
+    ]);
+    expect(out).toContain("<audio />");
+    expect(out).toContain("<video />");
+    expect(out).toContain("<data />");
+    expect(out).toContain("<document />");
+    expect(out).not.toContain("_AUDIO_BLOB_");
+    expect(out).not.toContain("_VIDEO_BLOB_");
+    expect(out).not.toContain("_DATA_BLOB_");
+    expect(out).not.toContain("_DOC_BLOB_");
+  });
+});
+
+// sanitizeStringify isn't exported; exercised here via state events, whose
+// `value` field is routed through the helper.
+describe("eventsToStr — sanitizeStringify (via state events)", () => {
+  const stateEvent = (value: unknown) =>
+    ({
+      event: "state",
+      uuid: "s",
+      span_id: null,
+      timestamp: "2026-04-29T00:00:00Z",
+      working_start: 0,
+      changes: [{ op: "replace", path: "/x", value }],
+    }) as unknown as Parameters<typeof eventsToStr>[0][number];
+
+  it("redacts ContentReasoning to summary when redacted", () => {
+    const out = eventsToStr([
+      stateEvent({
+        type: "reasoning",
+        reasoning: "OPAQUE_SIGNATURE",
+        summary: "human readable",
+        redacted: true,
+      }),
+    ]);
+    expect(out).toContain("human readable");
+    expect(out).not.toContain("OPAQUE_SIGNATURE");
+  });
+
+  it("replaces ContentImage with placeholder", () => {
+    const out = eventsToStr([
+      stateEvent({
+        type: "image",
+        image: "data:image/png;base64,_BIG_BLOB_",
+      }),
+    ]);
+    expect(out).toContain("<image />");
+    expect(out).not.toContain('"<image />"'); // placeholder must not be double-quoted
+    expect(out).not.toContain("_BIG_BLOB_");
+  });
+
+  it("preserves primitives and plain records", () => {
+    const out = eventsToStr([
+      stateEvent({ count: 3, label: "hello", nested: [1, 2, "x"] }),
+    ]);
+    expect(out).toContain('"count":3');
+    expect(out).toContain('"label":"hello"');
+    expect(out).toContain('"nested":[1,2,"x"]');
+  });
+
+  it("walks nested content arrays", () => {
+    const out = eventsToStr([
+      stateEvent({
+        messages: [
+          {
+            content: [
+              { type: "image", image: "data:_BIG_" },
+              { type: "text", text: "ok" },
+            ],
+          },
+        ],
+      }),
+    ]);
+    expect(out).toContain("<image />");
+    expect(out).toContain('"text":"ok"');
+    expect(out).not.toContain("_BIG_");
+  });
+
+  it("does not collapse user data with a colliding `type` discriminator", () => {
+    const out = eventsToStr([
+      stateEvent({
+        type: "image",
+        url: "https://example.com/diagram.svg",
+        label: "fig 1",
+      }),
+    ]);
+    expect(out).not.toContain("<image />");
+    expect(out).toContain("https://example.com/diagram.svg");
+    expect(out).toContain("fig 1");
+  });
+});
+
+const toolEvent = (result: unknown): ToolEvent =>
+  ({
+    event: "tool",
+    uuid: "t",
+    span_id: null,
+    timestamp: "2026-04-29T00:00:00Z",
+    working_start: 0,
+    pending: false,
+    function: "view_image",
+    arguments: { path: "/foo.png" },
+    result,
+    truncated: null,
+    view: null,
+    error: null,
+    events: [],
+    completed: null,
+    working_time: null,
+    agent: null,
+    failed: null,
+    metadata: null,
+  }) as unknown as ToolEvent;
+
+describe("eventsToStr — extractEventFields sanitization", () => {
+  it("sanitizes tool result containing image content", () => {
+    const out = eventsToStr([
+      toolEvent([
+        { type: "image", image: "data:image/png;base64,_HUGE_PNG_" },
+        { type: "text", text: "see image" },
+      ]),
+    ]);
+    expect(out).toContain("<image />");
+    expect(out).toContain("see image");
+    expect(out).not.toContain("_HUGE_PNG_");
+  });
+});
+
+const compactionEvent = (
+  partial: Partial<CompactionEvent> = {}
+): CompactionEvent =>
+  ({
+    event: "compaction",
+    uuid: "VYVv8bWPCmD5fJYzrYq5MT",
+    span_id: "SPJ9XpwBYA3GuLzkGwmdwR",
+    timestamp: "2026-04-25T03:12:30.042596+00:00",
+    working_start: 4195.599,
+    source: "inspect",
+    type: "summary",
+    tokens_before: 263089,
+    tokens_after: 1923,
+    metadata: {
+      strategy: "CompactionSummary",
+      messages_before: 190,
+      messages_after: 3,
+    },
+    ...partial,
+  }) as unknown as CompactionEvent;
+
+describe("eventsToStr — compaction event", () => {
+  it("renders only UI-visible fields (tokens + metadata), not full event JSON", () => {
+    const out = eventsToStr([compactionEvent()]);
+    expect(out).toContain("tokens_before");
+    expect(out).toContain("263089");
+    expect(out).toContain("tokens_after");
+    expect(out).toContain("1923");
+    expect(out).toContain("strategy");
+    expect(out).toContain("CompactionSummary");
+    expect(out).toContain("messages_before");
+    expect(out).toContain("190");
+    expect(out).not.toContain("VYVv8bWPCmD5fJYzrYq5MT"); // uuid
+    expect(out).not.toContain("SPJ9XpwBYA3GuLzkGwmdwR"); // span_id
+    expect(out).not.toContain("working_start");
+    expect(out).not.toContain('"event":"compaction"'); // discriminator inside JSON dump
+  });
+
+  it("omits source when it is the default 'inspect'", () => {
+    const out = eventsToStr([compactionEvent({ source: "inspect" })]);
+    expect(out).not.toMatch(/^source: /m);
+  });
+
+  it("includes source when it is non-default", () => {
+    const out = eventsToStr([compactionEvent({ source: "agent" })]);
+    expect(out).toContain("source: agent");
   });
 });

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -351,11 +351,11 @@ const extractContentText = (content: string | Array<Content>): string[] => {
         texts.push(item.text);
         break;
       case "reasoning": {
-        const reasoning = item;
-        if (reasoning.reasoning) {
-          texts.push(reasoning.reasoning);
-        } else if (reasoning.summary) {
-          texts.push(reasoning.summary);
+        const text = item.redacted
+          ? item.summary
+          : item.reasoning || item.summary;
+        if (text) {
+          texts.push(text);
         }
         break;
       }

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -3,6 +3,54 @@ import type { Content } from "@tsmono/inspect-common/types";
 import type { EventType } from "./types";
 import { EventNode } from "./types";
 
+// `type` -> required payload key. The payload-key check avoids collapsing
+// user data that happens to share a discriminator value but isn't a Content*.
+const SANITIZED_CONTENT_KEYS: Record<string, string> = {
+  image: "image",
+  audio: "audio",
+  video: "video",
+  data: "data",
+  document: "document",
+};
+
+// Mirror how the viewer renders Content* values: ContentReasoning becomes the
+// readable text (matching MessageContent.tsx), other Content* become a
+// `<type />` placeholder (matching the UI's <img>/<audio>/etc. tags). Returns
+// undefined for anything else, so the caller preserves the original value.
+const sanitizeContent = (val: unknown): string | undefined => {
+  if (val === null || typeof val !== "object" || !("type" in val)) {
+    return undefined;
+  }
+  if (val.type === "reasoning" && "reasoning" in val) {
+    const r = val as {
+      reasoning?: string | null;
+      summary?: string | null;
+      redacted?: boolean;
+    };
+    return r.redacted ? (r.summary ?? "") : r.reasoning || r.summary || "";
+  }
+  if (typeof val.type === "string") {
+    const payloadKey = SANITIZED_CONTENT_KEYS[val.type];
+    if (payloadKey && payloadKey in val) {
+      return `<${val.type} />`;
+    }
+  }
+  return undefined;
+};
+
+const sanitizeStringify = (v: unknown): string => {
+  // Top-level Content* values: bypass JSON.stringify, which would wrap a
+  // reviver-returned string in literal JSON quotes.
+  const rootSanitized = sanitizeContent(v);
+  if (rootSanitized !== undefined) {
+    return rootSanitized;
+  }
+  return JSON.stringify(v, (_key, val: unknown) => {
+    const replacement = sanitizeContent(val);
+    return replacement !== undefined ? replacement : val;
+  });
+};
+
 /**
  * Extracts labeled fields from an event for search and text serialization.
  */
@@ -65,7 +113,7 @@ const extractEventFields = (event: EventType): [string, string][] => {
         if (typeof toolEvent.result === "string") {
           fields.push(["result", toolEvent.result]);
         } else {
-          fields.push(["result", JSON.stringify(toolEvent.result)]);
+          fields.push(["result", sanitizeStringify(toolEvent.result)]);
         }
       }
       // Tool error
@@ -108,7 +156,7 @@ const extractEventFields = (event: EventType): [string, string][] => {
         if (typeof infoEvent.data === "string") {
           fields.push(["data", infoEvent.data]);
         } else {
-          fields.push(["data", JSON.stringify(infoEvent.data)]);
+          fields.push(["data", sanitizeStringify(infoEvent.data)]);
         }
       }
       break;
@@ -126,12 +174,23 @@ const extractEventFields = (event: EventType): [string, string][] => {
     }
 
     case "compaction": {
+      // Mirror CompactionEventView: title (source if non-default) plus the
+      // tokens/metadata MetaDataGrid.
       const compactionEvent = event;
-      // Source shown in title
-      if (compactionEvent.source) {
+      if (compactionEvent.source && compactionEvent.source !== "inspect") {
         fields.push(["source", compactionEvent.source]);
       }
-      fields.push(["event", JSON.stringify(compactionEvent)]);
+      if (compactionEvent.tokens_before != null) {
+        fields.push(["tokens_before", String(compactionEvent.tokens_before)]);
+      }
+      if (compactionEvent.tokens_after != null) {
+        fields.push(["tokens_after", String(compactionEvent.tokens_after)]);
+      }
+      if (compactionEvent.metadata) {
+        for (const [k, v] of Object.entries(compactionEvent.metadata)) {
+          fields.push([k, typeof v === "string" ? v : sanitizeStringify(v)]);
+        }
+      }
       break;
     }
 
@@ -158,10 +217,10 @@ const extractEventFields = (event: EventType): [string, string][] => {
       }
       // Input/result shown in summary
       if (subtaskEvent.input) {
-        fields.push(["input", JSON.stringify(subtaskEvent.input)]);
+        fields.push(["input", sanitizeStringify(subtaskEvent.input)]);
       }
       if (subtaskEvent.result) {
-        fields.push(["result", JSON.stringify(subtaskEvent.result)]);
+        fields.push(["result", sanitizeStringify(subtaskEvent.result)]);
       }
       break;
     }
@@ -236,7 +295,7 @@ const extractEventFields = (event: EventType): [string, string][] => {
         }
       }
       if (sample.metadata && Object.keys(sample.metadata).length > 0) {
-        fields.push(["metadata", JSON.stringify(sample.metadata)]);
+        fields.push(["metadata", sanitizeStringify(sample.metadata)]);
       }
       break;
     }
@@ -301,7 +360,7 @@ const extractEventFields = (event: EventType): [string, string][] => {
             "value",
             typeof change.value === "string"
               ? change.value
-              : JSON.stringify(change.value),
+              : sanitizeStringify(change.value),
           ]);
         }
       }
@@ -365,10 +424,27 @@ const extractContentText = (content: string | Array<Content>): string[] => {
           texts.push(toolUse.name);
         }
         if (toolUse.arguments) {
-          texts.push(JSON.stringify(toolUse.arguments));
+          texts.push(sanitizeStringify(toolUse.arguments));
+        }
+        if (toolUse.result) {
+          texts.push(
+            typeof toolUse.result === "string"
+              ? toolUse.result
+              : sanitizeStringify(toolUse.result)
+          );
+        }
+        if (toolUse.error) {
+          texts.push(toolUse.error);
         }
         break;
       }
+      case "image":
+      case "audio":
+      case "video":
+      case "data":
+      case "document":
+        texts.push(`<${item.type} />`);
+        break;
     }
   }
   return texts;


### PR DESCRIPTION
## Summary

Copy/Transcript and transcript search should reflect what is visible in the viewer.

#160 fixed an issue with missing reasoning. 

This fixes some more over- and under-extraction issues: Under-extraction in `tool_use` content blocks (missing `result` and `error`), over-extraction in nested base64 and compaction events. Also emit placeholders when we strip non-text content like images.

Motivated by a multimodal eval produced 80MB of clipboard data (mostly base64-encoded images).

### Details
- `extractEventFields` used `JSON.stringify` on event payloads that could contain nested `Content[]` arrays, dumping base64 image data and nested encrypted reasoning blobs (that #160 didn't reach) into transcript copy and the in-page search index.
- Compaction events also dumped the full event JSON, far more than `CompactionEventView` renders on screen.
- Added `sanitizeStringify` to strip `ContentReasoning` to its readable text and replace multimodal `Content*` with `<type />` placeholders.
- Wired the helper through tool result, info data, subtask input/result, sample_init metadata, and state/store values.
- Completed `extractContentText` content-type coverage to match `messagesToStr` (tool_use result/error, multimodal placeholders).
- Rewrote the compaction case to mirror `CompactionEventView` (`source` only when non-default, plus `tokens_before` / `tokens_after` / metadata entries — no uuid/span_id/working_start).

Stacks on top of #160 (`fix: copy/search of redacted reasoning text`).

## Test plan
- [x] Added automatic tests
- [x] Manual tests of several evals with a mix of reasoning, compaction, and multimodal content.