### PR TITLE
Prevent duplicate or corrupt message pool

### DIFF
--- a/apps/inspect/src/state/samplePolling.test.ts
+++ b/apps/inspect/src/state/samplePolling.test.ts
@@ -73,6 +73,108 @@ describe("samplePolling helpers", () => {
 });
 
 describe("createSamplePolling", () => {
+  it("does not let duplicate streamed pool rows shift refs", async () => {
+    const inputSystem = chatMessage("input-system", "system", "Input system");
+    const inputUser = chatMessage("input-user", "user", "Input user");
+    const inputAssistant = chatMessage(
+      "input-assistant",
+      "assistant",
+      "Input assistant"
+    );
+    const system = { role: "system", content: "System" };
+    const user = { role: "user", content: "User" };
+    const assistant = { role: "assistant", content: "Assistant" };
+
+    const getLogSampleData = vi.fn().mockResolvedValue({
+      status: "OK",
+      sampleData: {
+        attachments: [],
+        message_pool: [
+          messagePoolEntry(1, inputSystem),
+          messagePoolEntry(2, inputUser),
+          messagePoolEntry(1, inputSystem),
+          messagePoolEntry(2, inputUser),
+          messagePoolEntry(3, inputAssistant),
+        ],
+        call_pool: [
+          callPoolEntry(1, system),
+          callPoolEntry(2, user),
+          callPoolEntry(1, system),
+          callPoolEntry(2, user),
+          callPoolEntry(3, assistant),
+        ],
+        events: [
+          {
+            id: 1,
+            event_id: "model-event-1",
+            sample_id: "sample-1",
+            epoch: 1,
+            event: {
+              event: "model",
+              input: [],
+              input_refs: [[0, 3]],
+              model: "test",
+              tools: [],
+              tool_choice: "auto",
+              config: {},
+              output: { model: "test", choices: [] },
+              call: {
+                request: { model: "test" },
+                response: null,
+                call_refs: [[0, 3]],
+                call_key: "messages",
+              },
+            } as any,
+          },
+        ],
+      },
+    } satisfies SampleDataResponse);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: vi.fn(),
+      },
+      sample: {
+        runningEvents: [],
+      },
+      sampleActions,
+      log: {
+        selectedLogDetails: {
+          sampleSummaries: [],
+        },
+      },
+    } as unknown as StoreState;
+
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    polling.startPolling("log.json", createSummary("sample-1"));
+    await flushPromises();
+    polling.stopPolling();
+
+    const runningEvents = sampleActions.setRunningEvents.mock.calls.at(-1)?.[0];
+    expect(runningEvents[0].input).toEqual([
+      inputSystem,
+      inputUser,
+      inputAssistant,
+    ]);
+    expect(runningEvents[0].call.request.messages).toEqual([
+      system,
+      user,
+      assistant,
+    ]);
+  });
+
   it("aborts a stale completion fetch when a new polling session starts", async () => {
     const staleSampleDeferred = deferred<EvalSample | undefined>();
     const getLogSampleData = vi
@@ -132,6 +234,30 @@ const createSummary = (id: string) =>
     id,
     epoch: 1,
   }) as any;
+
+const chatMessage = (id: string, role: string, content: string) => ({
+  id,
+  role,
+  content,
+  source: "input",
+  metadata: null,
+});
+
+const messagePoolEntry = (id: number, data: object) => ({
+  id,
+  sample_id: "sample-1",
+  epoch: 1,
+  msg_id: `msg-${id}`,
+  data: JSON.stringify(data),
+});
+
+const callPoolEntry = (id: number, data: object) => ({
+  id,
+  sample_id: "sample-1",
+  epoch: 1,
+  hash: `hash-${id}`,
+  data: JSON.stringify(data),
+});
 
 const createEvalSample = (id: string) =>
   ({

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -42,6 +42,8 @@ interface PollingState {
   attachments: Record<string, string>;
   messagePool: ChatMessage[];
   callPool: JsonValue[];
+  messagePoolEntryIds: Set<number>;
+  callPoolEntryIds: Set<number>;
 
   eventMapping: Record<string, number>;
   events: Event[];
@@ -67,6 +69,8 @@ export function createSamplePolling(
     attachments: {},
     messagePool: [],
     callPool: [],
+    messagePoolEntryIds: new Set(),
+    callPoolEntryIds: new Set(),
     events: [],
   };
 
@@ -355,6 +359,8 @@ const resetPollingState = (state: PollingState) => {
   state.attachments = {};
   state.messagePool = [];
   state.callPool = [];
+  state.messagePoolEntryIds.clear();
+  state.callPoolEntryIds.clear();
   state.events = [];
 };
 
@@ -374,16 +380,22 @@ function processMessagePool(
 ) {
   if (!sampleData.message_pool.length) return;
   for (const entry of sampleData.message_pool) {
-    pollingState.messagePool.push(JSON.parse(entry.data) as ChatMessage);
     pollingState.messagePoolId = Math.max(pollingState.messagePoolId, entry.id);
+    if (pollingState.messagePoolEntryIds.has(entry.id)) continue;
+
+    pollingState.messagePoolEntryIds.add(entry.id);
+    pollingState.messagePool.push(JSON.parse(entry.data) as ChatMessage);
   }
 }
 
 function processCallPool(sampleData: SampleData, pollingState: PollingState) {
   if (!sampleData.call_pool.length) return;
   for (const entry of sampleData.call_pool) {
-    pollingState.callPool.push(JSON.parse(entry.data) as JsonValue);
     pollingState.callPoolId = Math.max(pollingState.callPoolId, entry.id);
+    if (pollingState.callPoolEntryIds.has(entry.id)) continue;
+
+    pollingState.callPoolEntryIds.add(entry.id);
+    pollingState.callPool.push(JSON.parse(entry.data) as JsonValue);
   }
 }
 


### PR DESCRIPTION
Live streaming uses pooled refs for API requests:

- Server sends call.request without the message list, plus call_refs/call_key.
- Client reconstructs it with request[msgKey] = expandRefs(call_refs, pollingState.callPool).
- If duplicate call_pool rows are appended during streaming, the client pool shifts and refs resolve to the wrong earlier entries. JSON.stringify(call.request) then faithfully shows the bad reconstructed request, even though the actual provider request was correct.

This fixes the live polling side to make pool processing idempotent by entry id for both message_pool and call_pool.

**rationale** we had reports of duplicated messages in API requests (that were confirmed not sent over the wire or written to disk, so were an artifact purely of streaming sample event). Afte rmuch digging, codex identified that if the server ever duplicated messages, those messages would flow through into the message pool and corrupt it