### PR TITLE
Expose selection hooks for log-viewer embedders

### DIFF
--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -51,7 +51,7 @@ const componentIcons: ComponentIcons = {
   toggleRight: ApplicationIcons["toggle-right"],
 };
 
-interface AppProps {
+export interface AppProps {
   api: ClientAPI;
 }
 

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -34,3 +34,7 @@ export {
   useSelectedScores,
   useLogSelection,
 } from "./state/hooks";
+
+// Selection-related types
+export type { SampleSummary } from "./client/api/types";
+export type { ScoreLabel } from "./app/types";

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -1,5 +1,5 @@
 // Main React App Component
-export { App } from "./app/App";
+export { App, type AppProps } from "./app/App";
 
 // Client APIs
 export { clientApi } from "./client/api/client-api";

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -27,3 +27,10 @@ export type {
 
 // State Store
 export { initializeStore } from "./state/store";
+
+// Selection hooks
+export {
+  useSelectedSampleSummary,
+  useSelectedScores,
+  useLogSelection,
+} from "./state/hooks";


### PR DESCRIPTION
## Summary

Apps that embed `<App>` has no way to react to the viewer's selection state (selected sample, selected scorers, currently loaded log) from outside the App tree.

## What's exposed

- `AppProps`: the prop type for `<App>`, so consumers can declare typed prop bags.
- `useSelectedSampleSummary`, `useSelectedScores`, `useLogSelection`: selection state hooks from `state/hooks.ts`.
- `SampleSummary`, `ScoreLabel`: the return / element types of those hooks.

Scope is intentionally narrow. Only the very most useful state is exposed.