### PR TITLE
viewer: render errored-before-start pending samples

### DIFF
--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -195,6 +195,7 @@ export const clientApi = (
       }
 
       function handleError(error: unknown) {
+        if (error instanceof SampleNotFoundError) return undefined;
         if (error instanceof FileSizeLimitError) {
           throw new SampleSizeLimitedExceededError(id, epoch, error.maxBytes);
         }
@@ -210,10 +211,10 @@ export const clientApi = (
             // Retry without cache
             return await fetchSample(false);
           } catch (retryError) {
-            handleError(retryError);
+            return handleError(retryError);
           }
         } else {
-          handleError(error);
+          return handleError(error);
         }
       }
     } else {

--- a/apps/inspect/src/state/samplePolling.test.ts
+++ b/apps/inspect/src/state/samplePolling.test.ts
@@ -3,7 +3,7 @@ import { StoreApi, UseBoundStore } from "zustand";
 
 import { EvalSample } from "@tsmono/inspect-common/types";
 
-import { SampleDataResponse } from "../client/api/types";
+import { SampleDataResponse, SampleSummary } from "../client/api/types";
 
 import {
   createSamplePolling,
@@ -226,6 +226,163 @@ describe("createSamplePolling", () => {
 
     expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
     expect(sampleActions.setSampleStatus).not.toHaveBeenCalledWith("ok");
+  });
+
+  it("surfaces an error when the body is missing and the summary has no error", async () => {
+    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+      status: "NotFound",
+    } satisfies SampleDataResponse);
+    const getLogSample = vi.fn().mockResolvedValue(undefined);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: { selectedLogDetails: { sampleSummaries: [] } },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    polling.startPolling("log.eval", createSummary("plain-sample"));
+    await flushPromises();
+
+    expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("error");
+    expect(sampleActions.setSampleError).toHaveBeenCalled();
+  });
+
+  it("uses the live store summary for the synthesis check, not the stub passed to startPolling", async () => {
+    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+      status: "NotFound",
+    } satisfies SampleDataResponse);
+    const getLogSample = vi.fn().mockResolvedValue(undefined);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    // Live store state: pending samples include the same sample with `error`.
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: {
+        selectedLogDetails: { sampleSummaries: [] },
+        pendingSampleSummaries: {
+          samples: [
+            {
+              id: "rocket-medium-vision",
+              epoch: 1,
+              error: "RuntimeError: server.py exited before becoming ready",
+              completed: true,
+            },
+          ],
+        },
+      },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    // Simulate the stub summary that usePollSample actually passes today.
+    polling.startPolling("log.eval", {
+      id: "rocket-medium-vision",
+      epoch: 1,
+    } as SampleSummary);
+    await flushPromises();
+
+    expect(getLogSample).toHaveBeenCalled();
+    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
+    const [synthesizedSample] = sampleActions.setSelectedSample.mock.calls[0];
+    expect(synthesizedSample.error?.message).toBe(
+      "RuntimeError: server.py exited before becoming ready"
+    );
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
+    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+  });
+
+  it("uses the fetched body when present, even if the summary carries an error", async () => {
+    // Errored-but-flushed scenario: the body IS in the .eval zip with rich
+    // events; the summary still reports the error. The fetched body must
+    // win — synthesizing from the summary would lose the rich data.
+    const realSample = {
+      ...createEvalSample("dig-medium-vision"),
+      error: {
+        message: "real sample error from .eval body",
+        traceback: "real-traceback",
+        traceback_ansi: "real-traceback",
+      },
+    };
+
+    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+      status: "NotFound",
+    } satisfies SampleDataResponse);
+    const getLogSample = vi.fn().mockResolvedValue(realSample);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: {
+        selectedLogDetails: { sampleSummaries: [] },
+        pendingSampleSummaries: {
+          samples: [
+            {
+              id: "dig-medium-vision",
+              epoch: 1,
+              error: "summary error string (would be used by synthesizer)",
+              completed: true,
+            },
+          ],
+        },
+      },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    polling.startPolling("log.eval", {
+      id: "dig-medium-vision",
+      epoch: 1,
+    } as SampleSummary);
+    await flushPromises();
+
+    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
+    const [passedSample] = sampleActions.setSelectedSample.mock.calls[0];
+    expect(passedSample.error?.message).toBe(
+      "real sample error from .eval body"
+    );
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
   });
 });
 

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -20,8 +20,12 @@ import {
 import { resolveAttachments } from "../utils/attachments";
 import { createPolling } from "../utils/polling";
 
-import { resolveSample } from "./sampleUtils";
+import {
+  resolveSample,
+  synthesizeErroredSampleFromSummary,
+} from "./sampleUtils";
 import { StoreState } from "./store";
+import { mergeSampleSummaries } from "./utils";
 
 const log = createLogger("samplePolling");
 
@@ -136,11 +140,20 @@ export function createSamplePolling(
 
         try {
           log.debug(message);
-          const sample = await api.get_log_sample(
-            logFile,
-            summary.id,
-            summary.epoch
-          );
+          // The closure-captured `summary` is the stub {id, epoch} from
+          // usePollSample, so re-resolve from the store to read its `error`.
+          const sample =
+            (await api.get_log_sample(logFile, summary.id, summary.epoch)) ??
+            (() => {
+              const liveSummary = findLiveSummary(
+                store.getState(),
+                summary.id,
+                summary.epoch
+              );
+              return liveSummary?.error
+                ? synthesizeErroredSampleFromSummary(liveSummary)
+                : undefined;
+            })();
 
           // If the user navigated away while we were fetching, don't overwrite
           // the new sample's state with this stale result.
@@ -319,6 +332,20 @@ const hasCompletedLogSummary = (
       sampleIdsEqual(sampleSummary.id, sampleId) &&
       sampleSummary.epoch === sampleEpoch &&
       sampleSummary.completed !== false
+  );
+};
+
+const findLiveSummary = (
+  state: StoreState,
+  sampleId: string | number,
+  sampleEpoch: number
+): SampleSummary | undefined => {
+  const merged = mergeSampleSummaries(
+    state.log.selectedLogDetails?.sampleSummaries ?? [],
+    state.log.pendingSampleSummaries?.samples ?? []
+  );
+  return merged.find(
+    (s) => sampleIdsEqual(s.id, sampleId) && s.epoch === sampleEpoch
   );
 };
 

--- a/apps/inspect/src/state/sampleUtils.test.ts
+++ b/apps/inspect/src/state/sampleUtils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveSample } from "./sampleUtils";
+import { SampleSummary } from "../client/api/types";
+
+import {
+  resolveSample,
+  synthesizeErroredSampleFromSummary,
+} from "./sampleUtils";
 
 const msg = (id: string, role: string, content: string) => ({
   id,
@@ -136,5 +141,64 @@ describe("resolveSample", () => {
     },
   ])("$name", ({ sample, check }) => {
     check(resolveSample(sample));
+  });
+});
+
+const baseSummary = (
+  overrides: Partial<SampleSummary> = {}
+): SampleSummary => ({
+  id: "rocket-medium-vision",
+  epoch: 1,
+  input: "task input",
+  target: "expected target",
+  scores: null,
+  error: "RuntimeError: server.py exited before becoming ready",
+  completed: true,
+  ...overrides,
+});
+
+describe("synthesizeErroredSampleFromSummary", () => {
+  it("populates EvalSample.error from the summary's error string", () => {
+    const sample = synthesizeErroredSampleFromSummary(baseSummary());
+
+    expect(sample.error).toBeTruthy();
+    expect(sample.error?.message).toBe(
+      "RuntimeError: server.py exited before becoming ready"
+    );
+    expect(sample.error?.traceback).toBe(
+      "RuntimeError: server.py exited before becoming ready"
+    );
+    expect(sample.error?.traceback_ansi).toBe(
+      "RuntimeError: server.py exited before becoming ready"
+    );
+  });
+
+  it("does not propagate the summary's string limit (EvalSample.limit is an object | null)", () => {
+    const sample = synthesizeErroredSampleFromSummary(
+      baseSummary({ limit: "context" })
+    );
+
+    expect(sample.limit).toBeNull();
+  });
+
+  it("returns empty events / messages / attachments / output", () => {
+    const sample = synthesizeErroredSampleFromSummary(baseSummary());
+
+    expect(sample.events).toEqual([]);
+    expect(sample.messages).toEqual([]);
+    expect(sample.attachments).toEqual({});
+    expect(sample.output).toBeDefined();
+    expect(sample.output.choices).toEqual([]);
+  });
+
+  it("survives resolveSample without throwing", () => {
+    const sample = synthesizeErroredSampleFromSummary(baseSummary());
+    expect(() => resolveSample(sample)).not.toThrow();
+  });
+
+  it("throws if the summary has no error", () => {
+    expect(() =>
+      synthesizeErroredSampleFromSummary(baseSummary({ error: undefined }))
+    ).toThrow();
   });
 });

