### PR TITLE
Fix message ordering in running-sample Messages tab (with cross-poll caching)

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -65,7 +65,10 @@ import {
   useSampleUrlBuilder,
 } from "../routing/url";
 
-import { messagesFromEvents } from "./messagesFromEvents";
+import {
+  messagesFromEvents,
+  type MessagesFromEventsState,
+} from "./messagesFromEvents";
 import styles from "./SampleDisplay.module.css";
 import { SampleJSONView } from "./SampleJSONView";
 import { SampleRetriedErrors } from "./SampleRetriedErrors";
@@ -140,12 +143,19 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   // Consolidate the events and messages into the proper list
   // whether running or not
   const sampleEvents = sample?.events || runningSampleData;
+  // Cache messagesFromEvents work across polls. The polling pipeline
+  // only ever appends to the running events array (or replaces a tail
+  // event during streaming updates), so a pure-extension call only
+  // processes the new tail. Diverging events trigger a rebuild.
+  const messagesRef = useRef<MessagesFromEventsState | null>(null);
   const sampleMessages = useMemo(() => {
     if (sample?.messages) {
+      messagesRef.current = null;
       return sample.messages;
     } else if (runningSampleData) {
-      return messagesFromEvents(runningSampleData);
+      return messagesFromEvents(runningSampleData, messagesRef);
     } else {
+      messagesRef.current = null;
       return [];
     }
   }, [sample?.messages, runningSampleData]);

