### PR TITLE
Outline: align close icon with title and make rootHeader sticky

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.module.css
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.module.css
@@ -55,7 +55,6 @@
 
 .outline {
   padding-left: 0.6rem;
-  padding-top: 0.2rem;
   /* Prevent stretching to the full grid-row height so that
      position:sticky has room to travel within the cell. */
   align-self: start;
@@ -181,13 +180,16 @@
   margin-right: -1.2rem;
 }
 
+/* Center the close icon vertically with the rootHeader title that follows
+   in the scroll content. The title (text-size-smaller) sits at the top of
+   that content; this offset aligns the icon's visual center with the title's. */
 .sidebarHeaderClose {
   all: unset;
   cursor: pointer;
   font-size: 0.9em;
   padding: 0.2rem 0.4rem;
   position: absolute;
-  top: 0;
+  top: -0.25em;
   right: 0;
   background-color: var(--bs-body-bg);
 }

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.module.css
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.module.css
@@ -10,6 +10,9 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 
 .panel {


### PR DESCRIPTION
## Summary
- Vertically center the outline close button on the rootHeader title
- Make the rootHeader sticky to the scroll container (so the title stays visible while scrolling)
- Drop `padding-top: 0.2rem` on `.outline` so the sticky title sits flush with the top of the scrollable area (fixes a ~2px gap where content scrolled behind the title)

Fixes #195

## Test plan
- [x] Open a transcript outline with an agent name (e.g. `main`) and confirm the × icon is vertically centered on the title
- [x] Scroll the outline and confirm the title remains pinned to the top, with no content visible above it
- [x] Confirm the close button still hides the outline when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)