### PR TITLE
Show newest successful retry instead of older crashed one

### DIFF
--- a/apps/inspect/src/state/hooks.test.ts
+++ b/apps/inspect/src/state/hooks.test.ts
@@ -63,7 +63,7 @@ describe("computeLogsWithRetried", () => {
     expect(result.find((r) => r.name === newer.name)?.retried).toBe(false);
   });
 
-  it("prefers started over success regardless of mtime", () => {
+  it("prefers newer success over older orphaned started", () => {
     const olderStarted = log({
       name: "/a/flow/2026_task_abc.eval",
       task_id: "abc",
@@ -79,11 +79,74 @@ describe("computeLogsWithRetried", () => {
       [newerSuccess.name]: preview("success"),
     });
     expect(result.find((r) => r.name === olderStarted.name)?.retried).toBe(
-      false
-    );
-    expect(result.find((r) => r.name === newerSuccess.name)?.retried).toBe(
       true
     );
+    expect(result.find((r) => r.name === newerSuccess.name)?.retried).toBe(
+      false
+    );
+  });
+
+  it("keeps started as active when it is the newest in the group", () => {
+    const olderSuccess = log({
+      name: "/a/flow/2026_task_abc.eval",
+      task_id: "abc",
+      mtime: 100,
+    });
+    const newerStarted = log({
+      name: "/a/flow/2027_task_abc.eval",
+      task_id: "abc",
+      mtime: 200,
+    });
+    const result = computeLogsWithRetried([olderSuccess, newerStarted], {
+      [olderSuccess.name]: preview("success"),
+      [newerStarted.name]: preview("started"),
+    });
+    expect(result.find((r) => r.name === olderSuccess.name)?.retried).toBe(
+      true
+    );
+    expect(result.find((r) => r.name === newerStarted.name)?.retried).toBe(
+      false
+    );
+  });
+
+  it("picks newest success when an orphaned started sits between failed retries", () => {
+    const oldError = log({
+      name: "/a/flow/2026-05-08T08-08-34_task_abc.eval",
+      task_id: "abc",
+      mtime: 100,
+    });
+    const orphanedStarted = log({
+      name: "/a/flow/2026-05-08T09-00-00_task_abc.eval",
+      task_id: "abc",
+      mtime: 200,
+    });
+    const midError = log({
+      name: "/a/flow/2026-05-08T09-49-08_task_abc.eval",
+      task_id: "abc",
+      mtime: 300,
+    });
+    const newestSuccess = log({
+      name: "/a/flow/2026-05-08T10-56-02_task_abc.eval",
+      task_id: "abc",
+      mtime: 400,
+    });
+    const result = computeLogsWithRetried(
+      [oldError, orphanedStarted, midError, newestSuccess],
+      {
+        [oldError.name]: preview("error"),
+        [orphanedStarted.name]: preview("started"),
+        [midError.name]: preview("error"),
+        [newestSuccess.name]: preview("success"),
+      }
+    );
+    expect(result.find((r) => r.name === newestSuccess.name)?.retried).toBe(
+      false
+    );
+    expect(result.find((r) => r.name === orphanedStarted.name)?.retried).toBe(
+      true
+    );
+    expect(result.find((r) => r.name === oldError.name)?.retried).toBe(true);
+    expect(result.find((r) => r.name === midError.name)?.retried).toBe(true);
   });
 
   it("prefers success over error regardless of mtime", () => {

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -654,8 +654,8 @@ export const useDocumentTitle = () => {
   return { setDocumentTitle };
 };
 
-const simplifiedStatusForDeduplication = (status: EvalLogStatus | undefined) =>
-  status === "started" || status === "success" ? status : "_other_";
+const isActiveStatus = (status: EvalLogStatus | undefined) =>
+  status === "started" || status === "success";
 
 export type LogHandleWithretried = LogHandle & { retried?: boolean };
 
@@ -669,8 +669,9 @@ type LogPreviewStatusMap = Record<
  *
  * Groups logs by (parent directory, task_id) so that logs sharing a task_id
  * across different folders (e.g. copied log directories under a shared parent)
- * are not treated as retries of each other. Within each group, the "best"
- * log wins (started > success > other, ties broken by newest mtime) and is
+ * are not treated as retries of each other. Within each group, logs whose
+ * status is `started` or `success` rank above other statuses; ties are
+ * broken by filename descending so the newest run wins. The winner is
  * marked `retried: false`; the rest are marked `retried: true`.
  */
 export const computeLogsWithRetried = (
@@ -691,23 +692,17 @@ export const computeLogsWithRetried = (
     },
     {}
   );
-  // For each group, select the best item (prefer running/complete over error)
-  // Sort by status priority: started > success > error, cancelled, or missing if logPreview is not loaded
-  // If same priority, take the latest one
+  // For each group, select the best item: prefer logs whose status is
+  // started or success (treated as equivalent — both mean "not failed"),
+  // then break ties by filename descending so the newest run wins.
+  // An older `started` log is treated as orphaned once a newer log exists.
   const bestByName: Record<string, LogHandleWithretried> = {};
   for (const items of Object.values(logsByGroup)) {
     items.sort((a, b) => {
-      const as = simplifiedStatusForDeduplication(logPreviews[a.name]?.status);
-      const bs = simplifiedStatusForDeduplication(logPreviews[b.name]?.status);
-
-      if (as === bs) return b.name.localeCompare(a.name);
-      if (as === "started") return -1;
-      if (bs === "started") return 1;
-      if (as === "success") return -1;
-      if (bs === "success") return 1;
-
-      console.warn(`Unexpected status combination: ${as}, ${bs}`, a, b);
-      return 0;
+      const aActive = isActiveStatus(logPreviews[a.name]?.status);
+      const bActive = isActiveStatus(logPreviews[b.name]?.status);
+      if (aActive !== bActive) return aActive ? -1 : 1;
+      return b.name.localeCompare(a.name);
     });
     const { name } = items[0];
     bestByName[name] = { ...items[0], retried: false };


### PR DESCRIPTION
## Summary

The eval log viewer was hiding the latest successful run of a retried task behind an earlier crashed run.

The dedup in `computeLogsWithRetried` ranked `started > success > error`, intending to surface in-progress runs. But an orphaned `started` log stays `started` forever, so an older orphan beat any newer successful retry. This collapses the rank to two tiers: `started`/`success` together as "active", everything else as "failed", and breaks ties by filename desc, so the newest non-failed log wins. Live-running evals are unaffected: their `started` log is by definition the newest in its group.