### PR TITLE
Apply score_color_scales to sample header chips

### DIFF
--- a/apps/inspect/src/app/samples/header-v2/ScorePanel.tsx
+++ b/apps/inspect/src/app/samples/header-v2/ScorePanel.tsx
@@ -6,6 +6,7 @@ import { ToolDropdownButton } from "@tsmono/react/components";
 import { ScoreValue } from "../../../@types/extraInspect";
 import { ScoreLabel } from "../../../app/types";
 import { BasicSampleData } from "../../../client/api/types";
+import { kScoreTypeBoolean, kScoreTypePassFail } from "../../../constants";
 import {
   resolveScorePanelSort,
   resolveScorePanelView,
@@ -14,7 +15,15 @@ import {
   useScorePanelSort,
   useScorePanelView,
 } from "../../../state/hooks";
+import {
+  colorForValue,
+  resolveScale,
+} from "../../shared/samples-grid/colorScale";
 import { EvalDescriptor } from "../descriptor/types";
+import {
+  useSamplesViewColorScalesEnabled,
+  useSamplesViewScoreColorScales,
+} from "../list/useSamplesView";
 
 import styles from "./ScorePanel.module.css";
 import { scoreTone, Tone } from "./scoreTone";
@@ -37,6 +46,9 @@ interface RenderedScore {
    *  heatmap border so the highest displayed value reads darkest and
    *  the lowest reads lightest. */
   numericIntensity?: number;
+  /** CSS color from `score_color_scales` — paints both the chip
+   *  border and the inner mini-pill background. */
+  bgColor?: string;
 }
 
 const TONE_RANK: Record<Tone, number> = {
@@ -58,16 +70,41 @@ export const ScorePanel: FC<ScorePanelProps> = ({
   sample,
   evalDescriptor,
 }) => {
+  const wireScoreColorScales = useSamplesViewScoreColorScales();
+  const colorScalesEnabled = useSamplesViewColorScalesEnabled();
+
   const renderedScores = useMemo<RenderedScore[]>(() => {
     const initial = scores.map((label) => {
       const selected = evalDescriptor.score(sample, label);
       const descriptor = evalDescriptor.scoreDescriptor(label);
+      // Pass/fail and boolean already render via semantic tones; opting
+      // them into a configured color scale would clash with the
+      // chipFail / chipWarn border. Match the grid's exclusion at
+      // columns.tsx:559-560.
+      const acceptsColorScale =
+        colorScalesEnabled &&
+        descriptor.scoreType !== kScoreTypePassFail &&
+        descriptor.scoreType !== kScoreTypeBoolean;
+      let bgColor: string | undefined;
+      if (acceptsColorScale) {
+        const wire = wireScoreColorScales[label.name];
+        if (wire) {
+          const resolved = resolveScale(wire, {
+            min: descriptor.min,
+            max: descriptor.max,
+          });
+          if (resolved) {
+            bgColor = colorForValue(resolved, selected?.value);
+          }
+        }
+      }
       return {
         label,
         key: `${label.scorer}__${label.name}`,
         value: selected?.value,
         scoreType: descriptor.scoreType,
         tone: scoreTone(selected?.value, descriptor.scoreType),
+        bgColor,
       };
     });
 
@@ -86,7 +123,13 @@ export const ScorePanel: FC<ScorePanelProps> = ({
         numbers.length <= 1 || range === 0 ? 1 : (s.value - min) / range;
       return { ...s, numericIntensity: intensity };
     });
-  }, [scores, sample, evalDescriptor]);
+  }, [
+    scores,
+    sample,
+    evalDescriptor,
+    wireScoreColorScales,
+    colorScalesEnabled,
+  ]);
 
   const count = renderedScores.length;
   const tight = count <= 6;
@@ -191,12 +234,15 @@ interface ScoreChipProps {
 }
 
 const ScoreChip: FC<ScoreChipProps> = ({ score }) => {
-  // Numeric chips with no semantic tone pick up a blue border whose
-  // darkness scales with the chip's value relative to the other
-  // numeric values in the panel. tone-attention chips (fail/warn)
-  // keep their semantic color regardless.
+  // Configured `score_color_scales` win: tint the chip border and the
+  // inner mini-pill with the resolved (subtle) color. Otherwise
+  // numeric neutral chips fall back to a blue border whose darkness
+  // scales with the value relative to the other numeric values in the
+  // panel. tone-attention chips (fail/warn) keep their semantic border.
   let style: CSSProperties | undefined;
-  if (score.tone === "neutral" && score.numericIntensity !== undefined) {
+  if (score.bgColor) {
+    style = { borderColor: score.bgColor };
+  } else if (score.tone === "neutral" && score.numericIntensity !== undefined) {
     const opacity = (0.25 + 0.75 * score.numericIntensity).toFixed(2);
     style = { borderColor: `rgba(var(--bs-primary-rgb), ${opacity})` };
   }
@@ -214,6 +260,7 @@ const ScoreChip: FC<ScoreChipProps> = ({ score }) => {
         value={score.value}
         scoreType={score.scoreType}
         size={16}
+        bgColor={score.bgColor}
       />
       <span className={styles.chipName}>{score.label.name}</span>
     </span>

--- a/apps/inspect/src/app/samples/header-v2/ScoreValueDisplay.tsx
+++ b/apps/inspect/src/app/samples/header-v2/ScoreValueDisplay.tsx
@@ -13,6 +13,10 @@ interface ScoreValueDisplayProps {
   /** Pixel diameter for grade / bool circles. Plain text scales with
    *  the surrounding font size and ignores this. */
   size?: number;
+  /** Optional CSS color expression resolved from the eval-author's
+   *  `score_color_scales`. When set on the chip variant, paints the
+   *  mini-pill background instead of the tone-derived class. */
+  bgColor?: string;
 }
 
 /**
@@ -98,15 +102,23 @@ export const ScoreChipValueDisplay: FC<ScoreValueDisplayProps> = ({
   value,
   scoreType,
   size = 16,
+  bgColor,
 }) => {
   if (isCircleScoreType(scoreType, value)) {
     return <CircleValue value={value} scoreType={scoreType} size={size} />;
   }
   const tone = scoreTone(value, scoreType);
   const formatted = formatPlainValue(value);
+  // A configured `bgColor` wins over the tone-derived class so the
+  // pill matches the chip border. Fall through to the tone class when
+  // no scale is configured for this score.
+  const pillStyle: CSSProperties | undefined = bgColor
+    ? { backgroundColor: bgColor }
+    : undefined;
   return (
     <span
-      className={clsx(styles.miniPill, toneMiniPillClass(tone))}
+      className={clsx(styles.miniPill, !bgColor && toneMiniPillClass(tone))}
+      style={pillStyle}
       title={formatted}
     >
       {formatted}


### PR DESCRIPTION
## Summary
- Sample header chips now honor the eval author's `score_color_scales` (the same wire palette the samples grid uses): the resolved color tints both the chip border and the inner mini-pill background.
- Falls back to the existing blue intensity heatmap when no scale is configured for a score, and respects the "Color scales" toggle.
- Pass/fail and boolean score types still render via their semantic tones (matching the grid's exclusion in `columns.tsx:559-560`).

Fixes #198

## Screenshot
<img width="560" height="151" alt="score-panel-chips" src="https://github.com/user-attachments/assets/26495305-032d-4631-bfa5-dcd510db73a5" />

## Test plan
- [x] `pnpm check` passes (typecheck, lint, format)
- [x] Manual UI check — chips pick up configured palette / categorical colors; uncolored scores keep today's blue intensity; pass/fail chips keep semantic borders