### PR TITLE
SampleList: fix click-twice navigation regression

### DIFF
--- a/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
@@ -284,8 +284,22 @@ export const SamplesGrid = <TRow,>(
     return { ...initialState, columnVisibility: { hiddenColIds } };
   }, [initialState, columnVisibility]);
 
+  // Only forward column/sort/filter changes. Transient sources like
+  // `focusedCell` fire on mousedown; round-tripping that through the store
+  // re-renders the grid mid-click, leaving the trailing `click` event
+  // pointed at a stale row and suppressing `onRowClicked` entirely.
   const handleStateUpdated = useCallback(
     (e: StateUpdatedEvent<TRow>) => {
+      const persistable = e.sources.some(
+        (s) =>
+          s === "columnVisibility" ||
+          s === "columnOrder" ||
+          s === "columnPinning" ||
+          s === "columnSizing" ||
+          s === "sort" ||
+          s === "filter"
+      );
+      if (!persistable) return;
       onStateUpdated?.(e.state);
     },
     [onStateUpdated]


### PR DESCRIPTION
## Summary
- ag-grid fires `stateUpdated` with source `focusedCell` on cell mousedown. `handleStateUpdated` was forwarding every event to the persisted store, writing a new view object on mousedown → React re-render → ag-grid rebuilt the row DOM mid-click. The trailing `click` event landed on a stale element and ag-grid suppressed `onRowClicked` entirely, so the first click did nothing and the user had to click twice to navigate.
- Filter to the sources we actually persist (column visibility/order/pinning/sizing, sort, filter); transient sources (focusedCell, rowSelection, scroll, …) no longer churn the store.

## Test plan
- [x] Click a sample row in the SampleList — navigates on the first click
- [x] Toggle column visibility, reorder, resize, sort, and filter — all still persist across reloads
- [x] Verify SamplesPanel grid (cross-log) still persists user-driven column state

🤖 Generated with [Claude Code](https://claude.com/claude-code)