--- a/apps/inspect/src/state/sampleUtils.ts
+++ b/apps/inspect/src/state/sampleUtils.ts
@@ -1,6 +1,7 @@
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { expandEvents } from "@tsmono/inspect-common/utils";
 
+import { SampleSummary } from "../client/api/types";
 import { resolveAttachments } from "../utils/attachments";
 
 /**
@@ -26,4 +27,53 @@ export const resolveSample = (sample: any): EvalSample => {
   sample.events = resolveAttachments(sample.events, sample.attachments);
   sample.attachments = {};
   return sample;
+};
+
+/**
+ * Build a minimal EvalSample from a pending-buffer summary that has errored.
+ *
+ * SampleSummary.error is a plain string but EvalSample.error is shaped
+ * `{ message, traceback, traceback_ansi }`; we populate all three with the
+ * same string since no real traceback is available.
+ */
+export const synthesizeErroredSampleFromSummary = (
+  summary: SampleSummary
+): EvalSample => {
+  if (!summary.error) {
+    throw new Error(
+      "synthesizeErroredSampleFromSummary requires summary.error to be set"
+    );
+  }
+  const errorMessage = summary.error;
+  return {
+    id: summary.id,
+    epoch: summary.epoch,
+    uuid: summary.uuid,
+    input: summary.input,
+    target: summary.target,
+    scores: summary.scores ?? null,
+    metadata: summary.metadata ?? {},
+    model_usage: summary.model_usage ?? {},
+    started_at: summary.started_at ?? null,
+    completed_at: summary.completed_at ?? null,
+    total_time: summary.total_time ?? null,
+    working_time: summary.working_time ?? null,
+    // SampleSummary.limit is a string but EvalSample.limit is an object,
+    // so don't propagate it.
+    limit: null,
+    error: {
+      message: errorMessage,
+      traceback: errorMessage,
+      traceback_ansi: errorMessage,
+    },
+    messages: [],
+    events: [],
+    attachments: {},
+    output: {
+      model: "",
+      choices: [],
+      usage: null,
+    },
+    store: {},
+  } as unknown as EvalSample;
 };

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -1,10 +1,16 @@
 import { useCallback, useEffect } from "react";
 
