### PR TITLE
fix: cmd+click/middle-click opens log in background tab

### DIFF
--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -31,6 +31,7 @@ import { useStore } from "../../../state/store";
 
 import "../../shared/agGrid";
 
+import { openInNewTab } from "../../shared/openInNewTab";
 import styles from "../../shared/gridCells.module.css";
 import { createGridKeyboardHandler } from "../../shared/gridKeyboardNavigation";
 import { createGridColumnResizer } from "../../shared/gridUtils";
@@ -253,20 +254,20 @@ export const LogListGrid: FC<LogListGridProps> = ({
         e.node.setSelected(true);
 
         const mouseEvent = e.event as MouseEvent | undefined;
-        const openInNewWindow =
+        // Modifier clicks are handled by the <a> overlay in the cell renderer
+        if (
           mouseEvent?.metaKey ||
           mouseEvent?.ctrlKey ||
           mouseEvent?.shiftKey ||
-          mouseEvent?.button === 1;
+          mouseEvent?.button === 1
+        ) {
+          return;
+        }
 
         const url = e.data.url;
         if (url) {
           setTimeout(() => {
-            if (openInNewWindow) {
-              window.open(`#${url}`, "_blank");
-            } else {
-              navigate(url);
-            }
+            navigate(url);
           }, 10);
         }
       }
@@ -281,7 +282,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
       }
       const openInNewWindow = e.metaKey || e.ctrlKey || e.shiftKey;
       if (openInNewWindow) {
-        window.open(`#${rowNode.data.url}`, "_blank");
+        openInNewTab(rowNode.data.url);
       } else {
         navigate(rowNode.data.url);
       }
@@ -310,12 +311,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
   }, [handleKeyDown]);
 
   const handleCellMouseDown = useCallback(
-    (e: CellMouseDownEvent<LogListRow>) => {
-      const mouseEvent = e.event as MouseEvent | undefined;
-      if (mouseEvent?.button === 1 && e.data?.url) {
-        mouseEvent.preventDefault();
-        window.open(`#${e.data.url}`, "_blank");
-      }
+    (_e: CellMouseDownEvent<LogListRow>) => {
+      // Middle-click and modifier clicks are handled by the <a> overlay
+      // in the cell renderer for native background-tab behavior
     },
     []
   );

--- a/apps/inspect/src/app/log-list/grid/columns/columns.module.css
+++ b/apps/inspect/src/app/log-list/grid/columns/columns.module.css
@@ -1,3 +1,17 @@
+.rowLink {
+  color: inherit;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+}
+
+.rowLink:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
 .nameCell {
   display: flex;
   align-items: center;

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -183,6 +183,7 @@ export const useLogListColumns = (
         pinned: "left",
         cellRenderer: (params: ICellRendererParams<LogListRow>) => {
           const type = params.data?.type;
+          const url = params.data?.url;
           const icon =
             type === "file" || type === "pending-task"
               ? ApplicationIcons.inspectFile
@@ -218,9 +219,34 @@ export const useLogListColumns = (
           if (item.type === "file") {
             value = item.task || parseLogFileName(item.name).name;
           }
+          const href = item.url
+            ? `${window.location.pathname}#${item.url}`
+            : undefined;
           return (
             <div className={styles.nameCell}>
-              {item.type === "folder" && item.url ? (
+              {href ? (
+                <a
+                  href={href}
+                  className={styles.rowLink}
+                  onClick={(e) => {
+                    // Normal click: prevent <a> navigation, let AG Grid handle
+                    if (
+                      !e.metaKey &&
+                      !e.ctrlKey &&
+                      !e.shiftKey &&
+                      e.button === 0
+                    ) {
+                      e.preventDefault();
+                    }
+                  }}
+                >
+                  {item.type === "folder" ? (
+                    <span className={styles.folder}>{value}</span>
+                  ) : (
+                    <span className={styles.taskText}>{value}</span>
+                  )}
+                </a>
+              ) : item.type === "folder" ? (
                 <span className={styles.folder}>{value}</span>
               ) : (
                 <span className={styles.taskText}>{value}</span>

--- a/apps/inspect/src/app/routing/sampleNavigation.ts
+++ b/apps/inspect/src/app/routing/sampleNavigation.ts
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useFilteredSamples } from "../../state/hooks";
 import { useStore } from "../../state/store";
 import { directoryRelativeUrl } from "../../utils/uri";
+import { openInNewTab } from "../shared/openInNewTab";
 import { sampleIdsEqual } from "../shared/sample";
 
 import {
@@ -280,7 +281,7 @@ export const useSamplesGridNavigation = () => {
 
       if (openInNewWindow) {
         // Open in new window/tab
-        window.open(`#${url}`, "_blank");
+        openInNewTab(url);
       } else {
         navigate(url);
       }

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -38,6 +38,8 @@ import {
 import { useScrollDirection } from "@tsmono/react/hooks";
 import { isHostedEnvironment, isVscode } from "@tsmono/util";
 
+import { openInNewTab } from "../shared/openInNewTab";
+
 import { Events } from "../../@types/extraInspect";
 import { SampleSummary } from "../../client/api/types";
 import { ActivityBar } from "../../components/ActivityBar";
@@ -266,7 +268,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
         effectiveSelectedTab,
         prefix
       );
-      window.open(`#${printUrl}`, "_blank");
+      openInNewTab(printUrl);
     }
   }, [printLogPath, printSampleId, printEpoch, effectiveSelectedTab, prefix]);
 

--- a/apps/inspect/src/app/shared/openInNewTab.ts
+++ b/apps/inspect/src/app/shared/openInNewTab.ts
@@ -1,0 +1,15 @@
+/**
+ * Opens a hash-route URL in a new background tab.
+ * Blurs the new window and refocuses the current window
+ * so the new tab doesn't steal focus.
+ */
+export function openInNewTab(hashRoute: string): void {
+  const newWin = window.open(
+    `${window.location.pathname}#${hashRoute}`,
+    "_blank",
+  );
+  if (newWin) {
+    newWin.blur();
+  }
+  window.focus();
+}

--- a/apps/scout/src/router/url.ts
+++ b/apps/scout/src/router/url.ts
@@ -293,5 +293,12 @@ export const updateColumnsParam = (
  * Handles the hash router URL format.
  */
 export const openRouteInNewTab = (route: string): void => {
-  window.open(`#${route}`, "_blank");
+  const newWin = window.open(
+    `${window.location.pathname}#${route}`,
+    "_blank",
+  );
+  if (newWin) {
+    newWin.blur();
+  }
+  window.focus();
 };


### PR DESCRIPTION
## Summary

- Render the task column in the log list grid as a real `<a>` tag so cmd+click uses native browser background-tab behavior instead of `window.open()` (which always steals focus)
- Skip modifier-key clicks in `onRowClicked` handler to avoid double navigation
- Fix `window.open()` URLs to include `window.location.pathname` for correct hash routing when the viewer is embedded at a subpath (e.g. `/eval-set/xxx#/logs/`)
- Add `openInNewTab` helper for keyboard shortcuts and other non-mouse contexts

https://github.com/user-attachments/assets/117550f2-20b0-408b-a1eb-e196c3eb178d
