### PR TITLE
Synchronously check for single-file mode

### DIFF
--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -80,10 +80,6 @@ export const App: FC<AppProps> = ({ api }) => {
   const loadLog = useStore((state) => state.logActions.syncLog);
   const pollLog = useStore((state) => state.logActions.pollLog);
 
-  const setSingleFileMode = useStore(
-    (state) => state.appActions.setSingleFileMode
-  );
-
   // Load a specific log
   useEffect(() => {
     const loadSpecificLog = async () => {
@@ -194,7 +190,6 @@ export const App: FC<AppProps> = ({ api }) => {
       if (embeddedState) {
         const state = JSON5.parse(embeddedState.textContent || "");
         onMessage({ data: state });
-        setSingleFileMode(true);
       } else {
         // For non-route URL params support (legacy)
         const urlParams = new URLSearchParams(window.location.search);
@@ -210,13 +205,11 @@ export const App: FC<AppProps> = ({ api }) => {
           setLogDir(undefined);
           // Load just the passed file
           setLogFiles([{ name: resolvedLogPath }]);
-          setSingleFileMode(true);
         } else {
           // If a log file was passed, select it
           const log_file = urlParams.get("log_file");
           if (log_file) {
             setSelectedLogFile(log_file);
-            setSingleFileMode(true);
           }
           // Else do nothing - RouteProvider will handle it
         }
@@ -232,7 +225,6 @@ export const App: FC<AppProps> = ({ api }) => {
     setSelectedLogFile,
     syncLogs,
     onMessage,
-    setSingleFileMode,
   ]);
 
   return (

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -71,6 +71,7 @@ export const App: FC<AppProps> = ({ api }) => {
   const setLoading = useStore((state) => state.appActions.setLoading);
 
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const initLogDir = useStore((state) => state.logsActions.initLogDir);
   const setLogDir = useStore((state) => state.logsActions.setLogDir);
   const setLogFiles = useStore((state) => state.logsActions.setLogHandles);
   const setSelectedLogFile = useStore(
@@ -209,6 +210,12 @@ export const App: FC<AppProps> = ({ api }) => {
           // If a log file was passed, select it
           const log_file = urlParams.get("log_file");
           if (log_file) {
+            // Resolve logDir first so setSelectedLogFile can produce an
+            // absolute path. Otherwise a bare basename gets stored and the
+            // first /api/log-info call goes out unqualified and 403s
+            // against OnlyDirAccessPolicy before the rest of the load
+            // self-recovers.
+            await initLogDir();
             setSelectedLogFile(log_file);
           }
           // Else do nothing - RouteProvider will handle it
@@ -223,6 +230,7 @@ export const App: FC<AppProps> = ({ api }) => {
     setLogDir,
     setLogFiles,
     setSelectedLogFile,
+    initLogDir,
     syncLogs,
     onMessage,
   ]);

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -210,11 +210,6 @@ export const App: FC<AppProps> = ({ api }) => {
           // If a log file was passed, select it
           const log_file = urlParams.get("log_file");
           if (log_file) {
-            // Resolve logDir first so setSelectedLogFile can produce an
-            // absolute path. Otherwise a bare basename gets stored and the
-            // first /api/log-info call goes out unqualified and 403s
-            // against OnlyDirAccessPolicy before the rest of the load
-            // self-recovers.
             await initLogDir();
             setSelectedLogFile(log_file);
           }

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -7,6 +7,7 @@ import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
 import { usePollSample } from "../../state/usePollSample";
 import { useLogSampleNavigation } from "../routing/sampleNavigation";
+import { isSingleFileMode } from "../singleFileMode";
 import {
   logSamplesUrl,
   logsUrl,
@@ -62,7 +63,6 @@ export const LogSampleDetailView: FC = () => {
   const selectedSampleHandle = useStore(
     (state) => state.log.selectedSampleHandle
   );
-  const singleFileMode = useStore((state) => state.app.singleFileMode);
 
   // Use route params if available, otherwise fall back to state
   const logPath = routeLogPath || selectedLogFile;
@@ -178,7 +178,7 @@ export const LogSampleDetailView: FC = () => {
         currentPath: logPath ? `${logPath}/sample` : undefined,
         fnNavigationUrl,
         bordered: true,
-        breadcrumbsEnabled: !singleFileMode,
+        breadcrumbsEnabled: !isSingleFileMode,
       }}
     />
   );

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -7,7 +7,6 @@ import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
 import { usePollSample } from "../../state/usePollSample";
 import { useLogSampleNavigation } from "../routing/sampleNavigation";
-import { isSingleFileMode } from "../singleFileMode";
 import {
   logSamplesUrl,
   logsUrl,
@@ -15,6 +14,7 @@ import {
   useRoutePrefix,
 } from "../routing/url";
 import { SampleDetailComponent } from "../samples/SampleDetailComponent";
+import { isSingleFileMode } from "../singleFileMode";
 
 /**
  * Component that displays a single sample in detail view within the logs route.

--- a/apps/inspect/src/app/log-view/LogViewLayout.tsx
+++ b/apps/inspect/src/app/log-view/LogViewLayout.tsx
@@ -12,6 +12,7 @@ import { FindBand } from "../../components/FindBand";
 import { useStore } from "../../state/store";
 import { ApplicationNavbar } from "../navbar/ApplicationNavbar";
 import { logsUrl, useLogRouteParams, useRoutePrefix } from "../routing/url";
+import { isSingleFileMode } from "../singleFileMode";
 
 import { LogView } from "./LogView";
 
@@ -27,7 +28,6 @@ export const LogViewLayout: FC = () => {
   const setShowFind = useStore((state) => state.appActions.setShowFind);
   const nativeFind = useStore((state) => state.app.nativeFind);
   const hideFind = useStore((state) => state.appActions.hideFind);
-  const singleFileMode = useStore((state) => state.app.singleFileMode);
 
   // Logs Data
   const logDir = useStore((state) => state.logs.logDir);
@@ -80,13 +80,13 @@ export const LogViewLayout: FC = () => {
           className={clsx(
             "app-main-grid",
             fullScreen ? "full-screen" : undefined,
-            singleFileMode ? "single-file-mode" : undefined,
+            isSingleFileMode ? "single-file-mode" : undefined,
             "log-view"
           )}
           tabIndex={0}
         >
           {showFind ? <FindBand /> : ""}
-          {!singleFileMode ? (
+          {!isSingleFileMode ? (
             <ApplicationNavbar
               fnNavigationUrl={navigationUrl}
               currentPath={logPath}

--- a/apps/inspect/src/app/routing/AppRouter.tsx
+++ b/apps/inspect/src/app/routing/AppRouter.tsx
@@ -9,10 +9,11 @@ import {
 
 import { ComponentNavigationProvider } from "@tsmono/react/components";
 
-import { storeImplementation, useStore } from "../../state/store";
+import { storeImplementation } from "../../state/store";
 import { AppErrorBoundary } from "../AppErrorBoundary";
 import { LogsPanel } from "../log-list/LogsPanel";
 import { LogSampleDetailView } from "../log-view/LogSampleDetailView";
+import { isSingleFileMode } from "../singleFileMode";
 import { LogViewContainer } from "../log-view/LogViewContainer";
 
 import { RouteDispatcher } from "./RouteDispatcher";
@@ -45,16 +46,13 @@ const AppLayout = () => {
     }
   }, [location]);
 
-  // Get log selection state from store
-  const singleFileMode = useStore((state) => state.app.singleFileMode);
-
   // Get route params to check for sample detail routes
   const { sampleId, epoch, sampleUuid } = useLogRouteParams();
 
   // Single file mode is a legacy mode that is used when an explicit
   // file is passed via URL (task_file or log_file params) or via
   // embedded state (VSCode)
-  if (singleFileMode) {
+  if (isSingleFileMode) {
     // Check if this is a sample detail URL
     const isSampleDetail = (sampleId && epoch) || sampleUuid;
 

--- a/apps/inspect/src/app/routing/AppRouter.tsx
+++ b/apps/inspect/src/app/routing/AppRouter.tsx
@@ -13,8 +13,8 @@ import { storeImplementation } from "../../state/store";
 import { AppErrorBoundary } from "../AppErrorBoundary";
 import { LogsPanel } from "../log-list/LogsPanel";
 import { LogSampleDetailView } from "../log-view/LogSampleDetailView";
-import { isSingleFileMode } from "../singleFileMode";
 import { LogViewContainer } from "../log-view/LogViewContainer";
+import { isSingleFileMode } from "../singleFileMode";
 
 import { RouteDispatcher } from "./RouteDispatcher";
 import { SamplesRouter } from "./SamplesRouter";

--- a/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
+++ b/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
@@ -12,6 +12,7 @@ import {
   useSamplesRouteParams,
 } from "../routing/url";
 import { SampleDetailComponent } from "../samples/SampleDetailComponent";
+import { isSingleFileMode } from "../singleFileMode";
 
 /**
  * Component that displays a single sample in detail view within the samples route.
@@ -53,7 +54,6 @@ export const SampleDetailView: FC = () => {
   );
   const clearLog = useStore((state) => state.logActions.clearLog);
   const clearSampleTab = useStore((state) => state.appActions.clearSampleTab);
-  const singleFileMode = useStore((state) => state.app.singleFileMode);
 
   // Find current sample in displayed samples list
   const currentIndex = useMemo(() => {
@@ -135,7 +135,7 @@ export const SampleDetailView: FC = () => {
         currentPath: routeLogPath,
         fnNavigationUrl: samplesUrl,
         bordered: true,
-        breadcrumbsEnabled: !singleFileMode,
+        breadcrumbsEnabled: !isSingleFileMode,
       }}
     />
   );

--- a/apps/inspect/src/app/singleFileMode.test.ts
+++ b/apps/inspect/src/app/singleFileMode.test.ts
@@ -5,7 +5,9 @@ import {
   detectInitialSingleFileMode,
 } from "./singleFileMode";
 
-const docWithEmbedded = (hasEmbedded: boolean): Pick<Document, "getElementById"> => ({
+const docWithEmbedded = (
+  hasEmbedded: boolean
+): Pick<Document, "getElementById"> => ({
   getElementById: (id: string) =>
     hasEmbedded && id === "logview-state" ? ({} as HTMLElement) : null,
 });
@@ -24,9 +26,9 @@ describe("detectInitialSingleFileMode", () => {
   });
 
   it("returns true when embedded logview-state element is present", () => {
-    expect(detectInitialSingleFileMode({ search: "" }, docWithEmbedded(true))).toBe(
-      true
-    );
+    expect(
+      detectInitialSingleFileMode({ search: "" }, docWithEmbedded(true))
+    ).toBe(true);
   });
 
   it("does not match log_file as a substring of another param", () => {

--- a/apps/inspect/src/app/singleFileMode.test.ts
+++ b/apps/inspect/src/app/singleFileMode.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { detectInitialSingleFileMode } from "./singleFileMode";
+
+const docWithEmbedded = (hasEmbedded: boolean): Pick<Document, "getElementById"> => ({
+  getElementById: (id: string) =>
+    hasEmbedded && id === "logview-state" ? ({} as HTMLElement) : null,
+});
+
+const emptyDoc = docWithEmbedded(false);
+
+describe("detectInitialSingleFileMode", () => {
+  it.each([
+    ["?log_file=foo.eval", true],
+    ["?task_file=foo.eval", true],
+    ["?log_file=foo.eval&other=1", true],
+    ["?other=1", false],
+    ["", false],
+  ])("returns %s for query %s", (search, expected) => {
+    expect(detectInitialSingleFileMode({ search }, emptyDoc)).toBe(expected);
+  });
+
+  it("returns true when embedded logview-state element is present", () => {
+    expect(detectInitialSingleFileMode({ search: "" }, docWithEmbedded(true))).toBe(
+      true
+    );
+  });
+
+  it("does not match log_file as a substring of another param", () => {
+    expect(
+      detectInitialSingleFileMode({ search: "?my_log_file=foo" }, emptyDoc)
+    ).toBe(false);
+  });
+});

--- a/apps/inspect/src/app/singleFileMode.test.ts
+++ b/apps/inspect/src/app/singleFileMode.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { detectInitialSingleFileMode } from "./singleFileMode";
+import {
+  deriveSingleFileLogDir,
+  detectInitialSingleFileMode,
+} from "./singleFileMode";
 
 const docWithEmbedded = (hasEmbedded: boolean): Pick<Document, "getElementById"> => ({
   getElementById: (id: string) =>
@@ -30,5 +33,18 @@ describe("detectInitialSingleFileMode", () => {
     expect(
       detectInitialSingleFileMode({ search: "?my_log_file=foo" }, emptyDoc)
     ).toBe(false);
+  });
+});
+
+describe("deriveSingleFileLogDir", () => {
+  it.each([
+    [undefined, undefined],
+    ["", undefined],
+    ["file.eval", undefined],
+    ["/abs/path/file.eval", "/abs/path"],
+    ["relative/path/file.eval", "relative/path"],
+    ["s3://bucket/path/file.eval", "s3://bucket/path"],
+  ])("derives %s -> %s", (input, expected) => {
+    expect(deriveSingleFileLogDir(input)).toBe(expected);
   });
 });

--- a/apps/inspect/src/app/singleFileMode.ts
+++ b/apps/inspect/src/app/singleFileMode.ts
@@ -1,3 +1,5 @@
+import { dirname } from "@tsmono/util";
+
 /**
  * Single-file mode is set when the viewer is opened against a specific log
  * rather than a directory listing — e.g. an embedded iframe deep-link. We
@@ -14,4 +16,16 @@ export const detectInitialSingleFileMode = (
   }
   const params = new URLSearchParams(location.search);
   return params.has("log_file") || params.has("task_file");
+};
+
+/**
+ * In single-file mode we don't ask the server for the log root (which would
+ * walk the whole directory) — we derive the log dir from the selected file.
+ */
+export const deriveSingleFileLogDir = (
+  logFile: string | undefined
+): string | undefined => {
+  if (!logFile) return undefined;
+  const dir = dirname(logFile);
+  return dir === "" ? undefined : dir;
 };

--- a/apps/inspect/src/app/singleFileMode.ts
+++ b/apps/inspect/src/app/singleFileMode.ts
@@ -1,0 +1,17 @@
+/**
+ * Single-file mode is set when the viewer is opened against a specific log
+ * rather than a directory listing — e.g. an embedded iframe deep-link. We
+ * need to know this before the first render so that AppRouter renders the
+ * log view directly instead of mounting LogsPanel, which would otherwise
+ * kick off directory-wide replication for every log in the directory.
+ */
+export const detectInitialSingleFileMode = (
+  location: { search: string },
+  doc: Pick<Document, "getElementById">
+): boolean => {
+  if (doc.getElementById("logview-state")) {
+    return true;
+  }
+  const params = new URLSearchParams(location.search);
+  return params.has("log_file") || params.has("task_file");
+};

--- a/apps/inspect/src/app/singleFileMode.ts
+++ b/apps/inspect/src/app/singleFileMode.ts
@@ -29,3 +29,14 @@ export const deriveSingleFileLogDir = (
   const dir = dirname(logFile);
   return dir === "" ? undefined : dir;
 };
+
+/**
+ * Resolved once at module import. Whether the viewer is in single-file mode
+ * is a startup-time property: it's a function of the URL the page loaded with
+ * (or embedded state injected by VSCode) and never flips during the session,
+ * so we don't need to thread it through application state.
+ */
+export const isSingleFileMode: boolean =
+  typeof window !== "undefined"
+    ? detectInitialSingleFileMode(window.location, document)
+    : false;

--- a/apps/inspect/src/app/types.ts
+++ b/apps/inspect/src/app/types.ts
@@ -67,7 +67,6 @@ export interface AppState {
     sample_epoch?: string;
   };
   rehydrated?: boolean;
-  singleFileMode?: boolean;
   displayMode?: "rendered" | "raw";
   logsSampleView: boolean;
 }

--- a/apps/inspect/src/main.tsx
+++ b/apps/inspect/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { getVscodeApi } from "@tsmono/util";
 
 import { App } from "./app/App";
+import { detectInitialSingleFileMode } from "./app/singleFileMode";
 import api from "./client/api/index";
 import { Capabilities } from "./client/api/types";
 import storage from "./client/storage";
@@ -40,6 +41,13 @@ if (vscode) {
 
 // Inititialize the application store
 initializeStore(applicationApi, capabilities, applicationStorage);
+
+// Set single-file mode synchronously before the first render. Otherwise
+// AppRouter mounts LogsPanel on the index route, which fans out directory-wide
+// replication requests before App's effect can flip the flag.
+if (detectInitialSingleFileMode(window.location, document)) {
+  storeImplementation?.getState().appActions.setSingleFileMode(true);
+}
 
 // Determine whether we need to restore a stored hash
 restoreHash();

--- a/apps/inspect/src/main.tsx
+++ b/apps/inspect/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { getVscodeApi } from "@tsmono/util";
 
 import { App } from "./app/App";
-import { detectInitialSingleFileMode } from "./app/singleFileMode";
 import api from "./client/api/index";
 import { Capabilities } from "./client/api/types";
 import storage from "./client/storage";
@@ -41,13 +40,6 @@ if (vscode) {
 
 // Inititialize the application store
 initializeStore(applicationApi, capabilities, applicationStorage);
-
-// Set single-file mode synchronously before the first render. Otherwise
-// AppRouter mounts LogsPanel on the index route, which fans out directory-wide
-// replication requests before App's effect can flip the flag.
-if (detectInitialSingleFileMode(window.location, document)) {
-  storeImplementation?.getState().appActions.setSingleFileMode(true);
-}
 
 // Determine whether we need to restore a stored hash
 restoreHash();

--- a/apps/inspect/src/state/appSlice.ts
+++ b/apps/inspect/src/state/appSlice.ts
@@ -65,8 +65,6 @@ export interface AppSlice {
 
     setUrlHash: (urlHash: string) => void;
 
-    setSingleFileMode: (singleFile: boolean) => void;
-
     setDisplayMode: (mode: "raw" | "rendered") => void;
 
     setLogsSampleView: (logsSampleView: boolean) => void;
@@ -353,11 +351,6 @@ export const createAppSlice = (
       setUrlHash: (urlHash: string) => {
         set((state) => {
           state.app.urlHash = urlHash;
-        });
-      },
-      setSingleFileMode: (singleFile: boolean) => {
-        set((state) => {
-          state.app.singleFileMode = singleFile;
         });
       },
       setDisplayMode: (mode: "raw" | "rendered") => {

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -4,6 +4,7 @@ import { EvalSet, LogHandle } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import type { SamplesViewState } from "../app/samples/list/samplesView";
+import { deriveSingleFileLogDir } from "../app/singleFileMode";
 import { DisplayedSample, LogsState } from "../app/types";
 import { EvalHeader, LogDetails, LogPreview } from "../client/api/types";
 import { DatabaseService } from "../client/database";
@@ -218,7 +219,22 @@ export const createLogsSlice = (
         });
       },
       initLogDir: async () => {
-        const api = get().api;
+        const state = get();
+
+        // In single-file mode there is no directory listing to fetch — derive
+        // the log dir from the selected file. Avoids a server round-trip that,
+        // depending on the backend, may walk the entire log directory.
+        if (state.app.singleFileMode) {
+          const existing = state.logs.logDir;
+          if (existing !== undefined) return existing;
+          const logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
+          if (logDir !== undefined) {
+            state.logsActions.setLogDir(logDir);
+          }
+          return logDir;
+        }
+
+        const api = state.api;
         if (!api) {
           console.error("API not initialized in LogsStore");
           return undefined;

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -221,15 +221,17 @@ export const createLogsSlice = (
       initLogDir: async () => {
         const state = get();
 
-        // In single-file mode there is no directory listing to fetch — derive
-        // the log dir from the selected file. Avoids a server round-trip that,
-        // depending on the backend, may walk the entire log directory.
+        let logDir: string | undefined;
+        let absLogDir: string | undefined;
+
         if (isSingleFileMode) {
-          const existing = state.logs.logDir;
-          if (existing !== undefined) return existing;
-          let logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
-          // When the deep link is just a basename there's no dir to derive;
-          // fall back to the server's configured log dir (cheap — no listing).
+          // No directory listing to fetch — derive the log dir from the
+          // selected file. Re-deriving against the same file would just
+          // produce the same answer, so short-circuit if it's already set.
+          if (state.logs.logDir !== undefined) return state.logs.logDir;
+          logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
+          // For bare-basename deep links there's no dir to derive; fall back
+          // to the server's configured log dir (cheap — no walk).
           if (logDir === undefined && state.api?.get_log_dir) {
             try {
               logDir = await state.api.get_log_dir();
@@ -237,35 +239,26 @@ export const createLogsSlice = (
               console.log(e);
             }
           }
-          if (logDir !== undefined) {
-            state.logsActions.setLogDir(logDir);
+        } else {
+          const api = state.api;
+          if (!api) {
+            console.error("API not initialized in LogsStore");
+            return undefined;
           }
-          return logDir;
-        }
-
-        const api = state.api;
-        if (!api) {
-          console.error("API not initialized in LogsStore");
-          return undefined;
-        }
-
-        // Determine the log directory
-        const loadLogInfo = async () => {
           try {
             const root = await api.get_log_root();
-            return { logDir: root.log_dir, absLogDir: root.abs_log_dir };
+            logDir = root.log_dir;
+            absLogDir = root.abs_log_dir;
           } catch (e) {
             console.log(e);
             get().appActions.setLoading(false, e as Error);
-            return undefined;
+            // Fall through with undefined to clear any stale state below.
           }
-        };
-        const info = await loadLogInfo();
-        const logDir = info?.logDir;
+        }
+
         if (get().logs.logDir !== logDir) {
           get().logsActions.setLogDir(logDir);
         }
-        const absLogDir = info?.absLogDir;
         if (get().logs.absLogDir !== absLogDir) {
           set((state) => {
             state.logs.absLogDir = absLogDir;

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -4,7 +4,10 @@ import { EvalSet, LogHandle } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import type { SamplesViewState } from "../app/samples/list/samplesView";
-import { deriveSingleFileLogDir, isSingleFileMode } from "../app/singleFileMode";
+import {
+  deriveSingleFileLogDir,
+  isSingleFileMode,
+} from "../app/singleFileMode";
 import { DisplayedSample, LogsState } from "../app/types";
 import { EvalHeader, LogDetails, LogPreview } from "../client/api/types";
 import { DatabaseService } from "../client/database";
@@ -420,10 +423,7 @@ export const createLogsSlice = (
           ) !== -1;
 
         if (!isInFileList) {
-          if (
-            state.replicationService?.isReplicating() &&
-            !isSingleFileMode
-          ) {
+          if (state.replicationService?.isReplicating() && !isSingleFileMode) {
             await state.logsActions.syncLogs();
             const logHandle = get().logs.logs.find((val: { name: string }) =>
               val.name.endsWith(logFile)

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -4,7 +4,7 @@ import { EvalSet, LogHandle } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import type { SamplesViewState } from "../app/samples/list/samplesView";
-import { deriveSingleFileLogDir } from "../app/singleFileMode";
+import { deriveSingleFileLogDir, isSingleFileMode } from "../app/singleFileMode";
 import { DisplayedSample, LogsState } from "../app/types";
 import { EvalHeader, LogDetails, LogPreview } from "../client/api/types";
 import { DatabaseService } from "../client/database";
@@ -224,7 +224,7 @@ export const createLogsSlice = (
         // In single-file mode there is no directory listing to fetch — derive
         // the log dir from the selected file. Avoids a server round-trip that,
         // depending on the backend, may walk the entire log directory.
-        if (state.app.singleFileMode) {
+        if (isSingleFileMode) {
           const existing = state.logs.logDir;
           if (existing !== undefined) return existing;
           let logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
@@ -328,7 +328,7 @@ export const createLogsSlice = (
           };
 
           // Don't enable syncing if there is no log directory
-          if (!logDir || get().app.singleFileMode) {
+          if (!logDir || isSingleFileMode) {
             if (useProgress) {
               get().appActions.setLoading(false);
             }
@@ -429,7 +429,7 @@ export const createLogsSlice = (
         if (!isInFileList) {
           if (
             state.replicationService?.isReplicating() &&
-            !state.app.singleFileMode
+            !isSingleFileMode
           ) {
             await state.logsActions.syncLogs();
             const logHandle = get().logs.logs.find((val: { name: string }) =>

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -227,7 +227,16 @@ export const createLogsSlice = (
         if (state.app.singleFileMode) {
           const existing = state.logs.logDir;
           if (existing !== undefined) return existing;
-          const logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
+          let logDir = deriveSingleFileLogDir(state.logs.selectedLogFile);
+          // When the deep link is just a basename there's no dir to derive;
+          // fall back to the server's configured log dir (cheap — no listing).
+          if (logDir === undefined && state.api?.get_log_dir) {
+            try {
+              logDir = await state.api.get_log_dir();
+            } catch (e) {
+              console.log(e);
+            }
+          }
           if (logDir !== undefined) {
             state.logsActions.setLogDir(logDir);
           }


### PR DESCRIPTION
Fixes #77

I had trouble truly reproducing this. When the `log_file` query param is present, we'll already go into single-file mode

https://github.com/meridianlabs-ai/ts-mono/blob/8025d3440770658c046a1fcb109fc28af47ca6a1/apps/inspect/src/app/App.tsx#L216-L219

But this is setting state within a `useEffect` call, so it seems possible for there to be a race condition that's resulting in this not always being the case. This value is not something that changes throughout the lifetime of the application, so we'll detect it synchronously on startup and prevent any races.

With a directory of 32 `.eval` files, we make just 8 fetch calls:
<img width="2126" height="833" alt="Screenshot 2026-05-20 at 12 36 24 PM" src="https://github.com/user-attachments/assets/5bf4c765-1cd0-4ac5-8ece-309f77cb7519" />
