### PR TITLE
fix model retry event ordering

### DIFF
--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -19,6 +19,7 @@ import {
 import { usePrismHighlight, useProperty } from "@tsmono/react/hooks";
 import { formatTime } from "@tsmono/util";
 
+import { attemptDurationSec } from "./event/attemptDuration";
 import { EventPanel } from "./event/EventPanel";
 import { EventSection } from "./event/EventSection";
 import { EventTimingPanel } from "./event/EventTimingPanel";
@@ -265,18 +266,8 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
 };
 
 function formatFailureTime(event: ModelEvent): string {
-  const explicit = event.output?.time ?? event.working_time;
-  if (typeof explicit === "number" && !Number.isNaN(explicit)) {
-    return ` · ${formatTime(explicit)}`;
-  }
-  if (event.timestamp && event.completed) {
-    const start = new Date(event.timestamp).getTime();
-    const end = new Date(event.completed).getTime();
-    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
-      return ` · ${formatTime((end - start) / 1000)}`;
-    }
-  }
-  return "";
+  const sec = attemptDurationSec(event);
+  return sec != null ? ` · ${formatTime(sec)}` : "";
 }
 
 interface APIViewProps {

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -16,14 +16,17 @@ import {
   MarkdownDiv,
   PulsingDots,
 } from "@tsmono/react/components";
-import { usePrismHighlight } from "@tsmono/react/hooks";
+import { usePrismHighlight, useProperty } from "@tsmono/react/hooks";
+import { formatTime } from "@tsmono/util";
 
 import { EventPanel } from "./event/EventPanel";
 import { EventSection } from "./event/EventSection";
 import { EventTimingPanel } from "./event/EventTimingPanel";
+import { RetryChip } from "./event/RetryChip";
 import { formatTiming, formatTitle } from "./event/utils";
 import { TranscriptIcons } from "./icons";
 import styles from "./ModelEventView.module.css";
+import { retryAttemptKey } from "./timeline/retryGrouping";
 import { EventNode, EventNodeContext, EventPanelCallbacks } from "./types";
 
 interface ModelEventViewProps {
@@ -41,13 +44,28 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   context,
   eventCallbacks,
 }) => {
-  const event = eventNode.event;
-  const totalUsage = event.output.usage?.total_tokens;
-  const callTime = event.output.time;
+  const successEvent = eventNode.event;
+  const attempts = context?.retryAttempts?.get(retryAttemptKey(successEvent));
+  const successKey = retryAttemptKey(successEvent);
+
+  const [selectedAttemptKey, setSelectedAttemptKey] = useProperty<string>(
+    eventNode.id,
+    "selectedAttempt",
+    { defaultValue: successKey }
+  );
+
+  const selectedEvent =
+    attempts?.find((a) => retryAttemptKey(a) === selectedAttemptKey) ??
+    successEvent;
+  const event = selectedEvent;
+  const isFailed = !!event.error;
+
+  const totalUsage = event.output?.usage?.total_tokens;
+  const callTime = event.output?.time;
 
   // Note: despite the type system saying otherwise, this has appeared empirically
   // to sometimes be undefined
-  const outputMessages = event.output.choices?.map((choice) => {
+  const outputMessages = event.output?.choices?.map((choice) => {
     return choice.message;
   });
 
@@ -118,15 +136,28 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     ? `Model Call (${event.role}): ${event.model}`
     : `Model Call: ${event.model}`;
 
+  const titleString = isFailed
+    ? `${panelTitle} · FAILED${formatFailureTime(event)}`
+    : formatTitle(panelTitle, totalUsage, callTime);
+
   const turnLabel = context?.turnInfo
     ? `turn ${context.turnInfo.turnNumber}/${context.turnInfo.totalTurns}`
     : undefined;
+
+  const retryChip = attempts ? (
+    <RetryChip
+      attempts={attempts}
+      selectedKey={selectedAttemptKey}
+      onSelect={setSelectedAttemptKey}
+      keyOf={retryAttemptKey}
+    />
+  ) : undefined;
 
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       className={className}
-      title={formatTitle(panelTitle, totalUsage, callTime)}
+      title={titleString}
       subTitle={
         event.timestamp
           ? formatTiming(event.timestamp, event.working_start)
@@ -134,6 +165,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       }
       icon={TranscriptIcons.model}
       turnLabel={turnLabel}
+      headerExtra={retryChip}
       eventCallbacks={eventCallbacks}
       collapsibleContent
     >
@@ -231,6 +263,21 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     </EventPanel>
   );
 };
+
+function formatFailureTime(event: ModelEvent): string {
+  const explicit = event.output?.time ?? event.working_time;
+  if (typeof explicit === "number" && !Number.isNaN(explicit)) {
+    return ` · ${formatTime(explicit)}`;
+  }
+  if (event.timestamp && event.completed) {
+    const start = new Date(event.timestamp).getTime();
+    const end = new Date(event.completed).getTime();
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+      return ` · ${formatTime((end - start) / 1000)}`;
+    }
+  }
+  return "";
+}
 
 interface APIViewProps {
   call: ModelCall;

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -330,10 +330,15 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
         : rawEventsForNodes,
     [rawEventsForNodes, hiddenEventTypes]
   );
-  const { eventNodes, defaultCollapsedIds } = useEventNodes(
+  const { eventNodes, defaultCollapsedIds, retryAttempts } = useEventNodes(
     eventsForNodes,
     running,
     showSwimlanes ? sourceSpans : undefined
+  );
+
+  const mergedEventNodeContext = useMemo<Partial<EventNodeContext>>(
+    () => ({ ...eventNodeContext, retryAttempts }),
+    [eventNodeContext, retryAttempts]
   );
 
   // ---------------------------------------------------------------------------
@@ -971,7 +976,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                 collapsedTranscript={collapseState?.transcript}
                 collapsedOutline={collapseState?.outline}
                 onCollapseTranscript={onCollapseTranscript}
-                eventNodeContext={eventNodeContext}
+                eventNodeContext={mergedEventNodeContext}
               />
             ) : emptyText !== null ? (
               <NoContentsPanel text={emptyText} />

--- a/packages/inspect-components/src/transcript/event/EventPanel.module.css
+++ b/packages/inspect-components/src/transcript/event/EventPanel.module.css
@@ -20,6 +20,19 @@
   justify-self: end;
 }
 
