### PR TITLE
Prevent horizontal scroll on messages tab

### DIFF
--- a/apps/scout/src/app/transcript/TranscriptBody.module.css
+++ b/apps/scout/src/app/transcript/TranscriptBody.module.css
@@ -70,6 +70,8 @@
 }
 
 .chatList {
+  flex: 1;
+  min-width: 0;
   padding: 0.5rem;
 }
 

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -402,21 +402,22 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
       scrollable={false}
     >
       {renderWithSearchSplit(
-        <ChatViewVirtualList
-          id={"transcript-id"}
-          messages={transcript.messages || []}
-          initialMessageId={messageParam}
-          className={styles.chatList}
-          scrollRef={activeScrollRef}
-          display={{
-            unlabeledRoles: ["assistant"],
-            formatDateTime,
-          }}
-          linking={{
-            enabled: isHostedEnvironment(),
-            getMessageUrl: getFullMessageUrl,
-          }}
-        />,
+        <div className={styles.chatList}>
+          <ChatViewVirtualList
+            id={"transcript-id"}
+            messages={transcript.messages || []}
+            initialMessageId={messageParam}
+            scrollRef={activeScrollRef}
+            display={{
+              unlabeledRoles: ["assistant"],
+              formatDateTime,
+            }}
+            linking={{
+              enabled: isHostedEnvironment(),
+              getMessageUrl: getFullMessageUrl,
+            }}
+          />
+        </div>,
         "messages"
       )}
     </TabPanel>


### PR DESCRIPTION
In Scout's viewer when the messages tab is selected, we always have a little bit of horizontal scroll:

https://github.com/user-attachments/assets/08c54fd2-c03d-4e8b-9fa2-d86fab8ef73c

This was bugging me, and I explored a few ways to address it. The core issue is that the `.chatList` horizontal padding was getting applied to the virtuoso list.

Finally I realized that `ChatViewVirtualList` is used in Inspect's viewer as well, and it already has nice padding that doesn't cause any horizontal scrolling. In that case, the padding is applied to a surrounding div, so we followed suit here.


https://github.com/user-attachments/assets/49b204c6-4467-4682-aed0-af4b4556f182

