### PR TITLE
Scout scan UI fixes and negative filter

### DIFF
--- a/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
+++ b/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
@@ -35,6 +35,7 @@ export const SelectScorer: FC<SelectScorerProps> = ({
         : `${selectedCount} Scores`;
 
   const allScoresSelected = selectedCount === scores.length;
+  const noneSelected = selectedCount === 0;
 
   return (
     <div style={{ display: "flex" }}>
@@ -92,6 +93,18 @@ export const SelectScorer: FC<SelectScorerProps> = ({
             }}
           >
             All
+          </a>
+          |
+          <a
+            className={clsx(
+              styles.link,
+              noneSelected ? styles.selected : undefined
+            )}
+            onClick={() => {
+              setSelectedScores([]);
+            }}
+          >
+            None
           </a>
         </div>
         <div className={styles.container}>

--- a/apps/scout/src/app/scan/ScanPanel.tsx
+++ b/apps/scout/src/app/scan/ScanPanel.tsx
@@ -8,6 +8,7 @@ import { useDocumentTitle } from "@tsmono/react/hooks";
 import { getScannerParam } from "../../router/url";
 import { useStore } from "../../state/store";
 import { ScansNavbar } from "../components/ScansNavbar";
+import { useScanRoute } from "../hooks/useScanRoute";
 import { useSelectedScan } from "../hooks/useSelectedScan";
 import { useAppConfig } from "../server/useAppConfig";
 import { getScanDisplayName } from "../utils/scan";
@@ -28,13 +29,16 @@ export const ScanPanel: React.FC = () => {
   // Set document title with scan location
   useDocumentTitle(getScanDisplayName(selectedScan, scansDir), "Scans");
 
-  // Clear scan state from the store on mount
+  // Clear scan state when viewing a different scan, but preserve it on back-nav
+  // to the same scan (so search text, sort, grouping survive round-trips).
+  const { scanPath } = useScanRoute();
+  const selectedScanLocation = useStore((state) => state.selectedScanLocation);
   const clearScanState = useStore((state) => state.clearScanState);
   useEffect(() => {
-    clearScanState();
-    // TODO: lint react-hooks/exhaustive-deps - should we just add clearScanState to the dependencies
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (scanPath !== selectedScanLocation) {
+      clearScanState();
+    }
+  }, [scanPath, selectedScanLocation, clearScanState]);
 
   // Sync URL query param with store state
   const [searchParams] = useSearchParams();

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -17,7 +17,7 @@ import { useStore } from "../../../../state/store";
 import { Status } from "../../../../types/api-types";
 import { useScanResultSummaries } from "../../../hooks/useScanResultSummaries";
 import { useScanRoute } from "../../../hooks/useScanRoute";
-import { ScanResultSummary } from "../../../types";
+import { ScanResultSummary, SortColumn } from "../../../types";
 import {
   resultIdentifierStr,
   resultLog,
@@ -99,6 +99,21 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
     }
   }, [selectedScan, selectedFilter, setSelectedFilter]);
 
+  const kDefaultSort: SortColumn[] = useMemo(
+    () => [{ column: "Result", direction: "asc" }],
+    []
+  );
+
+  // The sort used for rendering: user-explicit or default id/epoch asc.
+  const activeSort = sortResults ?? kDefaultSort;
+
+  // Sync the default to the store so the column header shows the sort indicator.
+  useEffect(() => {
+    if (!sortResults && scannerSummaries.length > 0) {
+      setSortResults(kDefaultSort);
+    }
+  }, [sortResults, scannerSummaries, kDefaultSort, setSortResults]);
+
   // Apply text filtering to the scanner summaries
   const filteredSummaries = useMemo(() => {
     let textFiltered = scannerSummaries;
@@ -127,35 +142,8 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
         ? textFiltered.filter((s) => !!s.value)
         : textFiltered;
 
-    // Return filtered sorted summaries
-    if (sortResults === undefined || sortResults.length === 0) {
-      return resultsFiltered;
-    } else {
-      return [...resultsFiltered].sort((a, b) =>
-        sortByColumns(a, b, sortResults)
-      );
-    }
-  }, [scannerSummaries, selectedFilter, scansSearchText, sortResults]);
-
-  // Set the default sort order when the filter changes (if there isn't an explicit order)
-  useEffect(() => {
-    if (filteredSummaries.length === 0 || sortResults) {
-      return;
-    }
-
-    if (
-      selectedFilter === kFilterAllResults &&
-      filteredSummaries.some((s) => !!s.scanError)
-    ) {
-      // Default sort for error filter: errors first, then by identifier
-      setSortResults([{ column: "Error", direction: "desc" }]);
-    } else if (
-      filteredSummaries.some((s) => s.validationResult !== undefined)
-    ) {
-      // Default sort for validations: validations first, then by identifier
-      setSortResults([{ column: "Validation", direction: "desc" }]);
-    }
-  }, [sortResults, selectedFilter, filteredSummaries, setSortResults]);
+    return [...resultsFiltered].sort((a, b) => sortByColumns(a, b, activeSort));
+  }, [scannerSummaries, selectedFilter, scansSearchText, activeSort]);
 
   // Compute the optimal column layout based on the current data
   const gridDescriptor = useMemo(() => {

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../../utils/results";
 import {
   kFilterAllResults,
+  kFilterNegativeResults,
   kFilterPositiveResults,
 } from "../results/ScannerResultsFilter";
 
@@ -136,11 +137,14 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
       });
     }
 
