### PR TITLE
Dark mode in scout viewer

### DIFF
--- a/apps/scout/index.html
+++ b/apps/scout/index.html
@@ -7,19 +7,75 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
     <script>
-      // Forward the theme (dark or light) onto the root html element
-      // this parameter will tend to appear when the view is hosted within
-      // an iframe (e.g. in vscode)
-      const urlParams = new URLSearchParams(window.location.search);
-      const theme = urlParams.get("inspectViewThemeCategory");
-      if (theme) {
-        document.documentElement.setAttribute("data-text-highlight", theme);
-        document.documentElement.setAttribute("data-bs-theme", theme);
-      }
+      (() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const explicitTheme = urlParams.get("inspectViewThemeCategory");
+        const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
+        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
+
+        const normalizeTheme = (theme) => {
+          if (theme === "dark" || theme === "vscode-dark") return "dark";
+          if (theme === "light" || theme === "vscode-light") return "light";
+          return systemTheme.matches ? "dark" : "light";
+        };
+
+        const currentTheme = () => {
+          if (explicitTheme || !isVscodeWebview) {
+            return normalizeTheme(explicitTheme);
+          }
+          return (
+            document.documentElement.getAttribute("data-bs-theme") || "light"
+          );
+        };
+
+        const applyRootTheme = (theme) => {
+          document.documentElement.setAttribute("data-text-highlight", theme);
+          document.documentElement.setAttribute("data-bs-theme", theme);
+        };
+
+        const applyBrowserBodyTheme = (theme) => {
+          if (!document.body) return;
+
+          const scoutManaged = document.body.hasAttribute(
+            "data-scout-browser-theme"
+          );
+          const vscodeManaged =
+            document.body.classList.contains("vscode-light") ||
+            document.body.classList.contains("vscode-dark") ||
+            document.body.classList.contains("vscode-high-contrast") ||
+            document.body.hasAttribute("data-vscode-theme-kind");
+
+          if (vscodeManaged && !scoutManaged) return;
+
+          document.body.setAttribute("data-scout-browser-theme", theme);
+          document.body.classList.toggle("vscode-dark", theme === "dark");
+        };
+
+        window.__SCOUT_APPLY_BROWSER_THEME__ = () => {
+          const theme = currentTheme();
+          if (explicitTheme || !isVscodeWebview) {
+            applyRootTheme(theme);
+          }
+          if (!isVscodeWebview) {
+            applyBrowserBodyTheme(theme);
+          }
+        };
+
+        window.__SCOUT_APPLY_BROWSER_THEME__();
+
+        if (!explicitTheme && !isVscodeWebview) {
+          systemTheme.addEventListener("change", () => {
+            window.__SCOUT_APPLY_BROWSER_THEME__();
+          });
+        }
+      })();
     </script>
   </head>
 
   <body style="min-width: 450px">
+    <script>
+      window.__SCOUT_APPLY_BROWSER_THEME__?.();
+    </script>
     <div id="app"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/scout/index.html