+.title {
+  min-width: 0;
+  line-height: 1.6;
+}
+
+.titleExtra {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: 0.5em;
+}
+
+
 .navs {
   justify-self: end;
   display: flex;
@@ -55,10 +68,12 @@
 
 .copyLink {
   font-size: 1.2em;
-  height: 1em;
   opacity: 0;
   padding-left: 0.2em;
-  padding-right: 2em;
+  padding-right: 0;
+  vertical-align: middle;
+  line-height: 1;
+  margin-left: 0.25em;
 }
 
 .hover .copyLink {

--- a/packages/inspect-components/src/transcript/event/EventPanel.module.css
+++ b/packages/inspect-components/src/transcript/event/EventPanel.module.css
@@ -32,7 +32,6 @@
   margin-left: 0.5em;
 }
 
-
 .navs {
   justify-self: end;
   display: flex;

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -184,11 +184,13 @@ export const EventPanel: FC<EventPanelProps> = ({
             </span>
           ) : null}
           {url ? (
-            <CopyButton
-              value={url}
-              icon={kLinkIcon}
-              className={clsx(styles.copyLink)}
-            />
+            <span onClick={(e) => e.stopPropagation()}>
+              <CopyButton
+                value={url}
+                icon={kLinkIcon}
+                className={clsx(styles.copyLink)}
+              />
+            </span>
           ) : null}
         </div>
         <div onClick={toggleCollapse}></div>

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -171,7 +171,11 @@ export const EventPanel: FC<EventPanelProps> = ({
           ""
         )}
         <div
-          className={clsx("text-style-secondary", "text-style-label", styles.title)}
+          className={clsx(
+            "text-style-secondary",
+            "text-style-label",
+            styles.title
+          )}
           onClick={toggleCollapse}
         >
           <span>{title}</span>

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -40,6 +40,8 @@ interface EventPanelProps {
   depth?: number;
   /** Turn label displayed in the header (e.g. "turn 1/3"). */
   turnLabel?: string;
+  /** Inline content rendered between the title and the trailing nav/turn label (e.g. retry chip on retried model events). */
+  headerExtra?: ReactNode;
   /** Collapse state and deep-link callbacks from the app store. */
   eventCallbacks?: EventPanelCallbacks;
 }
@@ -65,6 +67,7 @@ export const EventPanel: FC<EventPanelProps> = ({
   muted,
   depth,
   turnLabel,
+  headerExtra,
   eventCallbacks,
 }) => {
   const { onCollapse, getCollapsed, getEventUrl, linkingEnabled } =
@@ -120,15 +123,11 @@ export const EventPanel: FC<EventPanelProps> = ({
     gridColumns.push("max-content");
   }
 
-  // title
-  gridColumns.push("minmax(0, max-content)");
-  // id
-  if (url) {
-    gridColumns.push("minmax(0, max-content)");
-  }
-  gridColumns.push("auto");
-  gridColumns.push("minmax(0, max-content)");
-  gridColumns.push("minmax(0, max-content)");
+  // title (now also carries copy-link + headerExtra so they wrap with the title)
+  gridColumns.push("minmax(0px, auto)");
+  gridColumns.push("minmax(0px, 1fr)");
+  gridColumns.push("minmax(0px, max-content)");
+  gridColumns.push("minmax(0px, max-content)");
 
   const toggleCollapse = useCallback(() => {
     setCollapsed(!collapsed);
@@ -172,20 +171,26 @@ export const EventPanel: FC<EventPanelProps> = ({
           ""
         )}
         <div
-          className={clsx("text-style-secondary", "text-style-label")}
+          className={clsx("text-style-secondary", "text-style-label", styles.title)}
           onClick={toggleCollapse}
         >
-          {title}
+          <span>{title}</span>
+          {headerExtra ? (
+            <span
+              className={styles.titleExtra}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {headerExtra}
+            </span>
+          ) : null}
+          {url ? (
+            <CopyButton
+              value={url}
+              icon={kLinkIcon}
+              className={clsx(styles.copyLink)}
+            />
+          ) : null}
         </div>
-        {url ? (
-          <CopyButton
-            value={url}
-            icon={kLinkIcon}
-            className={clsx(styles.copyLink)}
-          />
-        ) : (
-          ""
-        )}
         <div onClick={toggleCollapse}></div>
         <div
           className={clsx("text-style-secondary", styles.label)}

--- a/packages/inspect-components/src/transcript/event/RetryChip.module.css
+++ b/packages/inspect-components/src/transcript/event/RetryChip.module.css
@@ -1,0 +1,118 @@
+.wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 7px 2px 6px;
+  background: var(--bs-secondary-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--bs-secondary-color);
+  text-transform: none;
+  line-height: 1;
+}
+
+.chip:hover,
+.chipOpen {
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
+}
+
+.chipText {
+  font-weight: 500;
+  padding-right: 0.5rem;
+}
+
+.chipIcon {
+  font-size: 11px;
+  line-height: 1;
+}
+
+.chipChevron {
+  font-size: 9px;
+  line-height: 1;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 280px;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+  padding: 4px;
+  z-index: 11;
+  font-size: 12px;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--bs-body-color);
+  text-align: left;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.item:hover {
+  background: var(--bs-tertiary-bg);
+}
+
+.itemActive {
+  background: var(--bs-secondary-bg);
+}
+
+.itemNum {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bs-secondary-bg);
+  color: var(--bs-secondary-color);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.itemLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemStatus {
+  margin-left: auto;
+  font-size: 10.5px;
+  color: var(--bs-secondary-color);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}

--- a/packages/inspect-components/src/transcript/event/RetryChip.tsx
+++ b/packages/inspect-components/src/transcript/event/RetryChip.tsx
@@ -2,7 +2,9 @@ import clsx from "clsx";
 import { FC, useEffect, useState } from "react";
 
 import type { ModelEvent } from "@tsmono/inspect-common/types";
+import { formatTime } from "@tsmono/util";
 
+import { attemptDurationSec } from "./attemptDuration";
 import styles from "./RetryChip.module.css";
 import { summarizeModelError } from "./summarizeModelError";
 
@@ -54,7 +56,6 @@ export const RetryChip: FC<RetryChipProps> = ({
         type="button"
         className={clsx(styles.chip, open && styles.chipOpen)}
         title={`${chipText} — click to view`}
-        aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
       >
@@ -71,7 +72,7 @@ export const RetryChip: FC<RetryChipProps> = ({
       {open && (
         <>
           <div className={styles.backdrop} onClick={() => setOpen(false)} />
-          <div className={styles.menu} role="menu">
+          <div className={styles.menu}>
             {attempts.map((attempt, idx) => {
               const key = keyOf(attempt);
               const isCurrent = idx === attempts.length - 1;
@@ -83,7 +84,6 @@ export const RetryChip: FC<RetryChipProps> = ({
                 <button
                   key={key}
                   type="button"
-                  role="menuitem"
                   className={clsx(
                     styles.item,
                     selectedKey === key && styles.itemActive
@@ -106,17 +106,6 @@ export const RetryChip: FC<RetryChipProps> = ({
 };
 
 function formatAttemptDuration(event: ModelEvent): string | null {
-  const explicit = event.output?.time ?? event.working_time;
-  if (typeof explicit === "number" && !Number.isNaN(explicit)) {
-    return `${Math.round(explicit)}s`;
-  }
-  if (event.timestamp && event.completed) {
-    const start = new Date(event.timestamp).getTime();
-    const end = new Date(event.completed).getTime();
-    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
-      const sec = Math.round((end - start) / 1000);
-      return `${sec}s`;
-    }
-  }
-  return null;
+  const sec = attemptDurationSec(event);
+  return sec != null ? formatTime(sec) : null;
 }

--- a/packages/inspect-components/src/transcript/event/RetryChip.tsx
+++ b/packages/inspect-components/src/transcript/event/RetryChip.tsx
@@ -1,0 +1,122 @@
+import clsx from "clsx";
+import { FC, useEffect, useState } from "react";
+
+import type { ModelEvent } from "@tsmono/inspect-common/types";
+
+import styles from "./RetryChip.module.css";
+import { summarizeModelError } from "./summarizeModelError";
+
+interface RetryChipProps {
+  attempts: ModelEvent[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+  keyOf: (event: ModelEvent) => string;
+}
+
+export const RetryChip: FC<RetryChipProps> = ({
+  attempts,
+  selectedKey,
+  onSelect,
+  keyOf,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  if (attempts.length <= 1) return null;
+
+  const priorCount = attempts.length - 1;
+  const selectedIndex = attempts.findIndex((a) => keyOf(a) === selectedKey);
+  const isCurrentSelected =
+    selectedIndex === -1 || selectedIndex === attempts.length - 1;
+
+  const chipText = isCurrentSelected
+    ? priorCount === 1
+      ? "1 prior retry"
+      : `${priorCount} prior retries`
+    : `attempt ${selectedIndex + 1} · ${summarizeModelError(attempts[selectedIndex]?.error)}`;
+
+  const handleSelect = (key: string) => {
+    setOpen(false);
+    onSelect(key);
+  };
+
+  return (
+    <span className={styles.wrap}>
+      <button
+        type="button"
+        className={clsx(styles.chip, open && styles.chipOpen)}
+        title={`${chipText} — click to view`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <i
+          className={clsx("bi", "bi-arrow-repeat", styles.chipIcon)}
+          aria-hidden="true"
+        />
+        <span className={styles.chipText}>{chipText}</span>
+        <i
+          className={clsx("bi", "bi-chevron-down", styles.chipChevron)}
+          aria-hidden="true"
+        />
+      </button>
+      {open && (
+        <>
+          <div className={styles.backdrop} onClick={() => setOpen(false)} />
+          <div className={styles.menu} role="menu">
+            {attempts.map((attempt, idx) => {
+              const key = keyOf(attempt);
+              const isCurrent = idx === attempts.length - 1;
+              const label = isCurrent
+                ? `Attempt ${idx + 1} · current`
+                : `Attempt ${idx + 1} · ${summarizeModelError(attempt.error)}`;
+              const duration = formatAttemptDuration(attempt);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  role="menuitem"
+                  className={clsx(
+                    styles.item,
+                    selectedKey === key && styles.itemActive
+                  )}
+                  onClick={() => handleSelect(key)}
+                >
+                  <span className={styles.itemNum}>{idx + 1}</span>
+                  <span className={styles.itemLabel}>{label}</span>
+                  {duration && (
+                    <span className={styles.itemStatus}>{duration}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </span>
+  );
+};
+
+function formatAttemptDuration(event: ModelEvent): string | null {
+  const explicit = event.output?.time ?? event.working_time;
+  if (typeof explicit === "number" && !Number.isNaN(explicit)) {
+    return `${Math.round(explicit)}s`;
+  }
+  if (event.timestamp && event.completed) {
+    const start = new Date(event.timestamp).getTime();
+    const end = new Date(event.completed).getTime();
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+      const sec = Math.round((end - start) / 1000);
+      return `${sec}s`;
+    }
+  }
+  return null;
+}

--- a/packages/inspect-components/src/transcript/event/attemptDuration.ts
+++ b/packages/inspect-components/src/transcript/event/attemptDuration.ts
@@ -1,0 +1,24 @@
+import type { ModelEvent } from "@tsmono/inspect-common/types";
+
+/**
+ * Best-effort duration in seconds for a single ModelEvent attempt.
+ *
+ * Falls back to (completed - timestamp) when neither `output.time` nor
+ * `working_time` is set (typical for failed attempts whose duration must
+ * be inferred from start/end timestamps). Returns `null` when no
+ * dependable duration can be derived.
+ */
+export function attemptDurationSec(event: ModelEvent): number | null {
+  const explicit = event.output?.time ?? event.working_time;
+  if (typeof explicit === "number" && !Number.isNaN(explicit)) {
+    return explicit;
+  }
+  if (event.timestamp && event.completed) {
+    const start = Date.parse(event.timestamp);
+    const end = Date.parse(event.completed);
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+      return (end - start) / 1000;
+    }
+  }
+  return null;
+}

--- a/packages/inspect-components/src/transcript/event/summarizeModelError.test.ts
+++ b/packages/inspect-components/src/transcript/event/summarizeModelError.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeModelError } from "./summarizeModelError";
+
+describe("summarizeModelError", () => {
+  it("matches 429 / rate limit", () => {
+    expect(summarizeModelError("HTTP 429 Too Many Requests")).toBe(
+      "429 rate limit"
+    );
+    expect(summarizeModelError("rate limit exceeded")).toBe("429 rate limit");
+  });
+
+  it("matches timeout variants", () => {
+    expect(summarizeModelError("Request timed out after 60s")).toBe("timeout");
+    expect(summarizeModelError("ReadTimeout")).toBe("timeout");
+  });
+
+  it("matches context length / too long", () => {
+    expect(summarizeModelError("Context length exceeded for model")).toBe(
+      "context length"
+    );
+    expect(summarizeModelError("Input is too long")).toBe("context length");
+  });
+
+  it("matches auth error variants", () => {
+    expect(summarizeModelError("HTTP 401 Unauthorized")).toBe("auth error");
+    expect(summarizeModelError("Invalid API key")).toBe("auth error");
+    expect(summarizeModelError("403 Forbidden")).toBe("auth error");
+  });
+
+  it("matches 5xx", () => {
+    expect(summarizeModelError("HTTP 503 Service Unavailable")).toBe(
+      "5xx error"
+    );
+  });
+
+  it("falls back to a truncated first segment", () => {
+    expect(summarizeModelError("Some weird transient failure mode")).toBe(
+      "Some weird transient failure mode"
+    );
+    const long = "a".repeat(60);
+    expect(summarizeModelError(long)).toBe("a".repeat(37) + "…");
+  });
+
+  it("handles null/empty input", () => {
+    expect(summarizeModelError(null)).toBe("error");
+    expect(summarizeModelError("")).toBe("error");
+  });
+});

--- a/packages/inspect-components/src/transcript/event/summarizeModelError.ts
+++ b/packages/inspect-components/src/transcript/event/summarizeModelError.ts
@@ -1,0 +1,31 @@
+/**
+ * Short, neutral label for a model error string. Used in the retry-attempt
+ * dropdown menu (e.g. "Attempt 1 · 429 rate limit"). Keep wording
+ * informational; avoid alerting language ("failure", "error", "warning").
+ */
+export function summarizeModelError(err: string | null | undefined): string {
+  if (!err) return "error";
+  const s = err.trim();
+  const lower = s.toLowerCase();
+
+  if (/\b429\b/.test(s) || lower.includes("rate limit"))
+    return "429 rate limit";
+  if (lower.includes("timeout") || lower.includes("timed out"))
+    return "timeout";
+  if (lower.includes("context length") || lower.includes("too long"))
+    return "context length";
+  if (
+    lower.includes("api key") ||
+    lower.includes("unauthorized") ||
+    lower.includes("authentication") ||
+    /\b401\b/.test(s) ||
+    /\b403\b/.test(s)
+  )
+    return "auth error";
+  if (/\b5\d{2}\b/.test(s)) return "5xx error";
+  if (/\b4\d{2}\b/.test(s)) return "4xx error";
+  if (lower.includes("connection")) return "connection error";
+
+  const first = s.split(/[\n.:]/)[0] ?? s;
+  return first.length > 40 ? first.slice(0, 37) + "…" : first;
+}

--- a/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
@@ -20,6 +20,7 @@ import { treeifyEvents } from "../../transform/treeify";
 import { EventNode, kCollapsibleEventTypes } from "../../types";
 import type { EventType } from "../../types";
 import type { TimelineSpan } from "../core";
+import { correctRetryTimestamps } from "../retryOrdering";
 import { attachSourceSpans } from "../timelineEventNodes";
 
 // =============================================================================
@@ -57,8 +58,12 @@ export const useEventNodes = (
     eventTree: EventNode[];
     defaultCollapsedIds: Record<string, true>;
   } => {
+    // Repair retry-inverted ModelEvent timestamps before any downstream
+    // sort sees them (treeifyEvents sorts span children by timestamp).
+    const orderedEvents = correctRetryTimestamps(events);
+
     // Apply fixups to the event stream
-    const resolvedEvents = fixupEventStream(events, !running);
+    const resolvedEvents = fixupEventStream(orderedEvents, !running);
 
     // Build the event tree
     const rawEventTree = treeifyEvents(resolvedEvents, 0);

--- a/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
@@ -9,6 +9,7 @@ import { useMemo } from "react";
 
 import type {
   Event,
+  ModelEvent,
   SpanBeginEvent,
   StepEvent,
   SubtaskEvent,
@@ -20,6 +21,7 @@ import { treeifyEvents } from "../../transform/treeify";
 import { EventNode, kCollapsibleEventTypes } from "../../types";
 import type { EventType } from "../../types";
 import type { TimelineSpan } from "../core";
+import { groupRetryAttempts } from "../retryGrouping";
 import { correctRetryTimestamps } from "../retryOrdering";
 import { attachSourceSpans } from "../timelineEventNodes";
 
@@ -54,16 +56,23 @@ export const useEventNodes = (
   running: boolean,
   sourceSpans?: ReadonlyMap<string, TimelineSpan>
 ) => {
-  const { eventTree, defaultCollapsedIds } = useMemo((): {
+  const { eventTree, defaultCollapsedIds, retryAttempts } = useMemo((): {
     eventTree: EventNode[];
     defaultCollapsedIds: Record<string, true>;
+    retryAttempts: Map<string, ModelEvent[]>;
   } => {
     // Repair retry-inverted ModelEvent timestamps before any downstream
     // sort sees them (treeifyEvents sorts span children by timestamp).
     const orderedEvents = correctRetryTimestamps(events);
 
+    // Fold consecutive same-span failed→success ModelEvent runs into a
+    // single visible event; the failed siblings are removed from the
+    // stream and surfaced via the retryAttempts map for the chip UI.
+    const { events: groupedEvents, attempts: retryAttempts } =
+      groupRetryAttempts(orderedEvents);
+
     // Apply fixups to the event stream
-    const resolvedEvents = fixupEventStream(orderedEvents, !running);
+    const resolvedEvents = fixupEventStream(groupedEvents, !running);
 
     // Build the event tree
     const rawEventTree = treeifyEvents(resolvedEvents, 0);
@@ -121,8 +130,8 @@ export const useEventNodes = (
     };
     findCollapsibleEvents(eventTree);
 
-    return { eventTree, defaultCollapsedIds };
+    return { eventTree, defaultCollapsedIds, retryAttempts };
   }, [events, running, sourceSpans]);
 
-  return { eventNodes: eventTree, defaultCollapsedIds };
+  return { eventNodes: eventTree, defaultCollapsedIds, retryAttempts };
 };

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -21,13 +21,13 @@ import {
   resolveForkTimestamp,
   type MarkerConfig,
 } from "../markers";
+import { correctRetryTimestamps } from "../retryOrdering";
 import {
   computeRowLayouts,
   rowHasEvents,
   type RowLayout,
 } from "../swimlaneLayout";
 import { isSingleSpan, type SwimlaneRow } from "../swimlaneRows";
-import { correctRetryTimestamps } from "../retryOrdering";
 import {
   collectPathWithNavigators,
   collectRawEvents,
@@ -123,10 +123,7 @@ export function useTranscriptTimeline(
     activeTimelineProps,
   } = options;
 
-  const events = useMemo(
-    () => correctRetryTimestamps(rawEvents),
-    [rawEvents]
-  );
+  const events = useMemo(() => correctRetryTimestamps(rawEvents), [rawEvents]);
 
   const includeUtility = timelineOptions?.includeUtility ?? false;
   const showBranches = timelineOptions?.showBranches ?? false;

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -27,6 +27,7 @@ import {
   type RowLayout,
 } from "../swimlaneLayout";
 import { isSingleSpan, type SwimlaneRow } from "../swimlaneRows";
+import { correctRetryTimestamps } from "../retryOrdering";
 import {
   collectPathWithNavigators,
   collectRawEvents,
@@ -114,13 +115,18 @@ export function useTranscriptTimeline(
   options: UseTranscriptTimelineOptions
 ): TranscriptTimelineResult {
   const {
-    events,
+    events: rawEvents,
     markerConfig = defaultMarkerConfig,
     timelineOptions,
     serverTimelines,
     timelineProps,
     activeTimelineProps,
   } = options;
+
+  const events = useMemo(
+    () => correctRetryTimestamps(rawEvents),
+    [rawEvents]
+  );
 
   const includeUtility = timelineOptions?.includeUtility ?? false;
   const showBranches = timelineOptions?.showBranches ?? false;

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  Event,
+  ModelEvent,
+  StateEvent,
+} from "@tsmono/inspect-common/types";
+
+import { groupRetryAttempts, retryAttemptKey } from "./retryGrouping";
+
+const NULL_CONFIG = {} as ModelEvent["config"];
+const EMPTY_OUTPUT = {
+  choices: [],
+  usage: null,
+  time: null,
+  metadata: null,
+  error: null,
+} as unknown as ModelEvent["output"];
+
+function model(
+  timestamp: string,
+  options?: { error?: string; spanId?: string | null }
+): ModelEvent {
+  return {
+    event: "model",
+    model: "test",
+    role: null,
+    input: [],
+    input_refs: null,
+    tools: [],
+    tool_choice: "auto",
+    config: NULL_CONFIG,
+    output: EMPTY_OUTPUT,
+    cache: null,
+    call: null,
+    error: options?.error ?? null,
+    span_id: options?.spanId === undefined ? null : options.spanId,
+    timestamp,
+    working_start: 0,
+  } as unknown as ModelEvent;
+}
+
+function state(timestamp: string): StateEvent {
+  return {
+    event: "state",
+    changes: [],
+    span_id: null,
+    timestamp,
+    working_start: 0,
+  } as unknown as StateEvent;
+}
+
+describe("groupRetryAttempts", () => {
+  it("returns input reference unchanged when no retries exist", () => {
+    const events: Event[] = [
+      model("2025-01-01T00:00:00.000Z"),
+      model("2025-01-01T00:00:01.000Z"),
+    ];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("folds a single failed attempt before a success", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", { error: "transient" });
+    const success = model("2025-01-01T00:00:01.000Z");
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([success]);
+    expect(out.attempts.get(retryAttemptKey(success))).toEqual([
+      failed,
+      success,
+    ]);
+  });
+
+  it("folds three failed attempts before a success", () => {
+    const f1 = model("2025-01-01T00:00:00.000Z", { error: "e1" });
+    const f2 = model("2025-01-01T00:00:01.000Z", { error: "e2" });
+    const f3 = model("2025-01-01T00:00:02.000Z", { error: "e3" });
+    const ok = model("2025-01-01T00:00:03.000Z");
+    const events: Event[] = [f1, f2, f3, ok];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([ok]);
+    expect(out.attempts.get(retryAttemptKey(ok))).toEqual([f1, f2, f3, ok]);
+  });
+
+  it("scopes grouping per span_id (sibling spans don't interfere)", () => {
+    const aFail = model("2025-01-01T00:00:00.000Z", {
+      spanId: "A",
+      error: "transient",
+    });
+    const bOk1 = model("2025-01-01T00:00:00.500Z", { spanId: "B" });
+    const bOk2 = model("2025-01-01T00:00:01.000Z", { spanId: "B" });
+    const aOk = model("2025-01-01T00:00:02.000Z", { spanId: "A" });
+    const events: Event[] = [aFail, bOk1, bOk2, aOk];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([bOk1, bOk2, aOk]);
+    expect(out.attempts.get(retryAttemptKey(aOk))).toEqual([aFail, aOk]);
+    expect(out.attempts.has(retryAttemptKey(bOk1))).toBe(false);
+    expect(out.attempts.has(retryAttemptKey(bOk2))).toBe(false);
+  });
+
+  it("preserves non-ModelEvents interleaved with the retry run", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", { error: "transient" });
+    const stateEvent = state("2025-01-01T00:00:00.500Z");
+    const success = model("2025-01-01T00:00:01.000Z");
+    const events: Event[] = [failed, stateEvent, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([stateEvent, success]);
+    expect(out.attempts.get(retryAttemptKey(success))).toEqual([
+      failed,
+      success,
+    ]);
+  });
+
+  it("handles two consecutive retried calls in the same span", () => {
+    const f1 = model("2025-01-01T00:00:00.000Z", { error: "e1" });
+    const ok1 = model("2025-01-01T00:00:01.000Z");
+    const f2 = model("2025-01-01T00:00:02.000Z", { error: "e2" });
+    const ok2 = model("2025-01-01T00:00:03.000Z");
+    const events: Event[] = [f1, ok1, f2, ok2];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([ok1, ok2]);
+    expect(out.attempts.get(retryAttemptKey(ok1))).toEqual([f1, ok1]);
+    expect(out.attempts.get(retryAttemptKey(ok2))).toEqual([f2, ok2]);
+  });
+
+  it("does not group a single-attempt call", () => {
+    const ok = model("2025-01-01T00:00:00.000Z");
+    const events: Event[] = [ok];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("leaves trailing failed attempts untouched (no terminal success)", () => {
+    const f1 = model("2025-01-01T00:00:00.000Z", { error: "e1" });
+    const f2 = model("2025-01-01T00:00:01.000Z", { error: "e2" });
+    const events: Event[] = [f1, f2];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+});

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
@@ -19,16 +19,24 @@ const EMPTY_OUTPUT = {
 
 function model(
   timestamp: string,
-  options?: { error?: string; spanId?: string | null }
+  options?: {
+    error?: string;
+    spanId?: string | null;
+    name?: string;
+    inputLen?: number;
+    tools?: string[];
+    toolChoice?: ModelEvent["tool_choice"];
+  }
 ): ModelEvent {
+  const inputLen = options?.inputLen ?? 0;
   return {
     event: "model",
-    model: "test",
+    model: options?.name ?? "test",
     role: null,
-    input: [],
+    input: Array.from({ length: inputLen }, () => ({}) as never),
     input_refs: null,
-    tools: [],
-    tool_choice: "auto",
+    tools: (options?.tools ?? []).map((name) => ({ name }) as never),
+    tool_choice: options?.toolChoice ?? "auto",
     config: NULL_CONFIG,
     output: EMPTY_OUTPUT,
     cache: null,
@@ -140,5 +148,81 @@ describe("groupRetryAttempts", () => {
     const out = groupRetryAttempts(events);
     expect(out.events).toBe(events);
     expect(out.attempts.size).toBe(0);
+  });
+
+  it("does not group failed model A with later success on different model B", () => {
+    const failedA = model("2025-01-01T00:00:00.000Z", {
+      name: "anthropic/sonnet",
+      error: "transient",
+    });
+    const successB = model("2025-01-01T00:00:01.000Z", {
+      name: "openai/gpt-5",
+    });
+    const events: Event[] = [failedA, successB];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("does not group when input length differs (fresh call, not a retry)", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", {
+      error: "transient",
+      inputLen: 3,
+    });
+    const success = model("2025-01-01T00:00:01.000Z", { inputLen: 5 });
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("does not group when tools differ", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", {
+      error: "transient",
+      tools: ["read_file"],
+    });
+    const success = model("2025-01-01T00:00:01.000Z", {
+      tools: ["read_file", "write_file"],
+    });
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("does not group when tool_choice differs", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", {
+      error: "transient",
+      toolChoice: "auto",
+    });
+    const success = model("2025-01-01T00:00:01.000Z", {
+      toolChoice: "any",
+    });
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toBe(events);
+    expect(out.attempts.size).toBe(0);
+  });
+
+  it("groups only the matching subset when prior failures mix unrelated calls", () => {
+    // Span has: failed call to model A (unrelated), then a retry sequence
+    // for model B (failed B then success B). Only the model-B failure
+    // should be grouped; the model-A failure stays visible.
+    const failedA = model("2025-01-01T00:00:00.000Z", {
+      name: "model-a",
+      error: "down",
+    });
+    const failedB = model("2025-01-01T00:00:01.000Z", {
+      name: "model-b",
+      error: "transient",
+    });
+    const successB = model("2025-01-01T00:00:02.000Z", { name: "model-b" });
+    const events: Event[] = [failedA, failedB, successB];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([failedA, successB]);
+    expect(out.attempts.get(retryAttemptKey(successB))).toEqual([
+      failedB,
+      successB,
+    ]);
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
@@ -237,7 +237,9 @@ describe("retryAttemptKey", () => {
 
   it("falls back to span_id + parsed epoch when uuid is missing", () => {
     const e = model("2025-01-01T00:00:00.000Z", { spanId: "S" });
-    expect(retryAttemptKey(e)).toBe(`ts:S:${Date.parse("2025-01-01T00:00:00.000Z")}`);
+    expect(retryAttemptKey(e)).toBe(
+      `ts:S:${Date.parse("2025-01-01T00:00:00.000Z")}`
+    );
   });
 
   it("returns equal keys for equivalent timestamps in different formats (no uuid)", () => {

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
@@ -26,6 +26,7 @@ function model(
     inputLen?: number;
     tools?: string[];
     toolChoice?: ModelEvent["tool_choice"];
+    uuid?: string | null;
   }
 ): ModelEvent {
   const inputLen = options?.inputLen ?? 0;
@@ -45,6 +46,7 @@ function model(
     span_id: options?.spanId === undefined ? null : options.spanId,
     timestamp,
     working_start: 0,
+    uuid: options?.uuid ?? null,
   } as unknown as ModelEvent;
 }
 
@@ -223,6 +225,71 @@ describe("groupRetryAttempts", () => {
     expect(out.attempts.get(retryAttemptKey(successB))).toEqual([
       failedB,
       successB,
+    ]);
+  });
+});
+
+describe("retryAttemptKey", () => {
+  it("uses uuid when present", () => {
+    const e = model("2025-01-01T00:00:00.000Z", { uuid: "abc-123" });
+    expect(retryAttemptKey(e)).toBe("uuid:abc-123");
+  });
+
+  it("falls back to span_id + parsed epoch when uuid is missing", () => {
+    const e = model("2025-01-01T00:00:00.000Z", { spanId: "S" });
+    expect(retryAttemptKey(e)).toBe(`ts:S:${Date.parse("2025-01-01T00:00:00.000Z")}`);
+  });
+
+  it("returns equal keys for equivalent timestamps in different formats (no uuid)", () => {
+    const z = model("2025-01-01T00:00:01.000Z", { spanId: "S" });
+    const offset = model("2025-01-01T00:00:01.000+00:00", { spanId: "S" });
+    expect(retryAttemptKey(z)).toBe(retryAttemptKey(offset));
+  });
+
+  it("returns distinct keys for same-timestamp same-span events with different uuids", () => {
+    const a = model("2025-01-01T00:00:00.000Z", {
+      spanId: "S",
+      uuid: "id-a",
+    });
+    const b = model("2025-01-01T00:00:00.000Z", {
+      spanId: "S",
+      uuid: "id-b",
+    });
+    expect(retryAttemptKey(a)).not.toBe(retryAttemptKey(b));
+  });
+
+  it("preserves timestamp string when unparseable (pathological fallback)", () => {
+    const e = model("not-a-real-timestamp", { spanId: "S" });
+    expect(retryAttemptKey(e)).toBe("ts:S:not-a-real-timestamp");
+  });
+});
+
+describe("groupRetryAttempts (uuid keying)", () => {
+  it("keys the attempts map by uuid when the success event has one", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", {
+      error: "transient",
+      uuid: "fail-1",
+    });
+    const success = model("2025-01-01T00:00:01.000Z", { uuid: "ok-1" });
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.attempts.get("uuid:ok-1")).toEqual([failed, success]);
+    // Lookup by retryAttemptKey on the success event still resolves.
+    expect(out.attempts.get(retryAttemptKey(success))).toEqual([
+      failed,
+      success,
+    ]);
+  });
+
+  it("groups correctly when neither attempt has a uuid (legacy log)", () => {
+    const failed = model("2025-01-01T00:00:00.000Z", { error: "transient" });
+    const success = model("2025-01-01T00:00:01.000Z");
+    const events: Event[] = [failed, success];
+    const out = groupRetryAttempts(events);
+    expect(out.events).toEqual([success]);
+    expect(out.attempts.get(retryAttemptKey(success))).toEqual([
+      failed,
+      success,
     ]);
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -29,8 +29,12 @@ import type {
   ToolChoice,
 } from "@tsmono/inspect-common/types";
 
-export const retryAttemptKey = (event: ModelEvent): string =>
-  `${event.span_id ?? ""}:${event.timestamp}`;
+export const retryAttemptKey = (event: ModelEvent): string => {
+  if (event.uuid) return `uuid:${event.uuid}`;
+  const epoch = Date.parse(event.timestamp);
+  const tsPart = Number.isNaN(epoch) ? event.timestamp : String(epoch);
+  return `ts:${event.span_id ?? ""}:${tsPart}`;
+};
 
 export interface RetryGroupingResult {
   events: Event[];

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -15,9 +15,19 @@
  *
  * When no retries are detected, returns the input array reference unchanged
  * so callers can memoize on identity.
+ *
+ * Identity guard: a failed event is only treated as a retry of a later
+ * successful event when their `model`, `input.length`, `tools` (length +
+ * names), and `tool_choice` match. Without this guard, an unrelated failure
+ * (e.g. failed model A then a fallback successful call to model B in the
+ * same span) would be hidden as a "retry" of an unrelated call.
  */
 
-import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
+import type {
+  Event,
+  ModelEvent,
+  ToolChoice,
+} from "@tsmono/inspect-common/types";
 
 export const retryAttemptKey = (event: ModelEvent): string =>
   `${event.span_id ?? ""}:${event.timestamp}`;
@@ -30,6 +40,32 @@ export interface RetryGroupingResult {
 interface PendingFailed {
   event: ModelEvent;
   index: number;
+}
+
+function toolChoiceEqual(a: ToolChoice, b: ToolChoice): boolean {
+  if (a === b) return true;
+  if (typeof a === "string" || typeof b === "string") return a === b;
+  return a?.name === b?.name;
+}
+
+function toolsEqual(
+  a: ModelEvent["tools"],
+  b: ModelEvent["tools"]
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.name !== b[i]?.name) return false;
+  }
+  return true;
+}
+
+function isSameCall(failed: ModelEvent, success: ModelEvent): boolean {
+  return (
+    failed.model === success.model &&
+    failed.input.length === success.input.length &&
+    toolsEqual(failed.tools, success.tools) &&
+    toolChoiceEqual(failed.tool_choice, success.tool_choice)
+  );
 }
 
 export function groupRetryAttempts(events: Event[]): RetryGroupingResult {
@@ -53,8 +89,16 @@ export function groupRetryAttempts(events: Event[]): RetryGroupingResult {
 
     const run = pendingFailed.get(key);
     if (run && run.length > 0) {
-      attempts.set(retryAttemptKey(m), [...run.map((p) => p.event), m]);
-      for (const p of run) dropIndices.add(p.index);
+      const matches = run.filter((p) => isSameCall(p.event, m));
+      if (matches.length > 0) {
+        attempts.set(retryAttemptKey(m), [
+          ...matches.map((p) => p.event),
+          m,
+        ]);
+        for (const p of matches) dropIndices.add(p.index);
+      }
+      // Any failed events that do NOT match the success's identity are
+      // unrelated failures — leave them visible in the transcript.
       pendingFailed.delete(key);
     }
   }

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -52,10 +52,7 @@ function toolChoiceEqual(a: ToolChoice, b: ToolChoice): boolean {
   return a?.name === b?.name;
 }
 
-function toolsEqual(
-  a: ModelEvent["tools"],
-  b: ModelEvent["tools"]
-): boolean {
+function toolsEqual(a: ModelEvent["tools"], b: ModelEvent["tools"]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (a[i]?.name !== b[i]?.name) return false;
@@ -95,10 +92,7 @@ export function groupRetryAttempts(events: Event[]): RetryGroupingResult {
     if (run && run.length > 0) {
       const matches = run.filter((p) => isSameCall(p.event, m));
       if (matches.length > 0) {
-        attempts.set(retryAttemptKey(m), [
-          ...matches.map((p) => p.event),
-          m,
-        ]);
+        attempts.set(retryAttemptKey(m), [...matches.map((p) => p.event), m]);
         for (const p of matches) dropIndices.add(p.index);
       }
       // Any failed events that do NOT match the success's identity are

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -1,0 +1,71 @@
+/**
+ * Group consecutive failed-then-successful ModelEvent retries inside the
+ * same `span_id` into a single visible event.
+ *
+ * Run AFTER `correctRetryTimestamps` so the success event's timestamp is
+ * already past its preceding failed siblings (the stable key relies on that
+ * post-correction uniqueness).
+ *
+ * Returns:
+ * - `events` — input list with failed retry attempts removed; the success
+ *    event survives unchanged.
+ * - `attempts` — map keyed by the success event's stable key, holding the
+ *    full ordered attempt list (failed first, success last). Single-attempt
+ *    calls are not added to the map.
+ *
+ * When no retries are detected, returns the input array reference unchanged
+ * so callers can memoize on identity.
+ */
+
+import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
+
+export const retryAttemptKey = (event: ModelEvent): string =>
+  `${event.span_id ?? ""}:${event.timestamp}`;
+
+export interface RetryGroupingResult {
+  events: Event[];
+  attempts: Map<string, ModelEvent[]>;
+}
+
+interface PendingFailed {
+  event: ModelEvent;
+  index: number;
+}
+
+export function groupRetryAttempts(events: Event[]): RetryGroupingResult {
+  const attempts = new Map<string, ModelEvent[]>();
+  const pendingFailed = new Map<string, PendingFailed[]>();
+  const dropIndices = new Set<number>();
+
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!;
+    if (e.event !== "model") continue;
+
+    const m = e;
+    const key = m.span_id ?? "";
+
+    if (m.error != null) {
+      const run = pendingFailed.get(key) ?? [];
+      run.push({ event: m, index: i });
+      pendingFailed.set(key, run);
+      continue;
+    }
+
+    const run = pendingFailed.get(key);
+    if (run && run.length > 0) {
+      attempts.set(retryAttemptKey(m), [...run.map((p) => p.event), m]);
+      for (const p of run) dropIndices.add(p.index);
+      pendingFailed.delete(key);
+    }
+  }
+
+  if (dropIndices.size === 0) {
+    return { events, attempts };
+  }
+
+  const filtered: Event[] = [];
+  for (let i = 0; i < events.length; i++) {
+    if (!dropIndices.has(i)) filtered.push(events[i]!);
+  }
+  return { events: filtered, attempts };
+}

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
@@ -154,7 +154,7 @@ describe("correctRetryTimestamps", () => {
       working_start: 0.0,
       working_time: 12.5,
       completed: "2025-01-01T00:00:12.500Z",
-    } as ModelEvent;
+    };
     const events: Event[] = [
       model("2025-01-01T00:00:01.000Z", { error: "transient" }),
       success,

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  Event,
+  ModelEvent,
+  StateEvent,
+} from "@tsmono/inspect-common/types";
+
+import { correctRetryTimestamps } from "./retryOrdering";
+
+const NULL_CONFIG = {} as ModelEvent["config"];
+const EMPTY_OUTPUT = {
+  choices: [],
+  usage: null,
+  time: null,
+  metadata: null,
+  error: null,
+} as unknown as ModelEvent["output"];
+
+function model(
+  timestamp: string,
+  options?: { error?: string; spanId?: string | null }
+): ModelEvent {
+  return {
+    event: "model",
+    model: "test",
+    role: null,
+    input: [],
+    input_refs: null,
+    tools: [],
+    tool_choice: "auto",
+    config: NULL_CONFIG,
+    output: EMPTY_OUTPUT,
+    cache: null,
+    call: null,
+    error: options?.error ?? null,
+    span_id: options?.spanId === undefined ? null : options.spanId,
+    timestamp,
+    working_start: 0,
+  } as unknown as ModelEvent;
+}
+
+function state(timestamp: string): StateEvent {
+  return {
+    event: "state",
+    changes: [],
+    span_id: null,
+    timestamp,
+    working_start: 0,
+  } as unknown as StateEvent;
+}
+
+function timestamps(events: Event[]): string[] {
+  return events.map((e) => (e as { timestamp?: string }).timestamp ?? "");
+}
+
+describe("correctRetryTimestamps", () => {
+  it("returns the same reference when no inversion exists", () => {
+    const events: Event[] = [
+      model("2025-01-01T00:00:00.000Z"),
+      model("2025-01-01T00:00:01.000Z"),
+      model("2025-01-01T00:00:02.000Z"),
+    ];
+    expect(correctRetryTimestamps(events)).toBe(events);
+  });
+
+  it("repairs a single retry inversion (failed, success rewritten)", () => {
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "transient" }),
+      model("2025-01-01T00:00:00.000Z"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(out).not.toBe(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:01.001Z",
+    ]);
+    // original input untouched
+    expect((events[1] as ModelEvent).timestamp).toBe(
+      "2025-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("repairs three failed retries followed by a success", () => {
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "e1" }),
+      model("2025-01-01T00:00:02.000Z", { error: "e2" }),
+      model("2025-01-01T00:00:03.000Z", { error: "e3" }),
+      model("2025-01-01T00:00:00.000Z"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:02.000Z",
+      "2025-01-01T00:00:03.000Z",
+      "2025-01-01T00:00:03.001Z",
+    ]);
+  });
+
+  it("scopes the inversion check per span_id (sibling spans don't interfere)", () => {
+    // Span A retried; span B has its own (correctly ordered) events that
+    // happen to fall inside span A's retry window.
+    const events: Event[] = [
+      model("2025-01-01T00:00:05.000Z", { spanId: "A", error: "transient" }),
+      model("2025-01-01T00:00:01.000Z", { spanId: "B" }),
+      model("2025-01-01T00:00:02.000Z", { spanId: "B" }),
+      model("2025-01-01T00:00:00.000Z", { spanId: "A" }),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:05.000Z",
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:02.000Z",
+      "2025-01-01T00:00:05.001Z",
+    ]);
+  });
+
+  it("ignores non-ModelEvents interleaved with the retry run", () => {
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "transient" }),
+      state("2025-01-01T00:00:01.500Z"),
+      model("2025-01-01T00:00:00.000Z"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:01.500Z",
+      "2025-01-01T00:00:01.001Z",
+    ]);
+  });
+
+  it("repairs cumulative inversions (each clamp informs the next)", () => {
+    // Two consecutive retried generations in the same span: failed/success,
+    // failed/success. Both successes' timestamps were rewritten backward.
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "e1" }),
+      model("2025-01-01T00:00:00.500Z"),
+      model("2025-01-01T00:00:00.700Z", { error: "e2" }),
+      model("2025-01-01T00:00:00.300Z"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:01.001Z",
+      // e2 (0.700) is earlier than the clamped 1.001 → clamp to 1.002
+      "2025-01-01T00:00:01.002Z",
+      "2025-01-01T00:00:01.003Z",
+    ]);
+  });
+
+  it("preserves working_start, working_time, and completed on the corrected event", () => {
+    const success: ModelEvent = {
+      ...model("2025-01-01T00:00:00.000Z"),
+      working_start: 0.0,
+      working_time: 12.5,
+      completed: "2025-01-01T00:00:12.500Z",
+    } as ModelEvent;
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "transient" }),
+      success,
+    ];
+    const out = correctRetryTimestamps(events);
+    const corrected = out[1] as ModelEvent;
+    expect(corrected.timestamp).toBe("2025-01-01T00:00:01.001Z");
+    expect(corrected.working_start).toBe(0.0);
+    expect(corrected.working_time).toBe(12.5);
+    expect(corrected.completed).toBe("2025-01-01T00:00:12.500Z");
+  });
+});

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
@@ -148,6 +148,43 @@ describe("correctRetryTimestamps", () => {
     ]);
   });
 
+  it("repairs inversion when input timestamps use +00:00 (backend format)", () => {
+    // Backend serializes timestamps as `+00:00`; corrected output is `Z`.
+    // Lexicographic compare would mishandle this — epoch parsing must.
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000+00:00", { error: "transient" }),
+      model("2025-01-01T00:00:00.000+00:00"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000+00:00",
+      "2025-01-01T00:00:01.001Z",
+    ]);
+  });
+
+  it("compares correctly when a previously-bumped Z value precedes a +00:00 input", () => {
+    // First retry pair clamps the success to ...001Z (epoch 1.001s).
+    // The next pair's failed event at 1.500+00:00 (epoch 1.500s) must be
+    // recognized as forward progress, not flagged as inverted vs the
+    // stored Z value. A naive string compare would mishandle this
+    // because '+' (0x2B) < '0' (0x30) < 'Z' (0x5A).
+    const events: Event[] = [
+      model("2025-01-01T00:00:01.000Z", { error: "e1" }),
+      model("2025-01-01T00:00:00.500Z"),
+      model("2025-01-01T00:00:01.500+00:00", { error: "e2" }),
+      model("2025-01-01T00:00:01.200+00:00"),
+    ];
+    const out = correctRetryTimestamps(events);
+    expect(timestamps(out)).toEqual([
+      "2025-01-01T00:00:01.000Z",
+      "2025-01-01T00:00:01.001Z",
+      // 1.500 > previous bumped 1.001 → no clamp, kept as-is
+      "2025-01-01T00:00:01.500+00:00",
+      // 1.200 < previous 1.500 → clamp to 1.501Z
+      "2025-01-01T00:00:01.501Z",
+    ]);
+  });
+
   it("preserves working_start, working_time, and completed on the corrected event", () => {
     const success: ModelEvent = {
       ...model("2025-01-01T00:00:00.000Z"),

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.ts
@@ -1,0 +1,56 @@
+/**
+ * Repair retry-inverted ModelEvent timestamps for display ordering.
+ *
+ * When `model.generate()` retries internally, each attempt emits its own
+ * ModelEvent (failed attempts carry `error`, the final attempt is the
+ * successful one). On the Python side, after retries complete, the
+ * successful event's `timestamp` is rewritten to a value captured *before*
+ * any retry — so that whole-call accounting (working_time) reflects the full
+ * duration. The side effect is that the success event ends up with a
+ * timestamp earlier than its preceding failed-retry siblings, and any sort
+ * by timestamp places it ahead of attempts that actually preceded it.
+ *
+ * This helper detects the inversion and clones offending events with their
+ * `timestamp` clamped so ModelEvents within a span are non-decreasing in
+ * emission order. Other timing fields (`working_start`, `working_time`,
+ * `completed`) are preserved so accounting stays intact.
+ */
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+const EPSILON_MS = 1;
+
+function bumpAfter(iso: string): string {
+  const t = new Date(iso).getTime();
+  return new Date(t + EPSILON_MS).toISOString();
+}
+
+/**
+ * Return `events` with retry-inverted ModelEvent timestamps repaired.
+ *
+ * Returns the input array reference unchanged when no inversion is
+ * detected, so callers can safely memoize on the result.
+ */
+export function correctRetryTimestamps(events: Event[]): Event[] {
+  const lastModelTs = new Map<string | null, string>();
+  let result: Event[] | null = null;
+
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!;
+    if (e.event !== "model") continue;
+    if (!e.timestamp) continue;
+
+    const key = e.span_id ?? null;
+    const prev = lastModelTs.get(key);
+    if (prev != null && e.timestamp < prev) {
+      const corrected = bumpAfter(prev);
+      if (!result) result = events.slice();
+      result[i] = { ...e, timestamp: corrected };
+      lastModelTs.set(key, corrected);
+    } else {
+      lastModelTs.set(key, e.timestamp);
+    }
+  }
+
+  return result ?? events;
+}

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.ts
@@ -20,19 +20,19 @@ import type { Event } from "@tsmono/inspect-common/types";
 
 const EPSILON_MS = 1;
 
-function bumpAfter(iso: string): string {
-  const t = new Date(iso).getTime();
-  return new Date(t + EPSILON_MS).toISOString();
-}
-
 /**
  * Return `events` with retry-inverted ModelEvent timestamps repaired.
  *
  * Returns the input array reference unchanged when no inversion is
  * detected, so callers can safely memoize on the result.
+ *
+ * Comparisons are done in parsed epoch milliseconds so mixed input
+ * formats (the backend emits `+00:00`; corrected outputs use `Z`) sort
+ * correctly. The output timestamp is always normalized to ISO-Z via
+ * `new Date(epoch).toISOString()`.
  */
 export function correctRetryTimestamps(events: Event[]): Event[] {
-  const lastModelTs = new Map<string | null, string>();
+  const lastModelTs = new Map<string | null, number>();
   let result: Event[] | null = null;
 
   for (let i = 0; i < events.length; i++) {
@@ -40,15 +40,19 @@ export function correctRetryTimestamps(events: Event[]): Event[] {
     if (e.event !== "model") continue;
     if (!e.timestamp) continue;
 
+    const epoch = Date.parse(e.timestamp);
+    if (Number.isNaN(epoch)) continue;
+
     const key = e.span_id ?? null;
     const prev = lastModelTs.get(key);
-    if (prev != null && e.timestamp < prev) {
-      const corrected = bumpAfter(prev);
+    if (prev != null && epoch < prev) {
+      const correctedEpoch = prev + EPSILON_MS;
+      const correctedIso = new Date(correctedEpoch).toISOString();
       if (!result) result = events.slice();
-      result[i] = { ...e, timestamp: corrected };
-      lastModelTs.set(key, corrected);
+      result[i] = { ...e, timestamp: correctedIso };
+      lastModelTs.set(key, correctedEpoch);
     } else {
-      lastModelTs.set(key, e.timestamp);
+      lastModelTs.set(key, epoch);
     }
   }
 

--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -173,4 +173,6 @@ export interface EventNodeContext {
   messageLabels?: Record<string, string>;
   /** Approval events paired to their tool event via `call.id == ToolEvent.id`. `ToolEventView` reads from this instead of scanning the tree, so paired approvals don't need to be nested as children (avoids spurious expand chevrons and duplicate flat rows). */
   toolApprovals?: Map<string, EventNode<ApprovalEvent>>;
+  /** Retry attempts paired to their successful ModelEvent via `retryAttemptKey(event)`. `ModelEventView` reads from this to render the inline retry chip and swap bodies between attempts. */
+  retryAttempts?: Map<string, ModelEvent[]>;
 }


### PR DESCRIPTION
Collapse retried model events into the successful model event. Show switch to permit viewing the previous model events.

<img width="893" height="63" alt="Screenshot 2026-05-06 at 11 19 42 AM" src="https://github.com/user-attachments/assets/c3c3f14c-482c-4739-9129-4b7c72472b4e" />


Fixes #196 