### PR TITLE
Add 7-day package soak period via pnpm + Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
 
     open-pull-requests-limit: 5
 
+    # Match the pnpm minimum-release-age soak in .npmrc so Dependabot waits
+    # before opening PRs. Without this, pnpm refuses the resolution and the
+    # update job errors out silently. Security updates bypass cooldown.
+    cooldown:
+      default-days: 3
+
     groups:
       minor-and-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,13 @@ updates:
 
     open-pull-requests-limit: 5
 
-    # Match the pnpm minimum-release-age soak in .npmrc so Dependabot waits
-    # before opening PRs. Without this, pnpm refuses the resolution and the
-    # update job errors out silently. Security updates bypass cooldown.
+    # Match the pnpm minimumReleaseAge soak in pnpm-workspace.yaml so
+    # Dependabot waits before opening PRs. Without this, pnpm refuses the
+    # resolution and the update job errors out silently. Note: Dependabot
+    # cooldown does not apply to transitive deps (dependabot-core#14683) —
+    # the pnpm-side setting covers those. Security updates bypass cooldown.
     cooldown:
-      default-days: 3
+      default-days: 7
 
     groups:
       minor-and-patch:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Require a 3-day soak before installing any newly published package version.
+# Mitigates supply-chain attacks where a compromised version is published and
+# yanked within a short window (pnpm >= 10.16).
+minimum-release-age=4320

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-# Require a 3-day soak before installing any newly published package version.
-# Mitigates supply-chain attacks where a compromised version is published and
-# yanked within a short window (pnpm >= 10.16).
-minimum-release-age=4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,9 @@ packages:
   - "apps/*"
   - "packages/*"
   - "tooling/*"
+
+# Require a 7-day soak before pnpm will resolve a newly published version.
+# Mitigates supply-chain attacks where a compromised release is detected and
+# yanked within days. pnpm 11 enables a 1-day floor by default; this is
+# stricter and aligns with current public guidance.
+minimumReleaseAge: 10080


### PR DESCRIPTION
Adds a 7-day minimum-release-age soak so newly published package versions can't be installed until they have aged on the registry. Mitigates "publish-and-yank" supply-chain attacks where a compromised version is published and pulled within hours or days (Axios, s1ngularity, etc.).

## Changes

- **`pnpm-workspace.yaml`**: `minimumReleaseAge: 10080` (7 days in minutes). Gates pnpm's resolution phase for any lockfile-generating install — humans, CI lockfile refreshes, and Dependabot. Placed here (not `.npmrc`) so it survives the pnpm 11 cutover, where `.npmrc` stops carrying non-auth settings.
- **`.github/dependabot.yml`**: `cooldown.default-days: 7` to match. Without this, Dependabot's own pnpm enforces the soak during lockfile generation and the update job errors out silently (no PR opens, failure only visible in Insights). The two layers are complementary rather than redundant: Dependabot cooldown doesn't apply to transitive deps ([dependabot-core#14683](https://github.com/dependabot/dependabot-core/issues/14683)), which the pnpm-side setting covers.

## Tradeoffs

- 7 days aligns with current public guidance (Datadog Security Labs, StepSecurity, yossarian, Mondoo). Recent npm incidents had detection windows of multiple days; 7 days covers the vast majority.
- **Security-update caveat**: Dependabot security-update PRs bypass `cooldown`, but the pnpm-side gate still applies. A fresh CVE patch will be unmergeable for up to 7 days unless the version ages in or the gate is overridden for that install.
- Requires pnpm >= 10.16 (currently on 10.29.3).

https://claude.ai/code/session_01TV5rPpPmBAKY5378WFhPcF