-    // Filter positives results if needed
+    // Filter results by value if needed
     const resultsFiltered =
-      selectedFilter === kFilterPositiveResults || selectedFilter === undefined
-        ? textFiltered.filter((s) => !!s.value)
-        : textFiltered;
+      selectedFilter === kFilterNegativeResults
+        ? textFiltered.filter((s) => !s.value)
+        : selectedFilter === kFilterPositiveResults ||
+            selectedFilter === undefined
+          ? textFiltered.filter((s) => !!s.value)
+          : textFiltered;
 
     return [...resultsFiltered].sort((a, b) => sortByColumns(a, b, activeSort));
   }, [scannerSummaries, selectedFilter, scansSearchText, activeSort]);
@@ -389,10 +393,17 @@ export const ScannerResultsList: FC<ScannerResultsListProps> = ({
   } else if (
     !isLoading &&
     filteredSummaries.length === 0 &&
-    selectedFilter !== kFilterAllResults &&
+    selectedFilter === kFilterPositiveResults &&
     !scansSearchText
   ) {
     noContentMessage = "No positive scan results were found.";
+  } else if (
+    !isLoading &&
+    filteredSummaries.length === 0 &&
+    selectedFilter === kFilterNegativeResults &&
+    !scansSearchText
+  ) {
+    noContentMessage = "No negative scan results were found.";
   } else if (!isLoading && filteredSummaries.length === 0) {
     noContentMessage = "No scan results match the current filter.";
   }

--- a/apps/scout/src/app/scan/scanners/results/ScannerResultsFilter.tsx
+++ b/apps/scout/src/app/scan/scanners/results/ScannerResultsFilter.tsx
@@ -7,6 +7,7 @@ import styles from "./ScannerResultsFilter.module.css";
 
 export const kFilterPositiveResults = "positive_results";
 export const kFilterAllResults = "all_results";
+export const kFilterNegativeResults = "negative_results";
 
 export const ScannerResultsFilter: FC = () => {
   const setSelectedFilter = useStore((state) => state.setSelectedFilter);
@@ -22,6 +23,7 @@ export const ScannerResultsFilter: FC = () => {
 
   const options = [
     { label: "Positive", val: kFilterPositiveResults },
+    { label: "Negative", val: kFilterNegativeResults },
     { label: "All", val: kFilterAllResults },
   ];
 

--- a/apps/scout/src/app/scan/scanners/results/ScannerResultsSearch.tsx
+++ b/apps/scout/src/app/scan/scanners/results/ScannerResultsSearch.tsx
@@ -20,7 +20,7 @@ export const ScannerResultsSearch: FC = () => {
   return (
     <TextInput
       icon={ApplicationIcons.search}
-      value={scansSearchText}
+      value={scansSearchText ?? ""}
       onChange={handleChange}
       placeholder={"Search"}
       className={styles.searchBox}

--- a/apps/scout/src/app/scans/ScansPanel.tsx
+++ b/apps/scout/src/app/scans/ScansPanel.tsx
@@ -64,11 +64,13 @@ export const ScansPanel: FC = () => {
     fetchNextPage({ cancelRefetch: false }).catch(console.error);
   }, [fetchNextPage]);
 
-  // Clear scan state from store on mount
+  // Clear both scan-level and scans-level state on mount
   const clearScansState = useStore((state) => state.clearScansState);
+  const clearScanState = useStore((state) => state.clearScanState);
   useEffect(() => {
     clearScansState();
-  }, [clearScansState]);
+    clearScanState();
+  }, [clearScansState, clearScanState]);
 
   return (
     <div className={clsx(styles.container)}>

--- a/apps/scout/src/app/utils/results.ts
+++ b/apps/scout/src/app/utils/results.ts
@@ -171,6 +171,7 @@ export const sortByColumns = (
     let comparison = 0;
 
     switch (sortCol.column.toLowerCase()) {
+      case "result":
       case "id": {
         const identifierA = resultIdentifier(a);
         const identifierB = resultIdentifier(b);

--- a/apps/scout/src/state/store.ts
+++ b/apps/scout/src/state/store.ts
@@ -416,6 +416,7 @@ export const createStore = (api: ScoutApiV2) =>
               state.selectedResultTab = undefined;
               state.groupResultsBy = undefined;
               state.scansSearchText = undefined;
+              state.sortResults = undefined;
             });
           },
           clearScansState: () => {


### PR DESCRIPTION
## Summary
- **Preserve scan state on back-nav**: Search text, sort, and grouping now survive round-trips to scan results. State only clears when navigating to a different scan or returning to the scan list.
- **Add negative results filter**: Scanner results can now be filtered to show only negative results, in addition to positive and all.
- **Default sort by Result column**: Scanner results default to ascending sort by Result, with the column header showing the sort indicator.
- **Add 'None' scorer selection**: Adds a "None" option to the scorer selection in inspect samples view.
- **Fix controlled input warning**: `ScannerResultsSearch` stays controlled when search text is cleared (`undefined` → `""`).

fixes #222 
fixes #223 
fixes #224

## Test plan
- [x] Navigate to a scan, type search text, click a result, press back — search text and filter should be preserved
- [x] Navigate to a scan, type search text, go to the scan list, return to the same scan — search text should be cleared
- [x] Verify the negative results filter option works
- [x] Verify default sort shows Result column sort indicator on load
- [x] Verify "None" option in scorer selection deselects all scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)