### PR TITLE
SampleList: preserve viewer_config sort across rehydration

### DIFF
--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -110,8 +110,15 @@ export const createLogsSlice = (
     logsActions: {
       setLogDir: (logDir?: string) => {
         set((state) => {
-          if (logDir !== state.logs.logDir) {
-            state.logs.logDir = logDir;
+          const prev = state.logs.logDir;
+          if (logDir === prev) return;
+          state.logs.logDir = logDir;
+          // Only wipe on real dir-to-dir transitions. undefined/"" are
+          // initialization signals (two competing sources race during load
+          // and rehydration) — wiping then would clobber the persisted sort.
+          const realPrev = prev !== undefined && prev !== "";
+          const realNew = logDir !== undefined && logDir !== "";
+          if (realPrev && realNew) {
             state.logs.samplesListState.byScope.samplesPanel.gridState =
               undefined;
             // SampleList: keep columns + multiline (general preferences);


### PR DESCRIPTION
## Summary

- `SampleList`'s `viewer_config` sort was being wiped on every WebView rehydration in VSCode (reproducible by backgrounding/foregrounding the tab, or navigating in/out of a sample in single-file mode).
- Root cause: two paths set `state.logs.logDir` during a load — App.tsx's URL-derived `setLogDir(dirname(url))` and `initLogDir`'s api-derived value (`""` in the VSCode legacy array path). On first load `view` is undefined so `setLogDir`'s wipe is a no-op, but the persisted state ends up with a logDir from one source. On rehydration the other source fires with a different value, wiping the rehydrated `view.sort` before `SamplesGrid` mounts.
- Fix: `setLogDir` now only wipes log-scoped view state on a real dir-to-dir transition; `undefined` and `""` are treated as initialization signals.

## Test plan

- [x] Manual: viewer_config sort survives backgrounding/foregrounding the VSCode tab
- [x] Manual: viewer_config sort survives navigating into a sample and back
- [x] `pnpm check` passes
- [ ] Genuine cross-folder navigation (web mode) still resets sort/filter as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)