+import { EvalSample } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
+
+import { SampleSummary } from "../client/api/types";
 
 import { useLogSelection, usePrevious, useSampleData } from "./hooks";
 import { getSamplePolling } from "./samplePollingInstance";
-import { resolveSample } from "./sampleUtils";
+import {
+  resolveSample,
+  synthesizeErroredSampleFromSummary,
+} from "./sampleUtils";
 import { useStore } from "./store";
 
 // List of virtuoso list keys that should be cleared when sample changes
@@ -53,7 +59,8 @@ export function useLoadSample() {
       logFile: string,
       id: number | string,
       epoch: number,
-      completed?: boolean
+      completed: boolean | undefined,
+      summary: SampleSummary | undefined
     ) => {
       // Skip if already loading this exact sample
       const currentId = sampleData.selectedSampleIdentifier;
@@ -95,13 +102,11 @@ export function useLoadSample() {
             });
           };
 
-          // Fetch the sample from the API
-          const sample = await api?.get_log_sample(
-            logFile,
-            id,
-            epoch,
-            onProgress
-          );
+          const sample: EvalSample | undefined =
+            (await api?.get_log_sample(logFile, id, epoch, onProgress)) ??
+            (summary?.error
+              ? synthesizeErroredSampleFromSummary(summary)
+              : undefined);
           sampleActions.setDownloadProgress(undefined);
           log.debug(`LOADED COMPLETED SAMPLE: ${id}-${epoch}`);
 
@@ -200,12 +205,14 @@ export function useLoadSample() {
           logSelection.logFile,
           sampleId,
           sampleEpoch,
-          sampleCompleted
+          sampleCompleted,
+          logSelection.sample
         );
       }
     }
   }, [
     logSelection.logFile,
+    logSelection.sample,
     sampleId,
     sampleEpoch,
     sampleCompleted,

--- a/apps/inspect/src/state/utils.test.ts
+++ b/apps/inspect/src/state/utils.test.ts
@@ -29,6 +29,25 @@ describe("mergeSampleSummaries", () => {
       logSummary,
     ]);
   });
+
+  test("preserves completed:true for pending samples that errored before any work", () => {
+    const result = mergeSampleSummaries(
+      [],
+      [
+        createSampleSummary({
+          id: "errored-before-start",
+          completed: true,
+          error: "RuntimeError: server.py exited before becoming ready",
+        }),
+      ]
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].completed).toBe(true);
+    expect(result[0].error).toBe(
+      "RuntimeError: server.py exited before becoming ready"
+    );
+  });
 });
 
 const createSampleSummary = (

--- a/apps/inspect/src/state/utils.ts
+++ b/apps/inspect/src/state/utils.ts
@@ -14,6 +14,13 @@ export const mergeSampleSummaries = (
   const uniquePendingSamples = pendingSamples
     .filter((sample) => !existingSampleIds.has(`${sample.id}-${sample.epoch}`))
     .map((sample) => {
+      // Terminal-with-error pending samples are rendered from the summary
+      // by the manifest-miss fallback in useLoadSample / samplePolling.
+      const isTerminalErrored = sample.completed === true && !!sample.error;
+      if (isTerminalErrored) {
+        return { ...sample };
+      }
+
       // Pending-buffer samples are not necessarily in the .eval ZIP yet,
       // even if their work has completed. Keep them on the streaming path
       // until they appear in the log summaries.


### PR DESCRIPTION
## Summary

When a sample errors before any work is recorded (e.g. sandbox dies during setup), the summary lands in the pending-samples buffer with `completed: true` and an `error` set, but the body isn't in the `.eval` zip yet. Opening the sample during that window fails with `SampleNotFoundError` ("not present in the manifest"). This PR makes the viewer render such samples directly from their summary.

## Test plan

- [x] Manual: open the manifest-miss sample. Error tab shows the synthesized RuntimeError; no manifest-miss banner.
- [x] Manual: open a sibling errored-but-flushed sample: full transcript with rich Python traceback renders from the `.eval` body.
