### PR TITLE
Make find work everywhere in the sample viewer

### DIFF
--- a/apps/inspect/src/app/log-view/LogViewLayout.tsx
+++ b/apps/inspect/src/app/log-view/LogViewLayout.tsx
@@ -1,7 +1,11 @@
 import clsx from "clsx";
 import { FC, useEffect, useRef } from "react";
 
-import { ErrorPanel, ExtendedFindProvider } from "@tsmono/react/components";
+import {
+  ErrorPanel,
+  ExtendedFindProvider,
+  FindTargetProvider,
+} from "@tsmono/react/components";
 
 import { ActivityBar } from "../../components/ActivityBar";
 import { FindBand } from "../../components/FindBand";
@@ -70,35 +74,37 @@ export const LogViewLayout: FC = () => {
 
   return (
     <ExtendedFindProvider>
-      <div
-        ref={mainAppRef}
-        className={clsx(
-          "app-main-grid",
-          fullScreen ? "full-screen" : undefined,
-          singleFileMode ? "single-file-mode" : undefined,
-          "log-view"
-        )}
-        tabIndex={0}
-      >
-        {showFind ? <FindBand /> : ""}
-        {!singleFileMode ? (
-          <ApplicationNavbar
-            fnNavigationUrl={navigationUrl}
-            currentPath={logPath}
-            showActivity="log"
-          />
-        ) : (
-          <ActivityBar animating={!!appStatus.loading} />
-        )}
-        {appStatus.error ? (
-          <ErrorPanel
-            title="An error occurred while loading this task."
-            error={appStatus.error}
-          />
-        ) : (
-          <LogView />
-        )}
-      </div>
+      <FindTargetProvider>
+        <div
+          ref={mainAppRef}
+          className={clsx(
+            "app-main-grid",
+            fullScreen ? "full-screen" : undefined,
+            singleFileMode ? "single-file-mode" : undefined,
+            "log-view"
+          )}
+          tabIndex={0}
+        >
+          {showFind ? <FindBand /> : ""}
+          {!singleFileMode ? (
+            <ApplicationNavbar
+              fnNavigationUrl={navigationUrl}
+              currentPath={logPath}
+              showActivity="log"
+            />
+          ) : (
+            <ActivityBar animating={!!appStatus.loading} />
+          )}
+          {appStatus.error ? (
+            <ErrorPanel
+              title="An error occurred while loading this task."
+              error={appStatus.error}
+            />
+          ) : (
+            <LogView />
+          )}
+        </div>
+      </FindTargetProvider>
     </ExtendedFindProvider>
   );
 };

--- a/apps/inspect/src/app/samples/SampleDetailComponent.tsx
+++ b/apps/inspect/src/app/samples/SampleDetailComponent.tsx
@@ -1,7 +1,10 @@
 import clsx from "clsx";
 import React, { FC, useCallback, useEffect, useMemo } from "react";
 
-import { ExtendedFindProvider } from "@tsmono/react/components";
+import {
+  ExtendedFindProvider,
+  FindTargetProvider,
+} from "@tsmono/react/components";
 
 import { FindBand } from "../../components/FindBand";
 import { useSampleData } from "../../state/hooks";
@@ -190,54 +193,56 @@ export const SampleDetailComponent: FC<SampleDetailComponentProps> = ({
 
   return (
     <ExtendedFindProvider>
-      {showFind ? <FindBand /> : ""}
-      <div className={styles.detail}>
-        <ApplicationNavbar
-          currentPath={currentPath}
-          fnNavigationUrl={fnNavigationUrl}
-          bordered={bordered}
-          breadcrumbsEnabled={breadcrumbsEnabled}
-        >
-          <div className={clsx(styles.sampleNav)}>
-            <div
-              onClick={hasPrevious ? onPrevious : undefined}
-              onKeyDown={(e) =>
-                handleNavButtonKeyDown(e, onPrevious, hasPrevious)
-              }
-              tabIndex={hasPrevious ? 0 : -1}
-              role="button"
-              aria-label="Previous sample"
-              aria-disabled={!hasPrevious}
-              className={clsx(!hasPrevious && styles.disabled, styles.nav)}
-            >
-              <i className={clsx(ApplicationIcons.previous)} />
+      <FindTargetProvider>
+        {showFind ? <FindBand /> : ""}
+        <div className={styles.detail}>
+          <ApplicationNavbar
+            currentPath={currentPath}
+            fnNavigationUrl={fnNavigationUrl}
+            bordered={bordered}
+            breadcrumbsEnabled={breadcrumbsEnabled}
+          >
+            <div className={clsx(styles.sampleNav)}>
+              <div
+                onClick={hasPrevious ? onPrevious : undefined}
+                onKeyDown={(e) =>
+                  handleNavButtonKeyDown(e, onPrevious, hasPrevious)
+                }
+                tabIndex={hasPrevious ? 0 : -1}
+                role="button"
+                aria-label="Previous sample"
+                aria-disabled={!hasPrevious}
+                className={clsx(!hasPrevious && styles.disabled, styles.nav)}
+              >
+                <i className={clsx(ApplicationIcons.previous)} />
+              </div>
+              <div className={clsx(styles.sampleInfo, "text-size-smallest")}>
+                Sample {sampleId} (Epoch {epoch})
+              </div>
+              <div
+                onClick={hasNext ? onNext : undefined}
+                onKeyDown={(e) => handleNavButtonKeyDown(e, onNext, hasNext)}
+                tabIndex={hasNext ? 0 : -1}
+                role="button"
+                aria-label="Next sample"
+                aria-disabled={!hasNext}
+                className={clsx(!hasNext && styles.disabled, styles.nav)}
+              >
+                <i className={clsx(ApplicationIcons.next)} />
+              </div>
             </div>
-            <div className={clsx(styles.sampleInfo, "text-size-smallest")}>
-              Sample {sampleId} (Epoch {epoch})
-            </div>
-            <div
-              onClick={hasNext ? onNext : undefined}
-              onKeyDown={(e) => handleNavButtonKeyDown(e, onNext, hasNext)}
-              tabIndex={hasNext ? 0 : -1}
-              role="button"
-              aria-label="Next sample"
-              aria-disabled={!hasNext}
-              className={clsx(!hasNext && styles.disabled, styles.nav)}
-            >
-              <i className={clsx(ApplicationIcons.next)} />
-            </div>
-          </div>
-        </ApplicationNavbar>
+          </ApplicationNavbar>
 
-        {sampleMatchesRequest && (
-          <InlineSampleComponent
-            showActivity={
-              sampleStatus === "loading" || sampleStatus === "streaming"
-            }
-            className={styles.panel}
-          />
-        )}
-      </div>
+          {sampleMatchesRequest && (
+            <InlineSampleComponent
+              showActivity={
+                sampleStatus === "loading" || sampleStatus === "streaming"
+              }
+              className={styles.panel}
+            />
+          )}
+        </div>
+      </FindTargetProvider>
     </ExtendedFindProvider>
   );
 };

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -231,8 +231,11 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
     [scrollRef]
   );
 
