### PR TITLE
Fix runtime errors when loading viewer libs in browsers

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -72,6 +72,8 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "fake-indexeddb": "^6.2.2",
     "globals": "^17.5.0",
+    "markdown-it-mathjax3": "^5.2.0",
+    "mathjax-full": "^3.2.2",
     "msw": "^2.13.6",
     "picocolors": "^1.1.1",
     "postcss": "^8.5.12",
@@ -115,8 +117,6 @@
     "json5": "^2.2.3",
     "jsondiffpatch": "^0.7.3",
     "markdown-it": "^14.1.1",
-    "markdown-it-mathjax3": "^5.2.0",
-    "mathjax-full": "^3.2.2",
     "postcss-url": "^10.1.3",
     "prismjs": "^1.30.0",
     "react": "^19.2.5",
@@ -125,5 +125,9 @@
     "react-router-dom": "^7.14.2",
     "react-virtuoso": "^4.18.6",
     "zustand": "^5.0.12"
+  },
+  "peerDependencies": {
+    "markdown-it-mathjax3": "^5.2.0",
+    "mathjax-full": "^3.2.2"
   }
 }

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -83,7 +83,19 @@ export default defineConfig(({ mode }) => {
           formats: ["es"],
         },
         rollupOptions: {
-          external: ["react", "react-dom"],
+          // Externalize as regex so `react/jsx-runtime`, `react-dom/client`,
+          // etc. are also externalized. Without this, Rolldown bundles the
+          // CJS versions and emits runtime `__require("react")` calls that
+          // throw in browsers.
+          //
+          // mathjax is heavy and registers globals; keep it external so the
+          // consumer installs/dedupes it once instead of each viewer
+          // shipping its own copy.
+          external: (id: string) =>
+            /^(react|react-dom)(\/|$)/.test(id) ||
+            id === "mathjax-full" ||
+            id.startsWith("mathjax-full/") ||
+            id === "markdown-it-mathjax3",
           output: {
             globals: {
               react: "React",

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -42,6 +42,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
+    "markdown-it-mathjax3": "^5.2.0",
+    "mathjax-full": "^3.2.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -68,6 +70,8 @@
     "eslint": "^9.39.4",
     "eventsource": "^4.1.0",
     "jsdom": "^29.1.0",
+    "markdown-it-mathjax3": "^5.2.0",
+    "mathjax-full": "^3.2.2",
     "msw": "^2.13.6",
     "openapi-typescript": "^7.10.1",
     "postcss-url": "^10.1.3",
@@ -108,8 +112,6 @@
     "lodash-es": "^4.18.1",
     "lz4js": "^0.2.0",
     "markdown-it": "^14.1.1",
-    "markdown-it-mathjax3": "^5.2.0",
-    "mathjax-full": "^3.2.2",
     "prismjs": "^1.30.0",
     "react-popper": "^2.3.0",
     "react-router-dom": "^7.14.2",

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -64,7 +64,19 @@ export default defineConfig(({ mode }) => {
           formats: ["es"],
         },
         rollupOptions: {
-          external: ["react", "react-dom", "@tanstack/react-query"],
+          // Externalize as regex so subpath imports like `react/jsx-runtime`
+          // are also externalized. Without this, Rolldown bundles the CJS
+          // versions and emits runtime `__require("react")` calls that
+          // throw in browsers.
+          //
+          // mathjax is heavy and registers globals; keep it external so the
+          // consumer installs/dedupes it once instead of each viewer
+          // shipping its own copy.
+          external: (id: string) =>
+            /^(react|react-dom|@tanstack\/react-query)(\/|$)/.test(id) ||
+            id === "mathjax-full" ||
+            id.startsWith("mathjax-full/") ||
+            id === "markdown-it-mathjax3",
           output: {
             globals: {
               react: "React",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,12 +141,6 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
-      markdown-it-mathjax3:
-        specifier: ^5.2.0
-        version: 5.2.0
-      mathjax-full:
-        specifier: ^3.2.2
-        version: 3.2.2
       postcss-url:
         specifier: ^10.1.3
         version: 10.1.3(postcss@8.5.12)
@@ -238,6 +232,12 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      markdown-it-mathjax3:
+        specifier: ^5.2.0
+        version: 5.2.0
+      mathjax-full:
+        specifier: ^3.2.2
+        version: 3.2.2
       msw:
         specifier: ^2.13.6
         version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
@@ -340,12 +340,6 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
-      markdown-it-mathjax3:
-        specifier: ^5.2.0
-        version: 5.2.0
-      mathjax-full:
-        specifier: ^3.2.2
-        version: 3.2.2
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -428,6 +422,12 @@ importers:
       jsdom:
         specifier: ^29.1.0
         version: 29.1.0
+      markdown-it-mathjax3:
+        specifier: ^5.2.0
+        version: 5.2.0
+      mathjax-full:
+        specifier: ^3.2.2
+        version: 3.2.2
       msw:
         specifier: ^2.13.6
         version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Consumers of `@meridianlabs/log-viewer` and `@meridianlabs/inspect-scout-viewer` hit two runtime errors in their browsers: `__require is not defined` whenever either viewer loads under Vite's dev server (so `pnpm dev` doesn't work — consumers fall back to `pnpm build && pnpm preview`), and `TypeError: Cannot set property Package` when an app loads both viewers on the same page. Both stem from the libs shipping things they shouldn't — bundled CJS shims for `react/jsx-runtime`, plus a private 6 MB MathJax copy embedded in each lib.

The fix is to externalize `react` / `react-dom` subpaths (was only externalizing the bare names, so Rolldown bundled the subpaths as CJS) and to externalize `mathjax-full` + `markdown-it-mathjax3` as peerDependencies. Each lib drops ~6 MB.

## Notes for reviewers

- **Breaking for consumers** of the published packages: the MathJax peerDeps require any consuming app to add `mathjax-full` and `markdown-it-mathjax3` to its own dependencies.