### PR TITLE
Add ModelEvent retry accounting fields

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -2155,9 +2155,23 @@ export interface components {
          * @description Call to a language model.
          */
         ModelEvent: {
+            /** Attempt */
+            attempt?: number | null;
             /** Cache */
             cache?: ("read" | "write") | null;
             call?: components["schemas"]["ModelCall"] | null;
+            /** Call Completed At */
+            call_completed_at?: string | null;
+            /** Call Id */
+            call_id?: string | null;
+            /** Call Retries */
+            call_retries?: number | null;
+            /** Call Started At */
+            call_started_at?: string | null;
+            /** Call Working Start */
+            call_working_start?: number | null;
+            /** Call Working Time */
+            call_working_time?: number | null;
             /** Completed */
             completed?: string | null;
             config: components["schemas"]["GenerateConfig"];
@@ -2169,6 +2183,8 @@ export interface components {
              * @constant
              */
             event: "model";
+            /** Http Retries */
+            http_retries?: number | null;
             /** Input */
             input: (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[];
             /** Input Refs */


### PR DESCRIPTION
Regenerated `packages/inspect-common/src/types/generated.ts` to include the new per-attempt retry accounting fields on `ModelEvent`:

- `call_id` (shared across all attempts of one `model.generate()`)
- `attempt` (1-indexed)
- `call_started_at` / `call_completed_at` (per-attempt UTC datetimes)
- `call_working_start` / `call_working_time` (per-attempt monotonic working-time span)
- `call_retries` — count of outer scheduled retries
- `http_retries` — count of provider/HTTP retry signals

Pairs with [UKGovernmentBEIS/inspect_ai#3860](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3860). The inspect_ai PR adds these fields to the Python `ModelEvent` model and bumps the OpenAPI schema; once this ts-mono PR merges, that PR will bump its `ts-mono` submodule pin so `check-schema-and-types` can pass.

Generated by `python src/inspect_ai/_view/schema.py` against `inspect_ai`'s updated `inspect-openapi.json`.