### PR TITLE
Pin ws to ^8.20.1 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "postcss-url>minimatch": "^3.1.3",
       "@microsoft/api-extractor": "^7.57.6",
       "rollup": "^4.59.0",
-      "fast-uri": "^3.1.2"
+      "fast-uri": "^3.1.2",
+      "ws": "^8.20.1"
     }
   },
   "manypkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
   fast-uri: ^3.1.2
+  ws: ^8.20.1
 
 importers:
 
@@ -5151,8 +5152,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9053,7 +9054,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.8.0
       use-sync-external-store: 1.6.0(react@19.2.6)
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       prettier: 3.8.3
     transitivePeerDependencies:
@@ -9599,7 +9600,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a pnpm override pinning `ws` to `^8.20.1`, bumping the transitive dependency from 8.20.0 to 8.20.1.
- Resolves [Dependabot alert #43](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/43).

## Test plan
- [ ] CI passes (build, lint, typecheck, test)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MhsURbEXHdmKA9vASeKTsG)_