### PR TITLE
Improve narrow-width viewing

### DIFF
--- a/apps/inspect/src/app/samples/SampleSummaryView.tsx
+++ b/apps/inspect/src/app/samples/SampleSummaryView.tsx
@@ -283,7 +283,11 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
         style={
           dynamicRightMax !== null
             ? {
-                gridTemplateColumns: `minmax(0, 1fr) minmax(220px, ${dynamicRightMax}px)`,
+                // Cap the right column at 40% of container so the score
+                // panel never dominates the width on narrow viewports.
+                // The panel is horizontally scrollable inside, so it can
+                // tolerate a tighter cell.
+                gridTemplateColumns: `minmax(0, 1fr) min(${dynamicRightMax}px, 40%)`,
               }
             : undefined
         }

--- a/packages/inspect-components/src/transcript/event/EventNavs.module.css
+++ b/packages/inspect-components/src/transcript/event/EventNavs.module.css
@@ -1,3 +1,31 @@
+.wrapper {
+  position: relative;
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  min-width: 0;
+  flex: 1;
+}
+
 .navs {
   margin-right: 0;
+  flex-wrap: nowrap;
+}
+
+/* Off-screen single-line copy of the pills used to measure the natural
+   width that determines whether to render tabs or the picker. */
+.probe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  visibility: hidden;
+  pointer-events: none;
+  width: max-content;
+  flex-wrap: nowrap;
+}
+
+.probeItem {
+  min-width: 4rem;
+  padding: 0.1rem 0.6rem;
+  white-space: nowrap;
 }

--- a/packages/inspect-components/src/transcript/event/EventNavs.tsx
+++ b/packages/inspect-components/src/transcript/event/EventNavs.tsx
@@ -1,8 +1,11 @@
 import clsx from "clsx";
-import { FC } from "react";
+import { FC, useCallback, useLayoutEffect, useRef, useState } from "react";
+
+import { useResizeObserver } from "@tsmono/react/hooks";
 
 import { EventNav } from "./EventNav";
 import styles from "./EventNavs.module.css";