--- a/apps/inspect/src/app/samples/messagesFromEvents.test.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.test.ts
@@ -210,12 +210,87 @@ describe("messagesFromEvents", () => {
 
       const r1 = messagesFromEvents([e1], ref);
       expect(r1.map((m) => m.id)).toEqual(["u1", "a1"]);
-      const cachedAfterFirst = ref.current;
 
       const r2 = messagesFromEvents([e1, e2], ref);
       expect(r2.map((m) => m.id)).toEqual(["u1", "a1", "t1", "a2"]);
-      // Same state object was mutated, not replaced.
-      expect(ref.current).toBe(cachedAfterFirst);
+    });
+
+    it("processes incremental extensions correctly across repeated calls", () => {
+      // Multi-step extension chain — each step should only process the new
+      // tail without losing earlier messages.
+      const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e2 = makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2",
+      });
+      const e3 = makeModelEvent({
+        input: [
+          userMsg("u1"),
+          assistantMsg("a1"),
+          toolMsg("t1"),
+          assistantMsg("a2"),
+          toolMsg("t2"),
+        ],
+        outputId: "a3",
+      });
+      const ref: Ref = { current: null };
+
+      expect(messagesFromEvents([e1], ref).map((m) => m.id)).toEqual([
+        "u1",
+        "a1",
+      ]);
+      expect(messagesFromEvents([e1, e2], ref).map((m) => m.id)).toEqual([
+        "u1",
+        "a1",
+        "a2",
+      ]);
+      expect(messagesFromEvents([e1, e2, e3], ref).map((m) => m.id)).toEqual([
+        "u1",
+        "a1",
+        "t1",
+        "a2",
+        "t2",
+        "a3",
+      ]);
+    });
+
+    it("rebuilds when a tail event is replaced at the same index", () => {
+      // samplePolling replaces an event at its existing index when streaming
+      // updates arrive (e.g., the model output completes after a partial).
+      // The new event reference at the same index must trigger a rebuild.
+      const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e2partial = makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2-partial",
+      });
+      const e2final = makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2-final",
+      });
+      const ref: Ref = { current: null };
+
+      messagesFromEvents([e1, e2partial], ref);
+      const r = messagesFromEvents([e1, e2final], ref);
+      // Rebuild discards the partial output and re-derives the list from
+      // scratch, so the final replaces it rather than appearing alongside.
+      expect(r.map((m) => m.id)).toEqual(["u1", "a1", "a2-final"]);
+    });
+
+    it("re-extends correctly after a divergence rebuild", () => {
+      // After a rebuild forces a fresh state, the next prefix-extension
+      // call must use the new cache (not the discarded prior one).
+      const e1a = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e1b = makeModelEvent({ inputId: "u2", outputId: "a1" });
+      const e2 = makeModelEvent({
+        input: [userMsg("u2"), assistantMsg("a1"), toolMsg("t1")],
+        outputId: "a2",
+      });
+      const ref: Ref = { current: null };
+
+      messagesFromEvents([e1a], ref);
+      messagesFromEvents([e1b], ref); // rebuild via divergence
+      const r = messagesFromEvents([e1b, e2], ref); // extend the new state
+      expect(r.map((m) => m.id)).toEqual(["u2", "a1", "t1", "a2"]);
     });
 
     it("returns the cached array unchanged when no new events were added", () => {
@@ -229,21 +304,17 @@ describe("messagesFromEvents", () => {
       expect(r2).toBe(r1);
     });
 
-    it("rebuilds state when an existing event reference changes", () => {
+    it("rebuilds when an existing event reference changes", () => {
       const e1a = makeModelEvent({ inputId: "u1", outputId: "a1" });
       const e1b = makeModelEvent({ inputId: "u2", outputId: "a1" });
       const ref: Ref = { current: null };
 
       messagesFromEvents([e1a], ref);
-      const cachedAfterFirst = ref.current;
-
       const r2 = messagesFromEvents([e1b], ref);
       expect(r2.map((m) => m.id)).toEqual(["u2", "a1"]);
-      // Divergence at index 0 forced a fresh state object.
-      expect(ref.current).not.toBe(cachedAfterFirst);
     });
 
-    it("rebuilds state when the events array shrinks", () => {
+    it("rebuilds when the events array shrinks", () => {
       const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
       const e2 = makeModelEvent({
         input: [userMsg("u1"), assistantMsg("a1")],
@@ -252,11 +323,8 @@ describe("messagesFromEvents", () => {
       const ref: Ref = { current: null };
 
       messagesFromEvents([e1, e2], ref);
-      const cachedAfterFirst = ref.current;
-
       const r2 = messagesFromEvents([e1], ref);
       expect(r2.map((m) => m.id)).toEqual(["u1", "a1"]);
-      expect(ref.current).not.toBe(cachedAfterFirst);
     });
   });
 

--- a/apps/inspect/src/app/samples/messagesFromEvents.test.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.test.ts
@@ -1,20 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
 
-import { messagesFromEvents } from "./messagesFromEvents";
+import {
+  messagesFromEvents,
+  type MessagesFromEventsState,
+} from "./messagesFromEvents";
+
+type Ref = { current: MessagesFromEventsState | null };
 
 const makeModelEvent = (opts: {
   error?: string;
+  input?: ChatMessage[];
   inputId?: string;
   outputId?: string;
 }): Event =>
   ({
     event: "model",
     error: opts.error ?? null,
-    input: opts.inputId
-      ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
-      : [],
+    input:
+      opts.input ??
+      (opts.inputId
+        ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
+        : []),
     output: {
       choices: [
         {
@@ -28,6 +36,23 @@ const makeModelEvent = (opts: {
       ],
     },
   }) as unknown as Event;
+
+const userMsg = (id: string): ChatMessage =>
+  ({ id, role: "user", content: "u", source: null }) as unknown as ChatMessage;
+const assistantMsg = (id: string): ChatMessage =>
+  ({
+    id,
+    role: "assistant",
+    content: "a",
+    source: "generate",
+  }) as unknown as ChatMessage;
+const toolMsg = (id: string): ChatMessage =>
+  ({
+    id,
+    role: "tool",
+    content: "t",
+    source: null,
+  }) as unknown as ChatMessage;
 
 describe("messagesFromEvents", () => {
   it("returns messages from successful model events", () => {
@@ -51,5 +76,225 @@ describe("messagesFromEvents", () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]!.id).toBe("msg-1");
     expect(messages[1]!.id).toBe("msg-2");
+  });
+
+  it("includes the latest event's output when not yet folded into a later input", () => {
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1")],
+        outputId: "a1",
+      }),
+    ];
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+
+  it("returns [] for an empty event stream", () => {
+    expect(messagesFromEvents([])).toEqual([]);
+  });
+
+  it("returns [] when every model event has an error", () => {
+    const events = [
+      makeModelEvent({
+        error: "429 rate limit",
+        inputId: "msg-1",
+        outputId: "msg-err-1",
+      }),
+      makeModelEvent({
+        error: "500 server error",
+        inputId: "msg-1",
+        outputId: "msg-err-2",
+      }),
+    ];
+    expect(messagesFromEvents(events)).toEqual([]);
+  });
+
+  it("interleaves tool results with their assistants when a later event folds them in", () => {
+    // Multiple model events produce tool-calling assistants without their
+    // tool results yet folded into subsequent inputs. A late event finally
+    // arrives with all the tool results interleaved. Each tool result must
+    // slot in immediately after the assistant whose call it answered.
+    const events = [
+      makeModelEvent({ input: [userMsg("u1")], outputId: "a1" }),
+      makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1"), assistantMsg("a2")],
+        outputId: "a3",
+      }),
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          assistantMsg("a1"),
+          toolMsg("t1"),
+          assistantMsg("a2"),
+          toolMsg("t2"),
+          assistantMsg("a3"),
+          toolMsg("t3"),
+        ],
+        outputId: "a4",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "t1",
+      "a2",
+      "t2",
+      "a3",
+      "t3",
+      "a4",
+    ]);
+  });
+
+  it("preserves pre-compaction messages when later inputs are compacted", () => {
+    // After compaction the next model event's input is a shortened summary
+    // view that omits earlier messages. Those earlier messages must still
+    // be visible, with the new compaction summary slotted in after them.
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2"), assistantMsg("a1")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [userMsg("summary"), assistantMsg("a2")],
+        outputId: "a3",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "u2",
+      "a1",
+      "a2",
+      "summary",
+      "a3",
+    ]);
+  });
+
+  it("ignores duplicate ids within a single event's input", () => {
+    // A duplicate input id would otherwise re-anchor the cursor backwards
+    // and corrupt the ordering of subsequent new messages in the same walk.
+    const events = [
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          assistantMsg("a1"),
+          userMsg("u1"),
+          toolMsg("t1"),
+        ],
+        outputId: "a2",
+      }),
+    ];
+    expect(messagesFromEvents(events).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "t1",
+      "a2",
+    ]);
+  });
+
+  describe("cross-call caching via stateRef", () => {
+    it("reuses cached state when events array extends with a new tail", () => {
+      const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e2 = makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1"), toolMsg("t1")],
+        outputId: "a2",
+      });
+      const ref: Ref = { current: null };
+
+      const r1 = messagesFromEvents([e1], ref);
+      expect(r1.map((m) => m.id)).toEqual(["u1", "a1"]);
+      const cachedAfterFirst = ref.current;
+
+      const r2 = messagesFromEvents([e1, e2], ref);
+      expect(r2.map((m) => m.id)).toEqual(["u1", "a1", "t1", "a2"]);
+      // Same state object was mutated, not replaced.
+      expect(ref.current).toBe(cachedAfterFirst);
+    });
+
+    it("returns the cached array unchanged when no new events were added", () => {
+      const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const ref: Ref = { current: null };
+
+      const r1 = messagesFromEvents([e1], ref);
+      const r2 = messagesFromEvents([e1], ref);
+      // Identity preserved across no-op calls so React useMemo consumers
+      // don't re-render.
+      expect(r2).toBe(r1);
+    });
+
+    it("rebuilds state when an existing event reference changes", () => {
+      const e1a = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e1b = makeModelEvent({ inputId: "u2", outputId: "a1" });
+      const ref: Ref = { current: null };
+
+      messagesFromEvents([e1a], ref);
+      const cachedAfterFirst = ref.current;
+
+      const r2 = messagesFromEvents([e1b], ref);
+      expect(r2.map((m) => m.id)).toEqual(["u2", "a1"]);
+      // Divergence at index 0 forced a fresh state object.
+      expect(ref.current).not.toBe(cachedAfterFirst);
+    });
+
+    it("rebuilds state when the events array shrinks", () => {
+      const e1 = makeModelEvent({ inputId: "u1", outputId: "a1" });
+      const e2 = makeModelEvent({
+        input: [userMsg("u1"), assistantMsg("a1")],
+        outputId: "a2",
+      });
+      const ref: Ref = { current: null };
+
+      messagesFromEvents([e1, e2], ref);
+      const cachedAfterFirst = ref.current;
+
+      const r2 = messagesFromEvents([e1], ref);
+      expect(r2.map((m) => m.id)).toEqual(["u1", "a1"]);
+      expect(ref.current).not.toBe(cachedAfterFirst);
+    });
+  });
+
+  it("places intermediate-output assistants between their event's neighbors", () => {
+    // Two events share the same input, the second produces an extra
+    // assistant. A later event has new tool/user messages folded in.
+    // The intermediate assistant slots between its event's last input
+    // anchor (u2) and its successor in the next event's input.
+    const events = [
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2")],
+        outputId: "a1",
+      }),
+      makeModelEvent({
+        input: [userMsg("u1"), userMsg("u2")],
+        outputId: "a2",
+      }),
+      makeModelEvent({
+        input: [
+          userMsg("u1"),
+          userMsg("u2"),
+          assistantMsg("a1"),
+          toolMsg("t1"),
+          userMsg("u3"),
+        ],
+        outputId: "a3",
+      }),
+    ];
+
+    const messages = messagesFromEvents(events);
+    expect(messages.map((m) => m.id)).toEqual([
+      "u1",
+      "u2",
+      "a1",
+      "t1",
+      "u3",
+      "a2",
+      "a3",
+    ]);
   });
 });

