### PR TITLE
Bidirectional column ↔ text filter sync for SampleList

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -1,4 +1,4 @@
-import type { ColDef } from "ag-grid-community";
+import type { ColDef, GridApi } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import {
   FC,
@@ -32,6 +32,8 @@ import {
 import { useStore } from "../../../state/store.ts";
 import { ApplicationIcons } from "../../appearance/icons.ts";
 import { NavbarButton } from "../../navbar/NavbarButton.tsx";
+import { filterModelToText } from "../../samples/sample-tools/filterModelToText.ts";
+import { buildSampleFilterRegistry } from "../../samples/sample-tools/filterRegistry.ts";
 import { ColumnSelectorPopover } from "../../shared/ColumnSelectorPopover.tsx";
 import { getFieldKey } from "../../shared/gridUtils.ts";
 import {
@@ -337,11 +339,35 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   // Tracked here so the column selector can mark filtered columns.
   // Updated via the grid's onFilterChanged callback.
   const [filteredFields, setFilteredFields] = useState<string[]>([]);
+
+  // Column → text filter sync (phase 2b). When a column header filter
+  // changes, synthesize a filtrex expression and push it into the toolbar
+  // text filter so the two surfaces stay in sync.
+  const filterRegistry = useMemo(
+    () => buildSampleFilterRegistry(samplesDescriptor?.evalDescriptor),
+    [samplesDescriptor]
+  );
+  const setFilter = useStore((state) => state.logActions.setFilter);
+  const currentFilter = useStore((state) => state.log.filter);
+  const currentFilterRef = useRef(currentFilter);
+  currentFilterRef.current = currentFilter;
   const handleFilterChanged = useCallback(
-    (api: { getFilterModel: () => Record<string, unknown> | null }) => {
-      setFilteredFields(Object.keys(api.getFilterModel() ?? {}));
+    (api: GridApi<SampleRow>) => {
+      const model = api.getFilterModel() ?? {};
+      setFilteredFields(Object.keys(model));
+
+      const hasColumns = Object.keys(model).length > 0;
+      const synthesized = hasColumns
+        ? filterModelToText(model, filterRegistry)
+        : "";
+      // Skip when columns are filtered but none are representable —
+      // leave whatever the user typed alone.
+      if (synthesized === null) return;
+      if (synthesized !== currentFilterRef.current) {
+        setFilter(synthesized);
+      }
     },
-    []
+    [filterRegistry, setFilter]
   );
 
   if (totalSampleCount === 0) {

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -32,6 +32,11 @@ import {
 import { useStore } from "../../../state/store.ts";
 import { ApplicationIcons } from "../../appearance/icons.ts";
 import { NavbarButton } from "../../navbar/NavbarButton.tsx";
+import {
+  astToFilterModel,
+  FilterModel,
+} from "../../samples/sample-tools/astToFilterModel.ts";
+import { parseFilter } from "../../samples/sample-tools/filterAst.ts";
 import { filterModelToText } from "../../samples/sample-tools/filterModelToText.ts";
 import { buildSampleFilterRegistry } from "../../samples/sample-tools/filterRegistry.ts";
 import { ColumnSelectorPopover } from "../../shared/ColumnSelectorPopover.tsx";
@@ -340,9 +345,20 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   // Updated via the grid's onFilterChanged callback.
   const [filteredFields, setFilteredFields] = useState<string[]>([]);
 
-  // Column → text filter sync (phase 2b). When a column header filter
-  // changes, synthesize a filtrex expression and push it into the toolbar
-  // text filter so the two surfaces stay in sync.
+  // Bidirectional filter sync (phases 2b + 2c). The toolbar text filter
+  // and the column `FilterModel` describe the same logical narrowing;
+  // this block keeps them in lock-step:
+  //
+  //   columns →  text:  on every grid filter change, synthesize a filtrex
+  //                     expression from the FilterModel and push to text.
+  //   text    → columns: when the text changes (and is round-trippable),
+  //                     parse it into a FilterModel and apply it to the
+  //                     grid. Non-round-trippable text clears the column
+  //                     filters so they don't double-narrow.
+  //
+  // The feedback loop is broken at each boundary by comparing the value
+  // we'd write against the value already there — the two sides are the
+  // canonical state, no separate trackers needed.
   const filterRegistry = useMemo(
     () => buildSampleFilterRegistry(samplesDescriptor?.evalDescriptor),
     [samplesDescriptor]
@@ -351,23 +367,66 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   const currentFilter = useStore((state) => state.log.filter);
   const currentFilterRef = useRef(currentFilter);
   currentFilterRef.current = currentFilter;
+
+  /** Parse `text` and project it to the FilterModel the column UI
+   *  should be holding — `{}` for empty or non-round-trippable text. */
+  const filterModelFromText = useCallback(
+    (text: string): FilterModel => {
+      const { ast } = parseFilter(text);
+      return ast ? (astToFilterModel(ast, filterRegistry) ?? {}) : {};
+    },
+    [filterRegistry]
+  );
+
   const handleFilterChanged = useCallback(
     (api: GridApi<SampleRow>) => {
       const model = api.getFilterModel() ?? {};
       setFilteredFields(Object.keys(model));
 
-      const hasColumns = Object.keys(model).length > 0;
-      const synthesized = hasColumns
-        ? filterModelToText(model, filterRegistry)
-        : "";
-      // Skip when columns are filtered but none are representable —
-      // leave whatever the user typed alone.
+      // If `currentFilter` already projects to the model we're seeing,
+      // the two sides are aligned — no echo needed. This covers both the
+      // round-trippable case (`tokens > 50` ↔ `{tokens: gt 50}`) and the
+      // expression-only case where text stays put while columns are `{}`.
+      const fromText = filterModelFromText(currentFilterRef.current);
+      if (JSON.stringify(fromText) === JSON.stringify(model)) return;
+
+      const synthesized = filterModelToText(model, filterRegistry);
+      // Columns are filtered but none are representable — leave text alone.
       if (synthesized === null) return;
-      if (synthesized !== currentFilterRef.current) {
-        setFilter(synthesized);
-      }
+      if (synthesized !== currentFilterRef.current) setFilter(synthesized);
     },
-    [filterRegistry, setFilter]
+    [filterRegistry, filterModelFromText, setFilter]
+  );
+
+  useEffect(() => {
+    const api = sampleListHandle.current?.api;
+    if (!api) return;
+    const desired = filterModelFromText(currentFilter);
+    const current = api.getFilterModel() ?? {};
+    if (JSON.stringify(current) === JSON.stringify(desired)) return;
+    api.setFilterModel(desired);
+  }, [currentFilter, filterModelFromText]);
+
+  // When the toolbar text is a non-round-trippable expression, hide the
+  // column-header filter buttons. Using one would overwrite the typed
+  // text with a much narrower synthesized version. Empty text and
+  // round-trippable text both leave the headers usable.
+  const columnFilteringAllowed = useMemo(() => {
+    if (!currentFilter.trim()) return true;
+    const { ast } = parseFilter(currentFilter);
+    if (!ast) return false;
+    return astToFilterModel(ast, filterRegistry) !== null;
+  }, [currentFilter, filterRegistry]);
+
+  const gridColumns = useMemo(
+    () =>
+      columnFilteringAllowed
+        ? allColumns
+        : allColumns.map((col) => ({
+            ...col,
+            suppressHeaderFilterButton: true,
+          })),
+    [allColumns, columnFilteringAllowed]
   );
 
   if (totalSampleCount === 0) {
@@ -395,7 +454,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
         <SampleList
           listHandle={sampleListHandle}
           items={items}
-          columns={allColumns}
+          columns={gridColumns}
           columnVisibility={visibilityForGrid}
           earlyStopping={selectedLogDetails?.results?.early_stopping}
           totalItemCount={evalSampleCount}

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -402,10 +402,22 @@ export const SamplesTab: FC<SamplesTabProps> = ({
     const api = sampleListHandle.current?.api;
     if (!api) return;
     const desired = filterModelFromText(currentFilter);
-    const current = api.getFilterModel() ?? {};
-    if (JSON.stringify(current) === JSON.stringify(desired)) return;
-    api.setFilterModel(desired);
-  }, [currentFilter, filterModelFromText]);
+    const current: FilterModel = (api.getFilterModel() ?? {}) as FilterModel;
+    // Preserve current model entries that the synthesizer would have
+    // skipped — they live only in the column UI and must not be wiped
+    // by a text-driven update. Entries the user can express in text
+    // (round-trippable ones) are governed by `desired`.
+    const merged: FilterModel = { ...desired };
+    for (const [colId, filter] of Object.entries(current)) {
+      const isRepresentable =
+        filterModelToText({ [colId]: filter }, filterRegistry) !== null;
+      if (!isRepresentable && !(colId in desired)) {
+        merged[colId] = filter;
+      }
+    }
+    if (JSON.stringify(current) === JSON.stringify(merged)) return;
+    api.setFilterModel(merged);
+  }, [currentFilter, filterModelFromText, filterRegistry]);
 
   // When the toolbar text is a non-round-trippable expression, hide the
   // column-header filter buttons. Using one would overwrite the typed

--- a/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
@@ -92,8 +92,9 @@ describe("astToFilterModel — string columns", () => {
   });
 
   test("regex-escaped contains argument unescapes round-trip", () => {
-    // What filterModelToText would emit for filter value "a.b+c".
-    expect(toModel('input_contains("a\\.b\\+c")')).toEqual({
+    // What filterModelToText emits for filter value "a.b+c" — character
+    // classes for metachars (filtrex's lexer rejects `\.` / `\+` etc.).
+    expect(toModel('input_contains("a[.]b[+]c")')).toEqual({
       input: { filterType: "text", type: "contains", filter: "a.b+c" },
     });
   });
@@ -185,6 +186,23 @@ describe("astToFilterModel — round-trip stability (text → model → text)", 
     expect(roundTrip("tokens > 50 and duration > 1")).toBe(
       "tokens > 50 and duration > 1"
     );
+  });
+
+  test("filter values with quotes and backslashes survive", () => {
+    // Synthesizer uses minimal `"` / `\` escaping, tokenizer recognizes
+    // them, parser unescapes. End-to-end identity through the cycle.
+    const fromModel = (filter: string) =>
+      filterModelToText(
+        { input: { filterType: "text", type: "equals", filter } },
+        registry
+      );
+    expect(fromModel('he said "hi"')).toBe('input == "he said \\"hi\\""');
+    const text = fromModel("path\\to");
+    expect(text).toBe('input == "path\\\\to"');
+    const { ast } = parseFilter(text!);
+    expect(astToFilterModel(ast!, registry)).toEqual({
+      input: { filterType: "text", type: "equals", filter: "path\\to" },
+    });
   });
 });
 

--- a/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
@@ -111,16 +111,21 @@ describe("astToFilterModel — string columns", () => {
   });
 
   test("~= 'literal' → contains (no anchors)", () => {
-    // `id` is the filtrex variable for the sampleId column.
-    expect(toModel('id ~= "abc"')).toEqual({
-      sampleId: { filterType: "text", type: "contains", filter: "abc" },
+    // `uuid` is a registered string column without a contains-fn.
+    expect(toModel('uuid ~= "abc"')).toEqual({
+      sampleUuid: { filterType: "text", type: "contains", filter: "abc" },
     });
   });
 
   test("~= '^both$' → equals", () => {
-    expect(toModel('id ~= "^xyz$"')).toEqual({
-      sampleId: { filterType: "text", type: "equals", filter: "xyz" },
+    expect(toModel('uuid ~= "^xyz$"')).toEqual({
+      sampleUuid: { filterType: "text", type: "equals", filter: "xyz" },
     });
+  });
+
+  test("`id` is not synced (numeric/string ambiguity)", () => {
+    expect(toModel('id == "1"')).toBeNull();
+    expect(toModel("id == 1")).toBeNull();
   });
 
   test("blank / notBlank for string column", () => {

--- a/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToFilterModel.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "vitest";
+
+import { astToFilterModel } from "./astToFilterModel";
+import { parseFilter } from "./filterAst";
+import { filterModelToText } from "./filterModelToText";
+import { buildSampleFilterRegistry } from "./filterRegistry";
+
+const registry = buildSampleFilterRegistry(undefined);
+
+const toModel = (text: string) => {
+  const { ast } = parseFilter(text);
+  if (!ast) throw new Error(`parse failed for: ${text}`);
+  return astToFilterModel(ast, registry);
+};
+
+describe("astToFilterModel — number column simple ops", () => {
+  test("equals", () => {
+    expect(toModel("epoch == 2")).toEqual({
+      epoch: { filterType: "number", type: "equals", filter: 2 },
+    });
+  });
+
+  test("comparators", () => {
+    expect(toModel("tokens > 100")).toEqual({
+      tokens: { filterType: "number", type: "greaterThan", filter: 100 },
+    });
+    expect(toModel("duration <= 1.5")).toEqual({
+      duration: { filterType: "number", type: "lessThanOrEqual", filter: 1.5 },
+    });
+  });
+
+  test("inRange detected from `>= a and <= b`", () => {
+    expect(toModel("tokens >= 100 and tokens <= 500")).toEqual({
+      tokens: {
+        filterType: "number",
+        type: "inRange",
+        filter: 100,
+        filterTo: 500,
+      },
+    });
+  });
+
+  test("two non-range conditions on same numeric column → combined AND", () => {
+    expect(toModel("tokens > 100 and tokens < 500")).toEqual({
+      tokens: {
+        filterType: "number",
+        operator: "AND",
+        conditions: [
+          { type: "greaterThan", filter: 100 },
+          { type: "lessThan", filter: 500 },
+        ],
+      },
+    });
+  });
+
+  test("blank / notBlank via None", () => {
+    expect(toModel("tokens == None")).toEqual({
+      tokens: { filterType: "number", type: "blank" },
+    });
+    expect(toModel("tokens != None")).toEqual({
+      tokens: { filterType: "number", type: "notBlank" },
+    });
+  });
+});
+
+describe("astToFilterModel — string columns", () => {
+  test("equals / notEqual on string column", () => {
+    expect(toModel('input == "hello"')).toEqual({
+      input: { filterType: "text", type: "equals", filter: "hello" },
+    });
+    expect(toModel('input != "x"')).toEqual({
+      input: { filterType: "text", type: "notEqual", filter: "x" },
+    });
+  });
+
+  test("xxx_contains() → contains", () => {
+    expect(toModel('input_contains("foo")')).toEqual({
+      input: { filterType: "text", type: "contains", filter: "foo" },
+    });
+    expect(toModel('target_contains("No")')).toEqual({
+      target: { filterType: "text", type: "contains", filter: "No" },
+    });
+    expect(toModel('answer_contains("yes")')).toEqual({
+      answer: { filterType: "text", type: "contains", filter: "yes" },
+    });
+  });
+
+  test("not xxx_contains() → notContains", () => {
+    expect(toModel('not error_contains("boom")')).toEqual({
+      error: { filterType: "text", type: "notContains", filter: "boom" },
+    });
+  });
+
+  test("regex-escaped contains argument unescapes round-trip", () => {
+    // What filterModelToText would emit for filter value "a.b+c".
+    expect(toModel('input_contains("a\\.b\\+c")')).toEqual({
+      input: { filterType: "text", type: "contains", filter: "a.b+c" },
+    });
+  });
+
+  test("~= '^prefix' → startsWith", () => {
+    expect(toModel('target ~= "^pre"')).toEqual({
+      target: { filterType: "text", type: "startsWith", filter: "pre" },
+    });
+  });
+
+  test("~= 'suffix$' → endsWith", () => {
+    expect(toModel('target ~= "post$"')).toEqual({
+      target: { filterType: "text", type: "endsWith", filter: "post" },
+    });
+  });
+
+  test("~= 'literal' → contains (no anchors)", () => {
+    // `id` is the filtrex variable for the sampleId column.
+    expect(toModel('id ~= "abc"')).toEqual({
+      sampleId: { filterType: "text", type: "contains", filter: "abc" },
+    });
+  });
+
+  test("~= '^both$' → equals", () => {
+    expect(toModel('id ~= "^xyz$"')).toEqual({
+      sampleId: { filterType: "text", type: "equals", filter: "xyz" },
+    });
+  });
+
+  test("blank / notBlank for string column", () => {
+    expect(toModel("error == None")).toEqual({
+      error: { filterType: "text", type: "blank" },
+    });
+  });
+});
+
+describe("astToFilterModel — multi-column", () => {
+  test("AND of two columns", () => {
+    expect(toModel("epoch == 1 and tokens > 100")).toEqual({
+      epoch: { filterType: "number", type: "equals", filter: 1 },
+      tokens: { filterType: "number", type: "greaterThan", filter: 100 },
+    });
+  });
+
+  test("preserves the user's tokens predicate when adding a duration filter", () => {
+    // The exact bug the user reported.
+    expect(toModel("tokens > 50 and duration > 1")).toEqual({
+      tokens: { filterType: "number", type: "greaterThan", filter: 50 },
+      duration: { filterType: "number", type: "greaterThan", filter: 1 },
+    });
+  });
+});
+
+describe("astToFilterModel — round-trip stability (text → model → text)", () => {
+  const roundTrip = (text: string): string | null => {
+    const { ast } = parseFilter(text);
+    if (!ast) return null;
+    const model = astToFilterModel(ast, registry);
+    if (!model) return null;
+    return filterModelToText(model, registry);
+  };
+
+  test("xxx_contains stays as xxx_contains", () => {
+    expect(roundTrip('target_contains("No")')).toBe('target_contains("No")');
+    expect(roundTrip('input_contains("hello")')).toBe(
+      'input_contains("hello")'
+    );
+  });
+
+  test("number comparisons survive", () => {
+    expect(roundTrip("epoch == 2")).toBe("epoch == 2");
+    expect(roundTrip("tokens > 100")).toBe("tokens > 100");
+  });
+
+  test("inRange round-trips through the parenthesized AND form", () => {
+    // The synthesizer emits inRange as `(var >= a and var <= b)` and the
+    // recognizer recovers it.
+    expect(roundTrip("tokens >= 100 and tokens <= 500")).toBe(
+      "(tokens >= 100 and tokens <= 500)"
+    );
+  });
+
+  test("multi-column AND survives", () => {
+    expect(roundTrip("tokens > 50 and duration > 1")).toBe(
+      "tokens > 50 and duration > 1"
+    );
+  });
+});
+
+describe("astToFilterModel — non-round-trippable", () => {
+  test("OR is rejected", () => {
+    expect(toModel("epoch == 1 or epoch == 2")).toBeNull();
+  });
+
+  test("arithmetic in predicate is rejected", () => {
+    expect(toModel("tokens + 5 == 10")).toBeNull();
+  });
+
+  test("unknown variable is rejected", () => {
+    expect(toModel("foo > 5")).toBeNull();
+  });
+
+  test("regex with real metachars is rejected", () => {
+    expect(toModel('input ~= "(test)"')).toBeNull();
+  });
+
+  test("3+ predicates on same column is rejected", () => {
+    expect(toModel("tokens > 1 and tokens > 2 and tokens > 3")).toBeNull();
+  });
+
+  test("type mismatch (string literal on number column) is rejected", () => {
+    expect(toModel('tokens == "five"')).toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/sample-tools/astToFilterModel.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToFilterModel.ts
@@ -28,6 +28,11 @@ interface PredicateResult {
 
 const REGEX_META = ".*+?^${}()|[]\\";
 
+// Match the synthesizer's style: regex metachars are wrapped as `[X]`,
+// literal backslash is written as `\\`. We don't accept bare `\X` for
+// metachars because filtrex's lexer rejects them anyway.
+const META_FOR_CLASS = ".*+?^${}()|[]";
+
 /** Walk top-level `and` nodes, collecting leaf predicates. */
 const collectAndPredicates = (ast: FilterAst): FilterAst[] => {
   if (ast.kind === "binary" && ast.op === "and") {
@@ -59,17 +64,29 @@ const parseRegexLiteral = (
   }
 
   let literal = "";
-  for (let i = 0; i < s.length; i++) {
+  let i = 0;
+  while (i < s.length) {
     const ch = s[i];
-    if (ch === "\\" && i + 1 < s.length && REGEX_META.includes(s[i + 1])) {
+    // `[X]` character-class shorthand for a literal regex metachar.
+    if (
+      ch === "[" &&
+      i + 2 < s.length &&
+      s[i + 2] === "]" &&
+      META_FOR_CLASS.includes(s[i + 1])
+    ) {
       literal += s[i + 1];
-      i++;
-    } else if (REGEX_META.includes(ch)) {
-      // Unescaped metachar — not a plain literal.
-      return null;
-    } else {
-      literal += ch;
+      i += 3;
+      continue;
     }
+    // `\\` for a literal backslash.
+    if (ch === "\\" && i + 1 < s.length && s[i + 1] === "\\") {
+      literal += "\\";
+      i += 2;
+      continue;
+    }
+    if (REGEX_META.includes(ch)) return null; // unescaped metachar
+    literal += ch;
+    i++;
   }
 
   if (anchorStart && anchorEnd) return { anchor: "both", literal };

--- a/apps/inspect/src/app/samples/sample-tools/astToFilterModel.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToFilterModel.ts
@@ -1,0 +1,332 @@
+import { FilterAst } from "./filterAst";
+import { FilterVarMapping, SampleFilterRegistry } from "./filterRegistry";
+
+type FilterType = "text" | "number";
+
+interface SimpleCondition {
+  type: string;
+  filter?: string | number;
+  filterTo?: string | number;
+}
+
+interface ColumnEntry {
+  filterType: FilterType;
+  type?: string;
+  filter?: string | number;
+  filterTo?: string | number;
+  operator?: "AND" | "OR";
+  conditions?: SimpleCondition[];
+}
+
+export type FilterModel = Record<string, ColumnEntry>;
+
+interface PredicateResult {
+  colId: string;
+  filterType: FilterType;
+  condition: SimpleCondition;
+}
+
+const REGEX_META = ".*+?^${}()|[]\\";
+
+/** Walk top-level `and` nodes, collecting leaf predicates. */
+const collectAndPredicates = (ast: FilterAst): FilterAst[] => {
+  if (ast.kind === "binary" && ast.op === "and") {
+    return [
+      ...collectAndPredicates(ast.left),
+      ...collectAndPredicates(ast.right),
+    ];
+  }
+  return [ast];
+};
+
+/** Try to interpret a `~=` regex literal as `^prefix`, `suffix$`, both, or
+ *  plain `contains`. Returns `null` if the regex contains real metachars
+ *  beyond the optional anchors. */
+const parseRegexLiteral = (
+  raw: string
+): { anchor: "start" | "end" | "both" | "none"; literal: string } | null => {
+  let s = raw;
+  let anchorStart = false;
+  let anchorEnd = false;
+  if (s.startsWith("^")) {
+    anchorStart = true;
+    s = s.slice(1);
+  }
+  // Trailing `$` is an anchor unless escaped (`\$`).
+  if (s.endsWith("$") && !s.endsWith("\\$")) {
+    anchorEnd = true;
+    s = s.slice(0, -1);
+  }
+
+  let literal = "";
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "\\" && i + 1 < s.length && REGEX_META.includes(s[i + 1])) {
+      literal += s[i + 1];
+      i++;
+    } else if (REGEX_META.includes(ch)) {
+      // Unescaped metachar — not a plain literal.
+      return null;
+    } else {
+      literal += ch;
+    }
+  }
+
+  if (anchorStart && anchorEnd) return { anchor: "both", literal };
+  if (anchorStart) return { anchor: "start", literal };
+  if (anchorEnd) return { anchor: "end", literal };
+  return { anchor: "none", literal };
+};
+
+/** Walk past a leading `not` to surface the inner predicate plus the
+ *  effective negation count (parity). */
+const stripNot = (ast: FilterAst): { negated: boolean; inner: FilterAst } => {
+  let negated = false;
+  let inner = ast;
+  while (inner.kind === "unary" && inner.op === "not") {
+    negated = !negated;
+    inner = inner.arg;
+  }
+  return { negated, inner };
+};
+
+const opposite: Record<string, string> = {
+  equals: "notEqual",
+  notEqual: "equals",
+  contains: "notContains",
+  notContains: "contains",
+  blank: "notBlank",
+  notBlank: "blank",
+};
+
+/** Map a leaf predicate to a single-column condition. Returns null when
+ *  the predicate isn't round-trippable. */
+const predicateToCondition = (
+  ast: FilterAst,
+  registry: SampleFilterRegistry
+): PredicateResult | null => {
+  const { negated, inner } = stripNot(ast);
+  const result = predicateToConditionInner(inner, registry);
+  if (!result) return null;
+  if (!negated) return result;
+  const flipped = opposite[result.condition.type];
+  if (!flipped) return null; // can't negate this operator
+  return {
+    ...result,
+    condition: { ...result.condition, type: flipped },
+  };
+};
+
+/** The non-negated portion of `predicateToCondition`. */
+const predicateToConditionInner = (
+  ast: FilterAst,
+  registry: SampleFilterRegistry
+): PredicateResult | null => {
+  // 1. xxx_contains("literal") -> { contains, filter: literal }
+  if (ast.kind === "call" && ast.args.length === 1) {
+    const fn = ast.fn;
+    const arg = ast.args[0];
+    if (arg.kind !== "str") return null;
+    const colId = colIdForContainsFn(fn, registry);
+    if (!colId) return null;
+    const mapping = registry.byColId.get(colId)!;
+    // The synthesizer regex-escapes the value before emitting; reverse
+    // that here so the FilterModel round-trips to the user's input. If
+    // the literal isn't a plain regex-escaped string, skip.
+    const parsed = parseRegexLiteral(arg.value);
+    if (!parsed || parsed.anchor !== "none") return null;
+    return {
+      colId,
+      filterType: filterTypeFor(mapping),
+      condition: { type: "contains", filter: parsed.literal },
+    };
+  }
+
+  // 2. var BINARY_OP literal
+  if (ast.kind === "binary") {
+    return binaryToCondition(ast, registry);
+  }
+
+  return null;
+};
+
+const colIdForContainsFn = (
+  fn: string,
+  registry: SampleFilterRegistry
+): string | null => {
+  for (const [colId, mapping] of registry.byColId) {
+    if (mapping.containsFn === fn) return colId;
+  }
+  return null;
+};
+
+const filterTypeFor = (m: FilterVarMapping): FilterType =>
+  m.kind === "number" ? "number" : "text";
+
+const binaryToCondition = (
+  ast: Extract<FilterAst, { kind: "binary" }>,
+  registry: SampleFilterRegistry
+): PredicateResult | null => {
+  // Only handle `var op literal` (or `var op None`).
+  if (ast.left.kind !== "var") return null;
+  const colId = registry.byVariable.get(ast.left.name);
+  if (!colId) return null;
+  const mapping = registry.byColId.get(colId)!;
+
+  // var == None / var != None  ->  blank / notBlank
+  if (ast.right.kind === "const" && ast.right.name === "None") {
+    if (ast.op === "==") {
+      return {
+        colId,
+        filterType: filterTypeFor(mapping),
+        condition: { type: "blank" },
+      };
+    }
+    if (ast.op === "!=") {
+      return {
+        colId,
+        filterType: filterTypeFor(mapping),
+        condition: { type: "notBlank" },
+      };
+    }
+    return null;
+  }
+
+  // var ~= "regex"  ->  contains / startsWith / endsWith / equals
+  if (ast.op === "~=" && ast.right.kind === "str") {
+    if (mapping.kind !== "string") return null;
+    const parsed = parseRegexLiteral(ast.right.value);
+    if (!parsed) return null;
+    let type: string;
+    switch (parsed.anchor) {
+      case "both":
+        type = "equals";
+        break;
+      case "start":
+        type = "startsWith";
+        break;
+      case "end":
+        type = "endsWith";
+        break;
+      case "none":
+        type = "contains";
+        break;
+    }
+    return {
+      colId,
+      filterType: "text",
+      condition: { type, filter: parsed.literal },
+    };
+  }
+
+  // Numeric comparators
+  if (mapping.kind === "number" && ast.right.kind === "num") {
+    const opMap: Record<string, string> = {
+      "==": "equals",
+      "!=": "notEqual",
+      "<": "lessThan",
+      "<=": "lessThanOrEqual",
+      ">": "greaterThan",
+      ">=": "greaterThanOrEqual",
+    };
+    const type = opMap[ast.op];
+    if (!type) return null;
+    return {
+      colId,
+      filterType: "number",
+      condition: { type, filter: ast.right.value },
+    };
+  }
+
+  // String equals/notEqual
+  if (mapping.kind === "string" && ast.right.kind === "str") {
+    if (ast.op === "==") {
+      return {
+        colId,
+        filterType: "text",
+        condition: { type: "equals", filter: ast.right.value },
+      };
+    }
+    if (ast.op === "!=") {
+      return {
+        colId,
+        filterType: "text",
+        condition: { type: "notEqual", filter: ast.right.value },
+      };
+    }
+  }
+
+  return null;
+};
+
+/** Detect the inRange pattern: `>= a` AND `<= b` on the same numeric
+ *  column. Returns the equivalent simple condition or null. */
+const tryInRange = (conds: SimpleCondition[]): SimpleCondition | null => {
+  if (conds.length !== 2) return null;
+  const [a, b] = conds;
+  let lower: number | undefined;
+  let upper: number | undefined;
+  for (const c of [a, b]) {
+    if (c.type === "greaterThanOrEqual" && typeof c.filter === "number") {
+      lower = c.filter;
+    } else if (c.type === "lessThanOrEqual" && typeof c.filter === "number") {
+      upper = c.filter;
+    }
+  }
+  if (lower === undefined || upper === undefined) return null;
+  return { type: "inRange", filter: lower, filterTo: upper };
+};
+
+/**
+ * Try to express the AST as an ag-grid `FilterModel`. The recognized
+ * subset is a top-level conjunction of column predicates — anything
+ * else (`or`, arithmetic, function calls outside `xxx_contains`,
+ * unsupported operators) returns `null`, signaling to the caller that
+ * the text is "expression-only".
+ */
+export const astToFilterModel = (
+  ast: FilterAst,
+  registry: SampleFilterRegistry
+): FilterModel | null => {
+  const predicates = collectAndPredicates(ast);
+
+  const perColumn = new Map<
+    string,
+    { filterType: FilterType; conditions: SimpleCondition[] }
+  >();
+
+  for (const pred of predicates) {
+    const result = predicateToCondition(pred, registry);
+    if (!result) return null;
+    let entry = perColumn.get(result.colId);
+    if (!entry) {
+      entry = { filterType: result.filterType, conditions: [] };
+      perColumn.set(result.colId, entry);
+    }
+    if (entry.filterType !== result.filterType) return null;
+    entry.conditions.push(result.condition);
+  }
+
+  const model: FilterModel = {};
+  for (const [colId, entry] of perColumn) {
+    if (entry.conditions.length === 1) {
+      model[colId] = { filterType: entry.filterType, ...entry.conditions[0] };
+    } else if (entry.conditions.length === 2) {
+      const range = tryInRange(entry.conditions);
+      if (range) {
+        model[colId] = { filterType: entry.filterType, ...range };
+      } else {
+        model[colId] = {
+          filterType: entry.filterType,
+          operator: "AND",
+          conditions: entry.conditions,
+        };
+      }
+    } else {
+      // ag-grid combined filters cap at 2 conditions per column.
+      return null;
+    }
+  }
+
+  return model;
+};

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "vitest";
+
+import { FilterAst, parseFilter } from "./filterAst";
+
+const parse = (s: string): FilterAst => {
+  const r = parseFilter(s);
+  if (!r.ast) throw new Error(`parse failed: ${r.error?.message ?? "?"}`);
+  return r.ast;
+};
+
+describe("parseFilter — primitives", () => {
+  test("number", () => {
+    expect(parse("42")).toEqual({ kind: "num", value: 42 });
+    expect(parse("3.14")).toEqual({ kind: "num", value: 3.14 });
+  });
+
+  test("string", () => {
+    expect(parse('"hello"')).toEqual({ kind: "str", value: "hello" });
+  });
+
+  test("variable", () => {
+    expect(parse("epoch")).toEqual({ kind: "var", name: "epoch" });
+  });
+
+  test("dotted variable", () => {
+    expect(parse("scorer.metric")).toEqual({
+      kind: "var",
+      name: "scorer.metric",
+    });
+  });
+
+  test("True/False/None constants", () => {
+    expect(parse("True")).toEqual({ kind: "const", name: "True" });
+    expect(parse("False")).toEqual({ kind: "const", name: "False" });
+    expect(parse("None")).toEqual({ kind: "const", name: "None" });
+  });
+});
+
+describe("parseFilter — relations", () => {
+  test("equals", () => {
+    expect(parse("epoch == 2")).toEqual({
+      kind: "binary",
+      op: "==",
+      left: { kind: "var", name: "epoch" },
+      right: { kind: "num", value: 2 },
+    });
+  });
+
+  test("greaterThan", () => {
+    expect(parse("tokens > 100")).toEqual({
+      kind: "binary",
+      op: ">",
+      left: { kind: "var", name: "tokens" },
+      right: { kind: "num", value: 100 },
+    });
+  });
+
+  test("regex match (~=)", () => {
+    expect(parse('input ~= "foo"')).toEqual({
+      kind: "binary",
+      op: "~=",
+      left: { kind: "var", name: "input" },
+      right: { kind: "str", value: "foo" },
+    });
+  });
+
+  test("blank check (== None)", () => {
+    expect(parse("error == None")).toEqual({
+      kind: "binary",
+      op: "==",
+      left: { kind: "var", name: "error" },
+      right: { kind: "const", name: "None" },
+    });
+  });
+});
+
+describe("parseFilter — boolean logic", () => {
+  test("AND chain", () => {
+    expect(parse("a and b and c")).toEqual({
+      kind: "binary",
+      op: "and",
+      left: {
+        kind: "binary",
+        op: "and",
+        left: { kind: "var", name: "a" },
+        right: { kind: "var", name: "b" },
+      },
+      right: { kind: "var", name: "c" },
+    });
+  });
+
+  test("OR chain", () => {
+    expect(parse("a or b or c")).toEqual({
+      kind: "binary",
+      op: "or",
+      left: {
+        kind: "binary",
+        op: "or",
+        left: { kind: "var", name: "a" },
+        right: { kind: "var", name: "b" },
+      },
+      right: { kind: "var", name: "c" },
+    });
+  });
+
+  test("AND has tighter precedence than OR", () => {
+    expect(parse("a or b and c")).toEqual({
+      kind: "binary",
+      op: "or",
+      left: { kind: "var", name: "a" },
+      right: {
+        kind: "binary",
+        op: "and",
+        left: { kind: "var", name: "b" },
+        right: { kind: "var", name: "c" },
+      },
+    });
+  });
+
+  test("not unary", () => {
+    expect(parse("not a")).toEqual({
+      kind: "unary",
+      op: "not",
+      arg: { kind: "var", name: "a" },
+    });
+  });
+
+  test("parens override precedence", () => {
+    expect(parse("(a or b) and c")).toEqual({
+      kind: "binary",
+      op: "and",
+      left: {
+        kind: "binary",
+        op: "or",
+        left: { kind: "var", name: "a" },
+        right: { kind: "var", name: "b" },
+      },
+      right: { kind: "var", name: "c" },
+    });
+  });
+});
+
+describe("parseFilter — calls", () => {
+  test("function call with one arg", () => {
+    expect(parse('input_contains("foo")')).toEqual({
+      kind: "call",
+      fn: "input_contains",
+      args: [{ kind: "str", value: "foo" }],
+    });
+  });
+
+  test("zero-arg call", () => {
+    expect(parse("min()")).toEqual({ kind: "call", fn: "min", args: [] });
+  });
+
+  test("multi-arg call", () => {
+    expect(parse("min(1, 2, 3)")).toEqual({
+      kind: "call",
+      fn: "min",
+      args: [
+        { kind: "num", value: 1 },
+        { kind: "num", value: 2 },
+        { kind: "num", value: 3 },
+      ],
+    });
+  });
+
+  test("not + call (notContains shape)", () => {
+    expect(parse('not error_contains("boom")')).toEqual({
+      kind: "unary",
+      op: "not",
+      arg: {
+        kind: "call",
+        fn: "error_contains",
+        args: [{ kind: "str", value: "boom" }],
+      },
+    });
+  });
+});
+
+describe("parseFilter — in / not in", () => {
+  test("in with values", () => {
+    expect(parse("epoch in (1, 2, 3)")).toEqual({
+      kind: "in",
+      negated: false,
+      left: { kind: "var", name: "epoch" },
+      values: [
+        { kind: "num", value: 1 },
+        { kind: "num", value: 2 },
+        { kind: "num", value: 3 },
+      ],
+    });
+  });
+
+  test("not in with values", () => {
+    expect(parse("epoch not in (1, 2)")).toEqual({
+      kind: "in",
+      negated: true,
+      left: { kind: "var", name: "epoch" },
+      values: [
+        { kind: "num", value: 1 },
+        { kind: "num", value: 2 },
+      ],
+    });
+  });
+});
+
+describe("parseFilter — errors", () => {
+  test("empty string returns null ast without error", () => {
+    expect(parseFilter("")).toEqual({ ast: null, error: null });
+    expect(parseFilter("   ")).toEqual({ ast: null, error: null });
+  });
+
+  test("trailing operator errors", () => {
+    const r = parseFilter("a and");
+    expect(r.ast).toBeNull();
+    expect(r.error).not.toBeNull();
+  });
+
+  test("unbalanced parens", () => {
+    expect(parseFilter("(a and b").error).not.toBeNull();
+  });
+
+  test("unterminated string", () => {
+    expect(parseFilter('a == "foo').error).not.toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.test.ts
@@ -18,6 +18,20 @@ describe("parseFilter — primitives", () => {
     expect(parse('"hello"')).toEqual({ kind: "str", value: "hello" });
   });
 
+  test("string with escaped quote", () => {
+    expect(parse('"he said \\"hi\\""')).toEqual({
+      kind: "str",
+      value: 'he said "hi"',
+    });
+  });
+
+  test("string with escaped backslash", () => {
+    expect(parse('"path\\\\to"')).toEqual({
+      kind: "str",
+      value: "path\\to",
+    });
+  });
+
   test("variable", () => {
     expect(parse("epoch")).toEqual({ kind: "var", name: "epoch" });
   });

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.ts
@@ -197,9 +197,11 @@ class Parser {
     }
     if (t.type === "string") {
       this.eat();
-      // tokenizer matches /^"[^"]*"/ — strip surrounding quotes; filtrex
-      // strings are simple (no escapes recognized in the tokenizer).
-      return { kind: "str", value: t.text.slice(1, -1) };
+      // Strip surrounding quotes and reverse filtrex's two string
+      // escapes (`\"` → `"`, `\\` → `\`). Keeps round-trip stable for
+      // filter values that contain quotes or backslashes.
+      const raw = t.text.slice(1, -1);
+      return { kind: "str", value: raw.replace(/\\(["\\])/g, "$1") };
     }
     if (t.type === "unterminatedString") {
       throw this.error("Unterminated string literal");

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.ts
@@ -1,0 +1,283 @@
+import { Token, tokenize } from "./sample-filter/tokenize";
+
+export type BinaryOp =
+  | "and"
+  | "or"
+  | "=="
+  | "!="
+  | "<"
+  | "<="
+  | ">"
+  | ">="
+  | "~="
+  | "+"
+  | "-"
+  | "*"
+  | "/"
+  | "^"
+  | "mod";
+
+export type FilterAst =
+  | { kind: "var"; name: string }
+  | { kind: "num"; value: number }
+  | { kind: "str"; value: string }
+  | { kind: "const"; name: "True" | "False" | "None" }
+  | { kind: "binary"; op: BinaryOp; left: FilterAst; right: FilterAst }
+  | { kind: "unary"; op: "not" | "-"; arg: FilterAst }
+  | { kind: "call"; fn: string; args: FilterAst[] }
+  | { kind: "in"; left: FilterAst; values: FilterAst[]; negated: boolean };
+
+export interface ParseError {
+  message: string;
+  position: number;
+}
+
+export interface ParseResult {
+  ast: FilterAst | null;
+  error: ParseError | null;
+}
+
+const RELATION_OPS = new Set(["==", "!=", "<", "<=", ">", ">=", "~="]);
+
+class Parser {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  private peek(offset = 0): Token | undefined {
+    return this.tokens[this.pos + offset];
+  }
+
+  private eat(): Token | undefined {
+    return this.tokens[this.pos++];
+  }
+
+  private match(type: string, text?: string): boolean {
+    const t = this.peek();
+    if (!t || t.type !== type) return false;
+    if (text !== undefined && t.text !== text) return false;
+    return true;
+  }
+
+  private consume(type: string, text?: string): Token {
+    const t = this.peek();
+    if (!t || t.type !== type || (text !== undefined && t.text !== text)) {
+      throw this.error(
+        `Expected ${text ?? type}${t ? `, got "${t.text}"` : ""}`
+      );
+    }
+    return this.eat()!;
+  }
+
+  private error(message: string): ParseError {
+    const at = this.peek();
+    return { message, position: at?.from ?? this.tokens.at(-1)?.to ?? 0 };
+  }
+
+  parse(): FilterAst {
+    const expr = this.parseOr();
+    if (this.pos < this.tokens.length) {
+      throw this.error(`Unexpected "${this.peek()!.text}"`);
+    }
+    return expr;
+  }
+
+  private parseOr(): FilterAst {
+    let left = this.parseAnd();
+    while (this.match("keyword", "or")) {
+      this.eat();
+      const right = this.parseAnd();
+      left = { kind: "binary", op: "or", left, right };
+    }
+    return left;
+  }
+
+  private parseAnd(): FilterAst {
+    let left = this.parseNot();
+    while (this.match("keyword", "and")) {
+      this.eat();
+      const right = this.parseNot();
+      left = { kind: "binary", op: "and", left, right };
+    }
+    return left;
+  }
+
+  private parseNot(): FilterAst {
+    if (this.match("keyword", "not")) {
+      this.eat();
+      const arg = this.parseNot();
+      return { kind: "unary", op: "not", arg };
+    }
+    return this.parseInOrRelation();
+  }
+
+  private parseInOrRelation(): FilterAst {
+    const left = this.parseRelation();
+    // postfix `in (a, b, c)` / `not in (a, b, c)`
+    if (this.match("keyword", "in") || this.match("keyword", "not in")) {
+      const negated = this.peek()!.text === "not in";
+      this.eat();
+      this.consume("miscOperator", "(");
+      const values: FilterAst[] = [];
+      if (!this.match("miscOperator", ")")) {
+        values.push(this.parseOr());
+        while (this.match("miscOperator", ",")) {
+          this.eat();
+          values.push(this.parseOr());
+        }
+      }
+      this.consume("miscOperator", ")");
+      return { kind: "in", left, values, negated };
+    }
+    return left;
+  }
+
+  private parseRelation(): FilterAst {
+    const left = this.parseAdd();
+    const t = this.peek();
+    if (t && t.type === "relation" && RELATION_OPS.has(t.text)) {
+      this.eat();
+      const right = this.parseAdd();
+      return { kind: "binary", op: t.text as BinaryOp, left, right };
+    }
+    return left;
+  }
+
+  private parseAdd(): FilterAst {
+    let left = this.parseMul();
+    while (this.match("miscOperator", "+") || this.match("miscOperator", "-")) {
+      const op = this.eat()!.text as BinaryOp;
+      const right = this.parseMul();
+      left = { kind: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  private parseMul(): FilterAst {
+    let left = this.parsePow();
+    while (
+      this.match("miscOperator", "*") ||
+      this.match("miscOperator", "/") ||
+      this.match("keyword", "mod")
+    ) {
+      const op = this.eat()!.text as BinaryOp;
+      const right = this.parsePow();
+      left = { kind: "binary", op, left, right };
+    }
+    return left;
+  }
+
+  private parsePow(): FilterAst {
+    const left = this.parseUnary();
+    if (this.match("miscOperator", "^")) {
+      this.eat();
+      // right-associative
+      const right = this.parsePow();
+      return { kind: "binary", op: "^", left, right };
+    }
+    return left;
+  }
+
+  private parseUnary(): FilterAst {
+    if (this.match("miscOperator", "-")) {
+      this.eat();
+      const arg = this.parseUnary();
+      return { kind: "unary", op: "-", arg };
+    }
+    return this.parsePrimary();
+  }
+
+  private parsePrimary(): FilterAst {
+    const t = this.peek();
+    if (!t) throw this.error("Unexpected end of expression");
+
+    if (t.type === "number") {
+      this.eat();
+      return { kind: "num", value: parseFloat(t.text) };
+    }
+    if (t.type === "string") {
+      this.eat();
+      // tokenizer matches /^"[^"]*"/ — strip surrounding quotes; filtrex
+      // strings are simple (no escapes recognized in the tokenizer).
+      return { kind: "str", value: t.text.slice(1, -1) };
+    }
+    if (t.type === "unterminatedString") {
+      throw this.error("Unterminated string literal");
+    }
+    if (t.type === "miscOperator" && t.text === "(") {
+      this.eat();
+      const inner = this.parseOr();
+      this.consume("miscOperator", ")");
+      return inner;
+    }
+    if (
+      t.type === "variable" ||
+      t.type === "sampleFunction" ||
+      t.type === "mathFunction"
+    ) {
+      this.eat();
+      const name = this.parseDottedTail(t.text);
+      // Function call
+      if (this.match("miscOperator", "(")) {
+        this.eat();
+        const args: FilterAst[] = [];
+        if (!this.match("miscOperator", ")")) {
+          args.push(this.parseOr());
+          while (this.match("miscOperator", ",")) {
+            this.eat();
+            args.push(this.parseOr());
+          }
+        }
+        this.consume("miscOperator", ")");
+        return { kind: "call", fn: name, args };
+      }
+      // Pseudo-constants True/False/None are tokenized as variables.
+      if (name === "True" || name === "False" || name === "None") {
+        return { kind: "const", name };
+      }
+      return { kind: "var", name };
+    }
+
+    throw this.error(`Unexpected "${t.text}"`);
+  }
+
+  /** Consume `.ident` repeats and return the joined identifier. */
+  private parseDottedTail(head: string): string {
+    let name = head;
+    while (
+      this.match("miscOperator", ".") &&
+      this.peek(1)?.type === "variable"
+    ) {
+      this.eat(); // dot
+      name += "." + this.eat()!.text;
+    }
+    return name;
+  }
+}
+
+/** Parse a filtrex expression into an AST. Returns `{ ast: null, error }`
+ *  on failure — callers fall back gracefully without recovery. */
+export function parseFilter(text: string): ParseResult {
+  const trimmed = text.trim();
+  if (trimmed === "") return { ast: null, error: null };
+
+  const tokens = tokenize(text).filter(
+    // The CodeMirror tokenizer doesn't emit whitespace as tokens, but it
+    // does emit `null`-type slices for unrecognized characters; skip them
+    // here too so the parser only sees recognized tokens.
+    (t) => t.type !== "null"
+  );
+  const parser = new Parser(tokens);
+  try {
+    const ast = parser.parse();
+    return { ast, error: null };
+  } catch (e) {
+    if (typeof e === "object" && e !== null && "message" in e) {
+      return { ast: null, error: e as ParseError };
+    }
+    return {
+      ast: null,
+      error: { message: String(e), position: 0 },
+    };
+  }
+}

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -116,12 +116,13 @@ describe("filterModelToText — string columns with contains-fn", () => {
 
 describe("filterModelToText — string columns without contains-fn", () => {
   test("contains falls back to filtrex regex match", () => {
+    // `sampleUuid` is a registered string column without a contains-fn.
     expect(
       filterModelToText(
-        { sampleId: { type: "contains", filter: "abc" } },
+        { sampleUuid: { type: "contains", filter: "abc" } },
         registry
       )
-    ).toBe('id ~= "abc"');
+    ).toBe('uuid ~= "abc"');
   });
 });
 

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -33,6 +33,24 @@ describe("filterModelToText — number columns", () => {
     ).toBe("(tokens >= 100 and tokens <= 500)");
   });
 
+  test("NaN / Infinity filter values are skipped (mid-type input)", () => {
+    expect(
+      filterModelToText({ tokens: { type: "equals", filter: NaN } }, registry)
+    ).toBeNull();
+    expect(
+      filterModelToText(
+        { tokens: { type: "equals", filter: Infinity } },
+        registry
+      )
+    ).toBeNull();
+    expect(
+      filterModelToText(
+        { tokens: { type: "inRange", filter: 1, filterTo: NaN } },
+        registry
+      )
+    ).toBeNull();
+  });
+
   test("blank/notBlank", () => {
     expect(filterModelToText({ tokens: { type: "blank" } }, registry)).toBe(
       "tokens == null"

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -51,12 +51,12 @@ describe("filterModelToText — number columns", () => {
     ).toBeNull();
   });
 
-  test("blank/notBlank", () => {
+  test("blank/notBlank uses filtrex's None sentinel", () => {
     expect(filterModelToText({ tokens: { type: "blank" } }, registry)).toBe(
-      "tokens == null"
+      "tokens == None"
     );
     expect(filterModelToText({ tokens: { type: "notBlank" } }, registry)).toBe(
-      "tokens != null"
+      "tokens != None"
     );
   });
 });

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "vitest";
+
+import { filterModelToText } from "./filterModelToText";
+import { buildSampleFilterRegistry } from "./filterRegistry";
+
+const registry = buildSampleFilterRegistry(undefined);
+
+describe("filterModelToText — number columns", () => {
+  test("equals", () => {
+    expect(
+      filterModelToText({ epoch: { type: "equals", filter: 2 } }, registry)
+    ).toBe("epoch == 2");
+  });
+
+  test("comparators", () => {
+    expect(
+      filterModelToText(
+        { tokens: { type: "greaterThanOrEqual", filter: 100 } },
+        registry
+      )
+    ).toBe("tokens >= 100");
+    expect(
+      filterModelToText({ duration: { type: "lessThan", filter: 5 } }, registry)
+    ).toBe("duration < 5");
+  });
+
+  test("inRange becomes a parenthesized AND", () => {
+    expect(
+      filterModelToText(
+        { tokens: { type: "inRange", filter: 100, filterTo: 500 } },
+        registry
+      )
+    ).toBe("(tokens >= 100 and tokens <= 500)");
+  });
+
+  test("blank/notBlank", () => {
+    expect(filterModelToText({ tokens: { type: "blank" } }, registry)).toBe(
+      "tokens == null"
+    );
+    expect(filterModelToText({ tokens: { type: "notBlank" } }, registry)).toBe(
+      "tokens != null"
+    );
+  });
+});
+
+describe("filterModelToText — string columns with contains-fn", () => {
+  test("contains uses the case-insensitive function", () => {
+    expect(
+      filterModelToText(
+        { input: { type: "contains", filter: "foo" } },
+        registry
+      )
+    ).toBe('input_contains("foo")');
+  });
+
+  test("regex metacharacters in the filter value are escaped", () => {
+    expect(
+      filterModelToText(
+        { input: { type: "contains", filter: "a.b+c" } },
+        registry
+      )
+    ).toBe('input_contains("a\\\\.b\\\\+c")');
+  });
+
+  test("notContains negates the function call", () => {
+    expect(
+      filterModelToText(
+        { error: { type: "notContains", filter: "boom" } },
+        registry
+      )
+    ).toBe('not error_contains("boom")');
+  });
+
+  test("equals uses literal string comparison", () => {
+    expect(
+      filterModelToText(
+        { input: { type: "equals", filter: "exact" } },
+        registry
+      )
+    ).toBe('input == "exact"');
+  });
+
+  test("startsWith / endsWith use anchored regex", () => {
+    expect(
+      filterModelToText(
+        { target: { type: "startsWith", filter: "pre" } },
+        registry
+      )
+    ).toBe('target ~= "^pre"');
+    expect(
+      filterModelToText(
+        { target: { type: "endsWith", filter: "post" } },
+        registry
+      )
+    ).toBe('target ~= "post$"');
+  });
+});
+
+describe("filterModelToText — string columns without contains-fn", () => {
+  test("contains falls back to filtrex regex match", () => {
+    expect(
+      filterModelToText(
+        { sampleId: { type: "contains", filter: "abc" } },
+        registry
+      )
+    ).toBe('id ~= "abc"');
+  });
+});
+
+describe("filterModelToText — combined per-column conditions", () => {
+  test("AND of two conditions", () => {
+    expect(
+      filterModelToText(
+        {
+          tokens: {
+            operator: "AND",
+            conditions: [
+              { type: "greaterThan", filter: 100 },
+              { type: "lessThan", filter: 500 },
+            ],
+          },
+        },
+        registry
+      )
+    ).toBe("(tokens > 100 and tokens < 500)");
+  });
+
+  test("OR of two conditions", () => {
+    expect(
+      filterModelToText(
+        {
+          epoch: {
+            operator: "OR",
+            conditions: [
+              { type: "equals", filter: 1 },
+              { type: "equals", filter: 3 },
+            ],
+          },
+        },
+        registry
+      )
+    ).toBe("(epoch == 1 or epoch == 3)");
+  });
+
+  test("legacy condition1/condition2 shape", () => {
+    expect(
+      filterModelToText(
+        {
+          tokens: {
+            operator: "AND",
+            condition1: { type: "greaterThan", filter: 0 },
+            condition2: { type: "lessThan", filter: 10 },
+          },
+        },
+        registry
+      )
+    ).toBe("(tokens > 0 and tokens < 10)");
+  });
+});
+
+describe("filterModelToText — multi-column", () => {
+  test("multiple columns are joined with AND", () => {
+    expect(
+      filterModelToText(
+        {
+          epoch: { type: "equals", filter: 1 },
+          tokens: { type: "greaterThan", filter: 100 },
+        },
+        registry
+      )
+    ).toBe("epoch == 1 and tokens > 100");
+  });
+
+  test("unrepresentable columns are dropped", () => {
+    expect(
+      filterModelToText(
+        {
+          // sampleStatus has no registry entry — dropped.
+          sampleStatus: { type: "equals", filter: "anything" },
+          epoch: { type: "equals", filter: 1 },
+        },
+        registry
+      )
+    ).toBe("epoch == 1");
+  });
+});
+
+describe("filterModelToText — empty / null cases", () => {
+  test("null model returns null", () => {
+    expect(filterModelToText(null, registry)).toBeNull();
+  });
+
+  test("empty object returns null", () => {
+    expect(filterModelToText({}, registry)).toBeNull();
+  });
+
+  test("only-unrepresentable columns returns null", () => {
+    expect(
+      filterModelToText(
+        { sampleStatus: { type: "equals", filter: "x" } },
+        registry
+      )
+    ).toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -204,15 +204,15 @@ describe("filterModelToText — multi-column", () => {
 });
 
 describe("filterModelToText — empty / null cases", () => {
-  test("null model returns null", () => {
-    expect(filterModelToText(null, registry)).toBeNull();
+  test("null model returns empty string (no filtering)", () => {
+    expect(filterModelToText(null, registry)).toBe("");
   });
 
-  test("empty object returns null", () => {
-    expect(filterModelToText({}, registry)).toBeNull();
+  test("empty object returns empty string (no filtering)", () => {
+    expect(filterModelToText({}, registry)).toBe("");
   });
 
-  test("only-unrepresentable columns returns null", () => {
+  test("only-unrepresentable columns returns null (leave text alone)", () => {
     expect(
       filterModelToText(
         { sampleStatus: { type: "equals", filter: "x" } },

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -192,17 +192,18 @@ describe("filterModelToText — multi-column", () => {
     ).toBe("epoch == 1 and tokens > 100");
   });
 
-  test("unrepresentable columns are dropped", () => {
+  test("any unrepresentable entry forces null (partial = leave text alone)", () => {
+    // Mixing one rep + one unrep would round-trip to a strict subset
+    // and wipe sampleStatus from the grid. Refuse to synthesize.
     expect(
       filterModelToText(
         {
-          // sampleStatus has no registry entry — dropped.
           sampleStatus: { type: "equals", filter: "anything" },
           epoch: { type: "equals", filter: 1 },
         },
         registry
       )
-    ).toBe("epoch == 1");
+    ).toBeNull();
   });
 });
 

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -71,13 +71,15 @@ describe("filterModelToText — string columns with contains-fn", () => {
     ).toBe('input_contains("foo")');
   });
 
-  test("regex metacharacters in the filter value are escaped", () => {
+  test("regex metacharacters in the filter value are escaped via [.] form", () => {
+    // Filtrex's string syntax doesn't recognize `\.` / `\+` escapes —
+    // we use single-element character classes instead.
     expect(
       filterModelToText(
         { input: { type: "contains", filter: "a.b+c" } },
         registry
       )
-    ).toBe('input_contains("a\\\\.b\\\\+c")');
+    ).toBe('input_contains("a[.]b[+]c")');
   });
 
   test("notContains negates the function call", () => {

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.test.ts
@@ -143,7 +143,10 @@ describe("filterModelToText — combined per-column conditions", () => {
     ).toBe("(tokens > 100 and tokens < 500)");
   });
 
-  test("OR of two conditions", () => {
+  test("OR of two conditions is dropped (not currently round-trippable)", () => {
+    // The AST recognizer only accepts top-level AND, so emitting `or`
+    // text would be cleared by the text→model effect. We skip the
+    // column instead of producing text we can't parse back.
     expect(
       filterModelToText(
         {
@@ -157,7 +160,7 @@ describe("filterModelToText — combined per-column conditions", () => {
         },
         registry
       )
-    ).toBe("(epoch == 1 or epoch == 3)");
+    ).toBeNull();
   });
 
   test("legacy condition1/condition2 shape", () => {

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -1,0 +1,161 @@
+import { FilterVarMapping, SampleFilterRegistry } from "./filterRegistry";
+
+/** ag-grid filter operator names (subset we round-trip). */
+type SimpleType =
+  | "equals"
+  | "notEqual"
+  | "lessThan"
+  | "lessThanOrEqual"
+  | "greaterThan"
+  | "greaterThanOrEqual"
+  | "inRange"
+  | "blank"
+  | "notBlank"
+  | "contains"
+  | "notContains"
+  | "startsWith"
+  | "endsWith";
+
+interface SimpleCondition {
+  filterType?: "text" | "number" | "date";
+  type?: SimpleType;
+  filter?: string | number | null;
+  filterTo?: string | number | null;
+}
+
+interface CombinedCondition {
+  filterType?: "text" | "number" | "date";
+  operator?: "AND" | "OR";
+  conditions?: SimpleCondition[];
+  // Legacy ag-grid shape:
+  condition1?: SimpleCondition;
+  condition2?: SimpleCondition;
+}
+
+type AnyColumnFilter = SimpleCondition & CombinedCondition;
+
+const REGEX_META = /[.*+?^${}()|[\]\\]/g;
+const regexEscape = (s: string): string => s.replace(REGEX_META, "\\$&");
+
+const stringLiteral = (s: string): string => JSON.stringify(s);
+
+const numberLiteral = (n: number): string => String(n);
+
+/** Convert a single ag-grid simple condition into a filtrex predicate
+ *  (string), or `null` if we can't represent it. */
+const conditionToFiltrex = (
+  mapping: FilterVarMapping,
+  cond: SimpleCondition
+): string | null => {
+  const v = mapping.variable;
+  const t = cond.type;
+  if (!t) return null;
+
+  if (t === "blank") return `${v} == null`;
+  if (t === "notBlank") return `${v} != null`;
+
+  // Number-style operators (also valid for string equals/notEqual).
+  if (mapping.kind === "number") {
+    const f = cond.filter;
+    if (typeof f !== "number") return null;
+    switch (t) {
+      case "equals":
+        return `${v} == ${numberLiteral(f)}`;
+      case "notEqual":
+        return `${v} != ${numberLiteral(f)}`;
+      case "lessThan":
+        return `${v} < ${numberLiteral(f)}`;
+      case "lessThanOrEqual":
+        return `${v} <= ${numberLiteral(f)}`;
+      case "greaterThan":
+        return `${v} > ${numberLiteral(f)}`;
+      case "greaterThanOrEqual":
+        return `${v} >= ${numberLiteral(f)}`;
+      case "inRange": {
+        const to = cond.filterTo;
+        if (typeof to !== "number") return null;
+        return `(${v} >= ${numberLiteral(f)} and ${v} <= ${numberLiteral(to)})`;
+      }
+      default:
+        return null;
+    }
+  }
+
+  // String column.
+  const f = cond.filter;
+  if (typeof f !== "string") return null;
+
+  switch (t) {
+    case "equals":
+      return `${v} == ${stringLiteral(f)}`;
+    case "notEqual":
+      return `${v} != ${stringLiteral(f)}`;
+    case "contains":
+      return mapping.containsFn
+        ? `${mapping.containsFn}(${stringLiteral(regexEscape(f))})`
+        : `${v} ~= ${stringLiteral(regexEscape(f))}`;
+    case "notContains":
+      return mapping.containsFn
+        ? `not ${mapping.containsFn}(${stringLiteral(regexEscape(f))})`
+        : `not (${v} ~= ${stringLiteral(regexEscape(f))})`;
+    case "startsWith":
+      return `${v} ~= ${stringLiteral("^" + regexEscape(f))}`;
+    case "endsWith":
+      return `${v} ~= ${stringLiteral(regexEscape(f) + "$")}`;
+    default:
+      return null;
+  }
+};
+
+/** Convert a full per-column filter (simple OR combined) to a filtrex
+ *  predicate. */
+const columnFilterToFiltrex = (
+  mapping: FilterVarMapping,
+  filter: AnyColumnFilter
+): string | null => {
+  // Combined: prefer the modern `conditions` array; fall back to
+  // condition1/condition2 for older shapes.
+  const conditions =
+    filter.conditions ??
+    [filter.condition1, filter.condition2].filter(
+      (c): c is SimpleCondition => !!c
+    );
+
+  if (conditions.length > 0 && filter.operator) {
+    const parts = conditions
+      .map((c) => conditionToFiltrex(mapping, c))
+      .filter((p): p is string => p !== null);
+    if (parts.length === 0) return null;
+    if (parts.length === 1) return parts[0];
+    const joiner = filter.operator === "OR" ? " or " : " and ";
+    return `(${parts.join(joiner)})`;
+  }
+
+  return conditionToFiltrex(mapping, filter);
+};
+
+/**
+ * Convert an ag-grid `FilterModel` into a filtrex expression suitable for
+ * the toolbar text filter.
+ *
+ * Returns `null` when the model contains *only* unrepresentable columns
+ * (so callers can leave the text filter alone). Columns that exist but
+ * aren't in the registry, or use unsupported operators, are skipped — the
+ * intent is best-effort surfacing of column filters in the DSL.
+ */
+export const filterModelToText = (
+  model: Record<string, AnyColumnFilter> | null | undefined,
+  registry: SampleFilterRegistry
+): string | null => {
+  if (!model) return null;
+  const parts: string[] = [];
+  for (const [colId, filter] of Object.entries(model)) {
+    const mapping = registry.byColId.get(colId);
+    if (!mapping) continue;
+    const text = columnFilterToFiltrex(mapping, filter);
+    if (text !== null) parts.push(text);
+  }
+  if (parts.length === 0) return null;
+  if (parts.length === 1) return parts[0];
+  return parts.join(" and ");
+};

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -138,12 +138,15 @@ const columnFilterToFiltrex = (
  * Three return values, each with distinct semantics for the caller:
  *  - `""`     — the model is empty (no column filters); callers should
  *               clear the text.
- *  - `null`   — the model has entries but *none* are representable in the
- *               DSL; callers should leave the text alone.
- *  - string   — the synthesized filtrex expression.
+ *  - `null`   — the model has entries but at least one isn't representable
+ *               in the DSL (a partial conversion would lose information,
+ *               so callers leave the text alone).
+ *  - string   — every entry was representable; the synthesized expression.
  *
- * Columns that aren't in the registry or use unsupported operators are
- * skipped — the intent is best-effort surfacing of column filters.
+ * Returning `null` whenever *any* entry is unrepresentable (rather than
+ * only when all are) is critical for round-trip safety: a partial text
+ * would be projected back to a strict-subset model by the recognizer,
+ * wiping the columns the synthesizer dropped.
  */
 export const filterModelToText = (
   model: Record<string, AnyColumnFilter> | null | undefined,
@@ -153,11 +156,11 @@ export const filterModelToText = (
   const parts: string[] = [];
   for (const [colId, filter] of Object.entries(model)) {
     const mapping = registry.byColId.get(colId);
-    if (!mapping) continue;
+    if (!mapping) return null;
     const text = columnFilterToFiltrex(mapping, filter);
-    if (text !== null) parts.push(text);
+    if (text === null) return null;
+    parts.push(text);
   }
-  if (parts.length === 0) return null;
   if (parts.length === 1) return parts[0];
   return parts.join(" and ");
 };

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -131,16 +131,21 @@ const columnFilterToFiltrex = (
  * Convert an ag-grid `FilterModel` into a filtrex expression suitable for
  * the toolbar text filter.
  *
- * Returns `null` when the model contains *only* unrepresentable columns
- * (so callers can leave the text filter alone). Columns that exist but
- * aren't in the registry, or use unsupported operators, are skipped — the
- * intent is best-effort surfacing of column filters in the DSL.
+ * Three return values, each with distinct semantics for the caller:
+ *  - `""`     — the model is empty (no column filters); callers should
+ *               clear the text.
+ *  - `null`   — the model has entries but *none* are representable in the
+ *               DSL; callers should leave the text alone.
+ *  - string   — the synthesized filtrex expression.
+ *
+ * Columns that aren't in the registry or use unsupported operators are
+ * skipped — the intent is best-effort surfacing of column filters.
  */
 export const filterModelToText = (
   model: Record<string, AnyColumnFilter> | null | undefined,
   registry: SampleFilterRegistry
 ): string | null => {
-  if (!model) return null;
+  if (!model || Object.keys(model).length === 0) return "";
   const parts: string[] = [];
   for (const [colId, filter] of Object.entries(model)) {
     const mapping = registry.byColId.get(colId);

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -22,10 +22,20 @@ interface CombinedCondition {
 
 type AnyColumnFilter = SimpleCondition & CombinedCondition;
 
-const REGEX_META = /[.*+?^${}()|[\]\\]/g;
-const regexEscape = (s: string): string => s.replace(REGEX_META, "\\$&");
+// Filtrex's string syntax only recognizes two escapes (`\"` and `\\`),
+// so `\.` / `\+` / etc. are *invalid* and would be rejected by the
+// filtrex lexer. To match a literal regex metachar inside a filtrex
+// string, we emit a single-element character class (`[.]`, `[+]`, …).
+// Backslash is the exception — its regex form `\\` is always written as
+// two characters and survives filtrex's string escape rules cleanly.
+const regexEscape = (s: string): string =>
+  s.replace(/\\/g, "\\\\").replace(/[.*+?^${}()|[\]]/g, "[$&]");
 
-const stringLiteral = (s: string): string => JSON.stringify(s);
+// Filtrex's lexer recognizes only two string escapes: `\"` and `\\`.
+// JSON.stringify additionally encodes control chars (`\n`, `\t`, …) which
+// filtrex would reject, so we use a minimal escape that produces
+// strings the parser can round-trip.
+const stringLiteral = (s: string): string => `"${s.replace(/[\\"]/g, "\\$&")}"`;
 
 const numberLiteral = (n: number): string => String(n);
 

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -1,30 +1,18 @@
 import { FilterVarMapping, SampleFilterRegistry } from "./filterRegistry";
 
-/** ag-grid filter operator names (subset we round-trip). */
-type SimpleType =
-  | "equals"
-  | "notEqual"
-  | "lessThan"
-  | "lessThanOrEqual"
-  | "greaterThan"
-  | "greaterThanOrEqual"
-  | "inRange"
-  | "blank"
-  | "notBlank"
-  | "contains"
-  | "notContains"
-  | "startsWith"
-  | "endsWith";
-
+/** ag-grid filter shape — kept loose because the same JSON travels
+ *  between this synthesizer, ag-grid's `setFilterModel`, and the
+ *  recognizer in `astToFilterModel.ts`. The conditional logic below
+ *  narrows by `type` at runtime. */
 interface SimpleCondition {
-  filterType?: "text" | "number" | "date";
-  type?: SimpleType;
+  filterType?: string;
+  type?: string;
   filter?: string | number | null;
   filterTo?: string | number | null;
 }
 
 interface CombinedCondition {
-  filterType?: "text" | "number" | "date";
+  filterType?: string;
   operator?: "AND" | "OR";
   conditions?: SimpleCondition[];
   // Legacy ag-grid shape:
@@ -51,8 +39,11 @@ const conditionToFiltrex = (
   const t = cond.type;
   if (!t) return null;
 
-  if (t === "blank") return `${v} == null`;
-  if (t === "notBlank") return `${v} != null`;
+  // `None` is filtrex's null sentinel (registered in
+  // `filterExpressionConstants` in filters.ts) — emitting `null` would
+  // resolve as an unbound identifier and error.
+  if (t === "blank") return `${v} == None`;
+  if (t === "notBlank") return `${v} != None`;
 
   // Number-style operators (also valid for string equals/notEqual).
   if (mapping.kind === "number") {

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -115,13 +115,17 @@ const columnFilterToFiltrex = (
     );
 
   if (conditions.length > 0 && filter.operator) {
+    // OR isn't currently round-trippable through the AST recognizer
+    // (top-level conjunction only). Skip the column rather than emit
+    // text the recognizer would reject — that previously caused the
+    // text→model effect to clear the entire grid filter.
+    if (filter.operator === "OR") return null;
     const parts = conditions
       .map((c) => conditionToFiltrex(mapping, c))
       .filter((p): p is string => p !== null);
     if (parts.length === 0) return null;
     if (parts.length === 1) return parts[0];
-    const joiner = filter.operator === "OR" ? " or " : " and ";
-    return `(${parts.join(joiner)})`;
+    return `(${parts.join(" and ")})`;
   }
 
   return conditionToFiltrex(mapping, filter);

--- a/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterModelToText.ts
@@ -57,7 +57,9 @@ const conditionToFiltrex = (
   // Number-style operators (also valid for string equals/notEqual).
   if (mapping.kind === "number") {
     const f = cond.filter;
-    if (typeof f !== "number") return null;
+    // Reject NaN / Infinity — ag-grid emits NaN when the user is mid-type
+    // (e.g. "I" parses as NaN), and `var == NaN` is invalid filtrex.
+    if (typeof f !== "number" || !Number.isFinite(f)) return null;
     switch (t) {
       case "equals":
         return `${v} == ${numberLiteral(f)}`;
@@ -73,7 +75,7 @@ const conditionToFiltrex = (
         return `${v} >= ${numberLiteral(f)}`;
       case "inRange": {
         const to = cond.filterTo;
-        if (typeof to !== "number") return null;
+        if (typeof to !== "number" || !Number.isFinite(to)) return null;
         return `(${v} >= ${numberLiteral(f)} and ${v} <= ${numberLiteral(to)})`;
       }
       default:

--- a/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
@@ -1,3 +1,4 @@
+import { kScoreTypeNumeric } from "../../../constants";
 import { perScorerFieldKey } from "../../shared/samples-grid/columns";
 import { EvalDescriptor } from "../descriptor/types";
 
@@ -62,7 +63,16 @@ export const buildSampleFilterRegistry = (
       const colId = perScorerFieldKey({ name, scorer });
       const variable =
         name === scorer || !banned.has(name) ? name : `${scorer}.${name}`;
-      entries.push([colId, { variable, kind: "number" }]);
+      // Match the column's filter type: numeric scores use the number
+      // filter and round-trip as numbers; everything else (boolean,
+      // passfail, categorical, etc.) uses the text filter.
+      const scoreType = evalDescriptor.scoreDescriptor({
+        name,
+        scorer,
+      })?.scoreType;
+      const kind: FilterVarKind =
+        scoreType === kScoreTypeNumeric ? "number" : "string";
+      entries.push([colId, { variable, kind }]);
     }
   }
 

--- a/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
@@ -1,4 +1,8 @@
-import { kScoreTypeNumeric } from "../../../constants";
+import {
+  kScoreTypeCategorical,
+  kScoreTypeNumeric,
+  kScoreTypePassFail,
+} from "../../../constants";
 import { perScorerFieldKey } from "../../shared/samples-grid/columns";
 import { EvalDescriptor } from "../descriptor/types";
 
@@ -23,8 +27,13 @@ export interface SampleFilterRegistry {
   byVariable: Map<string, string>;
 }
 
+// `sampleId` is intentionally absent: `sample.id` can be either number
+// or string, but the column's `valueGetter` stringifies it for filtering
+// and filtrex's `==` is strict. A sync would emit `id == "1"`, which
+// won't match a numeric `id = 1`. The column UI and the text filter
+// each work on their own; they just don't round-trip through each
+// other for IDs.
 const STATIC_ENTRIES: Array<[string, FilterVarMapping]> = [
-  ["sampleId", { variable: "id", kind: "string" }],
   ["sampleUuid", { variable: "uuid", kind: "string" }],
   ["epoch", { variable: "epoch", kind: "number" }],
   [
@@ -63,15 +72,27 @@ export const buildSampleFilterRegistry = (
       const colId = perScorerFieldKey({ name, scorer });
       const variable =
         name === scorer || !banned.has(name) ? name : `${scorer}.${name}`;
-      // Match the column's filter type: numeric scores use the number
-      // filter and round-trip as numbers; everything else (boolean,
-      // passfail, categorical, etc.) uses the text filter.
       const scoreType = evalDescriptor.scoreDescriptor({
         name,
         scorer,
       })?.scoreType;
-      const kind: FilterVarKind =
-        scoreType === kScoreTypeNumeric ? "number" : "string";
+      // Only sync score column filters where the column's text/number
+      // filter operates on values that match the runtime filtrex
+      // variable type. Booleans (filtrex sees `true`/`false`, the
+      // column's text filter sees the string `"true"`) and complex
+      // types (object/list/other) would generate expressions that
+      // never match the underlying values.
+      let kind: FilterVarKind;
+      if (scoreType === kScoreTypeNumeric) {
+        kind = "number";
+      } else if (
+        scoreType === kScoreTypeCategorical ||
+        scoreType === kScoreTypePassFail
+      ) {
+        kind = "string";
+      } else {
+        continue;
+      }
       entries.push([colId, { variable, kind }]);
     }
   }

--- a/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterRegistry.ts
@@ -1,0 +1,72 @@
+import { perScorerFieldKey } from "../../shared/samples-grid/columns";
+import { EvalDescriptor } from "../descriptor/types";
+
+import { bannedShortScoreNames } from "./filters";
+
+export type FilterVarKind = "string" | "number";
+
+export interface FilterVarMapping {
+  /** Filtrex variable name. */
+  variable: string;
+  kind: FilterVarKind;
+  /** If present, prefer this filtrex function for `contains`-style ag-grid
+   *  predicates — matches the case-insensitive semantics of the existing
+   *  `_contains` helpers. */
+  containsFn?: string;
+}
+
+export interface SampleFilterRegistry {
+  /** Lookup by ag-grid `colId` → filtrex variable. */
+  byColId: Map<string, FilterVarMapping>;
+  /** Lookup by filtrex variable name → ag-grid `colId`. */
+  byVariable: Map<string, string>;
+}
+
+const STATIC_ENTRIES: Array<[string, FilterVarMapping]> = [
+  ["sampleId", { variable: "id", kind: "string" }],
+  ["sampleUuid", { variable: "uuid", kind: "string" }],
+  ["epoch", { variable: "epoch", kind: "number" }],
+  [
+    "input",
+    { variable: "input", kind: "string", containsFn: "input_contains" },
+  ],
+  [
+    "target",
+    { variable: "target", kind: "string", containsFn: "target_contains" },
+  ],
+  [
+    "answer",
+    { variable: "answer", kind: "string", containsFn: "answer_contains" },
+  ],
+  ["tokens", { variable: "tokens", kind: "number" }],
+  ["duration", { variable: "duration", kind: "number" }],
+  [
+    "error",
+    { variable: "error", kind: "string", containsFn: "error_contains" },
+  ],
+  ["limit", { variable: "limit", kind: "string" }],
+  ["retries", { variable: "retries", kind: "number" }],
+];
+
+/** Build the column↔filtrex-variable registry. Score columns are added
+ *  dynamically from `evalDescriptor.scores` so the variable name matches
+ *  the same short/qualified rule used by `scoreVariables` in filters.ts. */
+export const buildSampleFilterRegistry = (
+  evalDescriptor: EvalDescriptor | undefined
+): SampleFilterRegistry => {
+  const entries: Array<[string, FilterVarMapping]> = [...STATIC_ENTRIES];
+
+  if (evalDescriptor) {
+    const banned = bannedShortScoreNames(evalDescriptor.scores);
+    for (const { name, scorer } of evalDescriptor.scores) {
+      const colId = perScorerFieldKey({ name, scorer });
+      const variable =
+        name === scorer || !banned.has(name) ? name : `${scorer}.${name}`;
+      entries.push([colId, { variable, kind: "number" }]);
+    }
+  }
+
+  const byColId = new Map(entries);
+  const byVariable = new Map(entries.map(([colId, m]) => [m.variable, colId]));
+  return { byColId, byVariable };
+};

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -40,7 +40,7 @@ const isFilteringSupportedForValue = (value: unknown): boolean =>
  * filter expressions because they are not unique. This should be applied only to
  * the nested scores, not to the top-level scorer names.
  */
-const bannedShortScoreNames = (scores: ScoreLabel[]): Set<string> => {
+export const bannedShortScoreNames = (scores: ScoreLabel[]): Set<string> => {
   const used: Set<string> = new Set();
   const banned: Set<string> = new Set();
   for (const { scorer, name } of scores) {

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -6,6 +6,7 @@ import { EvalSampleScore } from "../../../@types/extraInspect";
 import { FilterError, ScoreLabel } from "../../../app/types";
 import { SampleSummary } from "../../../client/api/types";
 import { kScoreTypeBoolean } from "../../../constants";
+import { SamplesDescriptor } from "../descriptor/samplesDescriptor";
 import { EvalDescriptor, ScoreDescriptor } from "../descriptor/types";
 
 import { kSampleMetadataPrefix } from "./sample-filter/language";
@@ -117,13 +118,38 @@ const getNestedPropertyValue = (obj: any, path: string): any => {
   return current;
 };
 
-const sampleVariables = (sample: SampleSummary): Record<string, unknown> => {
+const totalTokens = (sample: SampleSummary): number | null => {
+  if (!sample.model_usage) return null;
+  return Object.values(sample.model_usage).reduce(
+    (sum, u) => sum + (u.total_tokens ?? 0),
+    0
+  );
+};
+
+const targetString = (target: SampleSummary["target"]): string =>
+  Array.isArray(target) ? target.join(", ") : ((target as string) ?? "");
+
+const sampleVariables = (
+  sample: SampleSummary,
+  samplesDescriptor: SamplesDescriptor | undefined
+): Record<string, unknown> => {
   return {
     epoch: sample.epoch,
     has_error: !!sample.error,
+    has_limit: !!sample.limit,
     has_retries: sample.retries !== undefined && sample.retries > 0,
+    completed: sample.completed ?? true,
     id: sample.id,
     uuid: sample.uuid ?? null,
+    input: inputString(sample.input).join(" "),
+    target: targetString(sample.target),
+    answer:
+      samplesDescriptor?.selectedScorerDescriptor(sample)?.answer() ?? null,
+    error: sample.error ?? null,
+    limit: sample.limit ?? null,
+    retries: sample.retries ?? 0,
+    tokens: totalTokens(sample),
+    duration: sample.total_time ?? null,
     metadata: sample.metadata,
   };
 };
@@ -208,11 +234,12 @@ export const sampleFilterItems = (
 
 // TODO: Add case-insensitive string comparison.
 export const filterExpression = (
-  evalDescriptor: EvalDescriptor,
+  samplesDescriptor: SamplesDescriptor,
   sample: SampleSummary,
   filterValue: string
 ) => {
   try {
+    const evalDescriptor = samplesDescriptor.evalDescriptor;
     const inputContains = (regex: string): boolean => {
       return inputString(sample.input).some((msg) =>
         msg.match(new RegExp(regex, "i"))
@@ -227,6 +254,12 @@ export const filterExpression = (
     const errorContains = (regex: string): boolean => {
       return !!sample.error?.match(new RegExp(regex, "i"));
     };
+    const answerContains = (regex: string): boolean => {
+      const answer = samplesDescriptor
+        .selectedScorerDescriptor(sample)
+        ?.answer();
+      return !!answer?.match(new RegExp(regex, "i"));
+    };
 
     const isNan = (value: unknown): boolean =>
       typeof value === "number" && Number.isNaN(value);
@@ -235,9 +268,10 @@ export const filterExpression = (
       input_contains: inputContains,
       target_contains: targetContains,
       error_contains: errorContains,
+      answer_contains: answerContains,
       is_nan: isNan,
     };
-    const mySampleVariables = sampleVariables(sample);
+    const mySampleVariables = sampleVariables(sample, samplesDescriptor);
     const vars = {
       ...mySampleVariables,
       ...scoreVariables(evalDescriptor, sample.scores),
@@ -328,7 +362,7 @@ export const filterExpression = (
 };
 
 export const filterSamples = (
-  evalDescriptor: EvalDescriptor,
+  samplesDescriptor: SamplesDescriptor,
   samples: SampleSummary[],
   filterValue: string
 ): {
@@ -341,7 +375,7 @@ export const filterSamples = (
   const result = samples.filter((sample) => {
     if (filterValue) {
       const { matches, error: sampleError } = filterExpression(
-        evalDescriptor,
+        samplesDescriptor,
         sample,
         filterValue
       );

--- a/apps/inspect/src/app/samples/sample-tools/sample-filter/language.ts
+++ b/apps/inspect/src/app/samples/sample-tools/sample-filter/language.ts
@@ -20,16 +20,27 @@ export const MATH_FUNCTIONS: [string, string][] = [
 
 export const SAMPLE_VARIABLES: [string, string][] = [
   ["epoch", "The epoch (run) number of the sample"],
+  ["completed", "Whether the sample completed (true unless still running)"],
   ["has_error", "Checks if the sample has an error"],
+  ["has_limit", "Checks if the sample stopped due to a limit"],
   ["has_retries", "Checks if the sample has been retried"],
   [kSampleIdVariable, "The unique identifier of the sample"],
   [kSampleUuidVariable, "The globally unique identifier of the sample run"],
+  ["input", "The sample input as a string"],
+  ["target", "The sample target as a string"],
+  ["answer", "The sample answer (from the selected scorer)"],
+  ["error", "The sample error message (or null)"],
+  ["limit", "The limit kind that stopped the sample (or null)"],
+  ["retries", "The number of times the sample was retried (0 if none)"],
+  ["tokens", "Total tokens used across all models (or null)"],
+  ["duration", "Total wall-clock time of the sample, in seconds (or null)"],
   [kSampleMetadataVariable, "Metadata associated with the sample"],
 ];
 
 export const SAMPLE_FUNCTIONS: [string, string][] = [
   ["input_contains", "Checks if input contains a regular expression"],
   ["target_contains", "Checks if target contains a regular expression"],
+  ["answer_contains", "Checks if answer contains a regular expression"],
   ["error_contains", "Checks if error contains a regular expression"],
   ["is_nan", "Checks if a numeric value is NaN (e.g. is_nan(score))"],
 ];

--- a/apps/inspect/src/app/samples/sample-tools/sample-filter/tokenize.ts
+++ b/apps/inspect/src/app/samples/sample-tools/sample-filter/tokenize.ts
@@ -12,9 +12,16 @@ export interface Token {
 }
 
 // Constants
+//
+// STRING / UNTERMINATED_STRING mirror filtrex's actual lexer rules
+// (`/^"(?:\\"|\\\\|[^"\\])*"/`) so escaped quotes and backslashes inside
+// string literals tokenize correctly. The previous `[^"]*` form stopped
+// at the first inner `"` and prevented the synthesized text from
+// round-tripping through `parseFilter` whenever a filter value contained
+// a quote.
 const TOKEN_PATTERNS = {
-  STRING: /^"[^"]*"/,
-  UNTERMINATED_STRING: /^"[^"]*/,
+  STRING: /^"(?:\\"|\\\\|[^"\\])*"/,
+  UNTERMINATED_STRING: /^"(?:\\"|\\\\|[^"\\])*/,
   NUMBER: /^(-|\+)?\d+(\.\d+)?/,
   RELATION: /^(==|!=|<=|>=|<|>|~=)/,
   MISC_OPERATOR: /^(=|!|~)/,

--- a/apps/inspect/src/app/shared/samples-grid/SamplesGrid.module.css
+++ b/apps/inspect/src/app/shared/samples-grid/SamplesGrid.module.css
@@ -36,7 +36,11 @@
 }
 
 .gridChrome :global(.ag-header-cell) {
-  padding: 0;
+  /* Right gutter gives the active-filter icon (sibling of the header
+   * label inside `.ag-cell-label-container`) breathing room from the
+   * column boundary. Left padding is handled via the `::before` flex
+   * item below so it shrinks on narrow cells. */
+  padding: 0 4px 0 0;
 }
 
 .gridChrome :global(.ag-header-cell-label::before) {

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -11,6 +11,7 @@ import { arrayToString, filename, formatNumber } from "@tsmono/util";
 
 import { ScoreLabel } from "../../../app/types";
 import { LogDetails } from "../../../client/api/types";
+import { kScoreTypeNumeric } from "../../../constants";
 import { formatDateTime, formatTime } from "../../../utils/format";
 import { SamplesDescriptor } from "../../samples/descriptor/samplesDescriptor";
 import {
@@ -469,23 +470,30 @@ function buildScoreColumns(ctx: SampleGridContext): ColDef<SampleRow>[] {
       const colId = perScorerFieldKey(label);
       const headerName = useLabelHeader ? label.name : "Score";
       // Score values are typically 1 char or a short number, so the
-      // header is the binding constraint. 6.2px/char + 24px covers the
-      // sort icon, padding, and header gutter under the Balham theme.
+      // header is the binding constraint. 6.2px/char + 40px covers the
+      // sort icon, filter icon, padding, and header gutter under the
+      // Balham theme.
       const initialWidth = Math.max(
-        54,
-        Math.round(headerName.length * 6.2) + 24
+        70,
+        Math.round(headerName.length * 6.2) + 40
       );
+      const scoreType =
+        descriptor.evalDescriptor.scoreDescriptor(label)?.scoreType;
+      const isNumeric = scoreType === kScoreTypeNumeric;
       return {
         colId,
         field: colId,
         headerName,
         initialWidth,
-        minWidth: 44,
+        minWidth: 60,
         maxWidth: 120,
         sortable: true,
-        filter: "agNumberColumnFilter",
+        filter: isNumeric ? "agNumberColumnFilter" : "agTextColumnFilter",
         resizable: true,
-        comparator: comparators.number,
+        comparator: isNumeric
+          ? comparators.number
+          : (a: unknown, b: unknown) =>
+              String(a ?? "").localeCompare(String(b ?? "")),
         valueGetter: (params: ValueGetterParams<SampleRow>) => {
           const data = params.data?.data;
           if (!data) return undefined;

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -250,7 +250,7 @@ export const useSampleDescriptor = () => {
 
 // Provides the list of filtered and sorted samples
 export const useFilteredSamples = () => {
-  const evalDescriptor = useEvalDescriptor();
+  const samplesDescriptor = useSampleDescriptor();
   const sampleSummaries = useSampleSummaries();
   const filter = useStore((state) => state.log.filter);
   const setFilterError = useStore((state) => state.logActions.setFilterError);
@@ -261,8 +261,8 @@ export const useFilteredSamples = () => {
   return useMemo(() => {
     // Apply text filter
     const { result, error, allErrors } =
-      evalDescriptor && filter
-        ? filterSamples(evalDescriptor, sampleSummaries, filter)
+      samplesDescriptor && filter
+        ? filterSamples(samplesDescriptor, sampleSummaries, filter)
         : { result: sampleSummaries, error: undefined, allErrors: false };
 
     if (error && allErrors) {
@@ -290,7 +290,7 @@ export const useFilteredSamples = () => {
 
     return sorted;
   }, [
-    evalDescriptor,
+    samplesDescriptor,
     sampleSummaries,
     filter,
     setFilterError,


### PR DESCRIPTION
## Summary

Reworks the SampleList filtering UX so the toolbar text filter and the
ag-grid column-header filters describe the same logical narrowing and
stay in sync as the user edits either surface.

- **All visible single-log columns are now expressible in the filter
  DSL.** Adds variables (`tokens`, `duration`, `retries`, `limit`,
  `has_limit`, `completed`, `input`, `target`, `error`, `answer`) and
  an `answer_contains()` function. `filterSamples` / `filterExpression`
  now take a `SamplesDescriptor` so `answer` can resolve through the
  selected scorer.
- **Bidirectional sync.** Column-header filter changes synthesize a
  filtrex expression and write it to the toolbar; toolbar edits parse
  via a small AST recognizer (recursive-descent over the existing
  CodeMirror tokenizer) and apply a `FilterModel` to the grid.
- **Round-trippable subset only.** The recognizer accepts a top-level
  conjunction of single-column predicates; anything outside that
  surface (OR, arithmetic, mixed types, regex metachars in unsupported
  positions) is treated as expression-only.
- **Expression-only mode.** When the typed text isn't round-trippable,
  the column-header filter buttons are hidden so the user can't
  accidentally overwrite their typed expression.
- **Score columns pick a filter type by `scoreType`** — numeric scores
  keep the number filter; categorical / pass-fail use the text filter.
  Boolean / object / list / "other" scores aren't sync'd at all
  (filtrex sees the underlying value, the column UI sees a stringified
  version, so they wouldn't match).
- **Sample ID isn't sync'd** for the same reason — `sample.id` may be
  numeric or string and filtrex's `==` is strict.
- **Round-trip stability fixes** along the way:
  - blank/notBlank uses filtrex's `None` constant (was `null`, which
    isn't a registered filtrex constant).
  - Empty model clears text vs. partial model leaves text alone (the
    early returns previously collapsed both into "leave text alone").
  - Partial synthesis is refused; the text→model effect preserves
    column entries the synthesizer would have skipped.
  - Same-column OR is dropped from synthesis (recognizer only handles
    AND; emitting OR would have round-tripped through the recognizer
    to `null` and cleared the grid).
  - Regex metachars use single-element character classes (`a[.]b`)
    since filtrex's lexer rejects bare `\.`.
  - Tokenizer's STRING regex now matches filtrex's actual escape
    rules (`\"` and `\\`); synthesizer uses minimal escapes so it
    doesn't emit JSON-style `\n` etc. that filtrex rejects.

Bonus UX: bumped score-column width budget so the active-filter icon
has room next to the sort icon under the Balham theme; added a 4 px
right gutter to all sample-grid header cells so funnel icons aren't
flush against the column separator.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 230 passing (covering parser, recognizer,
      synthesizer, and end-to-end text→model→text round-trip stability,
      including filter values with quotes / backslashes / regex
      metachars)
- [x] `pnpm build` clean
- [x] Manual smoke (UI reviewer)
  - [x] Type `tokens > 50`; the Tokens column header funnel lights up.
  - [x] Add a Duration column filter via the header; text becomes
        `tokens > 50 and duration > 1`, both funnels stay active.
  - [x] Clear the last column filter; the text clears.
  - [x] Type a non-round-trippable expression
        (`score > 5 or score < 1`); column-header filter buttons hide
        and the typed text is preserved.
  - [x] Filter a Target column with a value containing a quote or
        regex metacharacter; round-trips cleanly through the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)