### PR TITLE
Pin fast-uri to >=3.1.2 (GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "seroval-plugins": ">=1.4.1",
       "postcss-url>minimatch": "^3.1.3",
       "@microsoft/api-extractor": "^7.57.6",
-      "rollup": "^4.59.0"
+      "rollup": "^4.59.0",
+      "fast-uri": "^3.1.2"
     }
   },
   "manypkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   postcss-url>minimatch: ^3.1.3
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
+  fast-uri: ^3.1.2
 
 importers:
 
@@ -3314,9 +3315,6 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -6002,7 +6000,7 @@ snapshots:
   '@redocly/ajv@8.17.4':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7676,10 +7674,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
-
-  fast-uri@3.1.2:
-    optional: true
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Pins `fast-uri` to `>=3.1.2` via a pnpm override to fix two HIGH-severity advisories pulled in transitively through `apps/scout > openapi-typescript > @redocly/openapi-core > @redocly/ajv > fast-uri@3.1.0`:
  - [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) / CVE-2026-6321 — path traversal via percent-encoded dot segments (fixed in 3.1.1)
  - [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) / CVE-2026-6322 — host confusion via percent-encoded authority delimiters (fixed in 3.1.2)
- Addresses Dependabot alert #42.

## Test plan
- [x] `pnpm install --lockfile-only` succeeds and resolves `fast-uri@3.1.2` in `pnpm-lock.yaml`
- [x] `pnpm audit` now reports "No known vulnerabilities found" (previously 2 high)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMRd7gywBUoxyPdjbvgJr)_