### PR TITLE
Redesign MetaDataGrid with section cards and striping

### DIFF
--- a/apps/scout/src/app/transcript/TranscriptBody.module.css
+++ b/apps/scout/src/app/transcript/TranscriptBody.module.css
@@ -74,7 +74,6 @@
 }
 
 .metadata {
-  padding: 0.5rem;
   padding-bottom: 50px;
 }
 

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -494,6 +494,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
             id="transcript-metadata-grid"
             entries={transcript.metadata || {}}
             className={clsx(styles.metadata)}
+            options={{ striped: true }}
           />
         </div>
       </TabPanel>
@@ -518,6 +519,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
           id="transcript-info-grid"
           entries={infoData}
           className={clsx(styles.metadata)}
+          options={{ striped: true }}
         />
       </div>
     </TabPanel>

--- a/packages/inspect-components/src/content/MetaDataGrid.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.tsx
@@ -1,7 +1,5 @@
-// TODO: lint @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 import clsx from "clsx";
-import { CSSProperties, FC, Fragment, useState } from "react";
+import { CSSProperties, FC, useState } from "react";
 
 import { MarkdownReference } from "@tsmono/react/components";
 
@@ -15,15 +13,27 @@ interface MetadataGridProps {
   style?: CSSProperties;
   entries: Record<string, unknown>;
   maxRows?: number;
+  depth?: number;
   options?: {
     size?: "mini" | "small";
     plain?: boolean;
+    striped?: boolean;
     previewRefsOnHover?: boolean;
   };
 }
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+
+const isNonEmptyObject = (v: unknown): v is Record<string, unknown> =>
+  isPlainObject(v) && Object.keys(v).length > 0;
+
 /**
- * Renders the MetaDataView component.
+ * Renders structured metadata as a grid with section cards.
+ *
+ * Top-level scalars render as key-value rows; nested objects are
+ * promoted to titled sections with a header rule. Recurses for
+ * deeply nested objects.
  */
 export const MetaDataGrid: FC<MetadataGridProps> = ({
   id,
@@ -33,71 +43,66 @@ export const MetaDataGrid: FC<MetadataGridProps> = ({
   style,
   maxRows,
   options,
+  depth = 0,
 }) => {
-  const baseId = "metadata-grid";
-  const fontStyle =
-    options?.size === "mini" ? "text-size-smallest" : "text-size-smaller";
+  const baseId = id ?? "metadata-grid";
+  const allEntries = entryRecords(entries);
+
+  const scalars = allEntries.filter((e) => !isNonEmptyObject(e.value));
+  const groups = allEntries.filter((e) => isNonEmptyObject(e.value));
 
   const [expanded, setExpanded] = useState(false);
-  const allEntries = entryRecords(entries);
-  const isCollapsible = maxRows != null && allEntries.length > maxRows;
-  const visibleEntries =
-    isCollapsible && !expanded ? allEntries.slice(0, maxRows) : allEntries;
+  const isCollapsible = maxRows != null && scalars.length > maxRows;
+  const visibleScalars =
+    isCollapsible && !expanded ? scalars.slice(0, maxRows) : scalars;
 
-  const entryEls = visibleEntries.map((entry, index) => {
-    const id = `${baseId}-value-${index}`;
-    return (
-      <Fragment key={`${baseId}-record-${index}`}>
-        {index !== 0 ? (
-          <div
-            style={{
-              gridColumn: "1 / -1",
-              borderBottom: `${!options?.plain ? "solid 1px var(--bs-light-border-subtle" : ""}`,
-            }}
-          ></div>
-        ) : undefined}
-        <div
-          className={clsx(
-            `${baseId}-key`,
-            styles.cell,
-            "text-style-label",
-            "text-style-secondary",
-            fontStyle
-          )}
-        >
-          {entry?.name}
-        </div>
-        <div className={clsx(styles.value, `${baseId}-value`, fontStyle)}>
-          {entry && (
-            <RenderedContent
-              id={id}
-              entry={entry}
-              references={references}
-              renderOptions={{
-                renderString: "markdown",
-                previewRefsOnHover: options?.previewRefsOnHover,
-              }}
-              renderObject={(obj: any) => {
-                return (
-                  <MetaDataGrid
-                    id={id}
-                    className={clsx(styles.nested)}
-                    entries={obj}
-                    options={options}
-                    references={references}
-                  />
-                );
-              }}
-            />
-          )}
-        </div>
-      </Fragment>
-    );
-  });
+  const depthClass =
+    depth === 1 ? styles.depth1 : depth >= 2 ? styles.depth2 : undefined;
 
   return (
-    <div id={id} className={clsx(className, styles.grid)} style={style}>
-      {entryEls}
+    <div
+      id={depth === 0 ? id : undefined}
+      className={clsx(
+        depth === 0 && className,
+        styles.grid,
+        depthClass,
+        options?.striped && depth === 0 && styles.striped
+      )}
+      style={depth === 0 ? style : undefined}
+    >
+      {visibleScalars.length > 0 && (
+        <div className={styles.rows}>
+          {visibleScalars.map((entry, index) => {
+            const entryId = `${baseId}-value-${index}`;
+            return (
+              <div key={entryId} className={styles.row}>
+                <div className={styles.key}>{entry.name}</div>
+                <div className={styles.val}>
+                  <RenderedContent
+                    id={entryId}
+                    entry={entry}
+                    references={references}
+                    renderOptions={{
+                      renderString: "markdown",
+                      previewRefsOnHover: options?.previewRefsOnHover,
+                    }}
+                    renderObject={(obj: Record<string, unknown>) => (
+                      <MetaDataGrid
+                        id={entryId}
+                        entries={obj}
+                        options={options}
+                        references={references}
+                        depth={depth + 1}
+                      />
+                    )}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       {isCollapsible && (
         <div className={styles.toggleContainer}>
           <button
@@ -106,21 +111,37 @@ export const MetaDataGrid: FC<MetadataGridProps> = ({
           >
             {expanded
               ? "less"
-              : `${allEntries.length - visibleEntries.length} more`}
+              : `${scalars.length - visibleScalars.length} more`}
             ...
           </button>
         </div>
       )}
+
+      {groups.map((entry, groupIndex) => {
+        const groupId = `${baseId}-group-${groupIndex}`;
+        return (
+          <section
+            key={groupId}
+            className={clsx(styles.group, depth >= 1 && styles.depth1Group)}
+          >
+            <header className={styles.groupHeader}>
+              <span className={styles.groupKey}>{entry.name}</span>
+              <span className={styles.groupRule} />
+            </header>
+            <MetaDataGrid
+              id={groupId}
+              entries={entry.value as Record<string, unknown>}
+              options={options}
+              references={references}
+              depth={depth + 1}
+            />
+          </section>
+        );
+      })}
     </div>
   );
 };
 
-// entries can be either a Record<string, stringable>
-// or an array of record with name/value on way in
-// but coerce to array of records for order
-/**
- * Ensure the proper type for entries
- */
 const entryRecords = (
   entries: { name: string; value: unknown }[] | Record<string, unknown>
 ): { name: string; value: unknown }[] => {

--- a/packages/inspect-components/src/content/MetadataGrid.module.css
+++ b/packages/inspect-components/src/content/MetadataGrid.module.css
@@ -1,23 +1,160 @@
+/* MetadataGrid — Section Cards
+   Compact density, mono labels, striped rows, rule-style section headers.
+   Colors mapped to existing theme variables for light/dark support. */
+
 .grid {
+  font-family: var(--bs-body-font-family);
+  font-size: var(--inspect-font-size-small);
+  color: var(--bs-body-color);
+  line-height: 1.5;
+}
+
+/* ── Rows ─────────────────────────────────────────────────────── */
+
+.rows {
   display: grid;
   grid-template-columns: auto 1fr;
-  column-gap: 0.5em;
-  row-gap: 0.2em;
+  column-gap: 1em;
 }
 
-.cell {
-  font-weight: 400;
+.row {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  padding-block: 3px;
+  border-bottom: 1px dotted var(--bs-light-border-subtle);
+  align-items: baseline;
 }
 
-.value {
+.rows > .row:last-child {
+  border-bottom: none;
+}
+
+/* ── Striped variant (opt-in via striped prop) ───────────────── */
+
+.striped .row {
+  padding-inline: 0.5rem;
+}
+
+.striped .rows > .row:nth-child(even) {
+  background: var(--bs-light-bg-subtle);
+}
+
+.key {
+  font-family: var(--bs-font-monospace);
+  font-size: var(--inspect-font-size-smallest);
+  color: var(--bs-secondary);
+  font-feature-settings: "calt" 0;
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.val {
+  color: var(--bs-body-color);
   overflow-wrap: anywhere;
+  font-feature-settings: "tnum";
 }
+
+.val pre {
+  margin: 0;
+  padding: 0;
+}
+
+.empty {
+  color: var(--bs-secondary);
+  font-style: italic;
+  font-size: var(--inspect-font-size-smallest);
+}
+
+.numVal {
+  color: var(--bs-code-color);
+}
+
+.boolVal {
+  color: var(--bs-success-text-emphasis, #198754);
+}
+
+/* ── Sections (nested objects promoted to titled groups) ──────── */
+
+.group {
+  margin-top: 14px;
+}
+
+.rows + .group {
+  margin-top: 14px;
+}
+
+.group + .group {
+  margin-top: 12px;
+}
+
+.groupHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+  padding-bottom: 2px;
+}
+
+.groupKey {
+  font-family: var(--bs-font-monospace);
+  font-size: var(--inspect-font-size-smallest);
+  font-weight: 500;
+  color: var(--bs-body-color);
+  letter-spacing: 0;
+}
+
+.groupRule {
+  flex: 1;
+  height: 1px;
+  background: var(--bs-light-border-subtle);
+}
+
+/* ── Depth 1 — tighter, lighter ──────────────────────────────── */
+
+.depth1 {
+  font-size: calc(var(--inspect-font-size-small) - 0.05rem);
+}
+
+.depth1 .row {
+  padding-block: 2px;
+}
+
+.depth1 .key {
+  color: var(--bs-tertiary-color);
+  font-size: var(--inspect-font-size-smallestest);
+}
+
+.depth1Group {
+  margin-top: 10px;
+}
+
+.depth1Group .groupHeader {
+  margin-bottom: 2px;
+}
+
+.depth1Group .groupKey {
+  color: var(--bs-secondary);
+  font-size: var(--inspect-font-size-smallestest);
+}
+
+/* ── Depth 2+ — yet tighter ──────────────────────────────────── */
+
+.depth2 {
+  font-size: calc(var(--inspect-font-size-small) - 0.1rem);
+}
+
+.depth2 .row {
+  padding-block: 2px;
+}
+
+/* ── Toggle (maxRows collapse) ───────────────────────────────── */
 
 .toggleContainer {
-  grid-column: 1 / -1;
   display: flex;
   height: 20px;
-  margin-top: 0.2em;
+  margin-top: 8px;
+  margin-left: 0.5rem;
   background-color: var(--bs-body-bg);
   border-radius: 5px;
   border: solid var(--bs-light-border-subtle) 1px;
@@ -25,7 +162,7 @@
 }
 
 .toggleButton {
-  font-size: var(--inspect-font-size-smaller);
+  font-size: var(--inspect-font-size-smallest);
   border: none;
   padding: 0 0.5rem;
   background-color: transparent;


### PR DESCRIPTION
Promote nested objects to titled sections with a header rule, add depth-aware styling, and introduce an opt-in striped variant. Drop the explicit-any escape hatch in favor of Record<string, unknown>. Enable striping for transcript Metadata and Info tabs.

fixes #227