### PR TITLE
Fetch pending sample data directly from S3 in viewer

### DIFF
--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { clientApi } from "./client-api";
+import { LogViewAPI, SampleData, SampleDataResponse } from "./types";
+
+const emptySampleData: SampleData = {
+  events: [],
+  attachments: [],
+  message_pool: [],
+  call_pool: [],
+};
+
+const okResponse = (has_more = false): SampleDataResponse => ({
+  status: "OK",
+  sampleData: emptySampleData,
+  has_more,
+});
+
+const baseApi = (): LogViewAPI => ({
+  client_events: vi.fn().mockResolvedValue([]),
+  get_eval_set: vi.fn().mockResolvedValue(undefined),
+  get_flow: vi.fn().mockResolvedValue(undefined),
+  get_log_root: vi.fn().mockResolvedValue(undefined),
+  get_log_contents: vi.fn(),
+  get_log_info: vi.fn(),
+  get_log_bytes: vi.fn(),
+  get_log_summaries: vi.fn().mockResolvedValue([]),
+  log_message: vi.fn(),
+  download_file: vi.fn(),
+  open_log_file: vi.fn(),
+});
+
+describe("clientApi.get_log_sample_data path selection", () => {
+  test("pins to direct on the first call when the probe succeeds", async () => {
+    const direct = vi.fn().mockResolvedValue(okResponse(true));
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+      eval_log_sample_data_direct: direct,
+    };
+    const client = clientApi(api);
+
+    const first = await client.get_log_sample_data!("log.eval", "s1", 0);
+    const second = await client.get_log_sample_data!("log.eval", "s1", 0);
+
+    expect(first?.has_more).toBe(true);
+    expect(second?.has_more).toBe(true);
+    expect(direct).toHaveBeenCalledTimes(2);
+    expect(proxy).not.toHaveBeenCalled();
+  });
+
+  test("pins to proxy when the probe returns undefined and never probes again", async () => {
+    const direct = vi.fn().mockResolvedValue(undefined);
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+      eval_log_sample_data_direct: direct,
+    };
+    const client = clientApi(api);
+
+    await client.get_log_sample_data!("log.eval", "s1", 0);
+    await client.get_log_sample_data!("log.eval", "s1", 0);
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(proxy).toHaveBeenCalledTimes(2);
+  });
+
+  test("uses proxy when the API doesn't expose the direct method", async () => {
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+    };
+    const client = clientApi(api);
+
+    await client.get_log_sample_data!("log.eval", "s1", 0);
+
+    expect(proxy).toHaveBeenCalledTimes(1);
+  });
+
+  test("real errors from the direct probe bubble up and don't pin a path", async () => {
+    const direct = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(okResponse());
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+      eval_log_sample_data_direct: direct,
+    };
+    const client = clientApi(api);
+
+    await expect(
+      client.get_log_sample_data!("log.eval", "s1", 0)
+    ).rejects.toThrow("network");
+
+    // Next call retries the probe (no path was pinned).
+    await client.get_log_sample_data!("log.eval", "s1", 0);
+    expect(direct).toHaveBeenCalledTimes(2);
+    expect(proxy).not.toHaveBeenCalled();
+  });
+
+  test("pins per-log_file independently", async () => {
+    const direct = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse()) // log A: probe ok
+      .mockResolvedValueOnce(undefined) // log B: not supported
+      .mockResolvedValueOnce(okResponse()); // log A: follow-up
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+      eval_log_sample_data_direct: direct,
+    };
+    const client = clientApi(api);
+
+    await client.get_log_sample_data!("a.eval", "s1", 0);
+    await client.get_log_sample_data!("b.eval", "s1", 0);
+    await client.get_log_sample_data!("a.eval", "s1", 0);
+    await client.get_log_sample_data!("b.eval", "s1", 0);
+
+    expect(direct).toHaveBeenCalledTimes(3); // a-probe, b-probe, a-followup
+    expect(proxy).toHaveBeenCalledTimes(2); // b-first (after probe), b-followup
+  });
+});

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -352,7 +352,12 @@ export const clientApi = (
     return api.eval_pending_samples(log_file, etag);
   };
 