-  const { hidden: headroomHidden, resetAnchor: headroomResetAnchor } =
-    useScrollDirection(scrollRefs);
+  const {
+    hidden: headroomHidden,
+    resetAnchor: headroomResetAnchor,
+    setHidden: setHeadroomHidden,
+  } = useScrollDirection(scrollRefs);
 
   const onHeadroomResetAnchor = useCallback(
     (debounce?: boolean) => headroomResetAnchor(debounce),
@@ -432,6 +435,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
       onMarkerNavigate={onMarkerNavigate}
       headroomHidden={headroomHidden}
       onHeadroomResetAnchor={onHeadroomResetAnchor}
+      onHeadroomSetHidden={setHeadroomHidden}
       eventNodeContext={eventNodeContext}
       listId={id}
       initialEventId={initialEventId}

--- a/apps/inspect/src/components/FindBand.tsx
+++ b/apps/inspect/src/components/FindBand.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 
-import { useExtendedFind } from "@tsmono/react/components";
+import { useExtendedFind, useFindTargetSetter } from "@tsmono/react/components";
 import { debounce } from "@tsmono/util";
 
 import { useStore } from "../state/store";
@@ -30,6 +30,7 @@ export const FindBand: FC<FindBandProps> = () => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
   const storeHideFind = useStore((state) => state.appActions.hideFind);
   const { extendedFindTerm, countAllMatches } = useExtendedFind();
+  const setFindTarget = useFindTargetSetter();
   const lastFoundItem = useRef<{
     text: string;
     offset: number;
@@ -44,37 +45,13 @@ export const FindBand: FC<FindBandProps> = () => {
     term: "",
     count: 0,
   });
-  const mutatedPanelsRef = useRef<
-    Map<
-      HTMLElement,
-      {
-        display: string;
-        maxHeight: string;
-        webkitLineClamp: string;
-        webkitBoxOrient: string;
-      }
-    >
-  >(new Map());
-
   const [matchCount, setMatchCount] = useState<number | null>(null);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
-
-  const getParentExpandablePanel = useCallback(
-    (selection: Selection): HTMLElement | undefined => {
-      let node = selection.anchorNode;
-      while (node) {
-        if (
-          node instanceof HTMLElement &&
-          node.hasAttribute("data-expandable-panel")
-        ) {
-          return node;
-        }
-        node = node.parentElement;
-      }
-      return undefined;
-    },
-    []
-  );
+  // Tracks whether the most recent search returned no result, separate
+  // from `matchCount`. On tabs that don't register a search source
+  // (Scoring/Metadata/JSON) the counter is unknown but `window.find` may
+  // still succeed — we use this flag for the "No results" UI instead.
+  const [noResults, setNoResults] = useState(false);
 
   const handleSearch = useCallback(
     async (back = false) => {
@@ -84,15 +61,25 @@ export const FindBand: FC<FindBandProps> = () => {
       if (!searchTerm) {
         setMatchCount(null);
         setCurrentMatchIndex(0);
+        setNoResults(false);
+        setFindTarget(null);
         return;
       }
 
-      if (currentSearchTerm.current !== searchTerm) {
+      const termChanged = currentSearchTerm.current !== searchTerm;
+      if (termChanged) {
         lastFoundItem.current = null;
         currentSearchTerm.current = searchTerm;
         setCurrentMatchIndex(0);
       }
 
+      // `total` only counts matches reported by registered search sources
+      // (transcript, chat virtual list). Tabs that are plain static markup
+      // — Scoring, Metadata, JSON — register no source, so total is 0 even
+      // though `window.find` could highlight visible text just fine. Don't
+      // bail on `total === 0`: try the find, and if it succeeds use the
+      // index-1-of-unknown UI; if it doesn't, the post-search "no result"
+      // branch handles it.
       let total: number;
       if (cachedCount.current.term === searchTerm) {
         total = cachedCount.current.count;
@@ -100,12 +87,7 @@ export const FindBand: FC<FindBandProps> = () => {
         total = countAllMatches(searchTerm);
         cachedCount.current = { term: searchTerm, count: total };
       }
-      setMatchCount(total);
-
-      if (total === 0) {
-        setCurrentMatchIndex(0);
-        return;
-      }
+      setMatchCount(total > 0 ? total : null);
 
       const focusedElement = document.activeElement as HTMLElement;
 
@@ -131,6 +113,7 @@ export const FindBand: FC<FindBandProps> = () => {
         return;
       }
 
+      setNoResults(!result);
       if (!result && savedRange) {
         const sel = window.getSelection();
         if (sel) {
@@ -156,6 +139,17 @@ export const FindBand: FC<FindBandProps> = () => {
             parentElement,
           };
 
+          // Publish the active term AFTER the find succeeds so consumers
+          // (ExpandablePanel) auto-expand panels whose subtree contains the
+          // term. Doing this after window.find avoids the auto-expand
+          // re-render landing in the middle of the search, which could
+          // detach the text node the selection is anchored on. The
+          // transcript's search source overlays this with a per-event
+          // target via its own setFindTarget call.
+          if (termChanged) {
+            setFindTarget({ term: searchTerm, eventId: "" });
+          }
+
           if (isNewMatch) {
             setCurrentMatchIndex((prev) => {
               if (back) {
@@ -164,22 +158,6 @@ export const FindBand: FC<FindBandProps> = () => {
                 return prev >= total ? 1 : prev + 1;
               }
             });
-          }
-
-          const parentPanel = getParentExpandablePanel(selection);
-          if (parentPanel) {
-            if (!mutatedPanelsRef.current.has(parentPanel)) {
-              mutatedPanelsRef.current.set(parentPanel, {
-                display: parentPanel.style.display,
-                maxHeight: parentPanel.style.maxHeight,
-                webkitLineClamp: parentPanel.style.webkitLineClamp,
-                webkitBoxOrient: parentPanel.style.webkitBoxOrient,
-              });
-            }
-            parentPanel.style.display = "block";
-            parentPanel.style.maxHeight = "none";
-            parentPanel.style.webkitLineClamp = "";
-            parentPanel.style.webkitBoxOrient = "";
           }
 
           if (scrollTimeoutRef.current !== null) {
@@ -193,7 +171,7 @@ export const FindBand: FC<FindBandProps> = () => {
 
       focusedElement?.focus();
     },
-    [getParentExpandablePanel, extendedFindTerm, countAllMatches]
+    [setFindTarget, extendedFindTerm, countAllMatches]
   );
 
   useEffect(() => {
@@ -202,7 +180,6 @@ export const FindBand: FC<FindBandProps> = () => {
       searchBoxRef.current?.select();
     }, 10);
 
-    const mutatedPanels = mutatedPanelsRef.current;
     const scrollTimeout = scrollTimeoutRef.current;
     const focusTimeout = focusTimeoutRef.current;
 
@@ -213,16 +190,9 @@ export const FindBand: FC<FindBandProps> = () => {
       if (focusTimeout !== null) {
         window.clearTimeout(focusTimeout);
       }
-      // Restore original styles on mutated expandable panels
-      mutatedPanels.forEach((originalStyles, panel) => {
-        panel.style.display = originalStyles.display;
-        panel.style.maxHeight = originalStyles.maxHeight;
-        panel.style.webkitLineClamp = originalStyles.webkitLineClamp;
-        panel.style.webkitBoxOrient = originalStyles.webkitBoxOrient;
-      });
-      mutatedPanels.clear();
+      setFindTarget(null);
     };
-  }, []);
+  }, [setFindTarget]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -344,7 +314,7 @@ export const FindBand: FC<FindBandProps> = () => {
       onKeyDown={handleKeyDown}
       onBeforeInput={handleBeforeInput}
       onChange={handleInputChange}
-      noResults={matchCount !== null && matchCount === 0}
+      noResults={noResults}
       matchCount={matchCount ?? undefined}
       matchIndex={
         matchCount !== null && matchCount > 0

--- a/apps/inspect/src/components/FindBandUI.tsx
+++ b/apps/inspect/src/components/FindBandUI.tsx
@@ -62,7 +62,7 @@ export const FindBandUI: FC<FindBandUIProps> = ({
       <span
         className={clsx(
           "findBand-match-count",
-          noResults && matchCount === 0 && "findBand-no-results"
+          noResults && "findBand-no-results"
         )}
         style={{ visibility: showStatus ? "visible" : "hidden" }}
       >

--- a/apps/scout/src/App.tsx
+++ b/apps/scout/src/App.tsx
@@ -16,6 +16,7 @@ import {
   ComponentIconProvider,
   ComponentIcons,
   ExtendedFindProvider,
+  FindTargetProvider,
 } from "@tsmono/react/components";
 import { ComponentStateProvider } from "@tsmono/react/state";
 
@@ -64,7 +65,9 @@ const AppContent: FC<AppProps> = ({ mode = "scans" }) => {
         <ComponentStateProvider hooks={scoutStateHooks}>
           <AppModeContext.Provider value={mode}>
             <ExtendedFindProvider>
-              <RouterProvider router={router} />
+              <FindTargetProvider>
+                <RouterProvider router={router} />
+              </FindTargetProvider>
             </ExtendedFindProvider>
           </AppModeContext.Provider>
         </ComponentStateProvider>

--- a/apps/scout/src/app/components/FindBand.tsx
+++ b/apps/scout/src/app/components/FindBand.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { FC, KeyboardEvent, useCallback, useEffect, useRef } from "react";
 
-import { useExtendedFind } from "@tsmono/react/components";
+import { useExtendedFind, useFindTargetSetter } from "@tsmono/react/components";
 
 import "./FindBand.css";
 
@@ -22,6 +22,7 @@ const findConfig = {
 export const FindBand: FC<FindBandProps> = ({ onClose }) => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
   const { extendedFindTerm } = useExtendedFind();
+  const setFindTarget = useFindTargetSetter();
   const lastFoundItem = useRef<{
     text: string;
     offset: number;
@@ -32,28 +33,12 @@ export const FindBand: FC<FindBandProps> = ({ onClose }) => {
   const needsCursorRestoreRef = useRef<boolean>(false);
   const lastNoResultTerm = useRef<string>("");
 
-  const getParentExpandablePanel = useCallback(
-    (selection: Selection): HTMLElement | undefined => {
-      let node = selection.anchorNode;
-      while (node) {
-        if (
-          node instanceof HTMLElement &&
-          node.hasAttribute("data-expandable-panel")
-        ) {
-          return node;
-        }
-        node = node.parentElement;
-      }
-      return undefined;
-    },
-    []
-  );
-
   const handleSearch = useCallback(
     async (back = false) => {
       // The search term
       const searchTerm = searchBoxRef.current?.value ?? "";
       if (!searchTerm) {
+        setFindTarget(null);
         return;
       }
 
@@ -118,14 +103,6 @@ export const FindBand: FC<FindBandProps> = ({ onClose }) => {
             parentElement,
           };
 
-          const parentPanel = getParentExpandablePanel(selection);
-          if (parentPanel) {
-            parentPanel.style.display = "block";
-            parentPanel.style.maxHeight = "none";
-            parentPanel.style.webkitLineClamp = "";
-            parentPanel.style.webkitBoxOrient = "";
-          }
-
           const element = range.startContainer.parentElement;
 
           if (element) {
@@ -141,7 +118,7 @@ export const FindBand: FC<FindBandProps> = ({ onClose }) => {
 
       focusedElement?.focus();
     },
-    [getParentExpandablePanel, extendedFindTerm]
+    [setFindTarget, extendedFindTerm]
   );
 
   useEffect(() => {
@@ -283,6 +260,12 @@ export const FindBand: FC<FindBandProps> = ({ onClose }) => {
       }
     };
   }, [handleSearch, restoreCursor, handleRestoreCursorIfNeeded]);
+
+  useEffect(() => {
+    return () => {
+      setFindTarget(null);
+    };
+  }, [setFindTarget]);
 
   return (
     <div data-unsearchable="true" className={clsx("findBand")}>

--- a/apps/scout/src/app/scan/ScanPanel.tsx
+++ b/apps/scout/src/app/scan/ScanPanel.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "react-router-dom";
 import {
   ErrorPanel,
   ExtendedFindProvider,
+  FindTargetProvider,
   LoadingBar,
 } from "@tsmono/react/components";
 import { useDocumentTitle } from "@tsmono/react/hooks";
@@ -62,7 +63,9 @@ export const ScanPanel: React.FC = () => {
         <>
           <ScanPanelTitle resultsDir={scansDir} selectedScan={selectedScan} />
           <ExtendedFindProvider>
-            <ScanPanelBody selectedScan={selectedScan} />
+            <FindTargetProvider>
+              <ScanPanelBody selectedScan={selectedScan} />
+            </FindTargetProvider>
           </ExtendedFindProvider>
         </>
       )}

--- a/apps/scout/src/app/scan/ScanPanel.tsx
+++ b/apps/scout/src/app/scan/ScanPanel.tsx
@@ -2,12 +2,7 @@ import clsx from "clsx";
 import React, { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 
-import {
-  ErrorPanel,
-  ExtendedFindProvider,
-  FindTargetProvider,
-  LoadingBar,
-} from "@tsmono/react/components";
+import { ErrorPanel, LoadingBar } from "@tsmono/react/components";
 import { useDocumentTitle } from "@tsmono/react/hooks";
 
 import { getScannerParam } from "../../router/url";
@@ -62,11 +57,7 @@ export const ScanPanel: React.FC = () => {
       {!error && selectedScan && (
         <>
           <ScanPanelTitle resultsDir={scansDir} selectedScan={selectedScan} />
-          <ExtendedFindProvider>
-            <FindTargetProvider>
-              <ScanPanelBody selectedScan={selectedScan} />
-            </FindTargetProvider>
-          </ExtendedFindProvider>
+          <ScanPanelBody selectedScan={selectedScan} />
         </>
       )}
     </div>

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "react-router-dom";
 
 import {
   ExtendedFindProvider,
+  FindTargetProvider,
   JSONPanel,
   LoadingBar,
   TabPanel,
@@ -363,35 +364,37 @@ export const ScannerResultPanel: FC = () => {
 
       {selectedResult && (
         <ExtendedFindProvider>
-          <div
-            className={clsx(
-              styles.contentArea,
-              !validationSidebarCollapsed && styles.withValidation
-            )}
-          >
-            {validationSidebarCollapsed || !selectedResult.transcriptId ? (
-              <div className={styles.tabSetWrapper}>
-                {renderTabSet(selectedResult)}
-              </div>
-            ) : (
-              <VscodeSplitLayout
-                className={styles.splitLayout}
-                fixedPane="end"
-                initialHandlePosition="80%"
-                minEnd="180px"
-                minStart="200px"
-              >
-                <div slot="start" className={styles.splitStart}>
+          <FindTargetProvider>
+            <div
+              className={clsx(
+                styles.contentArea,
+                !validationSidebarCollapsed && styles.withValidation
+              )}
+            >
+              {validationSidebarCollapsed || !selectedResult.transcriptId ? (
+                <div className={styles.tabSetWrapper}>
                   {renderTabSet(selectedResult)}
                 </div>
-                <div slot="end" className={styles.validationSidebar}>
-                  <ValidationCaseEditor
-                    transcriptId={selectedResult.transcriptId}
-                  />
-                </div>
-              </VscodeSplitLayout>
-            )}
-          </div>
+              ) : (
+                <VscodeSplitLayout
+                  className={styles.splitLayout}
+                  fixedPane="end"
+                  initialHandlePosition="80%"
+                  minEnd="180px"
+                  minStart="200px"
+                >
+                  <div slot="start" className={styles.splitStart}>
+                    {renderTabSet(selectedResult)}
+                  </div>
+                  <div slot="end" className={styles.validationSidebar}>
+                    <ValidationCaseEditor
+                      transcriptId={selectedResult.transcriptId}
+                    />
+                  </div>
+                </VscodeSplitLayout>
+              )}
+            </div>
+          </FindTargetProvider>
         </ExtendedFindProvider>
       )}
     </div>

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -5,8 +5,6 @@ import { FC, ReactNode, useCallback, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import {
-  ExtendedFindProvider,
-  FindTargetProvider,
   JSONPanel,
   LoadingBar,
   TabPanel,
@@ -363,39 +361,35 @@ export const ScannerResultPanel: FC = () => {
       />
 
       {selectedResult && (
-        <ExtendedFindProvider>
-          <FindTargetProvider>
-            <div
-              className={clsx(
-                styles.contentArea,
-                !validationSidebarCollapsed && styles.withValidation
-              )}
-            >
-              {validationSidebarCollapsed || !selectedResult.transcriptId ? (
-                <div className={styles.tabSetWrapper}>
-                  {renderTabSet(selectedResult)}
-                </div>
-              ) : (
-                <VscodeSplitLayout
-                  className={styles.splitLayout}
-                  fixedPane="end"
-                  initialHandlePosition="80%"
-                  minEnd="180px"
-                  minStart="200px"
-                >
-                  <div slot="start" className={styles.splitStart}>
-                    {renderTabSet(selectedResult)}
-                  </div>
-                  <div slot="end" className={styles.validationSidebar}>
-                    <ValidationCaseEditor
-                      transcriptId={selectedResult.transcriptId}
-                    />
-                  </div>
-                </VscodeSplitLayout>
-              )}
+        <div
+          className={clsx(
+            styles.contentArea,
+            !validationSidebarCollapsed && styles.withValidation
+          )}
+        >
+          {validationSidebarCollapsed || !selectedResult.transcriptId ? (
+            <div className={styles.tabSetWrapper}>
+              {renderTabSet(selectedResult)}
             </div>
-          </FindTargetProvider>
-        </ExtendedFindProvider>
+          ) : (
+            <VscodeSplitLayout
+              className={styles.splitLayout}
+              fixedPane="end"
+              initialHandlePosition="80%"
+              minEnd="180px"
+              minStart="200px"
+            >
+              <div slot="start" className={styles.splitStart}>
+                {renderTabSet(selectedResult)}
+              </div>
+              <div slot="end" className={styles.validationSidebar}>
+                <ValidationCaseEditor
+                  transcriptId={selectedResult.transcriptId}
+                />
+              </div>
+            </VscodeSplitLayout>
+          )}
+        </div>
       )}
     </div>
   );

--- a/apps/scout/src/app/scans/ScansPanel.tsx
+++ b/apps/scout/src/app/scans/ScansPanel.tsx
@@ -3,8 +3,6 @@ import { FC, useCallback, useEffect, useMemo } from "react";
 
 import {
   ErrorPanel,
-  ExtendedFindProvider,
-  FindTargetProvider,
   LoadingBar,
   NoContentsPanel,
 } from "@tsmono/react/components";
@@ -81,46 +79,39 @@ export const ScansPanel: FC = () => {
         bordered={true}
       />
       <LoadingBar loading={isFetching} />
-      <ExtendedFindProvider>
-        <FindTargetProvider>
-          {error && (
-            <ErrorPanel
-              title="Error Loading Scans"
-              error={{ message: error.message }}
-            />
-          )}
-          {!data && !error && (
-            <NoContentsPanel
-              icon={ApplicationIcons.running}
-              text="Loading..."
-            />
-          )}
-          {data && !error && (
-            <div className={styles.gridContainer}>
-              <ScansFilterBar
-                filterSuggestions={filterSuggestions}
-                onFilterColumnChange={onFilterColumnChange}
-              />
-              <ScansGrid
-                scans={scans}
-                resultsDir={scanDir}
-                loading={isFetching && scans.length === 0}
-                className={styles.grid}
-                onScrollNearEnd={handleScrollNearEnd}
-                hasMore={hasNextPage}
-                fetchThreshold={SCANS_INFINITE_SCROLL_CONFIG.threshold}
-                filterSuggestions={filterSuggestions}
-                onFilterColumnChange={onFilterColumnChange}
-              />
-            </div>
-          )}
-          <Footer
-            id={"scan-job-footer"}
-            itemCount={data?.pages[0]?.total_count ?? 0}
-            paginated={false}
+      {error && (
+        <ErrorPanel
+          title="Error Loading Scans"
+          error={{ message: error.message }}
+        />
+      )}
+      {!data && !error && (
+        <NoContentsPanel icon={ApplicationIcons.running} text="Loading..." />
+      )}
+      {data && !error && (
+        <div className={styles.gridContainer}>
+          <ScansFilterBar
+            filterSuggestions={filterSuggestions}
+            onFilterColumnChange={onFilterColumnChange}
           />
-        </FindTargetProvider>
-      </ExtendedFindProvider>
+          <ScansGrid
+            scans={scans}
+            resultsDir={scanDir}
+            loading={isFetching && scans.length === 0}
+            className={styles.grid}
+            onScrollNearEnd={handleScrollNearEnd}
+            hasMore={hasNextPage}
+            fetchThreshold={SCANS_INFINITE_SCROLL_CONFIG.threshold}
+            filterSuggestions={filterSuggestions}
+            onFilterColumnChange={onFilterColumnChange}
+          />
+        </div>
+      )}
+      <Footer
+        id={"scan-job-footer"}
+        itemCount={data?.pages[0]?.total_count ?? 0}
+        paginated={false}
+      />
     </div>
   );
 };

--- a/apps/scout/src/app/scans/ScansPanel.tsx
+++ b/apps/scout/src/app/scans/ScansPanel.tsx
@@ -4,6 +4,7 @@ import { FC, useCallback, useEffect, useMemo } from "react";
 import {
   ErrorPanel,
   ExtendedFindProvider,
+  FindTargetProvider,
   LoadingBar,
   NoContentsPanel,
 } from "@tsmono/react/components";
@@ -81,39 +82,44 @@ export const ScansPanel: FC = () => {
       />
       <LoadingBar loading={isFetching} />
       <ExtendedFindProvider>
-        {error && (
-          <ErrorPanel
-            title="Error Loading Scans"
-            error={{ message: error.message }}
+        <FindTargetProvider>
+          {error && (
+            <ErrorPanel
+              title="Error Loading Scans"
+              error={{ message: error.message }}
+            />
+          )}
+          {!data && !error && (
+            <NoContentsPanel
+              icon={ApplicationIcons.running}
+              text="Loading..."
+            />
+          )}
+          {data && !error && (
+            <div className={styles.gridContainer}>
+              <ScansFilterBar
+                filterSuggestions={filterSuggestions}
+                onFilterColumnChange={onFilterColumnChange}
+              />
+              <ScansGrid
+                scans={scans}
+                resultsDir={scanDir}
+                loading={isFetching && scans.length === 0}
+                className={styles.grid}
+                onScrollNearEnd={handleScrollNearEnd}
+                hasMore={hasNextPage}
+                fetchThreshold={SCANS_INFINITE_SCROLL_CONFIG.threshold}
+                filterSuggestions={filterSuggestions}
+                onFilterColumnChange={onFilterColumnChange}
+              />
+            </div>
+          )}
+          <Footer
+            id={"scan-job-footer"}
+            itemCount={data?.pages[0]?.total_count ?? 0}
+            paginated={false}
           />
-        )}
-        {!data && !error && (
-          <NoContentsPanel icon={ApplicationIcons.running} text="Loading..." />
-        )}
-        {data && !error && (
-          <div className={styles.gridContainer}>
-            <ScansFilterBar
-              filterSuggestions={filterSuggestions}
-              onFilterColumnChange={onFilterColumnChange}
-            />
-            <ScansGrid
-              scans={scans}
-              resultsDir={scanDir}
-              loading={isFetching && scans.length === 0}
-              className={styles.grid}
-              onScrollNearEnd={handleScrollNearEnd}
-              hasMore={hasNextPage}
-              fetchThreshold={SCANS_INFINITE_SCROLL_CONFIG.threshold}
-              filterSuggestions={filterSuggestions}
-              onFilterColumnChange={onFilterColumnChange}
-            />
-          </div>
-        )}
-        <Footer
-          id={"scan-job-footer"}
-          itemCount={data?.pages[0]?.total_count ?? 0}
-          paginated={false}
-        />
+        </FindTargetProvider>
       </ExtendedFindProvider>
     </div>
   );

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -6,7 +6,10 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 import { defaultRetry } from "@tsmono/react";
-import { ExtendedFindProvider } from "@tsmono/react/components";
+import {
+  ExtendedFindProvider,
+  FindTargetProvider,
+} from "@tsmono/react/components";
 import { getVscodeApi } from "@tsmono/util";
 
 import { ScoutApiV2 } from "./api/api";
@@ -76,7 +79,9 @@ root.render(
     <ApiProvider value={api}>
       <StoreProvider value={store}>
         <ExtendedFindProvider>
-          <App mode={scansMode ? "scans" : "workbench"} />
+          <FindTargetProvider>
+            <App mode={scansMode ? "scans" : "workbench"} />
+          </FindTargetProvider>
         </ExtendedFindProvider>
       </StoreProvider>
     </ApiProvider>

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -6,10 +6,6 @@ import "bootstrap-icons/font/bootstrap-icons.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 import { defaultRetry } from "@tsmono/react";
-import {
-  ExtendedFindProvider,
-  FindTargetProvider,
-} from "@tsmono/react/components";
 import { getVscodeApi } from "@tsmono/util";
 
 import { ScoutApiV2 } from "./api/api";
@@ -78,11 +74,7 @@ root.render(
   <QueryClientProvider client={queryClient}>
     <ApiProvider value={api}>
       <StoreProvider value={store}>
-        <ExtendedFindProvider>
-          <FindTargetProvider>
-            <App mode={scansMode ? "scans" : "workbench"} />
-          </FindTargetProvider>
-        </ExtendedFindProvider>
+        <App mode={scansMode ? "scans" : "workbench"} />
       </StoreProvider>
     </ApiProvider>
     <ReactQueryDevtools initialIsOpen={false} />

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -28,6 +28,31 @@ import {
   ChatViewToolOptions,
 } from "./types";
 
+// Stable Virtuoso Item wrapper. Defined at module scope so its identity
+// doesn't change across renders of ChatViewVirtualListComponent — Virtuoso
+// re-mounts every row when `components.Item` is a new ref, which detaches
+// the text node any active find selection is anchored to and silently
+// collapses the highlight after about a second of settling.
+const ChatVirtuosoItem = ({
+  children,
+  ...props
+}: ItemProps<unknown> & ContextProp<unknown>) => {
+  return (
+    <div
+      className={clsx(styles.item)}
+      data-index={props["data-index"]}
+      data-item-group-index={props["data-item-group-index"]}
+      data-item-index={props["data-item-index"]}
+      data-known-size={props["data-known-size"]}
+      style={props.style}
+    >
+      {children}
+    </div>
+  );
+};
+
+const chatVirtuosoComponents = { Item: ChatVirtuosoItem };
+
 export interface ChatViewVirtualListProps {
   id: string;
   messages: ChatMessage[];
@@ -179,24 +204,6 @@ export const ChatViewVirtualListComponent: FC<ChatViewVirtualListComponentProps>
       [id, display, labels, linking, tools, maxLabelLength]
     );
 
-    const Item = ({
-      children,
-      ...props
-    }: ItemProps<unknown> & ContextProp<unknown>) => {
-      return (
-        <div
-          className={clsx(styles.item)}
-          data-index={props["data-index"]}
-          data-item-group-index={props["data-item-group-index"]}
-          data-item-index={props["data-item-index"]}
-          data-known-size={props["data-known-size"]}
-          style={props.style}
-        >
-          {children}
-        </div>
-      );
-    };
-
     return (
       <LiveVirtualList<ResolvedMessage>
         id="chat-virtual-list"
@@ -209,7 +216,7 @@ export const ChatViewVirtualListComponent: FC<ChatViewVirtualListComponentProps>
         offsetTop={offsetTop}
         live={running}
         showProgress={running}
-        components={{ Item }}
+        components={chatVirtuosoComponents}
         animation={false}
         itemSearchText={messageSearchText}
       />

--- a/packages/inspect-components/src/chat/messageSearchText.ts
+++ b/packages/inspect-components/src/chat/messageSearchText.ts
@@ -57,8 +57,14 @@ const extractContentText = (content: string | Array<Content>): string[] => {
         texts.push(item.text);
         break;
       case "reasoning": {
+        // Mirror MessageContent.tsx's render logic for reasoning so the
+        // search matches what the user actually sees: redacted reasoning
+        // shows the summary (the raw reasoning is encrypted), unredacted
+        // shows reasoning when present and falls back to summary.
         const reasoning = item;
-        if (reasoning.reasoning) {
+        if (reasoning.redacted) {
+          if (reasoning.summary) texts.push(reasoning.summary);
+        } else if (reasoning.reasoning) {
           texts.push(reasoning.reasoning);
         } else if (reasoning.summary) {
           texts.push(reasoning.summary);

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -41,6 +41,7 @@ import {
   resolveMessageInBranches,
   resolveMessageToEvent,
 } from "./resolveMessageToEvent";
+import { useTranscriptSearchSource } from "./search";
 import { AgentCardView, TimelineSwimLanes } from "./timeline/components";
 import { spanHasBranches, type TimelineSpan } from "./timeline/core";
 import {
@@ -142,6 +143,10 @@ export interface TranscriptLayoutProps {
 
   // --- Headroom ---
   headroomHidden?: boolean;
+  /** Force the headroom into the given hidden state. Used by sources (e.g.
+   *  search) that drive scroll-direction-sensitive UI when their motion
+   *  doesn't match what the scroll-direction tracker would infer. */
+  onHeadroomSetHidden?: (hidden: boolean) => void;
   onHeadroomResetAnchor?: (debounce?: boolean) => void;
 
   // --- Event list ---
@@ -226,6 +231,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   onScrollToTop,
   headroomHidden,
   onHeadroomResetAnchor,
+  onHeadroomSetHidden,
   listId,
   initialEventId,
   initialMessageId,
@@ -335,6 +341,27 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     running,
     showSwimlanes ? sourceSpans : undefined
   );
+
+  const nullViewNodesRef = useRef<TranscriptViewNodesHandle | null>(null);
+
+  // Honor the same event-type filter the renderer uses. State/store events
+  // carry huge JSON payloads but aren't surfaced in the transcript tree;
+  // matching their fields would inflate the counter with unreachable results.
+  const searchableEvents = useMemo(() => {
+    if (!hiddenEventTypes || hiddenEventTypes.length === 0) return events;
+    const hidden = new Set(hiddenEventTypes);
+    return events.filter((e) => !hidden.has(e.event));
+  }, [events, hiddenEventTypes]);
+
+  useTranscriptSearchSource({
+    events: searchableEvents,
+    rows: timelineState.rows,
+    selected: timelineSelection?.selected ?? null,
+    onSelect: timelineSelection?.onSelect ?? (() => {}),
+    viewNodesRef: eventsListRef ?? nullViewNodesRef,
+    onHeadroomResetAnchor,
+    onHeadroomSetHidden,
+  });
 
   // ---------------------------------------------------------------------------
   // Sticky swimlane height

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -354,6 +354,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   }, [events, hiddenEventTypes]);
 
   useTranscriptSearchSource({
+    id: listId,
     events: searchableEvents,
     rows: timelineState.rows,
     selected: timelineSelection?.selected ?? null,

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
@@ -65,10 +65,14 @@ export interface TranscriptViewNodesProps {
 }
 
 export interface TranscriptViewNodesHandle {
-  /** Scroll to an event by its ID. */
+  /** Scroll to an event by its ID. Expands collapsed ancestors first if needed. */
   scrollToEvent: (eventId: string) => void;
   /** Scroll to a flattened-list index. */
   scrollToIndex: (index: number) => void;
+  /** Read-only accessor for the current flattened nodes (post-collapse filter). */
+  getFlattenedNodes: () => EventNode[];
+  /** Read-only accessor for Virtuoso's currently-rendered visible range. */
+  getVisibleRange: () => { startIndex: number; endIndex: number };
 }
 
 // =============================================================================
@@ -93,6 +97,29 @@ const escapeAttr = (id: string): string =>
   typeof CSS !== "undefined" && CSS.escape
     ? CSS.escape(id)
     : id.replace(/"/g, '\\"');
+
+/**
+ * Find the IDs of all ancestors of `eventId` in the EventNode tree.
+ * Returns an empty array if `eventId` is not found.
+ * Order: outermost ancestor first.
+ */
+function findAncestorIds(nodes: EventNode[], eventId: string): string[] {
+  const path: string[] = [];
+  const found = walk(nodes, eventId, path);
+  return found ? path : [];
+
+  function walk(nodes: EventNode[], target: string, path: string[]): boolean {
+    for (const n of nodes) {
+      if (n.id === target) return true;
+      if (n.children.length > 0) {
+        path.push(n.id);
+        if (walk(n.children, target, path)) return true;
+        path.pop();
+      }
+    }
+    return false;
+  }
+}
 
 /** Worst-case bottom edge of the top-pinned sticky bar (relative to the
  *  scroll container's top), based on each sticky element's CSS `top` +
@@ -327,23 +354,75 @@ export const TranscriptViewNodes = forwardRef<
 
   const scrollToEvent = useCallback(
     (eventId: string) => {
+      const tryScroll = (idx: number) => {
+        if (listHandle.current) {
+          listHandle.current.scrollToIndex({
+            index: idx,
+            align: "start",
+            behavior: "auto",
+            offset: offsetTop ? -offsetTop : undefined,
+          });
+        } else {
+          const el = scrollRef?.current?.querySelector(
+            `[id="${escapeAttr(eventId)}"]`
+          );
+          el?.scrollIntoView({ block: "start", behavior: "auto" });
+        }
+      };
+
       const idx = flattenedNodes.findIndex((e) => e.id === eventId);
-      if (idx !== -1 && listHandle.current) {
-        listHandle.current.scrollToIndex({
-          index: idx,
-          align: "start",
-          behavior: "auto",
-          offset: offsetTop ? -offsetTop : undefined,
-        });
-      } else {
-        // Non-virtual fallback: find the DOM element and scroll it into view
-        const el = scrollRef?.current?.querySelector(
-          `[id="${escapeAttr(eventId)}"]`
-        );
-        el?.scrollIntoView({ block: "start", behavior: "auto" });
+      if (idx !== -1) {
+        tryScroll(idx);
+        return;
       }
+
+      // Event is not in the flat list — likely a collapsed ancestor hides it.
+      // Walk the eventNodes tree to find ancestors and expand each that's collapsed.
+      const ancestorIds = findAncestorIds(eventNodes, eventId);
+      if (ancestorIds.length > 0 && onCollapseTranscript) {
+        const collapsedMap = collapsedTranscript ?? defaultCollapsedIds;
+        let didExpand = false;
+        for (const ancestorId of ancestorIds) {
+          if (collapsedMap[ancestorId]) {
+            onCollapseTranscript(ancestorId, false);
+            didExpand = true;
+          }
+        }
+        if (didExpand) {
+          // After the next render, the flat list will include the event.
+          // Retry up to 3 frames in case React batching pushes the commit later.
+          const retryScroll = (attemptsLeft: number) => {
+            const newIdx = flattenedNodesLatest.current.findIndex(
+              (e) => e.id === eventId
+            );
+            if (newIdx !== -1) {
+              tryScroll(newIdx);
+              return;
+            }
+            if (attemptsLeft > 0) {
+              requestAnimationFrame(() => retryScroll(attemptsLeft - 1));
+            }
+          };
+          requestAnimationFrame(() => retryScroll(3));
+          return;
+        }
+      }
+
+      // Fall back to direct DOM scroll.
+      const el = scrollRef?.current?.querySelector(
+        `[id="${escapeAttr(eventId)}"]`
+      );
+      el?.scrollIntoView({ block: "start", behavior: "auto" });
     },
-    [flattenedNodes, offsetTop, scrollRef]
+    [
+      flattenedNodes,
+      eventNodes,
+      collapsedTranscript,
+      defaultCollapsedIds,
+      onCollapseTranscript,
+      offsetTop,
+      scrollRef,
+    ]
   );
 
   const scrollToIndex = useCallback(
@@ -358,10 +437,26 @@ export const TranscriptViewNodes = forwardRef<
     [offsetTop]
   );
 
-  useImperativeHandle(ref, () => ({ scrollToEvent, scrollToIndex }), [
-    scrollToEvent,
-    scrollToIndex,
-  ]);
+  const flattenedNodesLatest = useRef<EventNode[]>(flattenedNodes);
+  useEffect(() => {
+    flattenedNodesLatest.current = flattenedNodes;
+  }, [flattenedNodes]);
+
+  const visibleRangeRef = useRef<{ startIndex: number; endIndex: number }>({
+    startIndex: 0,
+    endIndex: 0,
+  });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToEvent,
+      scrollToIndex,
+      getFlattenedNodes: () => flattenedNodesLatest.current,
+      getVisibleRange: () => visibleRangeRef.current,
+    }),
+    [scrollToEvent, scrollToIndex]
+  );
 
   // Runtime URL→event navigation. The mount-time anchor lives in
   // TranscriptVirtualListComponent (frozen at first render); after mount,
@@ -429,6 +524,7 @@ export const TranscriptViewNodes = forwardRef<
           turnMap={computedTurnMap}
           eventCallbacks={eventCallbacks}
           eventNodeContext={mergedEventNodeContext}
+          visibleRangeRef={visibleRangeRef}
         />
       </div>
     </StickyScrollProvider>

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -36,6 +36,8 @@ interface TranscriptVirtualListComponentProps {
   eventCallbacks?: EventPanelCallbacks;
   /** Extra context fields merged into every EventNodeContext entry. */
   eventNodeContext?: Partial<EventNodeContext>;
+  /** External ref filled with Virtuoso's current visible range, for find machinery. */
+  visibleRangeRef?: RefObject<{ startIndex: number; endIndex: number }>;
 }
 
 /**
@@ -59,6 +61,7 @@ export const TranscriptVirtualListComponent: FC<
   renderAgentCard,
   eventCallbacks,
   eventNodeContext,
+  visibleRangeRef,
 }) => {
   // Always virtualize when not explicitly disabled. The previous threshold
   // (`running || eventNodes.length > 100`) skipped virtualization for short
@@ -203,6 +206,10 @@ export const TranscriptVirtualListComponent: FC<
         live={running}
         animation={!!running}
         itemSearchText={eventSearchText}
+        disableFindRegistration={true}
+        onVisibleRangeChange={(range) => {
+          if (visibleRangeRef) visibleRangeRef.current = range;
+        }}
       />
     );
   } else {

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -54,7 +54,7 @@ const sanitizeStringify = (v: unknown): string => {
 /**
  * Extracts labeled fields from an event for search and text serialization.
  */
-const extractEventFields = (event: EventType): [string, string][] => {
+export const extractEventFields = (event: EventType): [string, string][] => {
   const fields: [string, string][] = [];
 
   switch (event.event) {
@@ -412,6 +412,10 @@ const extractContentText = (content: string | Array<Content>): string[] => {
         texts.push(item.text);
         break;
       case "reasoning": {
+        // The transcript uses MessageContent.tsx's reasoning renderer (via
+        // the chat view), which shows the summary when redacted (since the
+        // reasoning blob is encrypted) and the reasoning otherwise. Match
+        // that here so search hits what the user can see.
         const text = item.redacted
           ? item.summary
           : item.reasoning || item.summary;

--- a/packages/inspect-components/src/transcript/index.ts
+++ b/packages/inspect-components/src/transcript/index.ts
@@ -155,3 +155,6 @@ export {
 
 // Timeline utilities
 export * from "./timeline";
+
+// Search utilities
+export * from "./search";

--- a/packages/inspect-components/src/transcript/search/index.ts
+++ b/packages/inspect-components/src/transcript/search/index.ts
@@ -1,0 +1,2 @@
+export * from "./sampleSearch";
+export * from "./useTranscriptSearchSource";

--- a/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
+++ b/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import type {
+  Event,
+  InfoEvent,
+  ModelEvent,
+} from "@tsmono/inspect-common/types";
+
+import { TimelineEvent, TimelineSpan } from "../timeline/core";
+import type { SwimlaneRow } from "../timeline/swimlaneRows";
+
+import { buildEventToRowMap, findAllMatches } from "./sampleSearch";
+
+const ev = (uuid: string): TimelineEvent =>
+  new TimelineEvent({
+    event: "info",
+    uuid,
+    timestamp: "2026-04-29T00:00:00Z",
+    pending: false,
+    span_id: null,
+    working_start: 0,
+    source: null,
+    data: null,
+    metadata: null,
+  } as unknown as InfoEvent);
+
+const span = (
+  id: string,
+  content: (TimelineEvent | TimelineSpan)[],
+  spanType: string | null = "agent"
+): TimelineSpan => new TimelineSpan({ id, name: id, spanType, content });
+
+const row = (key: string, agent: TimelineSpan, depth = 0): SwimlaneRow => ({
+  key,
+  name: agent.name,
+  depth,
+  spans: [{ agent }],
+  totalTokens: 0,
+  startTime: new Date(0),
+  endTime: new Date(0),
+});
+
+describe("buildEventToRowMap", () => {
+  it("maps events directly under a row's agent to that row", () => {
+    const e1 = ev("e1");
+    const e2 = ev("e2");
+    const main = span("main", [e1, e2]);
+    const map = buildEventToRowMap([row("main", main)]);
+    expect(map.get("e1")).toBe("main");
+    expect(map.get("e2")).toBe("main");
+  });
+
+  it("maps events under a non-agent child span to the parent agent's row", () => {
+    const e1 = ev("e1");
+    const inner = span("step1", [e1], "step");
+    const main = span("main", [inner]);
+    const map = buildEventToRowMap([row("main", main)]);
+    expect(map.get("e1")).toBe("main");
+  });
+
+  it("does not map events under a nested agent span to the outer row", () => {
+    const eOuter = ev("eOuter");
+    const eInner = ev("eInner");
+    const subAgent = span("sub", [eInner], "agent");
+    const main = span("main", [eOuter, subAgent]);
+    // Both rows present in state.rows
+    const rows: SwimlaneRow[] = [
+      row("main", main, 0),
+      row("main/sub", subAgent, 1),
+    ];
+    const map = buildEventToRowMap(rows);
+    expect(map.get("eOuter")).toBe("main");
+    expect(map.get("eInner")).toBe("main/sub");
+  });
+
+  it("uses the deepest matching row when an event appears reachable via multiple", () => {
+    // Defensive: shouldn't happen in practice, but the rule is "deepest wins".
+    const e1 = ev("e1");
+    const sub = span("sub", [e1], "agent");
+    const main = span("main", [sub]);
+    const rows: SwimlaneRow[] = [row("main", main, 0), row("main/sub", sub, 1)];
+    const map = buildEventToRowMap(rows);
+    expect(map.get("e1")).toBe("main/sub");
+  });
+
+  it("handles parallel-span rows (multiple agents in one row)", () => {
+    const e1 = ev("e1");
+    const e2 = ev("e2");
+    const a1 = span("a1", [e1]);
+    const a2 = span("a2", [e2]);
+    const parallelRow: SwimlaneRow = {
+      key: "parallel",
+      name: "parallel",
+      depth: 0,
+      spans: [{ agents: [a1, a2] }],
+      totalTokens: 0,
+      startTime: new Date(0),
+      endTime: new Date(0),
+    };
+    const map = buildEventToRowMap([parallelRow]);
+    expect(map.get("e1")).toBe("parallel");
+    expect(map.get("e2")).toBe("parallel");
+  });
+
+  it("returns an empty map for empty rows", () => {
+    expect(buildEventToRowMap([]).size).toBe(0);
+  });
+});
+
+const modelEv = (uuid: string, output: string): ModelEvent =>
+  ({
+    event: "model",
+    uuid,
+    span_id: null,
+    timestamp: "2026-04-29T00:00:00Z",
+    working_start: 0,
+    pending: false,
+    model: "test/model",
+    role: null,
+    input: [],
+    tools: [],
+    tool_choice: "auto",
+    config: {},
+    output: {
+      model: "test/model",
+      completion: "",
+      choices: [
+        {
+          message: { role: "assistant", content: output, source: "generate" },
+          stop_reason: "stop",
+        },
+      ],
+      usage: null,
+    },
+    error: null,
+    cache: null,
+    call: null,
+    completed: null,
+    working_time: null,
+    style: null,
+    metadata: null,
+  }) as unknown as ModelEvent;
+
+describe("findAllMatches", () => {
+  it("returns empty for empty term", () => {
+    const events: Event[] = [modelEv("e1", "I'm wondering")];
+    const map = new Map([["e1", "main"]]);
+    expect(findAllMatches(events, "", map)).toEqual([]);
+  });
+
+  it("returns empty when term is not present", () => {
+    const events: Event[] = [modelEv("e1", "hello world")];
+    const map = new Map([["e1", "main"]]);
+    expect(findAllMatches(events, "absent", map)).toEqual([]);
+  });
+
+  it("finds a single match in model output", () => {
+    const events: Event[] = [modelEv("e1", "I'm wondering")];
+    const map = new Map([["e1", "main"]]);
+    const matches = findAllMatches(events, "wondering", map);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      rowKey: "main",
+      eventId: "e1",
+      fieldKey: "output",
+      occurrenceIndex: 0,
+    });
+  });
+
+  it("is case-insensitive", () => {
+    const events: Event[] = [modelEv("e1", "WonderingAgain")];
+    const map = new Map([["e1", "main"]]);
+    expect(findAllMatches(events, "wonder", map)).toHaveLength(1);
+  });
+
+  it("finds multiple occurrences in a single field with stable order", () => {
+    const events: Event[] = [modelEv("e1", "wondering wondering wondering")];
+    const map = new Map([["e1", "main"]]);
+    const matches = findAllMatches(events, "wondering", map);
+    expect(matches).toHaveLength(3);
+    expect(matches.map((m) => m.occurrenceIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("tags matches with the correct row when events span multiple rows", () => {
+    const events: Event[] = [
+      modelEv("e1", "wondering up here"),
+      modelEv("e2", "wondering down there"),
+    ];
+    const map = new Map([
+      ["e1", "main"],
+      ["e2", "main/sub"],
+    ]);
+    const matches = findAllMatches(events, "wondering", map);
+    expect(matches.map((m) => m.rowKey)).toEqual(["main", "main/sub"]);
+  });
+
+  it("preserves event-array order across rows", () => {
+    const events: Event[] = [
+      modelEv("e1", "wondering"),
+      modelEv("e2", "wondering"),
+      modelEv("e3", "wondering"),
+    ];
+    const map = new Map([
+      ["e1", "main"],
+      ["e2", "main/sub"],
+      ["e3", "main"],
+    ]);
+    const matches = findAllMatches(events, "wondering", map);
+    expect(matches.map((m) => m.eventId)).toEqual(["e1", "e2", "e3"]);
+  });
+
+  it("skips events whose uuid is not in the row map (defensive)", () => {
+    const events: Event[] = [modelEv("e1", "wondering")];
+    const map = new Map<string, string>(); // empty
+    expect(findAllMatches(events, "wondering", map)).toEqual([]);
+  });
+
+  // Mirrors the variant matching LiveVirtualList does for the chat counter:
+  // a quoted search like `"foo"` should match the bare `foo` in JSON-like
+  // text too, and a JSON-quoted occurrence should count once (not twice
+  // for both the quoted and unquoted forms).
+  it("counts quoted-search variants and dedupes overlapping matches", () => {
+    // `"foo"` (quoted) and `foo` (unquoted) both appear; the literal `"foo"`
+    // is matched by both variants but should only count as one occurrence.
+    const events: Event[] = [modelEv("e1", `prefix "foo" middle foo end`)];
+    const map = new Map([["e1", "main"]]);
+    const matches = findAllMatches(events, `"foo"`, map);
+    // Two distinct positions: the `"foo"` literal and the bare `foo`.
+    expect(matches).toHaveLength(2);
+    expect(matches.map((m) => m.occurrenceIndex)).toEqual([0, 1]);
+  });
+});

--- a/packages/inspect-components/src/transcript/search/sampleSearch.ts
+++ b/packages/inspect-components/src/transcript/search/sampleSearch.ts
@@ -1,0 +1,147 @@
+import type { Event } from "@tsmono/inspect-common/types";
+import { prepareSearchTerm } from "@tsmono/react/components";
+
+import { extractEventFields } from "../eventText";
+import { TimelineSpan } from "../timeline/core";
+import type { SwimlaneRow } from "../timeline/swimlaneRows";
+import { getAgents } from "../timeline/swimlaneRows";
+
+/**
+ * Build a map from event ID to the swimlane row key that contains it.
+ *
+ * Walks each row's agents. Within each agent, iterates through its `content`
+ * but stops descending into nested agent spans — those events belong to
+ * their own row (a separate entry in `state.rows`).
+ *
+ * If `state.rows` is sorted with deeper rows after their parents (the convention
+ * established by `useTimeline`), processing them in order means the deepest row
+ * wins when the same event would otherwise be reachable via multiple rows
+ * (defensive — normally each event has exactly one containing row).
+ */
+export function buildEventToRowMap(rows: SwimlaneRow[]): Map<string, string> {
+  const map = new Map<string, string>();
+  // Sort by depth ascending so deeper rows overwrite shallower ones.
+  const ordered = [...rows].sort((a, b) => a.depth - b.depth);
+
+  for (const row of ordered) {
+    for (const rowSpan of row.spans) {
+      for (const agent of getAgents(rowSpan)) {
+        recordRowEvents(agent, row.key, map);
+      }
+    }
+  }
+  return map;
+}
+
+function recordRowEvents(
+  agent: TimelineSpan,
+  rowKey: string,
+  out: Map<string, string>
+): void {
+  const stack: TimelineSpan[] = [agent];
+  while (stack.length > 0) {
+    const span = stack.pop()!;
+    for (const item of span.content) {
+      if (item.type === "event") {
+        // Use uuid (matching EventNode.id derivation in treeify.ts). Events without uuid get
+        // synthetic node IDs that aren't on the raw event — those can't be reached via
+        // sample-wide search and are skipped.
+        const uuid = item.event.uuid;
+        if (uuid) out.set(uuid, rowKey);
+      } else {
+        // Stop at nested agent spans — those events belong to their own row.
+        if (item.spanType === "agent") continue;
+        stack.push(item);
+      }
+    }
+  }
+}
+
+export interface SampleMatch {
+  rowKey: string;
+  eventId: string;
+  fieldKey: string;
+  /** 0-based index of the field-tuple within extractEventFields output for this event.
+   *  Distinguishes matches when extractEventFields emits the same fieldKey multiple times
+   *  (e.g. multi-choice model events). */
+  fieldIndex: number;
+  /** 0-based index of this occurrence within (eventId, fieldKey, fieldIndex). */
+  occurrenceIndex: number;
+}
+
+/**
+ * Find every occurrence of `term` across the sample's events.
+ *
+ * Reuses `extractEventFields` so the searchable text exactly matches what
+ * `eventSearchText` (the per-row counter) would extract. Events whose uuid
+ * isn't in `eventToRow` are skipped (they're not addressable by row switch).
+ *
+ * Order: events in input order, fields in `extractEventFields` order,
+ * occurrences left-to-right. Stable across calls with the same inputs.
+ */
+export function findAllMatches(
+  events: Event[],
+  term: string,
+  eventToRow: Map<string, string>
+): SampleMatch[] {
+  if (!term) return [];
+  const prepared = prepareSearchTerm(term);
+  const variants = [
+    prepared.simple,
+    ...(prepared.unquoted ? [prepared.unquoted] : []),
+    ...(prepared.jsonEscaped ? [prepared.jsonEscaped] : []),
+  ];
+  const out: SampleMatch[] = [];
+  for (const event of events) {
+    const uuid = event.uuid;
+    if (!uuid) continue;
+    const rowKey = eventToRow.get(uuid);
+    if (rowKey === undefined) continue;
+    const fields = extractEventFields(event);
+    let fieldIndex = 0;
+    for (const [fieldKey, text] of fields) {
+      const positions = findVariantPositions(text.toLowerCase(), variants);
+      for (let i = 0; i < positions.length; i++) {
+        out.push({
+          rowKey,
+          eventId: uuid,
+          fieldKey,
+          fieldIndex,
+          occurrenceIndex: i,
+        });
+      }
+      fieldIndex++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Find every occurrence of any `variants` substring in `lowered`, deduped by
+ * range so a JSON-quoted form `"foo"` matched by both `simple` and `unquoted`
+ * counts as one occurrence (the longer variant wins). Mirrors the variant
+ * matching `LiveVirtualList.searchInText` does for the chat counter so the
+ * two counters agree on the total.
+ */
+function findVariantPositions(lowered: string, variants: string[]): number[] {
+  const hits: { pos: number; len: number }[] = [];
+  for (const v of variants) {
+    if (!v) continue;
+    let from = 0;
+    let p = 0;
+    while ((p = lowered.indexOf(v, from)) !== -1) {
+      hits.push({ pos: p, len: v.length });
+      from = p + v.length;
+    }
+  }
+  hits.sort((a, b) => a.pos - b.pos || b.len - a.len);
+  const out: number[] = [];
+  let endOfLast = -1;
+  for (const h of hits) {
+    if (h.pos >= endOfLast) {
+      out.push(h.pos);
+      endOfLast = h.pos + h.len;
+    }
+  }
+  return out;
+}

--- a/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
+++ b/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ModelEvent } from "@tsmono/inspect-common/types";
+import {
+  ExtendedFindProvider,
+  FindTargetProvider,
+  useExtendedFind,
+  type FindDirection,
+} from "@tsmono/react/components";
+
+import { TimelineEvent, TimelineSpan } from "../timeline/core";
+import type { SwimlaneRow } from "../timeline/swimlaneRows";
+import type { TranscriptViewNodesHandle } from "../TranscriptViewNodes";
+import type { EventNode } from "../types";
+
+import { useTranscriptSearchSource } from "./useTranscriptSearchSource";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const ev = (uuid: string, output: string): ModelEvent =>
+  ({
+    event: "model",
+    uuid,
+    span_id: null,
+    timestamp: "2026-04-29T00:00:00Z",
+    working_start: 0,
+    pending: false,
+    model: "test/model",
+    role: null,
+    input: [],
+    tools: [],
+    tool_choice: "auto",
+    config: {},
+    output: {
+      model: "test/model",
+      completion: "",
+      choices: [
+        {
+          message: { role: "assistant", content: output, source: "generate" },
+          stop_reason: "stop",
+        },
+      ],
+      usage: null,
+    },
+    error: null,
+    cache: null,
+    call: null,
+    completed: null,
+    working_time: null,
+    style: null,
+    metadata: null,
+  }) as unknown as ModelEvent;
+
+function makeRow(key: string, agent: TimelineSpan, depth = 0): SwimlaneRow {
+  return {
+    key,
+    name: agent.name,
+    depth,
+    spans: [{ agent }],
+    totalTokens: 0,
+    startTime: new Date(0),
+    endTime: new Date(0),
+  };
+}
+
+function singleRowFixture(events: ModelEvent[]) {
+  const main = new TimelineSpan({
+    id: "main",
+    name: "main",
+    spanType: "agent",
+    content: events.map((e) => new TimelineEvent(e)),
+  });
+  return { events, rows: [makeRow("main", main, 0)] as SwimlaneRow[] };
+}
+
+function twoRowFixture() {
+  // main row contains e1 ("hello"); main/sub row contains e2 ("wondering")
+  const e1 = ev("e1", "hello");
+  const e2 = ev("e2", "wondering");
+  const sub = new TimelineSpan({
+    id: "sub",
+    name: "sub",
+    spanType: "agent",
+    content: [new TimelineEvent(e2)],
+  });
+  const main = new TimelineSpan({
+    id: "main",
+    name: "main",
+    spanType: "agent",
+    content: [new TimelineEvent(e1), sub],
+  });
+  return {
+    events: [e1, e2] as ModelEvent[],
+    rows: [
+      makeRow("main", main, 0),
+      makeRow("main/sub", sub, 1),
+    ] as SwimlaneRow[],
+  };
+}
+
+// =============================================================================
+// Test harness — mounts the hook and exposes the registered functions.
+// =============================================================================
+
+interface HarnessOptions {
+  events: ModelEvent[];
+  rows: SwimlaneRow[];
+  selected: string;
+  flattenedNodeIds?: string[];
+  panels?: { id: string; text: string }[];
+  onSelect?: (key: string | null) => void;
+  scrollToEvent?: (id: string) => void;
+}
+
+interface Harness {
+  countAll(term: string): number;
+  search(term: string, direction: FindDirection): Promise<boolean>;
+}
+
+/**
+ * Render placeholder panels for the given event ids so `waitForEventInDOM`
+ * (which polls `document.getElementById`) can complete. Panels listed here
+ * are "reachable"; events whose id is omitted simulate the
+ * filtered-out-of-the-rendered-tree case (e.g. nested under a collapsed
+ * subtask span) — the hook's skip-the-whole-event logic depends on this
+ * distinction.
+ */
+function renderHarness(opts: HarnessOptions): Harness {
+  const flattened: EventNode[] = (opts.flattenedNodeIds ?? []).map(
+    (id) => ({ id }) as EventNode
+  );
+  const harness: Partial<Harness> = {};
+  const Probe = () => {
+    const { extendedFindTerm, countAllMatches } = useExtendedFind();
+    harness.countAll = countAllMatches;
+    harness.search = extendedFindTerm;
+    const viewNodesRef = useRef<TranscriptViewNodesHandle | null>({
+      scrollToEvent: opts.scrollToEvent ?? vi.fn(),
+      scrollToIndex: vi.fn(),
+      getFlattenedNodes: () => flattened,
+      getVisibleRange: () => ({ startIndex: 0, endIndex: 0 }),
+    });
+    useTranscriptSearchSource({
+      events: opts.events,
+      rows: opts.rows,
+      selected: opts.selected,
+      onSelect: opts.onSelect ?? vi.fn(),
+      viewNodesRef,
+    });
+    return null;
+  };
+  render(
+    <ExtendedFindProvider>
+      <FindTargetProvider>
+        <Probe />
+        {opts.panels?.map((p) => (
+          <div key={p.id} id={p.id}>
+            {p.text}
+          </div>
+        ))}
+      </FindTargetProvider>
+    </ExtendedFindProvider>
+  );
+  if (!harness.countAll || !harness.search)
+    throw new Error("harness not ready");
+  return harness as Harness;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("useTranscriptSearchSource", () => {
+  it("counts matches across all rows", () => {
+    const { events, rows } = twoRowFixture();
+    const h = renderHarness({ events, rows, selected: "main" });
+    expect(h.countAll("wondering")).toBe(1);
+    expect(h.countAll("hello")).toBe(1);
+    expect(h.countAll("absent")).toBe(0);
+  });
+
+  it("returns false from search when the term has no matches", async () => {
+    const { events, rows } = twoRowFixture();
+    const onSelect = vi.fn();
+    const h = renderHarness({ events, rows, selected: "main", onSelect });
+    let result: boolean | null = null;
+    await act(async () => {
+      result = await h.search("absent", "forward");
+    });
+    expect(result).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("caches matches across repeated counter calls and invalidates on events change", () => {
+    let currentEvents: ModelEvent[] = [ev("e1", "wondering")];
+    const harness: Partial<Harness> = {};
+    const Probe = () => {
+      const { countAllMatches } = useExtendedFind();
+      harness.countAll = countAllMatches;
+      const viewNodesRef = useRef<TranscriptViewNodesHandle | null>(null);
+      const { rows } = singleRowFixture(currentEvents);
+      useTranscriptSearchSource({
+        events: currentEvents,
+        rows,
+        selected: "main",
+        onSelect: vi.fn(),
+        viewNodesRef,
+      });
+      return null;
+    };
+    const tree = () => (
+      <ExtendedFindProvider>
+        <FindTargetProvider>
+          <Probe />
+        </FindTargetProvider>
+      </ExtendedFindProvider>
+    );
+    const { rerender } = render(tree());
+    expect(harness.countAll!("wondering")).toBe(1);
+    expect(harness.countAll!("wondering")).toBe(1); // hits the cache
+
+    currentEvents = [ev("e1", "wondering"), ev("e2", "wondering more")];
+    rerender(tree());
+    expect(harness.countAll!("wondering")).toBe(2); // cache invalidated
+  });
+
+  // The headline integration test. The skip-the-whole-event branch of
+  // searchFn (matches sharing an unreachable eventId are advanced past in
+  // one shot) is the most fragile invariant in the production code: a regression
+  // here makes find silently get stuck at the boundary between reachable and
+  // unreachable matches. By omitting `e2`'s panel from the rendered DOM, we
+  // simulate the deeply-nested-under-collapsed-subtask case that motivated
+  // the skip logic, and assert that one Next press lands on `e3`.
+  it("skips a reachable-but-unmounted event in a single press", async () => {
+    const e1 = ev("e1", "wondering one");
+    const e2 = ev("e2", "wondering two");
+    const e3 = ev("e3", "wondering three");
+    const { events, rows } = singleRowFixture([e1, e2, e3]);
+    const scrollToEvent = vi.fn();
+    const h = renderHarness({
+      events,
+      rows,
+      selected: "main",
+      flattenedNodeIds: ["e1", "e2", "e3"],
+      panels: [
+        { id: "e1", text: "wondering one" },
+        // e2 intentionally omitted — its panel never mounts
+        { id: "e3", text: "wondering three" },
+      ],
+      scrollToEvent,
+    });
+
+    let result: boolean | null = null;
+    await act(async () => {
+      result = await h.search("wondering", "forward");
+    });
+    expect(result).toBe(true);
+    // Both e2 (skipped) and e3 (landed) are scrolled to; the production
+    // code calls scrollToEvent for each attempt. The contract that matters
+    // is the LAST scroll target.
+    const lastScroll = scrollToEvent.mock.calls.at(-1) as [string] | undefined;
+    expect(lastScroll?.[0]).toBe("e3");
+  });
+});

--- a/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.ts
+++ b/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.ts
@@ -1,0 +1,527 @@
+import { RefObject, useCallback, useEffect, useMemo, useRef } from "react";
+
+import type { Event } from "@tsmono/inspect-common/types";
+import {
+  useExtendedFind,
+  useFindTargetSetter,
+  type ExtendedFindFn,
+  type FindDirection,
+} from "@tsmono/react/components";
+
+import type { SwimlaneRow } from "../timeline/swimlaneRows";
+import type { TranscriptViewNodesHandle } from "../TranscriptViewNodes";
+
+import {
+  buildEventToRowMap,
+  findAllMatches,
+  SampleMatch,
+} from "./sampleSearch";
+
+const DEFAULT_ID = "transcript-sample";
+const SETTLE_LIMIT = 90;
+
+export interface UseTranscriptSearchSourceOptions {
+  events: Event[];
+  rows: SwimlaneRow[];
+  selected: string | null;
+  onSelect: (rowKey: string | null) => void;
+  viewNodesRef: RefObject<TranscriptViewNodesHandle | null>;
+  /** Suppress headroom-driven swimlane collapse during programmatic scrolls.
+   *  Without this, scrolling between matches makes the swimlane bar flicker
+   *  collapsed→expanded as the headroom hook misreads our scroll as a user
+   *  gesture. Pass `true` to enable the debounced lock; the hook releases it
+   *  automatically once the scroll settles. */
+  onHeadroomResetAnchor?: (debounce?: boolean) => void;
+  /** Force the headroom hidden state to match the search direction so a
+   *  Next press collapses the swimlane (like a manual scroll-down) and a
+   *  Prev press reveals it (like a scroll-up). Without this, the headroom
+   *  hook only reflects whatever residual scroll motion useScrollDirection
+   *  detected, which doesn't reliably correspond to the user's intent. */
+  onHeadroomSetHidden?: (hidden: boolean) => void;
+  /** Stable registration ID. Default `"transcript-sample"`. */
+  id?: string;
+}
+
+/**
+ * Registers a sample-wide search source with ExtendedFindContext.
+ *
+ * - count(term): findAllMatches over the full sample. Cached per term.
+ * - searchFn(term, dir): finds the next match across the entire sample,
+ *   switches swimlane row if needed, sets the find target (auto-expand),
+ *   then delegates to viewNodesRef.scrollToEvent.
+ *
+ * Preconditions: must be mounted inside an `ExtendedFindProvider`. The
+ * `FindTargetProvider` is optional — its setter no-ops when absent.
+ */
+export function useTranscriptSearchSource(
+  options: UseTranscriptSearchSourceOptions
+): void {
+  const {
+    events,
+    rows,
+    selected,
+    onSelect,
+    viewNodesRef,
+    onHeadroomResetAnchor,
+    onHeadroomSetHidden,
+    id = DEFAULT_ID,
+  } = options;
+  const { registerVirtualList, registerMatchCounter } = useExtendedFind();
+  const setFindTarget = useFindTargetSetter();
+
+  const eventToRow = useMemo(() => buildEventToRowMap(rows), [rows]);
+
+  const cacheRef = useRef<{
+    events: Event[];
+    eventToRow: Map<string, string>;
+    term: string;
+    matches: SampleMatch[];
+  } | null>(null);
+  const getMatches = useCallback(
+    (term: string): SampleMatch[] => {
+      const c = cacheRef.current;
+      if (
+        c &&
+        c.events === events &&
+        c.eventToRow === eventToRow &&
+        c.term === term
+      ) {
+        return c.matches;
+      }
+      const matches = findAllMatches(events, term, eventToRow);
+      cacheRef.current = { events, eventToRow, term, matches };
+      return matches;
+    },
+    [events, eventToRow]
+  );
+
+  // Read across `await` boundaries to detect "user is already on this row"
+  // mid-search; needs to be a ref so a row-switch in flight sees the update.
+  const selectedRef = useRef(selected);
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
+  const lastResolvedRef = useRef<{ match: SampleMatch; term: string } | null>(
+    null
+  );
+  const invocationIdRef = useRef(0);
+  // Self-correction timers scheduled at the end of searchFn. Tracked so
+  // unmount can clear them — otherwise they fire against detached DOM.
+  const pendingTimersRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    const timers = pendingTimersRef.current;
+    return () => {
+      for (const t of timers) clearTimeout(t);
+      timers.clear();
+    };
+  }, []);
+
+  // Active search term. Set by countFn on every keystroke so the listener
+  // below has it on the first selectionchange after a fresh search.
+  const activeTermRef = useRef<string>("");
+  // Keep `lastResolvedRef` in sync when window.find advances within a row
+  // without going through our searchFn. Otherwise the next cross-row
+  // navigation would pickNext from a stale position.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onSelectionChange = () => {
+      const term = activeTermRef.current;
+      if (!term) return;
+      const sel = document.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const range = sel.getRangeAt(0);
+      // Cheap pre-filter: a real find result is a single text node selection
+      // exactly the length of the term. Skip the expensive `range.toString()`
+      // serialization for everything else (Ctrl-A on a long transcript can
+      // make every keystroke in the find box block on MB-sized text).
+      if (range.startContainer !== range.endContainer) return;
+      if (range.endOffset - range.startOffset !== term.length) return;
+      if (range.toString().toLowerCase() !== term.toLowerCase()) return;
+      const matches = getMatches(term);
+      const match = matchAtSelection(matches, term);
+      if (match) lastResolvedRef.current = { match, term };
+    };
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () =>
+      document.removeEventListener("selectionchange", onSelectionChange);
+  }, [getMatches]);
+
+  const countFn = useCallback(
+    (term: string): number => {
+      // FindBand calls this on every keystroke before any navigation, so it's
+      // the natural place to record the active term for the selection
+      // listener — earlier than searchFn, which only fires on cross-row jumps.
+      activeTermRef.current = term;
+      return getMatches(term).length;
+    },
+    [getMatches]
+  );
+
+  const searchFn: ExtendedFindFn = useCallback(
+    async (term, direction, onContentReady) => {
+      const myId = ++invocationIdRef.current;
+      const isStale = () => myId !== invocationIdRef.current;
+
+      const matches = getMatches(term);
+      if (matches.length === 0) return false;
+      activeTermRef.current = term;
+
+      // Match the headroom UI to the user's search direction (forward press
+      // collapses the swimlane like manual scroll-down; backward expands it),
+      // and lock the scroll-direction tracker so its observations of the
+      // imminent imperative scroll don't fight us.
+      onHeadroomResetAnchor?.(true);
+      onHeadroomSetHidden?.(direction === "forward");
+
+      let position = resolvePosition(
+        matches,
+        lastResolvedRef.current,
+        viewNodesRef.current,
+        selectedRef.current,
+        term
+      );
+
+      // Iterate forward/backward until we find a match whose panel actually
+      // mounts. Some events (deeply nested under collapsed subtask spans, or
+      // filtered out of the rendered tree entirely) can be counted by
+      // buildEventToRowMap but never reach the DOM — without this skip, the
+      // user gets stuck at the boundary with no way forward. Cap attempts so
+      // a totally unreachable cluster doesn't spin for 30s+.
+      const SKIP_LIMIT = Math.min(matches.length, 8);
+      let next: SampleMatch | null = null;
+      for (let attempt = 0; attempt < SKIP_LIMIT; attempt++) {
+        next = pickNext(matches, position, direction);
+
+        if (next.rowKey !== selectedRef.current) {
+          onSelect(next.rowKey);
+          const ready = await waitForRow(viewNodesRef, next.eventId);
+          if (isStale()) return false;
+          if (!ready) {
+            position = matches.indexOf(next);
+            lastResolvedRef.current = { match: next, term };
+            continue;
+          }
+        }
+
+        setFindTarget({ term, eventId: next.eventId });
+        await raf();
+        if (isStale()) return false;
+        await raf();
+        if (isStale()) return false;
+
+        viewNodesRef.current?.scrollToEvent(next.eventId);
+        const inDom = await waitForEventInDOM(next.eventId);
+        if (isStale()) return false;
+        if (inDom) break;
+
+        // Unreachable event — advance past ALL matches sharing this eventId.
+        // A single nested-but-unrendered event typically has many occurrences;
+        // trying each would burn SKIP_LIMIT on identical failures.
+        const skippedEventId = next.eventId;
+        let lastSkipIdx = matches.indexOf(next);
+        const stride = direction === "forward" ? 1 : -1;
+        for (
+          let idx = lastSkipIdx + stride;
+          idx >= 0 &&
+          idx < matches.length &&
+          matches[idx]!.eventId === skippedEventId;
+          idx += stride
+        ) {
+          lastSkipIdx = idx;
+        }
+        position = lastSkipIdx;
+        lastResolvedRef.current = { match: matches[lastSkipIdx]!, term };
+        next = null;
+      }
+      if (!next) return false;
+
+      // Position the cursor so FindBand's subsequent `window.find` lands on
+      // the term inside OUR chosen panel. window.find advances FROM the
+      // current selection (it does NOT match at the cursor itself), so
+      // collapse JUST BEFORE the term going forward and JUST AFTER going
+      // backward. Bails silently if the term isn't rendered in the panel
+      // (e.g. a JSON-stringified field) — window.find then picks whatever.
+      positionSelectionAroundTerm(next.eventId, term, direction);
+
+      lastResolvedRef.current = { match: next, term };
+      onContentReady();
+
+      // The transcript renders many code blocks that get syntax-highlighted
+      // asynchronously (Prism splitting `<code>` text into many spans), and
+      // many ExpandablePanels that re-render on `setFindTarget`. Either
+      // can detach the text node `window.find` just anchored on, silently
+      // collapsing the highlight ~hundreds of ms after the search lands.
+      // Re-establish the selection after settling, but only if the current
+      // highlight is missing or wrong (no-op when it survives naturally).
+      const reselectId = next.eventId;
+      const timer = window.setTimeout(() => {
+        if (isStale()) return;
+        reselectTermInPanel(reselectId, term);
+      }, 300);
+      pendingTimersRef.current.add(timer);
+      return true;
+    },
+    [
+      getMatches,
+      viewNodesRef,
+      onSelect,
+      setFindTarget,
+      onHeadroomResetAnchor,
+      onHeadroomSetHidden,
+    ]
+  );
+
+  useEffect(() => {
+    const unCount = registerMatchCounter(id, countFn);
+    const unSearch = registerVirtualList(id, searchFn);
+    return () => {
+      unCount();
+      unSearch();
+    };
+  }, [id, registerMatchCounter, registerVirtualList, countFn, searchFn]);
+}
+
+function pickNext(
+  matches: SampleMatch[],
+  position: number,
+  dir: FindDirection
+): SampleMatch {
+  const len = matches.length;
+  // `position` is the index of the "current" match (or -1 if none).
+  if (position < 0) {
+    return dir === "forward" ? matches[0]! : matches[len - 1]!;
+  }
+  return dir === "forward"
+    ? matches[(position + 1) % len]!
+    : matches[(position - 1 + len) % len]!;
+}
+
+function resolvePosition(
+  matches: SampleMatch[],
+  last: { match: SampleMatch; term: string } | null,
+  view: TranscriptViewNodesHandle | null,
+  selected: string | null,
+  term: string
+): number {
+  // Prefer the last-resolved match when the term hasn't changed.
+  if (last && last.term === term) {
+    const idx = matches.findIndex(
+      (m) =>
+        m.eventId === last.match.eventId &&
+        m.fieldKey === last.match.fieldKey &&
+        m.fieldIndex === last.match.fieldIndex &&
+        m.occurrenceIndex === last.match.occurrenceIndex
+    );
+    if (idx !== -1) return idx;
+  }
+  // Fallback: first match in the currently-visible row.
+  const range = view?.getVisibleRange();
+  const flattened = view?.getFlattenedNodes() ?? [];
+  if (!range || flattened.length === 0) return -1;
+  const visibleIds = new Set(
+    flattened.slice(range.startIndex, range.endIndex + 1).map((n) => n.id)
+  );
+  const idx = matches.findIndex(
+    (m) => m.rowKey === selected && visibleIds.has(m.eventId)
+  );
+  return idx;
+}
+
+/**
+ * Find the SampleMatch corresponding to the current document selection, if any.
+ *
+ * Walks up from the selection's startContainer to find an event-panel element
+ * (one whose `id` is in `matches`'s eventId set). Then counts how many
+ * occurrences of `term` precede the selection within that event's text — that
+ * count is the DOM-order occurrence index, which we map to the n-th match in
+ * our array for that event.
+ *
+ * Returns `null` if there is no selection, no event ancestor, or the count
+ * runs past the matches we know about (e.g. selection isn't actually on a
+ * `term` instance).
+ */
+function matchAtSelection(
+  matches: SampleMatch[],
+  term: string
+): SampleMatch | null {
+  if (typeof window === "undefined" || !term) return null;
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return null;
+  const range = sel.getRangeAt(0);
+
+  const eventIds = new Set(matches.map((m) => m.eventId));
+  let el: Element | null =
+    range.startContainer.nodeType === Node.ELEMENT_NODE
+      ? (range.startContainer as Element)
+      : range.startContainer.parentElement;
+  while (el && !eventIds.has(el.id)) el = el.parentElement;
+  if (!el) return null;
+  const eventId = el.id;
+
+  const lowered = term.toLowerCase();
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  let occurrenceInEvent = 0;
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    const textNode = node as Text;
+    if (textNode === range.startContainer) {
+      const head = textNode.data.slice(0, range.startOffset).toLowerCase();
+      let from = 0;
+      while ((from = head.indexOf(lowered, from)) !== -1) {
+        occurrenceInEvent++;
+        from += lowered.length;
+      }
+      break;
+    }
+    const text = textNode.data.toLowerCase();
+    let from = 0;
+    while ((from = text.indexOf(lowered, from)) !== -1) {
+      occurrenceInEvent++;
+      from += lowered.length;
+    }
+  }
+
+  let seen = 0;
+  for (const m of matches) {
+    if (m.eventId !== eventId) continue;
+    if (seen === occurrenceInEvent) return m;
+    seen++;
+  }
+  return null;
+}
+
+/**
+ * Walk the DOM under the event element with `eventId` and place a collapsed
+ * selection adjacent to the FIRST occurrence of `term` (forward) or the LAST
+ * occurrence (backward), so FindBand's subsequent `window.find` advances onto
+ * exactly that occurrence.
+ *
+ * Forward: cursor BEFORE the first match — `window.find` searches forward
+ * from the cursor and lands on the term.
+ * Backward: cursor AFTER the last match — `window.find` with backward=true
+ * searches backward from the cursor and lands on the term. (If we collapsed
+ * before instead, backward would skip past it and either find nothing or
+ * land in unrelated DOM, which makes findExtendedInDOM return false and the
+ * counter fail to update.)
+ *
+ * If the panel isn't mounted or doesn't render the term as text (e.g. the
+ * match was in a JSON-stringified field we don't render), bail silently —
+ * FindBand will fall back to its default windowFind behavior.
+ */
+function positionSelectionAroundTerm(
+  eventId: string,
+  term: string,
+  direction: FindDirection
+): boolean {
+  const root = document.getElementById(eventId);
+  if (!root) return false;
+  const lowered = term.toLowerCase();
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let target: { node: Text; idx: number } | null = null;
+  for (let node; (node = walker.nextNode()); ) {
+    const textNode = node as Text;
+    const text = textNode.data.toLowerCase();
+    let from = 0;
+    while ((from = text.indexOf(lowered, from)) !== -1) {
+      target = { node: textNode, idx: from };
+      from += lowered.length;
+      if (direction === "forward") break;
+    }
+    if (target && direction === "forward") break;
+  }
+  if (!target) return false;
+  const sel = window.getSelection();
+  if (!sel) return false;
+  const range = document.createRange();
+  range.setStart(
+    target.node,
+    direction === "forward" ? target.idx : target.idx + term.length
+  );
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  return true;
+}
+
+/**
+ * If the current selection no longer covers `term` inside the panel
+ * (because a late settling pass — Virtuoso re-render, lazy syntax
+ * highlighting, ExpandablePanel auto-expand reflow — detached the text
+ * node `window.find` was anchored on), re-anchor the selection to the
+ * first occurrence of `term` in the panel. Returns false (no-op) when
+ * the existing highlight is intact.
+ */
+function reselectTermInPanel(eventId: string, term: string): boolean {
+  const root = document.getElementById(eventId);
+  if (!root) return false;
+  const sel = window.getSelection();
+  if (!sel) return false;
+  if (
+    sel.rangeCount > 0 &&
+    !sel.getRangeAt(0).collapsed &&
+    sel.getRangeAt(0).toString().toLowerCase() === term.toLowerCase() &&
+    root.contains(sel.getRangeAt(0).startContainer)
+  ) {
+    return true; // existing highlight is intact — don't disturb
+  }
+  const lowered = term.toLowerCase();
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  for (let node; (node = walker.nextNode()); ) {
+    const idx = (node.textContent ?? "").toLowerCase().indexOf(lowered);
+    if (idx === -1) continue;
+    const range = document.createRange();
+    range.setStart(node, idx);
+    range.setEnd(node, idx + term.length);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return true;
+  }
+  return false;
+}
+
+function raf(): Promise<void> {
+  return new Promise((resolve) =>
+    typeof requestAnimationFrame !== "undefined"
+      ? requestAnimationFrame(() => resolve())
+      : setTimeout(resolve, 0)
+  );
+}
+
+/**
+ * Wait for the freshly-selected row to mount: poll until the target eventId
+ * is present in the flattened-node list, or the budget expires.
+ * Returns false if the view is not mounted or the event never appears.
+ */
+async function waitForRow(
+  viewNodesRef: RefObject<TranscriptViewNodesHandle | null>,
+  eventId: string
+): Promise<boolean> {
+  for (let i = 0; i < SETTLE_LIMIT; i++) {
+    const view = viewNodesRef.current;
+    if (!view) {
+      // No mounted view to wait on — bail immediately.
+      return false;
+    }
+    if (view.getFlattenedNodes().some((n) => n.id === eventId)) return true;
+    await raf();
+  }
+  return false;
+}
+
+/**
+ * Wait until the event panel is actually rendered to the DOM. After
+ * `scrollToEvent` triggers a Virtuoso scroll for an off-screen target, the
+ * panel takes several frames to mount. Returns false on timeout. The budget
+ * is shorter than for row mount because we use this to detect unreachable
+ * matches and skip them — too long a wait makes skipping feel laggy.
+ */
+async function waitForEventInDOM(eventId: string): Promise<boolean> {
+  if (typeof document === "undefined") return false;
+  const DOM_BUDGET = 30;
+  for (let i = 0; i < DOM_BUDGET; i++) {
+    if (document.getElementById(eventId)) return true;
+    await raf();
+  }
+  return false;
+}

--- a/packages/react/src/components/ExpandablePanel.test.tsx
+++ b/packages/react/src/components/ExpandablePanel.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import React, { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ComponentStateProvider } from "../state/ComponentStateContext";
+
+import { ExpandablePanel } from "./ExpandablePanel";
+import { FindTargetProvider } from "./FindTargetContext";
+
+// --- ResizeObserver shim ---
+// jsdom does not fire ResizeObserver callbacks, so showToggle stays false and
+// expandableTruncated is never applied. We replace ResizeObserver with a shim
+// that immediately fires the callback when observe() is called (synchronously,
+// post-mount inside useEffect), ensuring showToggle=true.
+class FakeResizeObserver {
+  private cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+  observe(el: Element) {
+    // Fire synchronously so React batches the setShowToggle(true) update
+    // inside the same act() wrapping as the initial render.
+    this.cb([{ target: el, contentRect: {} } as ResizeObserverEntry], this);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+
+// jsdom returns "" for computed font-size; parseFloat("") = NaN causes the
+// maxCollapsedHeight comparison to fail. Stub getComputedStyle to return 16px.
+const origGetComputedStyle = window.getComputedStyle.bind(window);
+vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo) => {
+  const style = origGetComputedStyle(el, pseudo ?? null);
+  if (el === document.documentElement) {
+    return new Proxy(style, {
+      get(target, prop) {
+        if (prop === "fontSize") return "16px";
+        const val = (target as unknown as Record<string, unknown>)[
+          prop as string
+        ];
+        return typeof val === "function"
+          ? (val as () => unknown).bind(target)
+          : val;
+      },
+    });
+  }
+  return style;
+});
+
+// Make scrollHeight appear tall (999px >> 5rem=80px) so checkOverflow sets
+// showToggle=true.
+Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+  configurable: true,
+  get() {
+    return 999;
+  },
+});
+
+// --- Minimal ComponentStateHooks mock ---
+// useCollapsedState reads/writes collapsed state. For tests, a simple Map-backed
+// implementation is sufficient. Each test gets fresh state via the closure.
+function makeStateHooks() {
+  const store = new Map<string, unknown>();
+  const getKey = (id: string, prop: string) => `${id}::${prop}`;
+
+  return {
+    useValue: (id: string, prop: string) => store.get(getKey(id, prop)),
+    useSetValue: () => (id: string, prop: string, value: unknown) => {
+      store.set(getKey(id, prop), value);
+    },
+    useRemoveValue: () => (id: string, prop: string) => {
+      store.delete(getKey(id, prop));
+    },
+    useEntries: () => undefined,
+    useRemoveAll: () => () => {},
+    useRemoveByPrefix: () => () => {},
+  };
+}
+
+const Wrapper: React.FC<{
+  findTarget: { term: string; eventId: string } | null;
+  children: React.ReactNode;
+}> = ({ findTarget, children }) => {
+  const [hooks] = useState(() => makeStateHooks());
+  return (
+    <ComponentStateProvider hooks={hooks}>
+      <FindTargetProvider value={findTarget}>{children}</FindTargetProvider>
+    </ComponentStateProvider>
+  );
+};
+
+const longContent = (
+  <div>
+    {Array.from({ length: 50 }).map((_, i) => (
+      <p key={i}>Line {i}: lorem ipsum dolor sit amet</p>
+    ))}
+    <p data-testid="needle-paragraph">contains the wondering needle</p>
+  </div>
+);
+
+// Truncation is signalled by inline `maxHeight` on the content wrapper —
+// an `effectiveCollapsed=true` panel sets it to `${lines}rem`, an expanded
+// panel leaves it empty. Asserting on the inline style sidesteps the CSS
+// module classname (which would change if the rule were renamed).
+function isTruncated(container: HTMLElement): boolean {
+  const wrap = container.querySelector('[data-expandable-panel="true"]')
+    ?.firstElementChild as HTMLElement | null;
+  expect(wrap).toBeTruthy();
+  return wrap!.style.maxHeight !== "";
+}
+
+describe("ExpandablePanel auto-expand on find target", () => {
+  it.each([
+    { name: "no target → truncated", target: null, expectTruncated: true },
+    {
+      name: "matching target → expanded",
+      target: { term: "wondering", eventId: "e1" },
+      expectTruncated: false,
+    },
+    {
+      name: "non-matching target → truncated",
+      target: { term: "absent-term-xyz", eventId: "e1" },
+      expectTruncated: true,
+    },
+  ])("$name", async ({ target, expectTruncated }) => {
+    const { container } = render(
+      <Wrapper findTarget={target}>
+        <ExpandablePanel id="p" collapse={true} lines={5}>
+          {longContent}
+        </ExpandablePanel>
+      </Wrapper>
+    );
+    await waitFor(() => {
+      expect(isTruncated(container)).toBe(expectTruncated);
+    });
+  });
+
+  it("returns to truncated state when target clears", async () => {
+    const hooks = makeStateHooks();
+    const tree = (target: { term: string; eventId: string } | null) => (
+      <ComponentStateProvider hooks={hooks}>
+        <FindTargetProvider value={target}>
+          <ExpandablePanel id="p3" collapse={true} lines={5}>
+            {longContent}
+          </ExpandablePanel>
+        </FindTargetProvider>
+      </ComponentStateProvider>
+    );
+    const { rerender, container } = render(
+      tree({ term: "wondering", eventId: "e1" })
+    );
+    await waitFor(() => expect(isTruncated(container)).toBe(false));
+    rerender(tree(null));
+    await waitFor(() => expect(isTruncated(container)).toBe(true));
+  });
+});

--- a/packages/react/src/components/ExpandablePanel.tsx
+++ b/packages/react/src/components/ExpandablePanel.tsx
@@ -5,6 +5,7 @@ import {
   memo,
   ReactNode,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -12,6 +13,7 @@ import {
 import { useCollapsedState, useResizeObserver } from "../hooks";
 
 import styles from "./ExpandablePanel.module.css";
+import { useFindTarget } from "./FindTargetContext";
 
 interface ExpandablePanelProps {
   id: string;
@@ -61,6 +63,38 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
     );
     const contentRef = useResizeObserver(checkOverflow);
 
+    const findTarget = useFindTarget();
+    // Initialize optimistically: if there's an active find target when we
+    // mount, assume our subtree contains it and render expanded immediately.
+    // The post-render effect below will collapse us back if the term isn't
+    // actually present. This swaps a "collapsed→expanded" flash on remount
+    // (which the user sees on every search step as Virtuoso re-renders) for
+    // a much rarer "expanded→collapsed" flash on panels that don't match.
+    const [containsFindTarget, setContainsFindTarget] = useState(
+      () => findTarget !== null
+    );
+
+    // No dep array: intentionally re-runs after every render so that changes
+    // in children text (e.g. lazily loaded content) are picked up without an
+    // additional mechanism.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: re-run after every render to track subtree text changes
+    useEffect(() => {
+      if (!findTarget) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing React state with DOM subtree text; no external subscription possible
+        setContainsFindTarget(false);
+        return;
+      }
+      const root = contentRef.current;
+      if (!root) {
+        setContainsFindTarget(false);
+        return;
+      }
+      const text = (root.textContent ?? "").toLowerCase();
+      setContainsFindTarget(text.includes(findTarget.term.toLowerCase()));
+    });
+
+    const effectiveCollapsed = containsFindTarget ? false : collapsed;
+
     // `overflow: hidden` + `maxHeight` live on the inner content wrapper, not
     // the outer panel. Two reasons:
     //   1. Keeping it off the panel when expanded prevents the panel from
@@ -69,7 +103,7 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
     //      visible (clipped) area, so a `mask-image` gradient on the wrapper
     //      fades the bottom of the *visible* region — not the bottom of the
     //      natural-height content (which would sit off-screen).
-    const contentStyles: CSSProperties = collapsed
+    const contentStyles: CSSProperties = effectiveCollapsed
       ? { overflow: "hidden", maxHeight: `${lines}rem` }
       : {};
 
@@ -112,7 +146,9 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
             style={contentStyles}
             className={clsx(
               styles.expandableContentWrap,
-              collapsed && showToggle ? styles.expandableTruncated : undefined
+              effectiveCollapsed && showToggle
+                ? styles.expandableTruncated
+                : undefined
             )}
           >
             {children}

--- a/packages/react/src/components/ExtendedFindContext.tsx
+++ b/packages/react/src/components/ExtendedFindContext.tsx
@@ -12,10 +12,12 @@ import {
 // search is requested and no matches are found. In this case, they can 'look ahead'
 // and scroll an item into view if it is likely/certain to contain the search term.
 
+export type FindDirection = "forward" | "backward";
+
 // Find will call this when an extended find is requested
 export type ExtendedFindFn = (
   term: string,
-  direction: "forward" | "backward",
+  direction: FindDirection,
   onContentReady: () => void
 ) => Promise<boolean>;
 
@@ -27,7 +29,7 @@ export type ExtendedCountFn = (term: string) => number;
 interface ExtendedFindContextType {
   extendedFindTerm: (
     term: string,
-    direction: "forward" | "backward"
+    direction: FindDirection
   ) => Promise<boolean>;
   registerVirtualList: (id: string, searchFn: ExtendedFindFn) => () => void;
   countAllMatches: (term: string) => number;
@@ -47,10 +49,7 @@ export const ExtendedFindProvider = ({
   const matchCounters = useRef<Map<string, ExtendedCountFn>>(new Map());
 
   const extendedFindTerm = useCallback(
-    async (
-      term: string,
-      direction: "forward" | "backward"
-    ): Promise<boolean> => {
+    async (term: string, direction: FindDirection): Promise<boolean> => {
       for (const [, searchFn] of virtualLists.current) {
         const found = await new Promise<boolean>((resolve) => {
           let callbackFired = false;

--- a/packages/react/src/components/FindTargetContext.tsx
+++ b/packages/react/src/components/FindTargetContext.tsx
@@ -1,0 +1,61 @@
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+export interface FindTarget {
+  /** The current search term. Lower-cased comparisons are the consumer's responsibility. */
+  term: string;
+  /** ID of the event the search has navigated to. Consumers can use this for
+   *  finer-grained behavior; basic auto-expand uses only `term`. */
+  eventId: string;
+}
+
+interface FindTargetContextValue {
+  target: FindTarget | null;
+  setTarget: (target: FindTarget | null) => void;
+}
+
+const FindTargetContext = createContext<FindTargetContextValue | null>(null);
+
+/** Returns the active find target, or null. Consumers: ExpandablePanel and
+ *  any other UI that should react to find navigation. */
+export const useFindTarget = (): FindTarget | null =>
+  useContext(FindTargetContext)?.target ?? null;
+
+/** Returns the setter. Consumers: the search source (sets on match) and
+ *  FindBand (clears on close / empty term). */
+export const useFindTargetSetter = (): ((
+  target: FindTarget | null
+) => void) => {
+  const ctx = useContext(FindTargetContext);
+  // No-op when no provider — keeps consumers safe in environments without one.
+  return ctx?.setTarget ?? (() => {});
+};
+
+interface FindTargetProviderProps {
+  /** Controlled value. When provided, overrides internal state — useful for tests. */
+  value?: FindTarget | null;
+  children: ReactNode;
+}
+
+export const FindTargetProvider: FC<FindTargetProviderProps> = ({
+  value,
+  children,
+}) => {
+  const [internal, setInternal] = useState<FindTarget | null>(null);
+  const target = value !== undefined ? value : internal;
+  const ctxValue = useMemo<FindTargetContextValue>(
+    () => ({ target, setTarget: setInternal }),
+    [target]
+  );
+  return (
+    <FindTargetContext.Provider value={ctxValue}>
+      {children}
+    </FindTargetContext.Provider>
+  );
+};

--- a/packages/react/src/components/LiveVirtualList.tsx
+++ b/packages/react/src/components/LiveVirtualList.tsx
@@ -1,9 +1,11 @@
 import clsx from "clsx";
 import {
+  FC,
   ReactNode,
   RefObject,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -60,6 +62,19 @@ interface LiveVirtualListProps<T> {
   // If not provided, will use JSON.stringify as fallback
   // Return a string or array of strings to search within
   itemSearchText?: (item: T) => string | string[];
+
+  /**
+   * When true, this list does not register itself with ExtendedFindContext for
+   * search or counting. Use when an enclosing component owns find behavior
+   * for a wider scope (e.g. sample-wide transcript search).
+   */
+  disableFindRegistration?: boolean;
+
+  /** Called whenever Virtuoso reports a new visible range. */
+  onVisibleRangeChange?: (range: {
+    startIndex: number;
+    endIndex: number;
+  }) => void;
 }
 
 /**
@@ -79,6 +94,8 @@ export const LiveVirtualList = <T,>({
   components,
   itemSearchText,
   animation = true,
+  disableFindRegistration = false,
+  onVisibleRangeChange,
 }: LiveVirtualListProps<T>) => {
   // The list handle and list state management
   const { getRestoreState, isScrolling, visibleRange, setVisibleRange } =
@@ -355,6 +372,7 @@ export const LiveVirtualList = <T,>({
   );
 
   useEffect(() => {
+    if (disableFindRegistration) return;
     const unregisterSearch = registerVirtualList(id, searchInData);
     const unregisterCount = registerMatchCounter(id, countMatchesInData);
     return () => {
@@ -367,15 +385,31 @@ export const LiveVirtualList = <T,>({
     registerMatchCounter,
     searchInData,
     countMatchesInData,
+    disableFindRegistration,
   ]);
 
-  const Footer = () => {
-    return showProgress ? (
-      <div className={clsx(styles.progressContainer)}>
-        <PulsingDots subtle={false} size="medium" />
-      </div>
-    ) : undefined;
-  };
+  // Memoize Footer so its identity is stable across renders. A new ref
+  // on every render makes Virtuoso treat `components` as changed and
+  // re-mount every row, which detaches text nodes (and any find-selection
+  // anchored on them).
+  const Footer = useMemo(
+    () =>
+      Object.assign(
+        function LiveVirtualListFooter() {
+          return showProgress ? (
+            <div className={clsx(styles.progressContainer)}>
+              <PulsingDots subtle={false} size="medium" />
+            </div>
+          ) : undefined;
+        } as FC,
+        { displayName: "LiveVirtualListFooter" }
+      ),
+    [showProgress]
+  );
+  const mergedComponents = useMemo(
+    () => ({ Footer, ...components }),
+    [Footer, components]
+  );
 
   useEffect(() => {
     // Listen to scroll events
@@ -470,25 +504,23 @@ export const LiveVirtualList = <T,>({
       isScrolling={handleScrollingChange}
       rangeChanged={(range) => {
         setVisibleRange({ ...range, totalCount: data.length });
+        onVisibleRangeChange?.(range);
       }}
       skipAnimationFrameInResizeObserver={true}
       restoreStateFrom={getRestoreState()}
       totalListHeightChanged={heightChanged}
-      components={{
-        Footer,
-        ...components,
-      }}
+      components={mergedComponents}
     />
   );
 };
 
-type PreparedSearchTerms = {
+export type PreparedSearchTerms = {
   simple: string;
   unquoted?: string;
   jsonEscaped?: string;
 };
 
-const prepareSearchTerm = (term: string): PreparedSearchTerms => {
+export const prepareSearchTerm = (term: string): PreparedSearchTerms => {
   const lower = term.toLowerCase();
 
   // No special characters that need JSON handling

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -34,4 +34,5 @@ export * from "./LightboxCarousel";
 export * from "./HumanBaselineView";
 export * from "./LiveVirtualList";
 export * from "./ComponentNavigationContext";
+export * from "./FindTargetContext";
 export * from "./MarkdownDivWithReferences";

--- a/packages/react/src/hooks/useScrollDirection.ts
+++ b/packages/react/src/hooks/useScrollDirection.ts
@@ -42,6 +42,11 @@ interface UseScrollDirectionResult {
    *    stops (useful for Virtuoso multi-pass settling). When false (default),
    *    the lock uses a fixed timeout matching the CSS transition duration. */
   resetAnchor: (debounce?: boolean) => void;
+  /** Imperatively set the hidden state. Used by callers that drive scroll
+   *  motions for which `hidden` should match an explicit direction (e.g.
+   *  search Next = forward = collapse) — calling `resetAnchor` alone would
+   *  freeze the prior state instead of advancing to the new intended one. */
+  setHidden: (hidden: boolean) => void;
 }
 
 /**
@@ -276,5 +281,25 @@ export function useScrollDirection(
     [primaryRef, transitionLockMs]
   );
 
-  return { hidden, resetAnchor };
+  const setHiddenExternal = useCallback(
+    (next: boolean) => {
+      setHidden((prev) => {
+        if (prev === next) return prev;
+        // Match the internal state-change path: engage the transition lock so
+        // scroll events from the imminent imperative scroll don't fight us.
+        transitionLockedRef.current = true;
+        if (lockTimerRef.current !== null) {
+          clearTimeout(lockTimerRef.current);
+        }
+        lockTimerRef.current = setTimeout(() => {
+          transitionLockedRef.current = false;
+          lockTimerRef.current = null;
+        }, transitionLockMs);
+        return next;
+      });
+    },
+    [transitionLockMs]
+  );
+
+  return { hidden, resetAnchor, setHidden: setHiddenExternal };
 }


### PR DESCRIPTION
## Summary

The sample viewer's find experience was broken in several related ways across all four sample tabs. 

I have tried a balance that avoids a full rewrite, but also doesn't just add duct-tape everywhere.

So we rebuild it around a single sample-wide search source for the transcript, fix the chat-tab highlight loss at its DOM-mutation root, and remove the early-bail that left Scoring/Metadata/JSON entirely unsearchable.

The bugs that drove this work:
- **Cross-row navigation didn't work** in the transcript — matches in collapsed sub-agent rows were invisible to the counter and unreachable via Next/Prev.
- **Counter inflated by unrendered events** (state/store etc.) so users saw "1 of 20" but could only navigate to 10 of them.
- **Highlights vanished after ~1 second** on the Messages tab — caused by Virtuoso re-mounting every row when `components.Item` was a fresh function reference each render.
- **Search did nothing on Scoring/Metadata/JSON** because FindBand bailed out when `countAllMatches` returned 0; those tabs are static markup with no registered counter.
- **Reasoning matches were missed** when the model redacted the raw `reasoning` field — the search indexed the encrypted blob, not the visible summary.

## What changed

- `useTranscriptSearchSource` + `sampleSearch`: walks all events in the sample, knows which swimlane row each match lives in, switches rows + scrolls + auto-expands when navigating across rows, and skips events whose row isn't surfaced in the rendered tree (via the same `hiddenEventTypes` the renderer uses) so the counter only includes reachable matches.
- `FindTargetContext`: replaces imperative DOM-mutation with declarative auto-expand. `ExpandablePanel` self-detects when its subtree contains the active term and expands; mounts optimistically so Virtuoso re-renders during search don't flash collapsed→expanded.
- Hoisted `ChatVirtuosoItem` to module scope and memoized `LiveVirtualList`'s `Footer`/components — fixes the "highlight disappears after 1 second" symptom by stopping Virtuoso's mass-row remount.
- `messageSearchText` and `eventText` reasoning case: mirror the renderer's redacted→summary fallback so search hits what the user actually sees.
- FindBand no longer bails on `total === 0`; runs the find anyway and tracks "no results" as separate state. Static-content tabs (Scoring, Metadata, JSON) now search via `window.find` with no counter shown.

## Test plan

- [x] Sample with sub-agent rows: search a term that appears across multiple rows, verify counter, Next/Prev, and that target panels auto-expand
- [x] Search inside a clipped `ExpandablePanel` — confirm it expands without flashing collapsed→expanded
- [x] Messages tab: redacted-reasoning summary search (e.g. `hiccup` in the test eval) finds the term and the highlight stays past the ~1s mark
- [x] Scoring / Metadata / JSON tab: typing a visible term highlights it (no "X of Y" counter, that's expected); typing a non-existent term shows "No results"
- [x] Transcript Next/Prev: swimlane bar collapses on Next and expands on Prev (matches manual scroll-down/up)
- [x] Match counter accuracy on transcript: counts only reachable matches (not state/store events)