### PR TITLE
Fork navigator pills + path-based collection; StickyScroll render fix

### DIFF
--- a/packages/inspect-components/src/transcript/ForkNavigatorView.module.css
+++ b/packages/inspect-components/src/transcript/ForkNavigatorView.module.css
@@ -1,37 +1,43 @@
 .nav {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 8px;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 8px;
   margin: 4px 0;
   font-size: var(--inspect-font-size-smallest);
   color: var(--vscode-descriptionForeground, #717171);
-  border-left: 2px solid var(--bs-border-color);
-  background: var(--vscode-list-hoverBackground, rgba(0, 0, 0, 0.02));
 }
 
-.btn {
-  border: none;
+.icon {
+  font-size: 11px;
+  margin-right: 2px;
+  opacity: 0.7;
+}
+
+.pill {
+  border: 1px solid transparent;
   background: none;
-  padding: 2px 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: inherit;
+  color: var(--vscode-descriptionForeground, #717171);
   cursor: pointer;
-  color: inherit;
-  font-size: 10px;
-  border-radius: 3px;
 }
 
-.btn:hover {
-  background: var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.08));
+.pill:hover {
+  border-color: var(--bs-border-color);
   color: var(--vscode-foreground);
 }
 
-.count {
-  font-variant-numeric: tabular-nums;
-  min-width: 2.5em;
-  text-align: center;
-}
-
-.label {
+.selected {
+  border-color: var(--bs-border-color);
+  background: var(--vscode-list-hoverBackground, rgba(0, 0, 0, 0.04));
+  color: var(--vscode-foreground);
   font-weight: 500;
-  color: var(--vscode-foreground);
+  cursor: default;
+}
+
+.selected:hover {
+  border-color: var(--bs-border-color);
 }

--- a/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
+++ b/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 import type { SpanBeginEvent } from "@tsmono/inspect-common/types";
 
 import styles from "./ForkNavigatorView.module.css";
+import { TranscriptIcons } from "./icons";
 import type { ForkNavData } from "./timeline/timelineEventNodes";
 import { useTimelineRowSelect } from "./TimelineSelectContext";
 import { EventNode } from "./types";
@@ -23,37 +24,29 @@ export const ForkNavigatorView: FC<ForkNavigatorViewProps> = ({
   if (!data || data.options.length < 2) return null;
 
   const { options, selectedIndex } = data;
-  const n = options.length;
-  const go = (delta: number, el: HTMLElement) => {
-    const next = (selectedIndex + delta + n) % n;
-    selectRow?.(
-      options[next]!.rowKey,
-      el.closest<HTMLElement>("[data-index]") ?? el
-    );
-  };
 
   return (
     <div className={clsx(styles.nav, className)}>
-      <button
-        type="button"
-        className={styles.btn}
-        onClick={(e) => go(-1, e.currentTarget)}
-        aria-label="Previous continuation"
-      >
-        <i className="bi bi-chevron-left" />
-      </button>
-      <span className={styles.count}>
-        {selectedIndex + 1}/{n}
-      </span>
-      <button
-        type="button"
-        className={styles.btn}
-        onClick={(e) => go(1, e.currentTarget)}
-        aria-label="Next continuation"
-      >
-        <i className="bi bi-chevron-right" />
-      </button>
-      <span className={styles.label}>{options[selectedIndex]!.label}</span>
+      <i className={clsx(TranscriptIcons.fork, styles.icon)} />
+      {options.map((opt, i) => (
+        <button
+          key={opt.rowKey}
+          type="button"
+          className={clsx(styles.pill, i === selectedIndex && styles.selected)}
+          onClick={(e) =>
+            i === selectedIndex
+              ? undefined
+              : selectRow?.(
+                  opt.rowKey,
+                  e.currentTarget.closest<HTMLElement>("[data-index]") ??
+                    e.currentTarget
+                )
+          }
+          aria-current={i === selectedIndex ? "true" : undefined}
+        >
+          {opt.label}
+        </button>
+      ))}
     </div>
   );
 };

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
@@ -123,6 +123,9 @@ export const iconForNode = (node: EventNode): string | undefined => {
   if (node.sourceSpan?.spanType === "branch") {
     return TranscriptIcons.fork;
   }
+  if (node.event.event === "span_begin" && node.event.type === "fork_nav") {
+    return TranscriptIcons.fork;
+  }
 
   switch (node.event.event) {
     case "sample_limit":

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -388,10 +388,12 @@ function ancestorChain(
   return path;
 }
 
-function stripSuffix(e: Event, suffix: string, trajId: string): Event {
+export function stripSuffix(e: Event, suffix: string, trajId: string): Event {
   const update: Partial<Event> = {};
   if (e.span_id?.endsWith(suffix)) {
     update.span_id = e.span_id.slice(0, -suffix.length);
+  } else if (e.span_id === trajId) {
+    update.span_id = "";
   }
   if (e.event === "span_begin" || e.event === "span_end") {
     if (e.id.endsWith(suffix)) {

--- a/packages/inspect-components/src/transcript/timeline/index.ts
+++ b/packages/inspect-components/src/transcript/timeline/index.ts
@@ -81,7 +81,6 @@ export {
   attachSourceSpans,
   buildSelectionKey,
   buildSpanSelectKeys,
-  collectBranchWithContext,
   collectRawEvents,
   computeCompactionRegions,
   computeMinimapSelection,

--- a/packages/inspect-components/src/transcript/timeline/timeMapping.ts
+++ b/packages/inspect-components/src/transcript/timeline/timeMapping.ts
@@ -298,45 +298,6 @@ export function computeTimeMapping(node: TimelineSpan): TimeMapping {
 }
 
 /**
- * Creates a shifted time mapping for a branch row in fork-relative mode.
- *
- * The branch's wall-clock range [branchStart, branchEnd] is linearly remapped
- * so that it starts at `forkPercent` in the timeline's percentage space and
- * uses the trunk mapping's time scale for its width. This makes branch bars
- * proportional to their actual duration rather than stretching to 100%.
- *
- * @param branchStart   Branch content start time
- * @param branchEnd     Branch content end time
- * @param forkPercent   The fork marker's percentage position on the parent row (0-100)
- * @param trunkMapping  The parent/trunk time mapping, used to derive the time scale
- */
-export function createShiftedMapping(
-  branchStart: Date,
-  branchEnd: Date,
-  forkPercent: number,
-  trunkMapping: TimeMapping
-): TimeMapping {
-  const startMs = branchStart.getTime();
-  const endMs = branchEnd.getTime();
-  const branchDurationMs = endMs - startMs;
-
-  // Use the trunk mapping's scale: the branch's width in percent should match
-  // the proportion of time it would occupy on the trunk timeline.
-  const branchWidthPercent =
-    trunkMapping.toPercent(branchEnd) - trunkMapping.toPercent(branchStart);
-
-  return {
-    toPercent(timestamp: Date): number {
-      if (branchDurationMs <= 0) return forkPercent;
-      const t = (timestamp.getTime() - startMs) / branchDurationMs;
-      return Math.max(0, Math.min(100, forkPercent + t * branchWidthPercent));
-    },
-    hasCompression: false,
-    gaps: [],
-  };
-}
-
-/**
  * Compute active time (seconds) within [startMs, endMs] by subtracting
  * overlapping gap durations from the mapping.
  */

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -1,17 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type {
-  CompactionEvent,
-  Event,
-  InfoEvent,
-} from "@tsmono/inspect-common/types";
+import type { CompactionEvent, InfoEvent } from "@tsmono/inspect-common/types";
 
 import { TimelineEvent } from "./core";
-import { computeFlatSwimlaneRows } from "./swimlaneRows";
-import { getScenarioRoot, S11A_BRANCHES, ts } from "./testHelpers";
+import { ts } from "./testHelpers";
 import {
   buildSelectionKey,
-  collectBranchWithContext,
   computeCompactionRegions,
   getParentKeyFromBranch,
   parseSelection,
@@ -302,136 +296,5 @@ describe("getParentKeyFromBranch", () => {
         "solvers/agent/branch-550e8400-e29b-41d4-a716-446655440000-1"
       )
     ).toBe("solvers/agent");
-  });
-});
-
-// =============================================================================
-// collectBranchWithContext
-// =============================================================================
-
-describe("collectBranchWithContext", () => {
-  // Build rows from S11A scenario once — shared across tests.
-  const root = getScenarioRoot(S11A_BRANCHES);
-  const rows = computeFlatSwimlaneRows(root, { showBranches: true });
-
-  // The build row is the parent, branches are its children.
-  // Branch key pattern: "parentKey/branch-{branchedFrom}-{index}"
-  // In S11A, build is at "transcript/build" and branches fork at "model-call-5".
-  const buildRow = rows.find((r) => r.key === "transcript/build");
-  const branch1Key = "transcript/build/branch-model-call-5-1";
-  const branch1Row = rows.find((r) => r.key === branch1Key);
-
-  it("finds the expected build and branch rows", () => {
-    expect(buildRow).toBeDefined();
-    expect(branch1Row).toBeDefined();
-    expect(branch1Row!.branch).toBe(true);
-  });
-
-  it("includes parent events before the branch separator", () => {
-    const branch1Span = branch1Row!.spans[0]!;
-    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
-    expect(span).toBeDefined();
-
-    const result = collectBranchWithContext(rows, branch1Key, span!, {
-      includeUtility: false,
-      showBranches: false,
-      branchPrefix: "",
-    });
-
-    // The parent (build) has a model event with uuid "model-call-5" as first content.
-    // collectContentUpToFork should emit it, then stop.
-    // The first event in the stream should be from the build span's content.
-    const eventTypes = result.events.map((e: Event) => e.event);
-
-    // Should start with parent model event (the fork point)
-    expect(eventTypes[0]).toBe("model");
-    expect((result.events[0] as { uuid: string | null }).uuid).toBe(
-      "model-call-5"
-    );
-  });
-
-  it("includes a branch separator with spanType 'branch'", () => {
-    const branch1Span = branch1Row!.spans[0]!;
-    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
-
-    const result = collectBranchWithContext(rows, branch1Key, span!, {
-      includeUtility: false,
-      showBranches: false,
-      branchPrefix: "",
-    });
-
-    // Find the branch separator — a span_begin with type "branch"
-    const separatorIndex = result.events.findIndex(
-      (e: Event) => e.event === "span_begin" && e.type === "branch"
-    );
-    expect(separatorIndex).toBeGreaterThan(0);
-
-    // The separator should come after parent events and before branch content
-    const separator = result.events[separatorIndex]!;
-    expect(separator.event).toBe("span_begin");
-    if (separator.event === "span_begin") {
-      expect(separator.span_id).toBe(span!.id);
-    }
-  });
-
-  it("includes branch content after the separator", () => {
-    const branch1Span = branch1Row!.spans[0]!;
-    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
-
-    const result = collectBranchWithContext(rows, branch1Key, span!, {
-      includeUtility: false,
-      showBranches: false,
-      branchPrefix: "",
-    });
-
-    // Find the branch separator
-    const separatorIndex = result.events.findIndex(
-      (e: Event) => e.event === "span_begin" && e.type === "branch"
-    );
-
-    // After the separator + its end, we should have branch content.
-    // Branch 1 content includes agent spans (branch1-refactor, branch1-validate).
-    // These are agent spans so they emit as collapsed begin/end pairs.
-    const afterSeparator = result.events.slice(separatorIndex + 1);
-    const spanBegins = afterSeparator.filter(
-      (e: Event) => e.event === "span_begin"
-    );
-    // Should have at least the two agent spans from branch 1
-    expect(spanBegins.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("records source spans for the branch separator", () => {
-    const branch1Span = branch1Row!.spans[0]!;
-    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
-
-    const result = collectBranchWithContext(rows, branch1Key, span!, {
-      includeUtility: false,
-      showBranches: false,
-      branchPrefix: "",
-    });
-
-    // The branch span should be in sourceSpans for rendering as AgentCardView
-    expect(result.sourceSpans.has(span!.id)).toBe(true);
-  });
-
-  it("fork event is the last parent event before separator", () => {
-    const branch1Span = branch1Row!.spans[0]!;
-    const span = "agent" in branch1Span ? branch1Span.agent : undefined;
-
-    const result = collectBranchWithContext(rows, branch1Key, span!, {
-      includeUtility: false,
-      showBranches: false,
-      branchPrefix: "",
-    });
-
-    // Find the branch separator index
-    const separatorIndex = result.events.findIndex(
-      (e: Event) => e.event === "span_begin" && e.type === "branch"
-    );
-
-    // The event just before the separator should be the fork anchor
-    const forkEvent = result.events[separatorIndex - 1];
-    expect(forkEvent?.event).toBe("anchor");
-    expect((forkEvent as { anchor_id: string }).anchor_id).toBe("model-call-5");
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -17,6 +17,7 @@ import { EventNode } from "../types";
 
 import {
   createBranchSpan,
+  stripSuffix,
   type TimelineEvent,
   type TimelineSpan,
 } from "./core";
@@ -622,12 +623,6 @@ export function getParentKeyFromBranch(branchKey: string): string | null {
   return match ? match[1]! : null;
 }
 
-/** A link in the ancestor chain: a span and the fork message ID where the next level branches. */
-interface AncestorLink {
-  span: TimelineSpan;
-  forkMessageId: string;
-}
-
 // =============================================================================
 // Fork-navigator path collection
 // =============================================================================
@@ -701,35 +696,47 @@ function branchesByAnchor(
   return map;
 }
 
-function emitForkNav(
-  events: Event[],
-  anchorId: string,
-  timestamp: string,
-  data: ForkNavData
-): void {
+interface SyntheticSpanOpts {
+  id: string;
+  name: string;
+  type: string | null;
+  parentId: string | null;
+  start: string;
+  end?: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+/** Push a synthetic span_begin/span_end pair onto `events`. */
+function emitSyntheticSpan(events: Event[], opts: SyntheticSpanOpts): void {
   events.push({
     event: "span_begin",
-    name: data.options[data.selectedIndex]?.label ?? "fork",
-    id: `forknav-${anchorId}`,
-    span_id: `forknav-${anchorId}`,
-    type: "fork_nav",
-    timestamp,
-    parent_id: null,
+    name: opts.name,
+    id: opts.id,
+    span_id: opts.id,
+    type: opts.type,
+    timestamp: opts.start,
+    parent_id: opts.parentId,
     pending: false,
     working_start: 0,
-    uuid: `forknav-${anchorId}`,
-    metadata: { fork_nav: data } as Record<string, unknown>,
+    uuid: opts.id,
+    metadata: opts.metadata ?? null,
   } satisfies SpanBeginEvent);
   events.push({
     event: "span_end",
-    id: `forknav-${anchorId}`,
-    span_id: `forknav-${anchorId}`,
-    timestamp,
+    id: opts.id,
+    span_id: opts.id,
+    timestamp: opts.end ?? opts.start,
     pending: false,
     working_start: 0,
     uuid: null,
     metadata: null,
   } satisfies SpanEndEvent);
+}
+
+/** Outline label for a fork navigator: list children, capped to keep it short. */
+function forkNavLabel(children: ForkNavOption[]): string {
+  if (children.length <= 2) return children.map((c) => c.label).join(", ");
+  return `${children[0]!.label} +${children.length - 1}`;
 }
 
 /**
@@ -748,330 +755,76 @@ export function collectPathWithNavigators(
   const sourceSpans = new Map<string, TimelineSpan>();
   const path = buildPath(rows, selectedRowKey);
 
-  for (const seg of path) {
+  for (let segIdx = 0; segIdx < path.length; segIdx++) {
+    const seg = path[segIdx]!;
+    const nextRowKey = path[segIdx + 1]?.rowKey;
     const forks = branchesByAnchor(seg.span, seg.rowKey);
+    const suffix = `:${seg.span.id}`;
     sourceSpans.set(seg.span.id, seg.span);
+
+    /** Emit a navigator for `children` at `anchorId`; returns true if the path cuts here. */
+    const navAt = (
+      anchorId: string,
+      children: ForkNavOption[],
+      ts: string,
+      parentId: string | null
+    ): boolean => {
+      const options = [
+        { label: seg.span.name, rowKey: seg.rowKey },
+        ...children,
+      ];
+      const isCut = anchorId === seg.cutAnchor;
+      const sel = isCut ? options.findIndex((o) => o.rowKey === nextRowKey) : 0;
+      emitSyntheticSpan(events, {
+        id: `forknav-${seg.span.id}-${anchorId || "restart"}`,
+        name: forkNavLabel(children),
+        type: "fork_nav",
+        parentId,
+        start: ts,
+        metadata: {
+          fork_nav: {
+            anchorId,
+            options,
+            selectedIndex: Math.max(0, sel),
+          } satisfies ForkNavData,
+        },
+      });
+      return isCut;
+    };
+
     // Restart-style branches (branchedFrom === "") fork before any anchor.
     const restartForks = forks.get("");
     if (restartForks) {
-      const options: ForkNavOption[] = [
-        { label: seg.span.name, rowKey: seg.rowKey },
-        ...restartForks,
-      ];
-      const isCut = seg.cutAnchor === "";
-      const selectedIndex = isCut
-        ? options.findIndex(
-            (o) => o.rowKey === path[path.indexOf(seg) + 1]?.rowKey
-          )
-        : 0;
-      emitForkNav(
-        events,
-        `restart-${seg.span.id}`,
-        seg.span.startTime().toISOString(),
-        {
-          anchorId: "",
-          options,
-          selectedIndex: Math.max(0, selectedIndex),
-        }
-      );
-      if (isCut) continue;
+      const ts = seg.span.startTime().toISOString();
+      if (navAt("", restartForks, ts, null)) continue;
     }
     for (const item of seg.span.content) {
       if (item.type === "span") {
         sourceSpans.set(item.id, item);
-        emitSpanEnvelope(item, events);
+        emitSyntheticSpan(events, {
+          id: item.id,
+          name: item.name,
+          type: item.spanType,
+          parentId: null,
+          start: item.startTime().toISOString(),
+          end: item.endTime().toISOString(),
+        });
         continue;
       }
-      events.push(item.event);
+      const stripped = stripSuffix(item.event, suffix, seg.span.id);
+      events.push(stripped);
       if (item.event.event !== "anchor") continue;
       const anchorId = item.event.anchor_id;
       const children = forks.get(anchorId);
-      if (children && children.length > 0) {
-        const options: ForkNavOption[] = [
-          { label: seg.span.name, rowKey: seg.rowKey },
-          ...children,
-        ];
-        const isCut = anchorId === seg.cutAnchor;
-        const selectedIndex = isCut
-          ? options.findIndex(
-              (o) => o.rowKey === path[path.indexOf(seg) + 1]?.rowKey
-            )
-          : 0;
-        emitForkNav(events, anchorId, item.event.timestamp, {
-          anchorId,
-          options,
-          selectedIndex: Math.max(0, selectedIndex),
-        });
-        if (isCut) break;
+      if (children?.length) {
+        const ts = item.event.timestamp;
+        if (navAt(anchorId, children, ts, stripped.span_id ?? null)) break;
       } else if (anchorId === seg.cutAnchor) {
         break;
       }
     }
   }
   return { events, sourceSpans };
-}
-
-/** Emit a span_begin/span_end pair so nested agent spans render as collapsed cards. */
-function emitSpanEnvelope(span: TimelineSpan, events: Event[]): void {
-  events.push({
-    event: "span_begin",
-    name: span.name,
-    id: span.id,
-    span_id: span.id,
-    type: span.spanType,
-    timestamp: span.startTime().toISOString(),
-    parent_id: null,
-    pending: false,
-    working_start: 0,
-    uuid: span.id,
-    metadata: null,
-  } satisfies SpanBeginEvent);
-  events.push({
-    event: "span_end",
-    id: span.id,
-    span_id: span.id,
-    timestamp: span.endTime().toISOString(),
-    pending: false,
-    working_start: 0,
-    uuid: null,
-    metadata: null,
-  } satisfies SpanEndEvent);
-}
-
-/**
- * Builds the ancestor chain from a branch row up to the outermost non-branch row.
- *
- * Returns links ordered outermost ancestor → innermost parent, each paired
- * with the fork UUID where the next level (or the target branch) branches off.
- */
-function buildAncestorChain(
-  rows: SwimlaneRow[],
-  branchRowKey: string
-): AncestorLink[] {
-  const chain: AncestorLink[] = [];
-  let currentKey = branchRowKey;
-
-  while (true) {
-    const parentKey = getParentKeyFromBranch(currentKey);
-    if (!parentKey) break;
-
-    const parentRow = rows.find((r) => r.key === parentKey);
-    if (!parentRow || parentRow.spans.length === 0) break;
-
-    // Get the parent's TimelineSpan
-    const firstSpan = parentRow.spans[0]!;
-    const parentSpan = isSingleSpan(firstSpan)
-      ? firstSpan.agent
-      : getAgents(firstSpan)[0];
-    if (!parentSpan) break;
-
-    // Get the child branch's branchedFrom identifier
-    const childRow = rows.find((r) => r.key === currentKey);
-    if (!childRow || childRow.spans.length === 0) break;
-    const childFirstSpan = childRow.spans[0]!;
-    const childSpan = isSingleSpan(childFirstSpan)
-      ? childFirstSpan.agent
-      : getAgents(childFirstSpan)[0];
-    if (childSpan?.branchedFrom == null) break;
-
-    chain.unshift({ span: parentSpan, forkMessageId: childSpan.branchedFrom });
-
-    currentKey = parentKey;
-    // Keep walking if the parent is also a branch
-    if (!parentRow.branch) break;
-  }
-
-  return chain;
-}
-
-/**
- * Collects events from a span's content, stopping after the event whose
- * message ID matches `forkMessageId` (inclusive — the fork event is the
- * last parent event before the branch point).
- *
- * Returns true if the fork event was found, false otherwise.
- */
-function collectContentUpToFork(
-  content: ReadonlyArray<TimelineEvent | TimelineSpan>,
-  forkMessageId: string,
-  out: Event[],
-  sourceSpans: Map<string, TimelineSpan>,
-  includeUtility: boolean
-): boolean {
-  for (const item of content) {
-    if (item.type === "event") {
-      // Empty fork id (restart) ⇒ stop before the first anchor: only the
-      // pre-anchor preamble (e.g. seed-instructions info) is emitted.
-      if (forkMessageId === "" && item.event.event === "anchor") {
-        return true;
-      }
-      out.push(item.event);
-      if (item.matchesForkPoint(forkMessageId)) {
-        return true;
-      }
-    } else if (!includeUtility && item.utility) {
-      continue;
-    } else if (item.spanType === "agent") {
-      // Agent spans: emit collapsed begin/end pair
-      const beginEvent: SpanBeginEvent = {
-        event: "span_begin",
-        name: item.name,
-        id: item.id,
-        span_id: item.id,
-        type: item.spanType,
-        timestamp: item.startTime().toISOString(),
-        parent_id: null,
-        pending: false,
-        working_start: 0,
-        uuid: item.id,
-        metadata: null,
-      };
-      out.push(beginEvent);
-      sourceSpans.set(item.id, item);
-      const endEvent: SpanEndEvent = {
-        event: "span_end",
-        id: `${item.id}-end`,
-        span_id: item.id,
-        timestamp: item.endTime().toISOString(),
-        pending: false,
-        working_start: 0,
-        uuid: null,
-        metadata: null,
-      };
-      out.push(endEvent);
-    } else {
-      // Non-agent span: recurse into content, checking for fork
-      const beginEvent: SpanBeginEvent = {
-        event: "span_begin",
-        name: item.name,
-        id: item.id,
-        span_id: item.id,
-        type: item.spanType,
-        timestamp: item.startTime().toISOString(),
-        parent_id: null,
-        pending: false,
-        working_start: 0,
-        uuid: item.id,
-        metadata: null,
-      };
-      out.push(beginEvent);
-
-      const found = collectContentUpToFork(
-        item.content,
-        forkMessageId,
-        out,
-        sourceSpans,
-        includeUtility
-      );
-
-      const endEvent: SpanEndEvent = {
-        event: "span_end",
-        id: `${item.id}-end`,
-        span_id: item.id,
-        timestamp: item.endTime().toISOString(),
-        pending: false,
-        working_start: 0,
-        uuid: null,
-        metadata: null,
-      };
-      out.push(endEvent);
-
-      if (found) return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Collects events for a branch with full ancestor context.
- *
- * The resulting event stream contains:
- * 1. Ancestor events from the root down to each fork point
- * 2. A branch separator (AgentCardView) at each fork
- * 3. The branch's own events
- *
- * For nested branches (Branch 1.1), the full chain is included:
- * root events → fork → Branch 1 events → fork → Branch 1.1 events.
- */
-export function collectBranchWithContext(
-  rows: SwimlaneRow[],
-  branchRowKey: string,
-  branchSpan: TimelineSpan,
-  options: {
-    includeUtility: boolean;
-    showBranches: boolean;
-    branchPrefix: string;
-  }
-): CollectedEvents {
-  const events: Event[] = [];
-  const sourceSpans = new Map<string, TimelineSpan>();
-
-  const ancestorChain = buildAncestorChain(rows, branchRowKey);
-
-  // Emit each ancestor's prefix, with a branch separator before every
-  // non-root segment so the chain reads:
-  //   root … BRANCH 2 … b2 … BRANCH 3 … b3 … BRANCH leaf … leaf
-  for (let i = 0; i < ancestorChain.length; i++) {
-    const ancestor = ancestorChain[i]!;
-    if (i > 0) {
-      emitBranchSeparator(ancestor.span, events, sourceSpans);
-    }
-    collectContentUpToFork(
-      ancestor.span.content,
-      ancestor.forkMessageId,
-      events,
-      sourceSpans,
-      options.includeUtility
-    );
-  }
-
-  emitBranchSeparator(branchSpan, events, sourceSpans);
-
-  // Emit the branch's own content
-  collectFromContent(
-    branchSpan.content,
-    events,
-    sourceSpans,
-    undefined,
-    options.includeUtility,
-    options.showBranches,
-    branchSpan.branches.length > 0 ? branchSpan.branches : undefined,
-    options.branchPrefix
-  );
-
-  return { events, sourceSpans };
-}
-
-/** Emit a synthetic span_begin/span_end pair that renders as a branch separator card. */
-function emitBranchSeparator(
-  span: TimelineSpan,
-  events: Event[],
-  sourceSpans: Map<string, TimelineSpan>
-): void {
-  sourceSpans.set(span.id, span);
-  events.push({
-    event: "span_begin",
-    name: span.name,
-    id: span.id,
-    span_id: span.id,
-    type: "branch",
-    timestamp: span.startTime().toISOString(),
-    parent_id: null,
-    pending: false,
-    working_start: 0,
-    uuid: span.id,
-    metadata: null,
-  } satisfies SpanBeginEvent);
-  events.push({
-    event: "span_end",
-    id: `${span.id}-end`,
-    span_id: span.id,
-    timestamp: span.endTime().toISOString(),
-    pending: false,
-    working_start: 0,
-    uuid: null,
-    metadata: null,
-  } satisfies SpanEndEvent);
 }
 
 // =============================================================================

--- a/packages/react/src/components/StickyScroll.tsx
+++ b/packages/react/src/components/StickyScroll.tsx
@@ -54,6 +54,11 @@ export const StickyScroll = forwardRef<HTMLDivElement, StickyScrollProps>(
       [forwardedRef]
     );
     const [isSticky, setIsSticky] = useState(false);
+    // Mirror of `isSticky` for synchronous reads inside scroll/resize handlers
+    // (avoids stale closures and lets `checkSticky` bail out without a
+    // functional updater — side effects in updaters run during render and
+    // trigger cross-component setState warnings).
+    const isStickyRef = useRef(false);
     // Height captured just before entering sticky mode, used with preserveHeight
     // to keep the content area from collapsing when the sticky content shrinks.
     const [preStickHeight, setPreStickHeight] = useState(0);
@@ -79,17 +84,16 @@ export const StickyScroll = forwardRef<HTMLDivElement, StickyScrollProps>(
         // The element is sticky when it's at (or within 1px of) its sticky offset
         const nowSticky = contentTop <= containerTop + offsetTop + 1;
 
-        setIsSticky((prev) => {
-          if (prev === nowSticky) return prev;
+        if (isStickyRef.current === nowSticky) return;
+        isStickyRef.current = nowSticky;
 
-          // Capture height before entering sticky mode
-          if (nowSticky && preserveHeight && content) {
-            setPreStickHeight(content.getBoundingClientRect().height);
-          }
+        // Capture height before entering sticky mode
+        if (nowSticky && preserveHeight) {
+          setPreStickHeight(content.getBoundingClientRect().height);
+        }
 
-          onStickyChangeRef.current?.(nowSticky);
-          return nowSticky;
-        });
+        setIsSticky(nowSticky);
+        onStickyChangeRef.current?.(nowSticky);
       };
 
       // Check immediately in case we're already scrolled past the threshold
@@ -105,10 +109,6 @@ export const StickyScroll = forwardRef<HTMLDivElement, StickyScrollProps>(
     // resizes (e.g. the user collapsing the swimlane) update the preserved
     // height instead of leaving a whitespace gap.
     const childMeasureRef = useRef<HTMLDivElement>(null);
-    const isStickyRef = useRef(isSticky);
-    useEffect(() => {
-      isStickyRef.current = isSticky;
-    }, [isSticky]);
 
     useEffect(() => {
       if (!preserveHeight) return;


### PR DESCRIPTION
## Summary

Follow-up to #174. Replaces the `‹ n/N ›` fork navigator with an explicit pill selector and reworks how branch-path events are collected so navigators nest correctly inside custom-target sub-spans. Also fixes a pre-existing setState-in-render warning in `StickyScroll`.

### Fork navigator (`packages/inspect-components`)
- **`ForkNavigatorView`**: render one clickable pill per option (`[branch 1] [branch 2] …`) instead of prev/next arrows; clicking a non-current pill calls `selectRow(rowKey, anchorEl)` so the transcript can preserve scroll position.
- **`collectPathWithNavigators`**: builds the root→selected `PathSegment[]`, walks each segment's content, and at every anchor with children emits a synthetic `span_begin(type="fork_nav")`. The nav's `parent_id` is the anchor's stripped `span_id`, so when targets open sub-spans (e.g. petri-dish's `inner_agent`/per-turn spans) the navigator nests at the right depth in both the outline and event list. Restart-style branches (`branchedFrom===""`) get a navigator before any content.
- **`stripSuffix`** now also normalises `span_id === trajId → ""` so span begin/end pairs match across segment boundaries in `treeifyWithSpans`.
- **`forkNavLabel`** caps the outline label at two children (`"a, b"` or `"a +N"`) so wide fan-outs don't blow out the sidebar width.
- **`OutlineRow`**: fork icon + child labels for `fork_nav` spans.
- **Dead code removed** (~400 lines): `collectBranchWithContext`, `buildAncestorChain`, `emitBranchSeparator`, `AncestorLink`, `createShiftedMapping` — all superseded by the path-based collector.

### StickyScroll (`packages/react`)
- `onStickyChange` and `setPreStickHeight` were called inside the `setIsSticky((prev) ⇒ …)` updater. When React defers the updater (StickyScroll already has pending lanes from its ResizeObserver), the callback fires during render and updates `TranscriptLayout` state → `Cannot update a component while rendering a different component`. Now compares against `isStickyRef` synchronously in the scroll handler and calls everything in event-handler context. Also consolidates the duplicate lagging `isStickyRef` + sync effect.

## Test plan
- [x] `pnpm --filter @tsmono/inspect-components --filter @tsmono/react lint` / `test` — 336 tests pass
- [x] `tsc --noEmit` both packages
- [x] Live viewer sweep across 13 petri lineage fixtures (linear, single/double/nested rollback, two-siblings, restart, increasing-fork-points, custom-subspan/-nested-agent/-combined, target-tool-calls, ten-branches-mixed): swimlanes, outline, event list, pill↔row navigation, depth-3 chains, punch-down — all correct
- [x] Verified StickyScroll consumers (`useStickySwimLaneHeight`, `SampleDisplay`) unaffected; no `onStickyChange` caller depends on call phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)