--- a/apps/inspect/src/app/samples/messagesFromEvents.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.ts
@@ -1,41 +1,134 @@
 import type {
   ChatMessage,
-  ChatMessageAssistant,
-  ChatMessageSystem,
-  ChatMessageTool,
-  ChatMessageUser,
   Event,
+  ModelEvent,
 } from "@tsmono/inspect-common/types";
 
-export const messagesFromEvents = (runningEvents: Event[]): ChatMessage[] => {
-  const messages: Map<
-    string,
-    ChatMessageSystem | ChatMessageUser | ChatMessageAssistant | ChatMessageTool
-  > = new Map();
+/** Cached state for cross-call reuse. Hand the same object back via
+ *  React's `useRef` (or `{ current: null }` in tests) on every call. */
+export type MessagesFromEventsState = {
+  messages: ChatMessage[];
+  positions: Map<string, number>;
+  events: readonly Event[];
+  lastResult: ChatMessage[];
+};
 
-  runningEvents
-    .filter((e) => e.event === "model")
-    .filter((e) => !e.error)
-    .forEach((e) => {
-      for (const m of e.input) {
-        const inputMessage = m as
-          | ChatMessageSystem
-          | ChatMessageUser
-          | ChatMessageAssistant
-          | ChatMessageTool;
-        if (inputMessage.id && !messages.has(inputMessage.id)) {
-          messages.set(inputMessage.id, inputMessage);
-        }
-      }
-      const outputMessage = e.output.choices[0].message;
-      if (outputMessage.id) {
-        messages.set(outputMessage.id, outputMessage);
-      }
-    });
+const isSuccessfulModelEvent = (e: Event): e is ModelEvent =>
+  e.event === "model" && !e.error;
 
-  if (messages.size > 0) {
-    return messages.values().toArray();
-  } else {
-    return [];
+const createState = (): MessagesFromEventsState => ({
+  messages: [],
+  positions: new Map(),
+  events: [],
+  lastResult: [],
+});
+
+const insertAt = (
+  state: MessagesFromEventsState,
+  index: number,
+  m: ChatMessage,
+): void => {
+  state.messages.splice(index, 0, m);
+  // Reindex everything from `index` onward; the splice shifted all
+  // following messages right by one slot.
+  for (let i = index; i < state.messages.length; i++) {
+    const id = state.messages[i]!.id;
+    if (id) state.positions.set(id, i);
   }
+};
+
+const processEvent = (
+  state: MessagesFromEventsState,
+  e: ModelEvent,
+): void => {
+  // Build the conversation list by merging each model event's `input`
+  // (the model's view at that call) in order. Per event: reset a cursor
+  // to the last index in the list, then walk its input. Known ids
+  // re-anchor the cursor to their position without re-inserting; new
+  // ids splice at cursor + 1. The output appends at the end of the
+  // list (not at cursor + 1) and dedupes by id.
+  //
+  // The end-of-list cursor default lets an event whose input begins
+  // with unseen messages (e.g. a compaction summary introduced ahead
+  // of any prior anchor) extend the prefix rather than prepend. The
+  // output-at-end rule then keeps the post-compaction assistant after
+  // the summary, not between it and earlier history.
+  let cursor = state.messages.length - 1;
+  const seenInEvent = new Set<string>();
+  for (const m of e.input) {
+    if (!m.id || seenInEvent.has(m.id)) continue;
+    seenInEvent.add(m.id);
+    const known = state.positions.get(m.id);
+    if (known !== undefined) {
+      cursor = known;
+    } else {
+      cursor += 1;
+      insertAt(state, cursor, m);
+    }
+  }
+  const out = e.output.choices[0]?.message;
+  if (out?.id && !state.positions.has(out.id)) {
+    state.positions.set(out.id, state.messages.length);
+    state.messages.push(out);
+  }
+};
+
+/**
+ * Reconstruct the conversation message list shown in the running-sample
+ * Messages tab from a stream of events.
+ *
+ * If `stateRef` is supplied, the function tries to reuse cached work
+ * from the previous call. When `events` is a pure prefix-extension of
+ * the prior snapshot (events[i] === prior.events[i] for all prior
+ * indices), only the new tail is processed; otherwise we recompute
+ * from scratch. The cache is updated in place via `stateRef.current`.
+ */
+export const messagesFromEvents = (
+  events: Event[],
+  stateRef?: { current: MessagesFromEventsState | null },
+): ChatMessage[] => {
+  const prior = stateRef?.current ?? null;
+
+  // Find first divergence with prior's events snapshot.
+  let startFrom = 0;
+  if (prior) {
+    while (
+      startFrom < prior.events.length &&
+      startFrom < events.length &&
+      prior.events[startFrom] === events[startFrom]
+    ) {
+      startFrom++;
+    }
+  }
+
+  // Pure extension when we matched all of prior's events and `events`
+  // is at least as long. Anything else (replacement, shrink, mid-array
+  // reference change) triggers a full rebuild.
+  const canReuse =
+    prior !== null &&
+    startFrom === prior.events.length &&
+    events.length >= prior.events.length;
+
+  let state: MessagesFromEventsState;
+  if (canReuse) {
+    state = prior;
+  } else {
+    state = createState();
+    startFrom = 0;
+  }
+
+  let dirty = !canReuse;
+  for (let i = startFrom; i < events.length; i++) {
+    const e = events[i]!;
+    if (isSuccessfulModelEvent(e)) {
+      processEvent(state, e);
+      dirty = true;
+    }
+  }
+
+  state.events = events;
+  if (dirty) state.lastResult = state.messages.slice();
+
+  if (stateRef) stateRef.current = state;
+  return state.lastResult;
 };

--- a/apps/inspect/src/app/samples/messagesFromEvents.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.ts
@@ -32,7 +32,7 @@ const insertAt = (
   // Reindex everything from `index` onward; the splice shifted all
   // following messages right by one slot.
   for (let i = index; i < state.messages.length; i++) {
-    const id = state.messages[i]!.id;
+    const id = state.messages[i].id;
     if (id) state.positions.set(id, i);
   }
 };
@@ -79,6 +79,12 @@ const processEvent = (state: MessagesFromEventsState, e: ModelEvent): void => {
  * the prior snapshot (events[i] === prior.events[i] for all prior
  * indices), only the new tail is processed; otherwise we recompute
  * from scratch. The cache is updated in place via `stateRef.current`.
+ *
+ * Note: the polling pipeline replaces the trailing event in place when
+ * a streaming model call produces successive output chunks. That shows
+ * up as divergence at the last index and forces a rebuild every poll
+ * for the active turn, so the cache mainly earns its keep between
+ * turns and on idle polls, not while a single model call is streaming.
  */
 export const messagesFromEvents = (
   events: Event[],
@@ -114,17 +120,19 @@ export const messagesFromEvents = (
     startFrom = 0;
   }
 
-  let dirty = !canReuse;
+  // Track length to decide whether to refresh `lastResult`. processEvent
+  // only ever grows `state.messages`, so an unchanged length means no
+  // user-visible change and the prior cached array stays valid.
+  const priorLen = state.messages.length;
   for (let i = startFrom; i < events.length; i++) {
-    const e = events[i]!;
-    if (isSuccessfulModelEvent(e)) {
-      processEvent(state, e);
-      dirty = true;
-    }
+    const e = events[i];
+    if (isSuccessfulModelEvent(e)) processEvent(state, e);
   }
 
   state.events = events;
-  if (dirty) state.lastResult = state.messages.slice();
+  if (!canReuse || state.messages.length !== priorLen) {
+    state.lastResult = state.messages.slice();
+  }
 
   if (stateRef) stateRef.current = state;
   return state.lastResult;

--- a/apps/inspect/src/app/samples/messagesFromEvents.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.ts
@@ -26,7 +26,7 @@ const createState = (): MessagesFromEventsState => ({
 const insertAt = (
   state: MessagesFromEventsState,
   index: number,
-  m: ChatMessage,
+  m: ChatMessage
 ): void => {
   state.messages.splice(index, 0, m);
   // Reindex everything from `index` onward; the splice shifted all
@@ -37,10 +37,7 @@ const insertAt = (
   }
 };
 
-const processEvent = (
-  state: MessagesFromEventsState,
-  e: ModelEvent,
-): void => {
+const processEvent = (state: MessagesFromEventsState, e: ModelEvent): void => {
   // Build the conversation list by merging each model event's `input`
   // (the model's view at that call) in order. Per event: reset a cursor
   // to the last index in the list, then walk its input. Known ids
@@ -85,7 +82,7 @@ const processEvent = (
  */
 export const messagesFromEvents = (
   events: Event[],
-  stateRef?: { current: MessagesFromEventsState | null },
+  stateRef?: { current: MessagesFromEventsState | null }
 ): ChatMessage[] => {
   const prior = stateRef?.current ?? null;
 


### PR DESCRIPTION
## Summary

Combines the original ordering fix from #138 with the cross-poll caching that the discussion there agreed was the right perf shape.

While a sample is running, the Messages tab built its list by walking model events in stream order with a `Map<id, message>`. `Map.set` on an existing key keeps the original insertion position, so tool results and follow-up user turns from later events were appended at the end instead of slotting between the assistants that produced them. The bug self-healed once the sample completed, since the completed view uses the server-provided `sample.messages`.

The fix walks model events in order with a cursor that re-anchors at known ids without re-inserting, and splices new ids at `cursor + 1`. The output appends at the tail and dedupes by id. The end-of-list cursor default keeps a fresh first message in a post-compaction event after the existing prefix; the output-at-tail rule keeps the post-compaction assistant after its summary.

The Messages tab re-runs `messagesFromEvents` on every polling tick (`samplePolling.ts:255` spreads events into a new array each poll, defeating useMemo identity). Without amortization, every poll reprocesses all events from scratch, which is O(N²) in the size of the conversation. Around 5k turns that's ~1.4s per poll.

`messagesFromEvents` accepts an optional `stateRef` (matching React's `useRef` shape: `{ current: T | null }`). When the new events array is a pure prefix extension of the prior snapshot, only the new tail is processed and the cached result array is reused unchanged for identity stability. Any other shape (replacement, shrink, mid-array reference change) triggers a rebuild.

`SampleDisplay` holds a `useRef<MessagesFromEventsState | null>` directly and passes it in. The cache is reset on sample completion or when there's no running data.

Steady-state poll cost drops from O(N²) to O(M_new). First-paint cost is unchanged and only matters for users joining a long-running sample late — a one-time cost before polls become cheap.

## Bench

Node JIT, agentic trace where each event's input grows linearly:

| Turns | Cold | Warm poll |
|---|---|---|
| 1000  | 34ms      | 0.09ms |
| 5000  | 1.4s      | 0.84ms |
| 10000 | 7.4s      | 2.81ms |
| 20000 | 32.6s     | 3.18ms |
| 50000 (extrapolated) | ~200s | ~8–10ms |

Note that a cold start of a 50k turn in-progress sample can take 30+ minutes to load already (I am working on a separate PR to mitigate this), and the previous code was also O(n²) just with a slightly lower constant. But we _do_ pay a price for correctness here.

## Test plan

- [x] Manual: load a running sample with tool calls and verify Messages tab interleaves assistants/tools/users correctly; verify a long-running sample doesn't jank the UI per poll