+import { EventNavsPicker } from "./EventNavsPicker";
 
 interface EventNavsProps {
   navs: Array<{ id: string; title: string; target: string }>;
@@ -10,31 +13,123 @@ interface EventNavsProps {
   setSelectedNav: (target: string) => void;
 }
 
+// Hysteresis (px) so a measurement landing right at the threshold doesn't
+// flip modes on every resize tick.
+const SWITCH_TOLERANCE = 4;
+
 /**
- * Component to render navigation items.
+ * Renders the event panel's tab navigation. When the available width is
+ * smaller than the natural width of the pill row, collapses to a picker
+ * dropdown instead of letting the pills wrap to a second line.
  */
 export const EventNavs: FC<EventNavsProps> = ({
   navs,
   selectedNav,
   setSelectedNav,
 }) => {
+  const [mode, setMode] = useState<"tabs" | "picker">("tabs");
+  const [labelWidth, setLabelWidth] = useState(0);
+  const probeRef = useRef<HTMLUListElement>(null);
+  const naturalWidthRef = useRef(0);
+
+  // Re-measure whenever the nav set changes — titles, count, or order all
+  // affect the natural single-line width that drives the mode switch and the
+  // picker label's natural width.
+  useLayoutEffect(() => {
+    const probe = probeRef.current;
+    if (!probe) return;
+    naturalWidthRef.current = probe.scrollWidth;
+    // Measure each title's text width via canvas, using the font resolved on
+    // a real probe pill so the result honors `text-style-label` (uppercase)
+    // and `text-size-small`. Canvas avoids the layout/visibility quirks that
+    // can make DOM-based measurements come back as 0.
+    const sample = probe.querySelector<HTMLElement>(".nav-link");
+    if (!sample) return;
+    const cs = getComputedStyle(sample);
+    const ctx = document.createElement("canvas").getContext("2d");
+    if (!ctx) return;
+    ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+    const transform = cs.textTransform;
+    const transformed = (s: string) =>
+      transform === "uppercase"
+        ? s.toUpperCase()
+        : transform === "lowercase"
+          ? s.toLowerCase()
+          : s;
+    let max = 0;
+    navs.forEach((nav) => {
+      max = Math.max(max, ctx.measureText(transformed(nav.title)).width);
+    });
+    setLabelWidth(Math.ceil(max));
+  }, [navs]);
+
+  const handleResize = useCallback((entry: ResizeObserverEntry) => {
+    const available = entry.contentRect.width;
+    const natural = naturalWidthRef.current;
+    if (natural === 0) return;
+    setMode((current) => {
+      if (current === "tabs" && available < natural - SWITCH_TOLERANCE) {
+        return "picker";
+      }
+      if (current === "picker" && available >= natural + SWITCH_TOLERANCE) {
+        return "tabs";
+      }
+      return current;
+    });
+  }, []);
+
+  const containerRef = useResizeObserver(handleResize);
+
   return (
-    <ul
-      className={clsx("nav", "nav-pills", styles.navs)}
-      role="tablist"
-      aria-orientation="horizontal"
-    >
-      {navs.map((nav) => {
-        return (
-          <EventNav
-            key={nav.title}
-            target={nav.target}
-            title={nav.title}
-            selectedNav={selectedNav}
-            setSelectedNav={setSelectedNav}
-          />
-        );
-      })}
-    </ul>
+    <div ref={containerRef} className={styles.wrapper}>
+      {mode === "tabs" ? (
+        <ul
+          className={clsx("nav", "nav-pills", styles.navs)}
+          role="tablist"
+          aria-orientation="horizontal"
+        >
+          {navs.map((nav) => (
+            <EventNav
+              key={nav.title}
+              target={nav.target}
+              title={nav.title}
+              selectedNav={selectedNav}
+              setSelectedNav={setSelectedNav}
+            />
+          ))}
+        </ul>
+      ) : (
+        <EventNavsPicker
+          navs={navs}
+          selectedNav={selectedNav}
+          setSelectedNav={setSelectedNav}
+          labelWidth={labelWidth}
+        />
+      )}
+      <ul
+        ref={probeRef}
+        aria-hidden
+        className={clsx("nav", "nav-pills", styles.navs, styles.probe)}
+      >
+        {navs.map((nav) => (
+          <li key={nav.id} className="nav-item">
+            {/* Match EventNav's <button> element/classes so the probe's
+                scrollWidth equals the real pill row's natural width. */}
+            <button
+              type="button"
+              tabIndex={-1}
+              className={clsx(
+                "nav-link",
+                "text-style-label",
+                "text-size-small",
+                styles.probeItem
+              )}
+            >
+              {nav.title}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 };

--- a/packages/inspect-components/src/transcript/event/EventNavsPicker.module.css
+++ b/packages/inspect-components/src/transcript/event/EventNavsPicker.module.css
@@ -1,0 +1,84 @@
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.6rem;
+  border: none;
+  border-radius: var(--bs-border-radius);
+  white-space: nowrap;
+  max-width: 100%;
+  min-width: 0;
+  cursor: pointer;
+  /* `.nav-link.active` colors only apply inside a `.nav-pills` parent;
+     the picker button isn't nested in one, so apply them directly. */
+  background-color: var(--bs-nav-pills-link-active-bg, var(--bs-primary));
+  color: var(--bs-nav-pills-link-active-color, #fff);
+}
+
+.trigger:hover {
+  filter: brightness(1.05);
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  margin-left: 0.4em;
+  font-size: 0.75em;
+  flex-shrink: 0;
+}
+
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  /* Above Bootstrap's sticky-top (1020) so sticky bars don't occlude the menu. */
+  z-index: 1049;
+}
+
+.menu {
+  position: fixed;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  z-index: 1050;
+  overflow: hidden;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 0.75rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--bs-body-color);
+  white-space: nowrap;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.item:hover {
+  background-color: var(--bs-tertiary-bg);
+}
+
+.item:active {
+  background-color: var(--bs-secondary-bg);
+}
+
+.item.selected {
+  background-color: var(--bs-primary);
+  color: var(--bs-light);
+}
+
+.item.selected:hover {
+  background-color: var(--bs-primary);
+  filter: brightness(1.05);
+}

--- a/packages/inspect-components/src/transcript/event/EventNavsPicker.tsx
+++ b/packages/inspect-components/src/transcript/event/EventNavsPicker.tsx
@@ -1,0 +1,146 @@
+import clsx from "clsx";
+import {
+  FC,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+import styles from "./EventNavsPicker.module.css";
+
+interface EventNavsPickerProps {
+  navs: Array<{ id: string; title: string; target: string }>;
+  selectedNav: string;
+  setSelectedNav: (target: string) => void;
+  /** Natural width (px) of the longest option's text — sets the label's
+   *  preferred width so the button is wide enough to fit any selection
+   *  without truncation when there's room. */
+  labelWidth?: number;
+}
+
+/**
+ * Compact replacement for {@link EventNavs} when the tab row is too narrow
+ * to display all pills inline. Renders the active tab title as a single
+ * button that opens a portal-anchored menu of all navs.
+ */
+export const EventNavsPicker: FC<EventNavsPickerProps> = ({
+  navs,
+  selectedNav,
+  setSelectedNav,
+  labelWidth,
+}) => {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    right: number;
+    minWidth: number;
+  } | null>(null);
+
+  const computePosition = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setPosition({
+      top: rect.bottom,
+      right: window.innerWidth - rect.right,
+      minWidth: rect.width,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (open) computePosition();
+  }, [open, computePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = () => computePosition();
+    window.addEventListener("resize", handler);
+    window.addEventListener("scroll", handler, true);
+    return () => {
+      window.removeEventListener("resize", handler);
+      window.removeEventListener("scroll", handler, true);
+    };
+  }, [open, computePosition]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+      buttonRef.current?.focus();
+    }
+  }, []);
+
+  const selected = navs.find((nav) => nav.target === selectedNav) ?? navs[0];
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={clsx(
+          "nav-link",
+          "active",
+          "text-style-label",
+          "text-size-small",
+          styles.trigger
+        )}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={handleKeyDown}
+      >
+        <span
+          className={styles.label}
+          style={labelWidth ? { width: labelWidth } : undefined}
+        >
+          {selected?.title ?? ""}
+        </span>
+        <i className={clsx("bi", "bi-chevron-down", styles.chevron)} />
+      </button>
+      {open &&
+        position &&
+        createPortal(
+          <>
+            <div className={styles.backdrop} onClick={() => setOpen(false)} />
+            <div
+              role="listbox"
+              className={styles.menu}
+              style={{
+                top: position.top,
+                right: position.right,
+                minWidth: position.minWidth,
+              }}
+              onKeyDown={handleKeyDown}
+            >
+              {navs.map((nav) => {
+                const isSelected = nav.target === selectedNav;
+                return (
+                  <button
+                    key={nav.id}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    className={clsx(
+                      styles.item,
+                      isSelected ? styles.selected : undefined,
+                      "text-size-small"
+                    )}
+                    onClick={() => {
+                      setSelectedNav(nav.target);
+                      setOpen(false);
+                    }}
+                  >
+                    {nav.title}
+                  </button>
+                );
+              })}
+            </div>
+          </>,
+          document.body
+        )}
+    </>
+  );
+};

--- a/packages/inspect-components/src/transcript/event/EventPanel.module.css
+++ b/packages/inspect-components/src/transcript/event/EventPanel.module.css
@@ -33,13 +33,15 @@
 }
 
 .navs {
-  justify-self: end;
   display: flex;
   align-items: baseline;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .turnLabel {
-  margin-left: 0.625rem;
+  margin-left: 1rem;
+  margin-top: 0.2rem;
   opacity: 0.5;
   font-size: var(--inspect-font-size-smallest);
 }

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -123,11 +123,15 @@ export const EventPanel: FC<EventPanelProps> = ({
     gridColumns.push("max-content");
   }
 
-  // title (now also carries copy-link + headerExtra so they wrap with the title)
-  gridColumns.push("minmax(0px, auto)");
-  gridColumns.push("minmax(0px, 1fr)");
-  gridColumns.push("minmax(0px, max-content)");
-  gridColumns.push("minmax(0px, max-content)");
+  // title (carries copy-link + headerExtra so they wrap with the title)
+  gridColumns.push("minmax(0, max-content)");
+  gridColumns.push("minmax(0, 1fr)");
+  gridColumns.push("minmax(0, max-content)");
+  // navs: auto so it shrinks to picker mode when over-constrained
+  gridColumns.push("auto");
+  if (turnLabel) {
+    gridColumns.push("max-content");
+  }
 
   const toggleCollapse = useCallback(() => {
     setCollapsed(!collapsed);
@@ -227,10 +231,10 @@ export const EventPanel: FC<EventPanelProps> = ({
           ) : (
             ""
           )}
-          {turnLabel && (
-            <span className={clsx(styles.turnLabel)}>{turnLabel}</span>
-          )}
         </div>
+        {turnLabel && (
+          <span className={clsx(styles.turnLabel)}>{turnLabel}</span>
+        )}
       </div>
     ) : (
       ""


### PR DESCRIPTION
Fixes meridianlabs-ai/ts-mono#208 (and the upstream report at UKGovernmentBEIS/inspect_ai#208).

Two narrow-width fixes for the sample / transcript view:

## Summary

- **EventNavs**: when the event panel title row is too narrow to fit all tab pills, collapse them into a single dropdown (active-pill-styled label + chevron) instead of letting the pills wrap onto a second line. The picker label sizes to the widest option's text width (measured via canvas with the resolved font) and ellipsis-truncates if the cell is squeezed below that. The navs grid column uses `auto` so it prefers its natural tabs width when there's room and yields proportionally otherwise. The `turn N/N` annotation moved into its own grid column so it no longer eats into the navs cell.
- **SampleSummaryView**: cap the score panel column at `min(dynamicRightMax, 40%)` so it never claims more than 40% of the row. On narrow viewports the score panel was taking 560px of a 600px row, leaving Input/Target/Answer with 40px. The score panel is horizontally scrollable, so a tighter cell is fine.

## Test plan

- [x] Open a sample with multiple model-call event panels at viewport <700px (or with the right pane open). The tab row collapses to a labeled dropdown showing the active tab; clicking opens the menu; selecting an option updates the view; widening restores the tabs.
- [x] Open a sample with 3+ scores at viewport <800px. Input/Target/Answer get the bulk of the width; the score panel is narrower but scrolls horizontally.
- [x] Scroll the transcript with the picker open — menu re-anchors to the trigger.
- [x] At wide viewport (>1200px) tabs and full-width score panel still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)