-  const get_log_sample_data = (
+  // Probe-once selector: the only signal that flips the choice is an
+  // explicit "not supported" return from the direct probe; real errors
+  // bubble up.
+  const sampleDataPathByLog = new Map<string, "direct" | "proxy">();
+
+  const get_log_sample_data = async (
     log_file: string,
     id: string | number,
     epoch: number,
@@ -363,6 +368,47 @@ export const clientApi = (
   ): Promise<SampleDataResponse | undefined> => {
     if (!api.eval_log_sample_data) {
       throw new Error("API doesn't supported streamed sample data");
+    }
+
+    let path = sampleDataPathByLog.get(log_file);
+    if (path === undefined && api.eval_log_sample_data_direct) {
+      const probe = await api.eval_log_sample_data_direct(
+        log_file,
+        id,
+        epoch,
+        last_event,
+        last_attachment,
+        last_message_pool,
+        last_call_pool
+      );
+      if (probe !== undefined) {
+        sampleDataPathByLog.set(log_file, "direct");
+        return probe;
+      }
+    }
+    if (path === undefined) {
+      path = "proxy";
+      sampleDataPathByLog.set(log_file, path);
+    }
+
+    if (path === "direct") {
+      const result = await api.eval_log_sample_data_direct!(
+        log_file,
+        id,
+        epoch,
+        last_event,
+        last_attachment,
+        last_message_pool,
+        last_call_pool
+      );
+      if (result === undefined) {
+        // Probe succeeded but a later call says "not supported" — server state
+        // changed; fail loudly rather than silently switching paths.
+        throw new Error(
+          "Direct pending-sample-data path returned 'not supported' after probe"
+        );
+      }
+      return result;
     }
     return api.eval_log_sample_data(
       log_file,

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -79,6 +79,19 @@ export interface PendingSampleResponse {
 export interface SampleDataResponse {
   sampleData?: SampleData;
   status: "NotModified" | "NotFound" | "OK";
+  has_more?: boolean;
+}
+
+export interface SegmentRef {
+  id: number;
+  member_name: string;
+  direct_url: string | null;
+}
+
+export interface PendingSampleUrls {
+  segments: SegmentRef[];
+  complete: boolean;
+  has_more: boolean;
 }
 
 // Client-side types — looser than generated server types because they're
@@ -198,6 +211,18 @@ export interface LogViewAPI {
     etag?: string
   ) => Promise<PendingSampleResponse>;
   eval_log_sample_data?: (
+    log_file: string,
+    id: string | number,
+    epoch: number,
+    last_event?: number,
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
+  ) => Promise<SampleDataResponse | undefined>;
+  // Alternative to eval_log_sample_data that fetches segment zips directly
+  // from S3 via presigned URLs. Returns undefined when the server doesn't
+  // support this path (missing endpoint, non-S3 buffer); throws on real errors.
+  eval_log_sample_data_direct?: (
     log_file: string,
     id: string | number,
     epoch: number,

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -2,6 +2,7 @@ import { LogInfo } from "@tsmono/inspect-common/types";
 
 import { EvalScores } from "../../../@types/extraInspect";
 import { asyncJsonParse } from "../../../utils/json-worker";
+import { fetchPendingSampleDataDirect } from "../../remote/remotePendingSampleData";
 import { download_file } from "../shared/api-shared";
 import {
   Capabilities,
@@ -11,6 +12,7 @@ import {
   LogViewAPI,
   PendingSampleResponse,
   PendingSamples,
+  PendingSampleUrls,
   SampleData,
   SampleDataResponse,
 } from "../types";
@@ -363,6 +365,81 @@ export function viewServerApi(
     return result.parsed;
   };
 
+  const get_pending_sample_data_urls = async (
+    log_file: string,
+    id: string | number,
+    epoch: number,
+    last_event?: number,
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number,
+    max_segments?: number
+  ): Promise<PendingSampleUrls> => {
+    const params = new URLSearchParams();
+    params.append("log", log_file);
+    params.append("id", String(id));
+    params.append("epoch", String(epoch));
+    if (last_event !== undefined) {
+      params.append("last-event-id", String(last_event));
+    }
+
+    if (last_attachment !== undefined) {
+      params.append("after-attachment-id", String(last_attachment));
+    }
+
+    if (last_message_pool !== undefined) {
+      params.append("after-message-pool-id", String(last_message_pool));
+    }
+
+    if (last_call_pool !== undefined) {
+      params.append("after-call-pool-id", String(last_call_pool));
+    }
+
+    if (max_segments !== undefined) {
+      params.append("max-segments", String(max_segments));
+    }
+
+    const request: Request<PendingSampleUrls> = {
+      headers: {},
+      parse: async (text: string) => {
+        return await asyncJsonParse<PendingSampleUrls>(text);
+      },
+    };
+
+    const result = await requestApi.fetchType<PendingSampleUrls>(
+      "GET",
+      `/pending-sample-data-urls?${params.toString()}`,
+      request
+    );
+    return result.parsed;
+  };
+
+  const eval_log_sample_data_direct = async (
+    log_file: string,
+    id: string | number,
+    epoch: number,
+    last_event?: number,
+    last_attachment?: number,
+    last_message_pool?: number,
+    last_call_pool?: number
+  ): Promise<SampleDataResponse | undefined> => {
+    const direct = await fetchPendingSampleDataDirect(
+      get_pending_sample_data_urls,
+      log_file,
+      id,
+      epoch,
+      { last_event, last_attachment, last_message_pool, last_call_pool }
+    );
+    if (direct === undefined) {
+      return undefined;
+    }
+    return {
+      status: "OK",
+      sampleData: direct.sampleData,
+      has_more: direct.has_more,
+    };
+  };
+
   const download_log = async (log_file: string): Promise<void> => {
     const baseUrl = apiBaseUrl || __VIEW_SERVER_API_URL__;
     const url = `${baseUrl}/log-download/${encodeURIComponent(log_file)}`;
@@ -392,5 +469,6 @@ export function viewServerApi(
     open_log_file: async () => {},
     eval_pending_samples,
     eval_log_sample_data,
+    eval_log_sample_data_direct,
   };
 }

--- a/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ApiError } from "../api/view-server/request";
+
+import { fetchPendingSampleDataDirect } from "./remotePendingSampleData";
+
+vi.mock("./remoteZipFile", () => ({
+  openZipFileFromBuffer: vi.fn(async (bytes: Uint8Array) => ({
+    readFile: async (_member: string) => bytes,
+  })),
+}));
+
+vi.mock("../../utils/json-worker", () => ({
+  asyncJsonParseBytes: vi.fn(async (bytes: Uint8Array) =>
+    JSON.parse(new TextDecoder().decode(bytes))
+  ),
+}));
+
+describe("fetchPendingSampleDataDirect", () => {
+  describe("segment-order preservation", () => {
+    const realFetch = globalThis.fetch;
+
+    beforeEach(() => {
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        // Segment N encodes one event with id=N*10. Delay is inverse to N so
+        // higher-id segments resolve first, stressing arrival-order merging.
+        const match = url.match(/seg-(\d+)/);
+        const idx = match ? Number(match[1]) : 0;
+        const eventId = idx * 10;
+        const delay = (3 - idx) * 20;
+        await new Promise((r) => setTimeout(r, delay));
+        const body = new TextEncoder().encode(
+          JSON.stringify({
+            events: [
+              {
+                id: eventId,
+                event_id: `e${eventId}`,
+                sample_id: "s1",
+                epoch: 0,
+                event: {},
+              },
+            ],
+            attachments: [],
+            message_pool: [],
+            call_pool: [],
+          })
+        );
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          arrayBuffer: async () => body.buffer,
+        } as unknown as Response;
+      }) as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+      vi.restoreAllMocks();
+    });
+
+    test("merges events in segment order even when fetches resolve out of order", async () => {
+      const getUrls = vi.fn().mockResolvedValue({
+        segments: [
+          { id: 0, member_name: "m0", direct_url: "https://example/seg-0" },
+          { id: 1, member_name: "m1", direct_url: "https://example/seg-1" },
+          { id: 2, member_name: "m2", direct_url: "https://example/seg-2" },
+          { id: 3, member_name: "m3", direct_url: "https://example/seg-3" },
+        ],
+        complete: false,
+        has_more: false,
+      });
+
+      const result = await fetchPendingSampleDataDirect(
+        getUrls,
+        "log.eval",
+        "sample1",
+        0,
+        {}
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.sampleData.events.map((e) => e.id)).toEqual([
+        0, 10, 20, 30,
+      ]);
+    });
+  });
+
+  test("returns undefined on ApiError(404) from getUrls (server doesn't support direct path)", async () => {
+    const getUrls = vi.fn().mockRejectedValue(new ApiError(404, "not found"));
+
+    const result = await fetchPendingSampleDataDirect(
+      getUrls,
+      "log.eval",
+      "sample1",
+      0,
+      {}
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  test("rethrows non-404 errors from getUrls", async () => {
+    const getUrls = vi.fn().mockRejectedValue(new ApiError(500, "boom"));
+
+    await expect(
+      fetchPendingSampleDataDirect(getUrls, "log.eval", "sample1", 0, {})
+    ).rejects.toThrow(ApiError);
+  });
+
+  test("returns undefined when any segment lacks direct_url (non-S3 buffer)", async () => {
+    const getUrls = vi.fn().mockResolvedValue({
+      segments: [
+        { id: 0, member_name: "m0", direct_url: "https://example/seg-0" },
+        { id: 1, member_name: "m1", direct_url: null },
+      ],
+      complete: false,
+      has_more: false,
+    });
+
+    const result = await fetchPendingSampleDataDirect(
+      getUrls,
+      "log.eval",
+      "sample1",
+      0,
+      {}
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns has_more from the URL manifest on the empty-segments short-circuit", async () => {
+    const getUrls = vi.fn().mockResolvedValue({
+      segments: [],
+      complete: false,
+      has_more: true,
+    });
+
+    const result = await fetchPendingSampleDataDirect(
+      getUrls,
+      "log.eval",
+      "sample1",
+      0,
+      {}
+    );
+
+    expect(result).toBeDefined();
+    expect(result!.has_more).toBe(true);
+    expect(result!.sampleData).toEqual({
+      events: [],
+      attachments: [],
+      message_pool: [],
+      call_pool: [],
+    });
+  });
+});

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -1,0 +1,136 @@
+import { asyncJsonParseBytes } from "../../utils/json-worker";
+import { PendingSampleUrls, SampleData, SegmentRef } from "../api/types";
+import { ApiError } from "../api/view-server/request";
+
+import { openZipFileFromBuffer } from "./remoteZipFile";
+
+// Cap segments per call so the poll loop can yield between chunks (via the
+// polling helper's "immediate" setTimeout(0)) — without this, long-running
+// evals with thousands of segments starve the renderer. 25 keeps each chunk
+// under ~1s at typical segment sizes.
+const SEGMENT_CAP_PER_CALL = 25;
+
+export type GetPendingSampleDataUrls = (
+  log_file: string,
+  id: string | number,
+  epoch: number,
+  last_event?: number,
+  last_attachment?: number,
+  last_message_pool?: number,
+  last_call_pool?: number,
+  max_segments?: number
+) => Promise<PendingSampleUrls>;
+
+export interface DirectPendingResult {
+  sampleData: SampleData;
+  has_more: boolean;
+}
+
+/**
+ * Fetch one chunk of pending-sample data via presigned S3 URLs.
+ * Returns `undefined` when this transport isn't supported (404, or any
+ * segment lacks a presigned URL); all other failures throw.
+ */
+export const fetchPendingSampleDataDirect = async (
+  getUrls: GetPendingSampleDataUrls,
+  log_file: string,
+  id: string | number,
+  epoch: number,
+  cursors: {
+    last_event?: number;
+    last_attachment?: number;
+    last_message_pool?: number;
+    last_call_pool?: number;
+  }
+): Promise<DirectPendingResult | undefined> => {
+  let urls: PendingSampleUrls;
+  try {
+    urls = await getUrls(
+      log_file,
+      id,
+      epoch,
+      cursors.last_event,
+      cursors.last_attachment,
+      cursors.last_message_pool,
+      cursors.last_call_pool,
+      SEGMENT_CAP_PER_CALL
+    );
+  } catch (e) {
+    // 404 = endpoint missing on this server; treat as "not supported".
+    if (e instanceof ApiError && e.status === 404) {
+      return undefined;
+    }
+    throw e;
+  }
+
+  if (urls.segments.length === 0) {
+    return {
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+      has_more: urls.has_more,
+    };
+  }
+
+  const canDirect = urls.segments.every((s) => s.direct_url != null);
+  if (!canDirect) {
+    return undefined;
+  }
+
+  // Fetch concurrently but concatenate in segment order — downstream code
+  // expects events/attachments in id order.
+  const parts: SampleData[] = await Promise.all(
+    urls.segments.map((seg: SegmentRef) => readSegment(seg))
+  );
+  const out: SampleData = {
+    events: parts.flatMap((p) => p.events),
+    attachments: parts.flatMap((p) => p.attachments),
+    message_pool: parts.flatMap((p) => p.message_pool),
+    call_pool: parts.flatMap((p) => p.call_pool),
+  };
+  return {
+    sampleData: applyCursorFilter(out, cursors),
+    has_more: urls.has_more,
+  };
+};
+
+const readSegment = async (seg: SegmentRef): Promise<SampleData> => {
+  const url = seg.direct_url as string;
+  // Whole-zip fetch: segments contain one member per (sample, epoch), so
+  // the zip is ~the member plus trivial framing — ranging buys nothing.
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    throw new Error(
+      `Failed to fetch segment: ${resp.status} ${resp.statusText}`
+    );
+  }
+  const bytes = new Uint8Array(await resp.arrayBuffer());
+  const zip = await openZipFileFromBuffer(bytes);
+  const memberBytes = await zip.readFile(seg.member_name);
+  return (await asyncJsonParseBytes(memberBytes)) as SampleData;
+};
+
+// Over-inclusive segment filter -> per-item filter here. Mirrors
+// SampleBufferFilestore.get_sample_data. `-1` acts as "no cursor".
+const applyCursorFilter = (
+  out: SampleData,
+  cursors: {
+    last_event?: number;
+    last_attachment?: number;
+    last_message_pool?: number;
+    last_call_pool?: number;
+  }
+): SampleData => {
+  const lastEvent = cursors.last_event ?? -1;
+  const lastAttachment = cursors.last_attachment ?? -1;
+  const lastMessagePool = cursors.last_message_pool ?? -1;
+  const lastCallPool = cursors.last_call_pool ?? -1;
+  out.events = out.events.filter((e) => e.id > lastEvent);
+  out.attachments = out.attachments.filter((a) => a.id > lastAttachment);
+  out.message_pool = out.message_pool.filter((m) => m.id > lastMessagePool);
+  out.call_pool = out.call_pool.filter((c) => c.id > lastCallPool);
+  return out;
+};

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -278,6 +278,84 @@ export const openRemoteZipFile = async (
   };
 };
 
+/**
+ * Opens an in-memory ZIP buffer and provides a method to read files within it.
+ */
+export const openZipFileFromBuffer = async (
+  bytes: Uint8Array
+): Promise<{
+  centralDirectory: Map<string, CentralDirectoryEntry>;
+  readFile: (file: string, maxBytes?: number) => Promise<Uint8Array>;
+}> => {
+  const contentLength = bytes.length;
+  if (contentLength < 22) {
+    throw new Error("Buffer too small to be a ZIP file");
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  // Assumes no ZIP comment (true for segments written by SampleBufferFilestore).
+  const eocdrStart = contentLength - 22;
+  if (view.getUint32(eocdrStart, true) !== 0x06054b50) {
+    throw new Error("End of central directory record not found");
+  }
+
+  let centralDirOffset = view.getUint32(eocdrStart + 16, true);
+  let centralDirSize = view.getUint32(eocdrStart + 12, true);
+
+  if (centralDirOffset === 0xffffffff || centralDirSize === 0xffffffff) {
+    const locatorStart = eocdrStart - 20;
+    if (view.getUint32(locatorStart, true) !== 0x07064b50) {
+      throw new Error("ZIP64 End of central directory locator not found");
+    }
+    const zip64EOCDOffset = Number(view.getBigUint64(locatorStart + 8, true));
+    if (view.getUint32(zip64EOCDOffset, true) !== 0x06064b50) {
+      throw new Error("ZIP64 End of central directory record not found");
+    }
+    centralDirSize = Number(view.getBigUint64(zip64EOCDOffset + 40, true));
+    centralDirOffset = Number(view.getBigUint64(zip64EOCDOffset + 48, true));
+  }
+
+  // slice() rather than subarray() because parseCentralDirectory and
+  // parseZipFileEntry build a DataView from `buffer` without a byteOffset.
+  const centralDirectory = parseCentralDirectory(
+    bytes.slice(centralDirOffset, centralDirOffset + centralDirSize)
+  );
+
+  return {
+    centralDirectory,
+    readFile: async (file, maxBytes): Promise<Uint8Array> => {
+      const entry = centralDirectory.get(file);
+      if (!entry) {
+        throw new Error(`File not found: ${file}`);
+      }
+      const headerSize = 30;
+      if (entry.fileOffset + headerSize > bytes.length) {
+        throw new Error(`File entry header is truncated for ${file}`);
+      }
+      const extraFieldLength =
+        bytes[entry.fileOffset + 28] + (bytes[entry.fileOffset + 29] << 8);
+      const totalSize =
+        headerSize +
+        entry.filenameLength +
+        extraFieldLength +
+        entry.compressedSize;
+      if (maxBytes && totalSize > maxBytes) {
+        throw new FileSizeLimitError(file, maxBytes);
+      }
+      const zipFileEntry = await parseZipFileEntry(
+        file,
+        bytes.slice(entry.fileOffset, entry.fileOffset + totalSize)
+      );
+      return decompressData(
+        zipFileEntry.data,
+        zipFileEntry.compressionMethod,
+        zipFileEntry.uncompressedSize,
+        file
+      );
+    },
+  };
+};
+
 export const fetchSize = async (url: string): Promise<number> => {
   // Make a HEAD request to find whether the server supports range requests
   const acceptResponse = await fetch(url, { method: "HEAD" });

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -18,7 +18,7 @@ import {
   SampleSummary,
 } from "../client/api/types";
 import { resolveAttachments } from "../utils/attachments";
-import { createPolling } from "../utils/polling";
+import { createPolling, PollingCallbackResult } from "../utils/polling";
 
 import {
   resolveSample,
@@ -114,7 +114,7 @@ export function createSamplePolling(
 
     // Create the polling callback
     log.debug(`Polling sample: ${summary.id}-${summary.epoch}`);
-    const pollCallback = async () => {
+    const pollCallback = async (): Promise<PollingCallbackResult> => {
       const state = store.getState();
       const { sampleActions } = state;
 
@@ -186,19 +186,19 @@ export function createSamplePolling(
         return false;
       };
 
-      // Fetch sample data
-      const eventId = pollingState.eventId;
-      const attachmentId = pollingState.attachmentId;
-      const messagePoolId = pollingState.messagePoolId;
-      const callPoolId = pollingState.callPoolId;
+      // Snapshot cursors before the call so we can detect progress below.
+      const priorEventId = pollingState.eventId;
+      const priorAttachmentId = pollingState.attachmentId;
+      const priorMessagePoolId = pollingState.messagePoolId;
+      const priorCallPoolId = pollingState.callPoolId;
       const sampleDataResponse = await api.get_log_sample_data(
         logFile,
         summary.id,
         summary.epoch,
-        eventId,
-        attachmentId,
-        messagePoolId !== kNoId ? messagePoolId : undefined,
-        callPoolId !== kNoId ? callPoolId : undefined
+        priorEventId,
+        priorAttachmentId,
+        priorMessagePoolId,
+        priorCallPoolId
       );
 
       if (localAbort.signal.aborted) {
@@ -231,50 +231,60 @@ export function createSamplePolling(
         }
         sampleActions.setSampleStatus("streaming");
 
-        if (sampleDataResponse.sampleData) {
-          // Process attachments
-          processAttachments(sampleDataResponse.sampleData, pollingState);
+        // Process attachments
+        processAttachments(sampleDataResponse.sampleData, pollingState);
 
-          // Process pool entries (must come before events so refs can be resolved)
-          processMessagePool(sampleDataResponse.sampleData, pollingState);
-          processCallPool(sampleDataResponse.sampleData, pollingState);
+        // Process pool entries (must come before events so refs can be resolved)
+        processMessagePool(sampleDataResponse.sampleData, pollingState);
+        processCallPool(sampleDataResponse.sampleData, pollingState);
 
-          // Process events
-          const processedEvents = processEvents(
-            sampleDataResponse.sampleData,
-            pollingState,
-            api,
-            logFile
+        // Process events
+        const processedEvents = processEvents(
+          sampleDataResponse.sampleData,
+          pollingState,
+          api,
+          logFile
+        );
+
+        // update max attachment id
+        if (sampleDataResponse.sampleData.attachments.length > 0) {
+          const maxAttachment = findMaxId(
+            sampleDataResponse.sampleData.attachments,
+            pollingState.attachmentId
           );
+          log.debug(`New max attachment ${maxAttachment}`);
+          pollingState.attachmentId = maxAttachment;
+        }
 
-          // update max attachment id
-          if (sampleDataResponse.sampleData.attachments.length > 0) {
-            const maxAttachment = findMaxId(
-              sampleDataResponse.sampleData.attachments,
-              pollingState.attachmentId
-            );
-            log.debug(`New max attachment ${maxAttachment}`);
-            pollingState.attachmentId = maxAttachment;
-          }
+        // update max event id
+        if (sampleDataResponse.sampleData.events.length > 0) {
+          const maxEvent = findMaxId(
+            sampleDataResponse.sampleData.events,
+            pollingState.eventId
+          );
+          log.debug(`New max event ${maxEvent}`);
+          pollingState.eventId = maxEvent;
+        }
 
-          // update max event id
-          if (sampleDataResponse.sampleData.events.length > 0) {
-            const maxEvent = findMaxId(
-              sampleDataResponse.sampleData.events,
-              pollingState.eventId
-            );
-            log.debug(`New max event ${maxEvent}`);
-            pollingState.eventId = maxEvent;
-          }
+        // Update the running events (ensure identity of runningEvents fails equality)
+        if (processedEvents) {
+          sampleActions.setRunningEvents([...pollingState.events]);
+        }
 
-          // Update the running events (ensure identity of runningEvents fails equality)
-          if (processedEvents) {
-            sampleActions.setRunningEvents([...pollingState.events]);
-          }
+        // Catch-up poll when the server truncated the segment list — but
+        // only if we actually advanced, otherwise we'd spin.
+        const advanced =
+          pollingState.eventId > priorEventId ||
+          pollingState.attachmentId > priorAttachmentId ||
+          pollingState.messagePoolId > priorMessagePoolId ||
+          pollingState.callPoolId > priorCallPoolId;
+
+        if (sampleDataResponse.has_more === true && advanced) {
+          return "immediate";
         }
       }
 
-      // Continue polling
+      // Continue polling at the normal cadence
       return true;
     };
 

--- a/apps/inspect/src/utils/polling.test.ts
+++ b/apps/inspect/src/utils/polling.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createPolling } from "./polling";
+
+describe("createPolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("calls back after interval when callback returns true", async () => {
+    const cb = vi.fn().mockResolvedValue(true);
+    const p = createPolling("t", cb, { maxRetries: 3, interval: 2 });
+
+    p.start();
+    await vi.waitFor(() => expect(cb).toHaveBeenCalledTimes(1));
+
+    // Before the interval elapses, still only 1 call.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // After 2s total, a second call is scheduled.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    p.stop();
+  });
+
+  test("re-enters immediately when callback returns 'immediate'", async () => {
+    let count = 0;
+    const cb = vi.fn().mockImplementation(async () => {
+      count += 1;
+      return count < 3 ? "immediate" : true;
+    });
+    const p = createPolling("t", cb, { maxRetries: 3, interval: 2 });
+
+    p.start();
+
+    // "immediate" schedules via setTimeout(0) so the renderer and GC can run
+    // between iterations. Advance past each zero-delay tick until the three
+    // back-to-back calls have happened.
+    await vi.waitFor(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      expect(cb).toHaveBeenCalledTimes(3);
+    });
+
+    // After the third call returns `true` (normal cadence), no further call
+    // should happen on a zero-delay tick — it waits the full 2s interval.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(cb).toHaveBeenCalledTimes(3);
+
+    p.stop();
+  });
+
+  test("stops when callback returns false", async () => {
+    const cb = vi.fn().mockResolvedValue(false);
+    const p = createPolling("t", cb, { maxRetries: 3, interval: 2 });
+
+    p.start();
+    await vi.waitFor(() => expect(cb).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/inspect/src/utils/polling.ts
+++ b/apps/inspect/src/utils/polling.ts
@@ -11,9 +11,11 @@ export interface Polling {
   stop: () => void;
 }
 
+export type PollingCallbackResult = boolean | "immediate";
+
 export const createPolling = (
   name: string,
-  callback: () => Promise<boolean>,
+  callback: () => Promise<PollingCallbackResult>,
   options: PollingOptions
 ): Polling => {
   const log = createLogger(`Polling ${name}`);
@@ -58,6 +60,12 @@ export const createPolling = (
       // Reset retry count on success
       retryCount = 0;
       if (!isPolling || isStopped) {
+        return;
+      }
+      if (shouldContinue === "immediate") {
+        // setTimeout(0) yields to the task queue so the renderer can paint
+        // and GC between iterations; queueMicrotask would starve both.
+        timeoutId = setTimeout(poll, 0);
         return;
       }
       timeoutId = setTimeout(poll, interval * 1000);


### PR DESCRIPTION
The viewer currently proxies every segment zip for live samples through the inspect view server, which bottlenecks on server CPU and network for samples with many segments. This PR teaches the client to call a new presigned-URL endpoint, fetch segment zips directly from S3 in parallel, and chunk requests via a server-driven `has_more` cursor so the renderer paints between chunks instead of starving on a single long sweep. Any failure (presign unavailable, old server, network error, non-S3 buffer) falls back transparently to the proxy endpoint.

Server side lives in the parent inspect_ai repo (UKGovernmentBEIS/inspect_ai#3835).
