### PR TITLE
Inspect View: Filter NaN from score-column type detection

### DIFF
--- a/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -144,6 +144,13 @@ export const createEvalDescriptor = (
           .filter((value) => {
             return value !== undefined;
           })
+          // NaN is the canonical "unscored" sentinel (see Score.unscored()).
+          // Excluding it from type detection keeps a column of "C"/"I" strings
+          // with some unscored samples from being misclassified as numeric
+          // (which would render every cell — including the C/I ones — as NaN).
+          .filter((value) => {
+            return !(typeof value === "number" && Number.isNaN(value));
+          })
       ),
     ];
     const uniqScoreTypes = [
@@ -172,6 +179,8 @@ export const createEvalDescriptor = (
     if (score === null) {
       return "null";
     } else if (score === undefined) {
+      return "";
+    } else if (typeof score === "number" && Number.isNaN(score)) {
       return "";
     } else if (descriptor && descriptor.render) {
       return descriptor.render(score);


### PR DESCRIPTION
## Summary

A score column that contains both `CORRECT`/`INCORRECT` strings and `NaN` "unscored" samples (e.g. when a scorer returns `Score.unscored()` for samples it can't grade) currently renders every cell as the text `NaN` — including the C/I cells — masking the underlying values.

## Reproduction

1. Define a categorical scorer that returns `Score(value=CORRECT)` or `Score(value=INCORRECT)` for samples it can grade, and `Score.unscored()` (or equivalently `Score(value=float("nan"))`) for samples it cannot.
2. Run an eval where some samples opt in and some don't.
3. Open the log in `inspect view`.
4. Expected: scored cells show green/red C/I circles; unscored cells show blank.
5. Actual: every cell in the column shows the text `"NaN"`.

The aggregate metric in the scoring panel is computed correctly (`results.py:294-303` filters NaN before any metric runs) — only the per-cell display is wrong.

## Root cause

`createEvalDescriptor` in `samplesDescriptor.tsx` builds `uniqScoreTypes` via:

```ts
const uniqScoreTypes = [
  ...new Set(uniqScoreValues.map((scoreValue) => typeof scoreValue)),
];
```

`typeof NaN === "number"`, so a column with `"C"`/`"I"` strings plus NaN gets `types = ["string", "number"]`. The `passFailScoreDescriptor` requires `types.length === 1 && types[0] === "string"` and is skipped. Selection falls through to `numericScoreDescriptor`, which renders every cell via `formatDecimalNoTrailingZeroes(Number(score))`. `Number("C")` is `NaN`, so the entire column displays as `"NaN"`.

## Fix

Two-line change in `samplesDescriptor.tsx`:

1. Add a `.filter` step that drops NaN from `uniqScoreValues` before computing `uniqScoreTypes`, alongside the existing `null`/`undefined` filters. A column of mostly C/I strings now correctly classifies as PassFail and renders circles.
2. Render NaN cells as blank (`""`) in `scoreRendered`, matching the existing handling for `null`/`undefined`, so unscored rows don't fall through to a descriptor that doesn't know how to render them.

## Notes

- This is consistent with the existing convention that NaN is the "unscored" sentinel — `Score.unscored()` literally constructs `Score(value=float("nan"))`, and metric aggregation already skips NaN samples (`results.py:294-303`). The viewer was the only place that didn't know to skip them.
- No tests added; the `descriptor/` directory has no existing test files. Happy to add one if maintainers want — I'd put it next to `samplesDescriptor.tsx` covering: pure-C/I column → PassFail, pure-NaN → numeric, mixed C/I + NaN → PassFail (the new behavior).

## Test plan
- [x] Build viewer locally with `pnpm build`
- [x] Open a log with a scorer that mixes `CORRECT`/`INCORRECT` and `Score.unscored()`; confirm circles render for graded samples and blank for unscored
- [x] Confirm pure-NaN column still renders as numeric (descriptor type detection now sees `types = []`, falls through to `otherScoreDescriptor` which renders `String(NaN)`; actually worth double-checking this edge case)
- [x] Confirm aggregate metrics shown in scoring panel are unchanged