+++ b/apps/scout/index.html
@@ -13,25 +13,24 @@
         const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
         const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-        const resolveTheme = () => {
-          if (explicitTheme === "dark" || explicitTheme === "vscode-dark") {
-            return "dark";
-          }
-          if (explicitTheme === "light" || explicitTheme === "vscode-light") {
-            return "light";
-          }
+        const resolvedTheme = () => {
+          if (explicitTheme) return explicitTheme;
           return systemTheme.matches ? "dark" : "light";
+        };
+
+        const isDarkTheme = (theme) => {
+          return theme === "dark" || theme === "vscode-dark";
         };
 
         const applyTheme = () => {
           if (isVscodeWebview && !explicitTheme) return;
 
-          const theme = resolveTheme();
+          const theme = resolvedTheme();
           document.documentElement.setAttribute("data-text-highlight", theme);
           document.documentElement.setAttribute("data-bs-theme", theme);
 
           if (!isVscodeWebview) {
-            document.body?.classList.toggle("vscode-dark", theme === "dark");
+            document.body?.classList.toggle("vscode-dark", isDarkTheme(theme));
           }
         };
 

--- a/apps/scout/index.html
+++ b/apps/scout/index.html
@@ -13,60 +13,33 @@
         const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
         const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-        const normalizeTheme = (theme) => {
-          if (theme === "dark" || theme === "vscode-dark") return "dark";
-          if (theme === "light" || theme === "vscode-light") return "light";
+        const resolveTheme = () => {
+          if (explicitTheme === "dark" || explicitTheme === "vscode-dark") {
+            return "dark";
+          }
+          if (explicitTheme === "light" || explicitTheme === "vscode-light") {
+            return "light";
+          }
           return systemTheme.matches ? "dark" : "light";
         };
 
-        const currentTheme = () => {
-          if (explicitTheme || !isVscodeWebview) {
-            return normalizeTheme(explicitTheme);
-          }
-          return (
-            document.documentElement.getAttribute("data-bs-theme") || "light"
-          );
-        };
+        const applyTheme = () => {
+          if (isVscodeWebview && !explicitTheme) return;
 
-        const applyRootTheme = (theme) => {
+          const theme = resolveTheme();
           document.documentElement.setAttribute("data-text-highlight", theme);
           document.documentElement.setAttribute("data-bs-theme", theme);
-        };
 
-        const applyBrowserBodyTheme = (theme) => {
-          if (!document.body) return;
-
-          const scoutManaged = document.body.hasAttribute(
-            "data-scout-browser-theme"
-          );
-          const vscodeManaged =
-            document.body.classList.contains("vscode-light") ||
-            document.body.classList.contains("vscode-dark") ||
-            document.body.classList.contains("vscode-high-contrast") ||
-            document.body.hasAttribute("data-vscode-theme-kind");
-
-          if (vscodeManaged && !scoutManaged) return;
-
-          document.body.setAttribute("data-scout-browser-theme", theme);
-          document.body.classList.toggle("vscode-dark", theme === "dark");
-        };
-
-        window.__SCOUT_APPLY_BROWSER_THEME__ = () => {
-          const theme = currentTheme();
-          if (explicitTheme || !isVscodeWebview) {
-            applyRootTheme(theme);
-          }
           if (!isVscodeWebview) {
-            applyBrowserBodyTheme(theme);
+            document.body?.classList.toggle("vscode-dark", theme === "dark");
           }
         };
 
+        window.__SCOUT_APPLY_BROWSER_THEME__ = applyTheme;
         window.__SCOUT_APPLY_BROWSER_THEME__();
 
         if (!explicitTheme && !isVscodeWebview) {
-          systemTheme.addEventListener("change", () => {
-            window.__SCOUT_APPLY_BROWSER_THEME__();
-          });
+          systemTheme.addEventListener("change", applyTheme);
         }
       })();
     </script>

--- a/apps/scout/index.html
+++ b/apps/scout/index.html
@@ -5,68 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Inspect Scout</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-
-    <script>
-      (() => {
-        const SETTINGS_KEY = "inspect-scout-user-settings";
-        const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
-        const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const readThemePreference = () => {
-          try {
-            const raw = localStorage.getItem(SETTINGS_KEY);
-            if (!raw) return "system";
-            const parsed = JSON.parse(raw);
-            const value = parsed?.state?.themePreference;
-            return value === "light" || value === "dark" || value === "system"
-              ? value
-              : "system";
-          } catch {
-            return "system";
-          }
-        };
-
-        const isDarkTheme = (theme) => {
-          return theme === "dark" || theme === "vscode-dark";
-        };
-
-        const applyTheme = () => {
-          const urlParams = new URLSearchParams(window.location.search);
-          const explicitTheme = urlParams.get("inspectViewThemeCategory");
-          const themePreference = readThemePreference();
-          const userOverride =
-            themePreference === "light" || themePreference === "dark"
-              ? themePreference
-              : null;
-
-          if (!userOverride && isVscodeWebview && !explicitTheme) return;
-
-          let theme;
-          if (userOverride) {
-            theme = userOverride;
-          } else if (explicitTheme) {
-            theme = explicitTheme;
-          } else {
-            theme = systemTheme.matches ? "dark" : "light";
-          }
-
-          document.documentElement.setAttribute("data-text-highlight", theme);
-          document.documentElement.setAttribute(
-            "data-bs-theme",
-            isDarkTheme(theme) ? "dark" : "light"
-          );
-
-          if (!isVscodeWebview || userOverride) {
-            document.body?.classList.toggle("vscode-dark", isDarkTheme(theme));
-          }
-        };
-
-        window.__SCOUT_APPLY_BROWSER_THEME__ = applyTheme;
-        window.__SCOUT_APPLY_BROWSER_THEME__();
-
-        systemTheme.addEventListener("change", applyTheme);
-      })();
-    </script>
+    <!-- THEME_BOOTSTRAP -->
   </head>
 
   <body style="min-width: 450px">

--- a/apps/scout/index.html
+++ b/apps/scout/index.html
@@ -8,14 +8,22 @@
 
     <script>
       (() => {
-        const urlParams = new URLSearchParams(window.location.search);
-        const explicitTheme = urlParams.get("inspectViewThemeCategory");
+        const SETTINGS_KEY = "inspect-scout-user-settings";
         const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
         const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
 
-        const resolvedTheme = () => {
-          if (explicitTheme) return explicitTheme;
-          return systemTheme.matches ? "dark" : "light";
+        const readThemePreference = () => {
+          try {
+            const raw = localStorage.getItem(SETTINGS_KEY);
+            if (!raw) return "system";
+            const parsed = JSON.parse(raw);
+            const value = parsed?.state?.themePreference;
+            return value === "light" || value === "dark" || value === "system"
+              ? value
+              : "system";
+          } catch {
+            return "system";
+          }
         };
 
         const isDarkTheme = (theme) => {
@@ -23,13 +31,32 @@
         };
 
         const applyTheme = () => {
-          if (isVscodeWebview && !explicitTheme) return;
+          const urlParams = new URLSearchParams(window.location.search);
+          const explicitTheme = urlParams.get("inspectViewThemeCategory");
+          const themePreference = readThemePreference();
+          const userOverride =
+            themePreference === "light" || themePreference === "dark"
+              ? themePreference
+              : null;
 
-          const theme = resolvedTheme();
+          if (!userOverride && isVscodeWebview && !explicitTheme) return;
+
+          let theme;
+          if (userOverride) {
+            theme = userOverride;
+          } else if (explicitTheme) {
+            theme = explicitTheme;
+          } else {
+            theme = systemTheme.matches ? "dark" : "light";
+          }
+
           document.documentElement.setAttribute("data-text-highlight", theme);
-          document.documentElement.setAttribute("data-bs-theme", theme);
+          document.documentElement.setAttribute(
+            "data-bs-theme",
+            isDarkTheme(theme) ? "dark" : "light"
+          );
 
-          if (!isVscodeWebview) {
+          if (!isVscodeWebview || userOverride) {
             document.body?.classList.toggle("vscode-dark", isDarkTheme(theme));
           }
         };
@@ -37,9 +64,7 @@
         window.__SCOUT_APPLY_BROWSER_THEME__ = applyTheme;
         window.__SCOUT_APPLY_BROWSER_THEME__();
 
-        if (!explicitTheme && !isVscodeWebview) {
-          systemTheme.addEventListener("change", applyTheme);
-        }
+        systemTheme.addEventListener("change", applyTheme);
       })();
     </script>
   </head>

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -67,6 +67,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "esbuild": "0.27.7",
     "eslint": "^9.39.4",
     "eventsource": "^4.1.0",
     "jsdom": "^29.1.0",

--- a/apps/scout/src/App.tsx
+++ b/apps/scout/src/App.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useMemo } from "react";
+import { createContext, FC, useEffect, useMemo } from "react";
 import { RouterProvider } from "react-router-dom";
 
 import "prismjs";
@@ -25,6 +25,7 @@ import { AppErrorBoundary } from "./AppErrorBoundary";
 import { createAppRouter } from "./AppRouter";
 import { ApplicationIcons } from "./icons";
 import { scoutStateHooks } from "./state/componentStateAdapter";
+import { useUserSettings } from "./state/userSettings";
 
 const componentIcons: ComponentIcons = {
   chevronDown: ApplicationIcons.chevron.down,
@@ -51,8 +52,16 @@ export interface AppProps {
 
 export const App: FC<AppProps> = (props) => {
   const invalidationReady = useTopicInvalidation();
+  useThemePreferenceSync();
 
   return invalidationReady ? <AppContent {...props} /> : null;
+};
+
+const useThemePreferenceSync = () => {
+  const themePreference = useUserSettings((s) => s.themePreference);
+  useEffect(() => {
+    window.__SCOUT_APPLY_BROWSER_THEME__?.();
+  }, [themePreference]);
 };
 
 const AppContent: FC<AppProps> = ({ mode = "scans" }) => {

--- a/apps/scout/src/AppRouter.tsx
+++ b/apps/scout/src/AppRouter.tsx
@@ -17,6 +17,7 @@ import { ScanPanel } from "./app/scan/ScanPanel";
 import { ScannerResultPanel } from "./app/scannerResult/ScannerResultPanel";
 import { ScansPanel } from "./app/scans/ScansPanel";
 import { useAppConfig } from "./app/server/useAppConfig";
+import { SettingsPanel } from "./app/settings/SettingsPanel";
 import { TranscriptPanel } from "./app/transcript/TranscriptPanel";
 import { TranscriptsPanel } from "./app/transcripts/TranscriptsPanel";
 import { ValidationPanel } from "./app/validation/ValidationPanel";
@@ -31,6 +32,7 @@ import {
   kScansRootRouteUrlPattern,
   kScansRouteUrlPattern,
   kScansWithPathRouteUrlPattern,
+  kSettingsRouteUrlPattern,
   kTranscriptDetailRoute,
   kTranscriptsRouteUrlPattern,
   kValidationRouteUrlPattern,
@@ -156,6 +158,10 @@ export const createAppRouter = (config: AppRouterConfig) => {
           {
             path: kValidationRouteUrlPattern,
             element: <ValidationPanel />,
+          },
+          {
+            path: kSettingsRouteUrlPattern,
+            element: <SettingsPanel />,
           },
           {
             path: kTranscriptDetailRoute,

--- a/apps/scout/src/app/settings/SettingsPanel.module.css
+++ b/apps/scout/src/app/settings/SettingsPanel.module.css
@@ -1,0 +1,43 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
+  padding: 1.5rem 1.75rem;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  margin: 0 0 1.25rem 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 480px;
+}
+
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--vscode-foreground);
+}
+
+.select {
+  max-width: 240px;
+}

--- a/apps/scout/src/app/settings/SettingsPanel.tsx
+++ b/apps/scout/src/app/settings/SettingsPanel.tsx
@@ -20,9 +20,11 @@ export const SettingsPanel: FC = () => {
   const setThemePreference = useUserSettings((s) => s.setThemePreference);
 
   const handleThemeChange = (e: Event) => {
-    const value = (e.target as HTMLSelectElement).value;
-    if (isThemePreference(value)) {
-      setThemePreference(value);
+    if (e.target instanceof HTMLSelectElement) {
+      const { value } = e.target;
+      if (isThemePreference(value)) {
+        setThemePreference(value);
+      }
     }
   };
 

--- a/apps/scout/src/app/settings/SettingsPanel.tsx
+++ b/apps/scout/src/app/settings/SettingsPanel.tsx
@@ -20,11 +20,14 @@ export const SettingsPanel: FC = () => {
   const setThemePreference = useUserSettings((s) => s.setThemePreference);
 
   const handleThemeChange = (e: Event) => {
-    if (e.target instanceof HTMLSelectElement) {
-      const { value } = e.target;
-      if (isThemePreference(value)) {
-        setThemePreference(value);
-      }
+    const value =
+      e.target !== null &&
+      "value" in e.target &&
+      typeof e.target.value === "string"
+        ? e.target.value
+        : "";
+    if (isThemePreference(value)) {
+      setThemePreference(value);
     }
   };
 

--- a/apps/scout/src/app/settings/SettingsPanel.tsx
+++ b/apps/scout/src/app/settings/SettingsPanel.tsx
@@ -1,0 +1,52 @@
+import {
+  VscodeOption,
+  VscodeSingleSelect,
+} from "@vscode-elements/react-elements";
+import { FC } from "react";
+
+import { useDocumentTitle } from "@tsmono/react/hooks";
+
+import { ThemePreference, useUserSettings } from "../../state/userSettings";
+
+import styles from "./SettingsPanel.module.css";
+
+const isThemePreference = (value: string): value is ThemePreference =>
+  value === "system" || value === "light" || value === "dark";
+
+export const SettingsPanel: FC = () => {
+  useDocumentTitle("Settings");
+
+  const themePreference = useUserSettings((s) => s.themePreference);
+  const setThemePreference = useUserSettings((s) => s.setThemePreference);
+
+  const handleThemeChange = (e: Event) => {
+    const value = (e.target as HTMLSelectElement).value;
+    if (isThemePreference(value)) {
+      setThemePreference(value);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Settings</h1>
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Appearance</h2>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="theme-preference">
+            Theme
+          </label>
+          <VscodeSingleSelect
+            id="theme-preference"
+            className={styles.select}
+            value={themePreference}
+            onChange={handleThemeChange}
+          >
+            <VscodeOption value="system">System</VscodeOption>
+            <VscodeOption value="light">Light</VscodeOption>
+            <VscodeOption value="dark">Dark</VscodeOption>
+          </VscodeSingleSelect>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/apps/scout/src/icons.ts
+++ b/apps/scout/src/icons.ts
@@ -142,6 +142,7 @@ export const ApplicationIcons = {
   scanner: "bi bi-radar",
   scorer: "bi bi-calculator",
   search: "bi bi-search",
+  settings: "bi bi-sliders",
   sidebar: "bi bi-list",
   solvers: {
     default: "bi bi-arrow-return-right",

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -20,6 +20,7 @@ declare global {
   interface Window {
     __SCOUT_BASE_PATH__?: string;
     __SCOUT_DISABLE_SSE__?: boolean;
+    __SCOUT_APPLY_BROWSER_THEME__?: () => void;
   }
 }
 

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -20,7 +20,6 @@ declare global {
   interface Window {
     __SCOUT_BASE_PATH__?: string;
     __SCOUT_DISABLE_SSE__?: boolean;
-    __SCOUT_APPLY_BROWSER_THEME__?: () => void;
   }
 }
 

--- a/apps/scout/src/router/activities.tsx
+++ b/apps/scout/src/router/activities.tsx
@@ -60,9 +60,13 @@ const allActivities: ActivityConfig[] = [
   },
 ];
 
-export const activities = allActivities.filter(
-  (a) => a.id !== "runScan" || __SCOUT_RUN_SCAN__
-);
+const isVscodeWebview = typeof window.acquireVsCodeApi === "function";
+
+export const activities = allActivities.filter((a) => {
+  if (a.id === "runScan" && !__SCOUT_RUN_SCAN__) return false;
+  if (a.id === "settings" && isVscodeWebview) return false;
+  return true;
+});
 
 export const getActivityByRoute = (
   path: string

--- a/apps/scout/src/router/activities.tsx
+++ b/apps/scout/src/router/activities.tsx
@@ -50,6 +50,14 @@ const allActivities: ActivityConfig[] = [
     routePatterns: ["/validation"],
     description: "Manage validation sets",
   },
+  {
+    id: "settings",
+    label: "Settings",
+    icon: ApplicationIcons.settings,
+    route: "/settings",
+    routePatterns: ["/settings"],
+    description: "Scout settings",
+  },
 ];
 
 export const activities = allActivities.filter(

--- a/apps/scout/src/router/url.ts
+++ b/apps/scout/src/router/url.ts
@@ -9,6 +9,7 @@ export const kScanResultRouteUrlPattern = "/scan/:scansDir/*/*";
 export const kTranscriptsRouteUrlPattern = "/transcripts";
 export const kProjectRouteUrlPattern = "/project";
 export const kValidationRouteUrlPattern = "/validation";
+export const kSettingsRouteUrlPattern = "/settings";
 export const kTranscriptDetailRoute =
   "/transcripts/:transcriptsDir/:transcriptId";
 export const kTranscriptDetailRouteUrlPattern =
@@ -74,6 +75,8 @@ export const transcriptsRoute = (searchParams?: URLSearchParams) => {
 export const projectRoute = () => "/project";
 
 export const validationRoute = () => "/validation";
+
+export const settingsRoute = () => "/settings";
 
 export const transcriptRoute = (
   transcriptsDir: string,

--- a/apps/scout/src/state/userSettings.ts
+++ b/apps/scout/src/state/userSettings.ts
@@ -6,17 +6,25 @@ export interface ColumnPreset {
   columns: string[];
 }
 
+export type ThemePreference = "system" | "light" | "dark";
+
 interface UserSettingsState {
   dataframeColumnPresets: ColumnPreset[];
+  themePreference: ThemePreference;
   setDataframeColumnPresets: (presets: ColumnPreset[]) => void;
+  setThemePreference: (themePreference: ThemePreference) => void;
 }
 
 export const useUserSettings = create<UserSettingsState>()(
   persist(
     (set) => ({
       dataframeColumnPresets: [],
+      themePreference: "system",
       setDataframeColumnPresets: (presets: ColumnPreset[]) => {
         set({ dataframeColumnPresets: presets });
+      },
+      setThemePreference: (themePreference: ThemePreference) => {
+        set({ themePreference });
       },
     }),
     {

--- a/apps/scout/src/theme/bootstrap.ts
+++ b/apps/scout/src/theme/bootstrap.ts
@@ -1,0 +1,36 @@
+import { readThemePreference, resolveTheme } from "./resolveTheme";
+
+declare global {
+  interface Window {
+    __SCOUT_APPLY_BROWSER_THEME__?: () => void;
+  }
+}
+
+const applyTheme = (): void => {
+  const params = new URLSearchParams(window.location.search);
+  const result = resolveTheme({
+    preference: readThemePreference(localStorage),
+    explicitParam: params.get("inspectViewThemeCategory"),
+    isVscodeWebview: typeof window.acquireVsCodeApi === "function",
+    prefersDark: window.matchMedia("(prefers-color-scheme: dark)").matches,
+  });
+
+  if (result.kind === "skip") return;
+
+  document.documentElement.setAttribute("data-text-highlight", result.theme);
+  document.documentElement.setAttribute(
+    "data-bs-theme",
+    result.isDark ? "dark" : "light"
+  );
+
+  if (result.toggleBodyClass) {
+    document.body?.classList.toggle("vscode-dark", result.isDark);
+  }
+};
+
+window.__SCOUT_APPLY_BROWSER_THEME__ = applyTheme;
+applyTheme();
+
+window
+  .matchMedia("(prefers-color-scheme: dark)")
+  .addEventListener("change", applyTheme);

--- a/apps/scout/src/theme/resolveTheme.test.ts
+++ b/apps/scout/src/theme/resolveTheme.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readThemePreference,
+  resolveTheme,
+  SETTINGS_STORAGE_KEY,
+  ThemePreference,
+} from "./resolveTheme";
+
+const fakeStorage = (raw: string | null): Pick<Storage, "getItem"> => ({
+  getItem: (key) => (key === SETTINGS_STORAGE_KEY ? raw : null),
+});
+
+const persisted = (themePreference?: unknown): string =>
+  JSON.stringify({ state: { themePreference }, version: 0 });
+
+describe("readThemePreference", () => {
+  it("defaults to 'system' when storage is empty", () => {
+    expect(readThemePreference(fakeStorage(null))).toBe("system");
+  });
+
+  it("defaults to 'system' when JSON is malformed", () => {
+    expect(readThemePreference(fakeStorage("{not json"))).toBe("system");
+  });
+
+  it("defaults to 'system' when state is missing", () => {
+    expect(readThemePreference(fakeStorage("{}"))).toBe("system");
+  });
+
+  it("defaults to 'system' when themePreference has unknown value", () => {
+    expect(readThemePreference(fakeStorage(persisted("solar")))).toBe("system");
+  });
+
+  it.each<ThemePreference>(["system", "light", "dark"])(
+    "returns persisted value '%s'",
+    (value) => {
+      expect(readThemePreference(fakeStorage(persisted(value)))).toBe(value);
+    }
+  );
+});
+
+describe("resolveTheme", () => {
+  const baseInput = {
+    preference: "system" as ThemePreference,
+    explicitParam: null,
+    isVscodeWebview: false,
+    prefersDark: false,
+  };
+
+  it("standalone + system + light OS → light", () => {
+    expect(resolveTheme({ ...baseInput, prefersDark: false })).toEqual({
+      kind: "apply",
+      theme: "light",
+      isDark: false,
+      toggleBodyClass: true,
+    });
+  });
+
+  it("standalone + system + dark OS → dark", () => {
+    expect(resolveTheme({ ...baseInput, prefersDark: true })).toEqual({
+      kind: "apply",
+      theme: "dark",
+      isDark: true,
+      toggleBodyClass: true,
+    });
+  });
+
+  it("standalone + light override wins regardless of OS", () => {
+    expect(
+      resolveTheme({ ...baseInput, preference: "light", prefersDark: true })
+    ).toMatchObject({ theme: "light", isDark: false });
+  });
+
+  it("standalone + dark override wins regardless of OS", () => {
+    expect(
+      resolveTheme({ ...baseInput, preference: "dark", prefersDark: false })
+    ).toMatchObject({ theme: "dark", isDark: true });
+  });
+
+  it("VS Code + system + no explicit param → skip (let VS Code own theme)", () => {
+    expect(resolveTheme({ ...baseInput, isVscodeWebview: true })).toEqual({
+      kind: "skip",
+    });
+  });
+
+  it("VS Code + explicit param 'vscode-dark' → apply, treated as dark", () => {
+    expect(
+      resolveTheme({
+        ...baseInput,
+        isVscodeWebview: true,
+        explicitParam: "vscode-dark",
+      })
+    ).toEqual({
+      kind: "apply",
+      theme: "vscode-dark",
+      isDark: true,
+      toggleBodyClass: false,
+    });
+  });
+
+  it("VS Code + user override applies and toggles body class", () => {
+    expect(
+      resolveTheme({
+        ...baseInput,
+        isVscodeWebview: true,
+        preference: "dark",
+      })
+    ).toEqual({
+      kind: "apply",
+      theme: "dark",
+      isDark: true,
+      toggleBodyClass: true,
+    });
+  });
+
+  it("standalone + explicit param + system → uses explicit param", () => {
+    expect(
+      resolveTheme({ ...baseInput, explicitParam: "light", prefersDark: true })
+    ).toMatchObject({ theme: "light", isDark: false });
+  });
+
+  it("user override beats explicit param", () => {
+    expect(
+      resolveTheme({
+        ...baseInput,
+        preference: "dark",
+        explicitParam: "light",
+      })
+    ).toMatchObject({ theme: "dark", isDark: true });
+  });
+});

--- a/apps/scout/src/theme/resolveTheme.test.ts
+++ b/apps/scout/src/theme/resolveTheme.test.ts
@@ -98,19 +98,24 @@ describe("resolveTheme", () => {
     });
   });
 
-  it("VS Code + user override applies and toggles body class", () => {
+  it.each<"light" | "dark">(["light", "dark"])(
+    "VS Code ignores in-app override '%s' and skips",
+    (preference) => {
+      expect(
+        resolveTheme({ ...baseInput, isVscodeWebview: true, preference })
+      ).toEqual({ kind: "skip" });
+    }
+  );
+
+  it("VS Code + explicit param wins even when override is also set", () => {
     expect(
       resolveTheme({
         ...baseInput,
         isVscodeWebview: true,
-        preference: "dark",
+        preference: "light",
+        explicitParam: "vscode-dark",
       })
-    ).toEqual({
-      kind: "apply",
-      theme: "dark",
-      isDark: true,
-      toggleBodyClass: true,
-    });
+    ).toMatchObject({ theme: "vscode-dark", isDark: true });
   });
 
   it("standalone + explicit param + system → uses explicit param", () => {

--- a/apps/scout/src/theme/resolveTheme.ts
+++ b/apps/scout/src/theme/resolveTheme.ts
@@ -45,15 +45,24 @@ const isDarkTheme = (theme: string): boolean =>
   theme === "dark" || theme === "vscode-dark";
 
 export const resolveTheme = (input: ResolveInput): ResolveOutput => {
-  const userOverride = input.preference !== "system" ? input.preference : null;
-
-  if (!userOverride && input.isVscodeWebview && !input.explicitParam) {
-    return { kind: "skip" };
+  // Inside VS Code we always defer to VS Code's own theme machinery;
+  // the in-app preference is hidden in that environment, so any persisted
+  // override from a standalone session must stay inert. An explicit theme
+  // query parameter is still honored since callers use it to embed Scout
+  // with a specific theme.
+  if (input.isVscodeWebview) {
+    if (!input.explicitParam) return { kind: "skip" };
+    return {
+      kind: "apply",
+      theme: input.explicitParam,
+      isDark: isDarkTheme(input.explicitParam),
+      toggleBodyClass: false,
+    };
   }
 
   let theme: string;
-  if (userOverride) {
-    theme = userOverride;
+  if (input.preference !== "system") {
+    theme = input.preference;
   } else if (input.explicitParam) {
     theme = input.explicitParam;
   } else {
@@ -64,6 +73,6 @@ export const resolveTheme = (input: ResolveInput): ResolveOutput => {
     kind: "apply",
     theme,
     isDark: isDarkTheme(theme),
-    toggleBodyClass: !input.isVscodeWebview || userOverride !== null,
+    toggleBodyClass: true,
   };
 };

--- a/apps/scout/src/theme/resolveTheme.ts
+++ b/apps/scout/src/theme/resolveTheme.ts
@@ -1,0 +1,69 @@
+export const SETTINGS_STORAGE_KEY = "inspect-scout-user-settings";
+
+export type ThemePreference = "system" | "light" | "dark";
+
+export const isThemePreference = (value: unknown): value is ThemePreference =>
+  value === "system" || value === "light" || value === "dark";
+
+export const readThemePreference = (
+  storage: Pick<Storage, "getItem">
+): ThemePreference => {
+  try {
+    const raw = storage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return "system";
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && "state" in parsed) {
+      const state = parsed.state;
+      if (state && typeof state === "object" && "themePreference" in state) {
+        const value = state.themePreference;
+        if (isThemePreference(value)) return value;
+      }
+    }
+    return "system";
+  } catch {
+    return "system";
+  }
+};
+
+export type ResolveInput = {
+  preference: ThemePreference;
+  explicitParam: string | null;
+  isVscodeWebview: boolean;
+  prefersDark: boolean;
+};
+
+export type ResolveOutput =
+  | { kind: "skip" }
+  | {
+      kind: "apply";
+      theme: string;
+      isDark: boolean;
+      toggleBodyClass: boolean;
+    };
+
+const isDarkTheme = (theme: string): boolean =>
+  theme === "dark" || theme === "vscode-dark";
+
+export const resolveTheme = (input: ResolveInput): ResolveOutput => {
+  const userOverride = input.preference !== "system" ? input.preference : null;
+
+  if (!userOverride && input.isVscodeWebview && !input.explicitParam) {
+    return { kind: "skip" };
+  }
+
+  let theme: string;
+  if (userOverride) {
+    theme = userOverride;
+  } else if (input.explicitParam) {
+    theme = input.explicitParam;
+  } else {
+    theme = input.prefersDark ? "dark" : "light";
+  }
+
+  return {
+    kind: "apply",
+    theme,
+    isDark: isDarkTheme(theme),
+    toggleBodyClass: !input.isVscodeWebview || userOverride !== null,
+  };
+};

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -2,6 +2,7 @@ import { cpSync, rmSync } from "fs";
 import { join, resolve } from "path";
 
 import react from "@vitejs/plugin-react";
+import { build as esbuild } from "esbuild";
 import pc from "picocolors";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
@@ -11,6 +12,29 @@ import {
   findPythonRepoRoot,
   warnIfWatchingWithoutSubmodule,
 } from "../../tooling/python-repo/index.js";
+
+function inlineThemeBootstrap(): Plugin {
+  const entry = resolve(__dirname, "src/theme/bootstrap.ts");
+  const placeholder = "<!-- THEME_BOOTSTRAP -->";
+  return {
+    name: "inline-theme-bootstrap",
+    transformIndexHtml: {
+      order: "pre",
+      async handler(html) {
+        const result = await esbuild({
+          entryPoints: [entry],
+          bundle: true,
+          format: "iife",
+          target: "es2020",
+          minify: true,
+          write: false,
+        });
+        const code = result.outputFiles[0].text.trim();
+        return html.replace(placeholder, `<script>${code}</script>`);
+      },
+    },
+  };
+}
 
 function copyToPythonRepo(): Plugin {
   return {
@@ -101,6 +125,7 @@ export default defineConfig(({ mode }) => {
       ...baseConfig,
       plugins: [
         ...baseConfig.plugins,
+        inlineThemeBootstrap(),
         warnIfWatchingWithoutSubmodule("inspect_scout"),
         copyToPythonRepo(),
       ],

--- a/packages/theme/src/vscode.css
+++ b/packages/theme/src/vscode.css
@@ -1,11 +1,14 @@
-/* VS Code Light Modern theme defaults (for non-VS Code context) */
+/* VS Code Light/Dark Modern theme defaults (for non-VS Code context) */
 /* Complete set of variables used by @vscode-elements/elements */
 /* These are overridden by actual VS Code theme variables when running in VS Code */
 
 :root {
+  color-scheme: light;
+
   /* Core colors */
   --vscode-foreground: #3b3b3b;
   --vscode-descriptionForeground: #717171;
+  --vscode-disabledForeground: rgba(0, 0, 0, 0.4);
   --vscode-errorForeground: #f14c4c;
   --vscode-icon-foreground: #424242;
   --vscode-focusBorder: #0090f1;
@@ -25,8 +28,17 @@
   --vscode-editor-background: #ffffff;
   --vscode-editor-foreground: #3b3b3b;
   --vscode-editor-inlineValuesForeground: rgba(0, 0, 0, 0.5);
+  --vscode-editor-inactiveSelectionBackground: #e5ebf1;
+  --vscode-editor-selectionBackground: #add6ff;
+  --vscode-editor-selectionHighlightBackground: rgba(173, 214, 255, 0.45);
   --vscode-editorGroup-border: #e7e7e7;
+  --vscode-editorHoverWidget-background: #f3f3f3;
+  --vscode-editorInfo-foreground: #316bcd;
+  --vscode-editorLink-activeForeground: #006ab1;
+  --vscode-editorWarning-foreground: #bf8803;
+  --vscode-editorWidget-background: #f3f3f3;
   --vscode-editorWidget-border: #d4d4d4;
+  --vscode-editorWidget-foreground: #3b3b3b;
 
   /* Input colors */
   --vscode-input-background: #ffffff;
@@ -42,6 +54,11 @@
   --vscode-inputValidation-warningBorder: #be8800;
   --vscode-inputValidation-errorBackground: #f2dede;
   --vscode-inputValidation-errorBorder: #be1100;
+
+  /* Dropdown colors */
+  --vscode-dropdown-background: #ffffff;
+  --vscode-dropdown-foreground: #3b3b3b;
+  --vscode-dropdown-border: #cecece;
 
   /* Settings controls (used by vscode-elements textfield, checkbox, dropdown) */
   --vscode-settings-textInputBackground: #ffffff;
@@ -107,8 +124,18 @@
   --vscode-activityBarBadge-background: #007acc;
   --vscode-activityBarBadge-foreground: #ffffff;
 
+  /* Banner, breadcrumb, notifications, links */
+  --vscode-banner-iconForeground: #007acc;
+  --vscode-breadcrumb-foreground: #616161;
+  --vscode-notificationLink-foreground: #006ab1;
+  --vscode-notifications-background: #ffffff;
+  --vscode-notifications-foreground: #3b3b3b;
+  --vscode-textLink-foreground: #006ab1;
+  --vscode-textLink-activeForeground: #005a9e;
+
   /* Panel colors */
   --vscode-panel-background: #ffffff;
+  --vscode-panel-border: #e7e7e7;
   --vscode-panelTitle-activeBorder: #007acc;
   --vscode-panelTitle-activeForeground: #3b3b3b;
   --vscode-panelTitle-inactiveForeground: #717171;
@@ -116,7 +143,17 @@
   /* Sidebar colors */
   --vscode-sideBar-background: #f3f3f3;
   --vscode-sideBarSectionHeader-background: #f3f3f3;
+  --vscode-sideBarSectionHeader-border: #e7e7e7;
+  --vscode-sideBarSectionHeader-foreground: #3b3b3b;
   --vscode-sideBarTitle-foreground: #3b3b3b;
+
+  /* Peek view */
+  --vscode-peekViewTitle-background: #f3f3f3;
+  --vscode-peekViewTitleDescription-foreground: #616161;
+
+  /* Diff colors */
+  --vscode-diffEditor-insertedTextBackground: #dafbe1;
+  --vscode-diffEditor-removedTextBackground: #ffebe9;
 
   /* Progress bar */
   --vscode-progressBar-background: #007acc;
@@ -133,6 +170,216 @@
   /* Tree colors */
   --vscode-tree-indentGuidesStroke: #d4d4d4;
   --vscode-tree-inactiveIndentGuidesStroke: rgba(212, 212, 212, 0.5);
+
+  /* Terminal ANSI colors */
+  --vscode-terminal-ansiBlack: #000000;
+  --vscode-terminal-ansiRed: #cd3131;
+  --vscode-terminal-ansiGreen: #00bc00;
+  --vscode-terminal-ansiYellow: #949800;
+  --vscode-terminal-ansiBlue: #0451a5;
+  --vscode-terminal-ansiMagenta: #bc05bc;
+  --vscode-terminal-ansiCyan: #0598bc;
+  --vscode-terminal-ansiWhite: #555555;
+  --vscode-terminal-ansiBrightBlack: #666666;
+  --vscode-terminal-ansiBrightRed: #cd3131;
+  --vscode-terminal-ansiBrightGreen: #14ce14;
+  --vscode-terminal-ansiBrightYellow: #b5ba00;
+  --vscode-terminal-ansiBrightBlue: #0451a5;
+  --vscode-terminal-ansiBrightMagenta: #bc05bc;
+  --vscode-terminal-ansiBrightCyan: #0598bc;
+  --vscode-terminal-ansiBrightWhite: #a5a5a5;
+
+  /* Keybinding table */
+  --vscode-keybindingTable-headerBackground: rgba(128, 128, 128, 0.1);
+  --vscode-keybindingTable-rowsBackground: rgba(128, 128, 128, 0.04);
+}
+
+:root[data-bs-theme="dark"] {
+  color-scheme: dark;
+
+  /* Core colors */
+  --vscode-foreground: #cccccc;
+  --vscode-descriptionForeground: #9d9d9d;
+  --vscode-disabledForeground: rgba(204, 204, 204, 0.5);
+  --vscode-errorForeground: #f48771;
+  --vscode-icon-foreground: #c5c5c5;
+  --vscode-focusBorder: #007fd4;
+  --vscode-contrastBorder: transparent;
+
+  /* Font settings */
+  --vscode-font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  --vscode-font-size: 13px;
+  --vscode-font-weight: normal;
+  --vscode-editor-font-family: Menlo, Monaco, "Courier New", monospace;
+  --vscode-editor-font-size: 12px;
+  --vscode-editor-font-weight: normal;
+
+  /* Editor colors */
+  --vscode-editor-background: #1e1e1e;
+  --vscode-editor-foreground: #d4d4d4;
+  --vscode-editor-inlineValuesForeground: rgba(255, 255, 255, 0.5);
+  --vscode-editor-inactiveSelectionBackground: #3a3d41;
+  --vscode-editor-selectionBackground: #264f78;
+  --vscode-editor-selectionHighlightBackground: rgba(173, 214, 255, 0.15);
+  --vscode-editorGroup-border: #2b2b2b;
+  --vscode-editorHoverWidget-background: #252526;
+  --vscode-editorInfo-foreground: #3794ff;
+  --vscode-editorLink-activeForeground: #4e94ce;
+  --vscode-editorWarning-foreground: #cca700;
+  --vscode-editorWidget-background: #252526;
+  --vscode-editorWidget-border: #454545;
+  --vscode-editorWidget-foreground: #cccccc;
+
+  /* Input colors */
+  --vscode-input-background: #313131;
+  --vscode-input-foreground: #cccccc;
+  --vscode-input-border: #3c3c3c;
+  --vscode-input-placeholderForeground: #a6a6a6;
+  --vscode-inputOption-activeBackground: rgba(0, 127, 212, 0.4);
+  --vscode-inputOption-activeBorder: #007acc;
+  --vscode-inputOption-activeForeground: #ffffff;
+
+  /* Input validation */
+  --vscode-inputValidation-warningBackground: #352a05;
+  --vscode-inputValidation-warningBorder: #b89500;
+  --vscode-inputValidation-errorBackground: #5a1d1d;
+  --vscode-inputValidation-errorBorder: #be1100;
+
+  /* Dropdown colors */
+  --vscode-dropdown-background: #313131;
+  --vscode-dropdown-foreground: #f0f0f0;
+  --vscode-dropdown-border: #3c3c3c;
+
+  /* Settings controls (used by vscode-elements textfield, checkbox, dropdown) */
+  --vscode-settings-textInputBackground: #313131;
+  --vscode-settings-textInputForeground: #cccccc;
+  --vscode-settings-textInputBorder: #3c3c3c;
+  --vscode-settings-checkboxBackground: #313131;
+  --vscode-settings-checkboxForeground: #cccccc;
+  --vscode-settings-checkboxBorder: #3c3c3c;
+  --vscode-settings-dropdownBackground: #313131;
+  --vscode-settings-dropdownForeground: #cccccc;
+  --vscode-settings-dropdownBorder: #3c3c3c;
+  --vscode-settings-dropdownListBorder: #454545;
+  --vscode-settings-headerBorder: rgba(128, 128, 128, 0.35);
+
+  /* Checkbox colors */
+  --vscode-checkbox-background: #313131;
+  --vscode-checkbox-foreground: #cccccc;
+  --vscode-checkbox-border: #3c3c3c;
+
+  /* Button colors */
+  --vscode-button-background: #0e639c;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-hoverBackground: #1177bb;
+  --vscode-button-border: transparent;
+  --vscode-button-separator: rgba(255, 255, 255, 0.4);
+  --vscode-button-secondaryBackground: #3a3d41;
+  --vscode-button-secondaryForeground: #ffffff;
+  --vscode-button-secondaryHoverBackground: #45494e;
+
+  /* Widget/shadow colors */
+  --vscode-widget-shadow: rgba(0, 0, 0, 0.36);
+  --vscode-widget-border: #454545;
+
+  /* Toolbar */
+  --vscode-toolbar-hoverBackground: rgba(90, 93, 94, 0.31);
+  --vscode-toolbar-activeBackground: rgba(99, 102, 103, 0.31);
+  --vscode-toolbar-hoverOutline: transparent;
+
+  /* List colors (used by select/dropdown components) */
+  --vscode-list-hoverBackground: #2a2d2e;
+  --vscode-list-hoverForeground: #f0f0f0;
+  --vscode-list-activeSelectionBackground: #04395e;
+  --vscode-list-activeSelectionForeground: #ffffff;
+  --vscode-list-activeSelectionIconForeground: #ffffff;
+  --vscode-list-inactiveSelectionBackground: #37373d;
+  --vscode-list-focusOutline: #007fd4;
+  --vscode-list-focusAndSelectionOutline: #007fd4;
+  --vscode-list-focusHighlightForeground: #2aaaff;
+  --vscode-list-highlightForeground: #2aaaff;
+
+  /* Menu colors */
+  --vscode-menu-background: #252526;
+  --vscode-menu-foreground: #cccccc;
+  --vscode-menu-border: #454545;
+  --vscode-menu-selectionBackground: #04395e;
+  --vscode-menu-selectionForeground: #ffffff;
+  --vscode-menu-selectionBorder: transparent;
+  --vscode-menu-separatorBackground: #454545;
+
+  /* Badge colors */
+  --vscode-badge-background: #4d4d4d;
+  --vscode-badge-foreground: #ffffff;
+  --vscode-activityBarBadge-background: #007acc;
+  --vscode-activityBarBadge-foreground: #ffffff;
+
+  /* Banner, breadcrumb, notifications, links */
+  --vscode-banner-iconForeground: #3794ff;
+  --vscode-breadcrumb-foreground: rgba(204, 204, 204, 0.8);
+  --vscode-notificationLink-foreground: #3794ff;
+  --vscode-notifications-background: #252526;
+  --vscode-notifications-foreground: #cccccc;
+  --vscode-textLink-foreground: #3794ff;
+  --vscode-textLink-activeForeground: #4e94ce;
+
+  /* Panel colors */
+  --vscode-panel-background: #1e1e1e;
+  --vscode-panel-border: #2b2b2b;
+  --vscode-panelTitle-activeBorder: #007acc;
+  --vscode-panelTitle-activeForeground: #e7e7e7;
+  --vscode-panelTitle-inactiveForeground: #9d9d9d;
+
+  /* Sidebar colors */
+  --vscode-sideBar-background: #252526;
+  --vscode-sideBarSectionHeader-background: #2d2d2d;
+  --vscode-sideBarSectionHeader-border: #2b2b2b;
+  --vscode-sideBarSectionHeader-foreground: #cccccc;
+  --vscode-sideBarTitle-foreground: #bbbbbb;
+
+  /* Peek view */
+  --vscode-peekViewTitle-background: #252526;
+  --vscode-peekViewTitleDescription-foreground: #cccccc;
+
+  /* Diff colors */
+  --vscode-diffEditor-insertedTextBackground: rgba(156, 204, 44, 0.2);
+  --vscode-diffEditor-removedTextBackground: rgba(255, 0, 0, 0.2);
+
+  /* Progress bar */
+  --vscode-progressBar-background: #0e70c0;
+
+  /* Scrollbar colors */
+  --vscode-scrollbar-shadow: #000000;
+  --vscode-scrollbarSlider-background: rgba(121, 121, 121, 0.4);
+  --vscode-scrollbarSlider-hoverBackground: rgba(100, 100, 100, 0.7);
+  --vscode-scrollbarSlider-activeBackground: rgba(191, 191, 191, 0.4);
+
+  /* Sash (resizable borders) */
+  --vscode-sash-hoverBorder: #007fd4;
+
+  /* Tree colors */
+  --vscode-tree-indentGuidesStroke: #585858;
+  --vscode-tree-inactiveIndentGuidesStroke: rgba(88, 88, 88, 0.5);
+
+  /* Terminal ANSI colors */
+  --vscode-terminal-ansiBlack: #000000;
+  --vscode-terminal-ansiRed: #cd3131;
+  --vscode-terminal-ansiGreen: #0dbc79;
+  --vscode-terminal-ansiYellow: #e5e510;
+  --vscode-terminal-ansiBlue: #2472c8;
+  --vscode-terminal-ansiMagenta: #bc3fbc;
+  --vscode-terminal-ansiCyan: #11a8cd;
+  --vscode-terminal-ansiWhite: #e5e5e5;
+  --vscode-terminal-ansiBrightBlack: #666666;
+  --vscode-terminal-ansiBrightRed: #f14c4c;
+  --vscode-terminal-ansiBrightGreen: #23d18b;
+  --vscode-terminal-ansiBrightYellow: #f5f543;
+  --vscode-terminal-ansiBrightBlue: #3b8eea;
+  --vscode-terminal-ansiBrightMagenta: #d670d6;
+  --vscode-terminal-ansiBrightCyan: #29b8db;
+  --vscode-terminal-ansiBrightWhite: #e5e5e5;
 
   /* Keybinding table */
   --vscode-keybindingTable-headerBackground: rgba(128, 128, 128, 0.1);

--- a/packages/theme/src/vscode.css
+++ b/packages/theme/src/vscode.css
@@ -1,4 +1,4 @@
-/* VS Code Light/Dark Modern theme defaults (for non-VS Code context) */
+/* VS Code theme defaults (for non-VS Code context) */
 /* Complete set of variables used by @vscode-elements/elements */
 /* These are overridden by actual VS Code theme variables when running in VS Code */
 
@@ -198,13 +198,21 @@
   color-scheme: dark;
 
   /* Core colors */
-  --vscode-foreground: #cccccc;
-  --vscode-descriptionForeground: #9d9d9d;
-  --vscode-disabledForeground: rgba(204, 204, 204, 0.5);
+  --vscode-foreground: #bfbfbf;
+  --vscode-descriptionForeground: #8c8c8c;
+  --vscode-disabledForeground: #555555;
   --vscode-errorForeground: #f48771;
-  --vscode-icon-foreground: #c5c5c5;
-  --vscode-focusBorder: #007fd4;
+  --vscode-icon-foreground: #8c8c8c;
+  --vscode-focusBorder: #3994bcb3;
   --vscode-contrastBorder: transparent;
+
+  /* Text colors */
+  --vscode-textBlockQuote-background: #242526;
+  --vscode-textBlockQuote-border: #2a2b2cff;
+  --vscode-textCodeBlock-background: #242526;
+  --vscode-textPreformat-background: #262626;
+  --vscode-textPreformat-foreground: #8c8c8c;
+  --vscode-textSeparator-foreground: #2a2a2aff;
 
   /* Font settings */
   --vscode-font-family:
@@ -217,151 +225,162 @@
   --vscode-editor-font-weight: normal;
 
   /* Editor colors */
-  --vscode-editor-background: #1e1e1e;
-  --vscode-editor-foreground: #d4d4d4;
-  --vscode-editor-inlineValuesForeground: rgba(255, 255, 255, 0.5);
-  --vscode-editor-inactiveSelectionBackground: #3a3d41;
-  --vscode-editor-selectionBackground: #264f78;
-  --vscode-editor-selectionHighlightBackground: rgba(173, 214, 255, 0.15);
-  --vscode-editorGroup-border: #2b2b2b;
-  --vscode-editorHoverWidget-background: #252526;
-  --vscode-editorInfo-foreground: #3794ff;
-  --vscode-editorLink-activeForeground: #4e94ce;
-  --vscode-editorWarning-foreground: #cca700;
-  --vscode-editorWidget-background: #252526;
-  --vscode-editorWidget-border: #454545;
-  --vscode-editorWidget-foreground: #cccccc;
+  --vscode-editor-background: #121314;
+  --vscode-editor-foreground: #bbbebf;
+  --vscode-editor-inlineValuesForeground: #8c8c8c;
+  --vscode-editor-inactiveSelectionBackground: #27678260;
+  --vscode-editor-selectionBackground: #276782dd;
+  --vscode-editor-selectionHighlightBackground: #27678260;
+  --vscode-editorGroup-border: #2a2b2cff;
+  --vscode-editorHoverWidget-background: #202122;
+  --vscode-editorInfo-foreground: #3a94bc;
+  --vscode-editorLink-activeForeground: #3a94bc;
+  --vscode-editorWarning-foreground: #e5ba7d;
+  --vscode-editorWidget-background: #202122;
+  --vscode-editorWidget-border: #2a2b2cff;
+  --vscode-editorWidget-foreground: #bfbfbf;
 
   /* Input colors */
-  --vscode-input-background: #313131;
-  --vscode-input-foreground: #cccccc;
-  --vscode-input-border: #3c3c3c;
-  --vscode-input-placeholderForeground: #a6a6a6;
-  --vscode-inputOption-activeBackground: rgba(0, 127, 212, 0.4);
-  --vscode-inputOption-activeBorder: #007acc;
-  --vscode-inputOption-activeForeground: #ffffff;
+  --vscode-input-background: #191a1b;
+  --vscode-input-foreground: #bfbfbf;
+  --vscode-input-border: #333536ff;
+  --vscode-input-placeholderForeground: #555555;
+  --vscode-inputOption-activeBackground: #3994bc33;
+  --vscode-inputOption-activeBorder: #2a2b2cff;
+  --vscode-inputOption-activeForeground: #bfbfbf;
 
   /* Input validation */
   --vscode-inputValidation-warningBackground: #352a05;
   --vscode-inputValidation-warningBorder: #b89500;
-  --vscode-inputValidation-errorBackground: #5a1d1d;
+  --vscode-inputValidation-warningForeground: #bfbfbf;
+  --vscode-inputValidation-errorBackground: #3a1d1d;
   --vscode-inputValidation-errorBorder: #be1100;
+  --vscode-inputValidation-errorForeground: #bfbfbf;
 
   /* Dropdown colors */
-  --vscode-dropdown-background: #313131;
-  --vscode-dropdown-foreground: #f0f0f0;
-  --vscode-dropdown-border: #3c3c3c;
+  --vscode-dropdown-background: #191a1b;
+  --vscode-dropdown-foreground: #bfbfbf;
+  --vscode-dropdown-border: #333536;
+  --vscode-dropdown-listBackground: #191a1b;
 
   /* Settings controls (used by vscode-elements textfield, checkbox, dropdown) */
-  --vscode-settings-textInputBackground: #313131;
-  --vscode-settings-textInputForeground: #cccccc;
-  --vscode-settings-textInputBorder: #3c3c3c;
-  --vscode-settings-checkboxBackground: #313131;
-  --vscode-settings-checkboxForeground: #cccccc;
-  --vscode-settings-checkboxBorder: #3c3c3c;
-  --vscode-settings-dropdownBackground: #313131;
-  --vscode-settings-dropdownForeground: #cccccc;
-  --vscode-settings-dropdownBorder: #3c3c3c;
-  --vscode-settings-dropdownListBorder: #454545;
+  --vscode-settings-textInputBackground: #191a1b;
+  --vscode-settings-textInputForeground: #bfbfbf;
+  --vscode-settings-textInputBorder: #333536ff;
+  --vscode-settings-checkboxBackground: #242526;
+  --vscode-settings-checkboxForeground: #8c8c8c;
+  --vscode-settings-checkboxBorder: #333536;
+  --vscode-settings-dropdownBackground: #191a1b;
+  --vscode-settings-dropdownForeground: #bfbfbf;
+  --vscode-settings-dropdownBorder: #333536;
+  --vscode-settings-dropdownListBorder: #333536;
   --vscode-settings-headerBorder: rgba(128, 128, 128, 0.35);
 
   /* Checkbox colors */
-  --vscode-checkbox-background: #313131;
-  --vscode-checkbox-foreground: #cccccc;
-  --vscode-checkbox-border: #3c3c3c;
+  --vscode-checkbox-background: #242526;
+  --vscode-checkbox-foreground: #8c8c8c;
+  --vscode-checkbox-border: #333536;
 
   /* Button colors */
-  --vscode-button-background: #0e639c;
+  --vscode-button-background: #297aa0;
   --vscode-button-foreground: #ffffff;
-  --vscode-button-hoverBackground: #1177bb;
-  --vscode-button-border: transparent;
+  --vscode-button-hoverBackground: #2b7da3;
+  --vscode-button-border: #333536ff;
   --vscode-button-separator: rgba(255, 255, 255, 0.4);
-  --vscode-button-secondaryBackground: #3a3d41;
-  --vscode-button-secondaryForeground: #ffffff;
-  --vscode-button-secondaryHoverBackground: #45494e;
+  --vscode-button-secondaryBackground: #00000000;
+  --vscode-button-secondaryForeground: #cccccc;
+  --vscode-button-secondaryHoverBackground: #ffffff10;
 
   /* Widget/shadow colors */
   --vscode-widget-shadow: rgba(0, 0, 0, 0.36);
-  --vscode-widget-border: #454545;
+  --vscode-widget-border: #2a2b2cff;
 
   /* Toolbar */
-  --vscode-toolbar-hoverBackground: rgba(90, 93, 94, 0.31);
-  --vscode-toolbar-activeBackground: rgba(99, 102, 103, 0.31);
+  --vscode-toolbar-hoverBackground: #ffffff18;
+  --vscode-toolbar-activeBackground: #ffffff18;
   --vscode-toolbar-hoverOutline: transparent;
 
   /* List colors (used by select/dropdown components) */
-  --vscode-list-hoverBackground: #2a2d2e;
-  --vscode-list-hoverForeground: #f0f0f0;
-  --vscode-list-activeSelectionBackground: #04395e;
-  --vscode-list-activeSelectionForeground: #ffffff;
-  --vscode-list-activeSelectionIconForeground: #ffffff;
-  --vscode-list-inactiveSelectionBackground: #37373d;
-  --vscode-list-focusOutline: #007fd4;
-  --vscode-list-focusAndSelectionOutline: #007fd4;
-  --vscode-list-focusHighlightForeground: #2aaaff;
-  --vscode-list-highlightForeground: #2aaaff;
+  --vscode-list-hoverBackground: #ffffff0d;
+  --vscode-list-hoverForeground: #bfbfbf;
+  --vscode-list-activeSelectionBackground: #3994bc26;
+  --vscode-list-activeSelectionForeground: #ededed;
+  --vscode-list-activeSelectionIconForeground: #ededed;
+  --vscode-list-inactiveSelectionBackground: #2c2d2e;
+  --vscode-list-inactiveSelectionForeground: #ededed;
+  --vscode-list-focusBackground: #3994bc26;
+  --vscode-list-focusForeground: #bfbfbf;
+  --vscode-list-focusOutline: #3994bcb3;
+  --vscode-list-focusAndSelectionOutline: #3994bcb3;
+  --vscode-list-focusHighlightForeground: #48a0c7;
+  --vscode-list-highlightForeground: #48a0c7;
+  --vscode-list-invalidItemForeground: #444444;
+  --vscode-list-errorForeground: #f48771;
+  --vscode-list-warningForeground: #e5ba7d;
 
   /* Menu colors */
-  --vscode-menu-background: #252526;
-  --vscode-menu-foreground: #cccccc;
-  --vscode-menu-border: #454545;
-  --vscode-menu-selectionBackground: #04395e;
-  --vscode-menu-selectionForeground: #ffffff;
+  --vscode-menu-background: #202122;
+  --vscode-menu-foreground: #bfbfbf;
+  --vscode-menu-border: #2a2b2cff;
+  --vscode-menu-selectionBackground: #3994bc26;
+  --vscode-menu-selectionForeground: #bfbfbf;
   --vscode-menu-selectionBorder: transparent;
-  --vscode-menu-separatorBackground: #454545;
+  --vscode-menu-separatorBackground: #2a2b2c;
 
   /* Badge colors */
-  --vscode-badge-background: #4d4d4d;
+  --vscode-badge-background: #3994bcf0;
   --vscode-badge-foreground: #ffffff;
-  --vscode-activityBarBadge-background: #007acc;
+  --vscode-activityBarBadge-background: #3994bc;
   --vscode-activityBarBadge-foreground: #ffffff;
 
   /* Banner, breadcrumb, notifications, links */
-  --vscode-banner-iconForeground: #3794ff;
-  --vscode-breadcrumb-foreground: rgba(204, 204, 204, 0.8);
-  --vscode-notificationLink-foreground: #3794ff;
-  --vscode-notifications-background: #252526;
-  --vscode-notifications-foreground: #cccccc;
-  --vscode-textLink-foreground: #3794ff;
-  --vscode-textLink-activeForeground: #4e94ce;
+  --vscode-banner-iconForeground: #48a0c7;
+  --vscode-breadcrumb-foreground: #8c8c8c;
+  --vscode-notificationLink-foreground: #3a94bc;
+  --vscode-notifications-background: #202122;
+  --vscode-notifications-foreground: #bfbfbf;
+  --vscode-textLink-foreground: #48a0c7;
+  --vscode-textLink-activeForeground: #53a5ca;
 
   /* Panel colors */
-  --vscode-panel-background: #1e1e1e;
-  --vscode-panel-border: #2b2b2b;
-  --vscode-panelTitle-activeBorder: #007acc;
-  --vscode-panelTitle-activeForeground: #e7e7e7;
-  --vscode-panelTitle-inactiveForeground: #9d9d9d;
+  --vscode-panel-background: #191a1b;
+  --vscode-panel-border: #2a2b2cff;
+  --vscode-panelTitle-activeBorder: #3994bc;
+  --vscode-panelTitle-activeForeground: #bfbfbf;
+  --vscode-panelTitle-inactiveForeground: #8c8c8c;
 
   /* Sidebar colors */
-  --vscode-sideBar-background: #252526;
-  --vscode-sideBarSectionHeader-background: #2d2d2d;
-  --vscode-sideBarSectionHeader-border: #2b2b2b;
-  --vscode-sideBarSectionHeader-foreground: #cccccc;
-  --vscode-sideBarTitle-foreground: #bbbbbb;
+  --vscode-sideBar-background: #191a1b;
+  --vscode-sideBar-foreground: #bfbfbf;
+  --vscode-sideBar-border: #2a2b2cff;
+  --vscode-sideBarSectionHeader-background: #191a1b;
+  --vscode-sideBarSectionHeader-border: #2a2b2cff;
+  --vscode-sideBarSectionHeader-foreground: #bfbfbf;
+  --vscode-sideBarTitle-foreground: #bfbfbf;
 
   /* Peek view */
-  --vscode-peekViewTitle-background: #252526;
-  --vscode-peekViewTitleDescription-foreground: #cccccc;
+  --vscode-peekViewTitle-background: #242526;
+  --vscode-peekViewTitleDescription-foreground: #8c8c8c;
 
   /* Diff colors */
-  --vscode-diffEditor-insertedTextBackground: rgba(156, 204, 44, 0.2);
-  --vscode-diffEditor-removedTextBackground: rgba(255, 0, 0, 0.2);
+  --vscode-diffEditor-insertedTextBackground: #57ab5a4d;
+  --vscode-diffEditor-removedTextBackground: #f470674d;
 
   /* Progress bar */
-  --vscode-progressBar-background: #0e70c0;
+  --vscode-progressBar-background: #878889;
 
   /* Scrollbar colors */
-  --vscode-scrollbar-shadow: #000000;
-  --vscode-scrollbarSlider-background: rgba(121, 121, 121, 0.4);
-  --vscode-scrollbarSlider-hoverBackground: rgba(100, 100, 100, 0.7);
-  --vscode-scrollbarSlider-activeBackground: rgba(191, 191, 191, 0.4);
+  --vscode-scrollbar-shadow: #191b1d4d;
+  --vscode-scrollbarSlider-background: #83848533;
+  --vscode-scrollbarSlider-hoverBackground: #83848566;
+  --vscode-scrollbarSlider-activeBackground: #83848599;
 
   /* Sash (resizable borders) */
-  --vscode-sash-hoverBorder: #007fd4;
+  --vscode-sash-hoverBorder: #3994bcb3;
 
   /* Tree colors */
-  --vscode-tree-indentGuidesStroke: #585858;
-  --vscode-tree-inactiveIndentGuidesStroke: rgba(88, 88, 88, 0.5);
+  --vscode-tree-indentGuidesStroke: #8384854d;
+  --vscode-tree-inactiveIndentGuidesStroke: #83848533;
 
   /* Terminal ANSI colors */
   --vscode-terminal-ansiBlack: #000000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
       eslint:
         specifier: ^9.39.4
         version: 9.39.4


### PR DESCRIPTION
Scout's viewer theme is driven by CSS variables, allowing us to adopt the vscode theme when embedded in the extension. Operating systems' color preferences can be detected [in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme):

> The `prefers-color-scheme` [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) [media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries/Using#targeting_media_features) is used to detect if a user has requested light or dark color themes. A user indicates their preference through an operating system setting (e.g., light or dark mode) or a user agent setting.

We can connect these dots and have Scout switch into dark mode if the user prefers.


https://github.com/user-attachments/assets/c0abf65e-33f5-4638-8f47-e936476654ac

`vscode.css` has been updated to include dark mode colors too. Claude also added colors to the light theme that I guess were missing before.

Someone might like to use Scout in a different theme than their OS settings. They can override their system settings on our new settings page:


https://github.com/user-attachments/assets/180c14ea-58a3-4bc6-8205-f4bf7c408f4d

In vscode, we'll always use the vscode theme, so we won't show the settings page at all.

<img width="882" height="555" alt="Screenshot 2026-05-07 at 12 50 14 PM" src="https://github.com/user-attachments/assets/c54ef29d-e579-4d7e-89e0-7de8fccf688d" />
