### PR TITLE
Fix explanation column collapsing in the scoring tab

### DIFF
--- a/apps/inspect/src/app/samples/scores/SampleScoresGrid.module.css
+++ b/apps/inspect/src/app/samples/scores/SampleScoresGrid.module.css
@@ -1,7 +1,7 @@
 .container {
   display: grid;
   grid-template-columns:
-    minmax(0, max-content) minmax(0, auto) minmax(0, max-content)
+    minmax(0, max-content) fit-content(20em) minmax(0, max-content)
     minmax(0, 1fr);
   column-gap: 0.75em;
 }


### PR DESCRIPTION
## Summary

Columns widths make Score page unreadable: Answer column takes its full unwrapped width -> Explanation 1fr collapses -> overflow-wrap: anywhere wraps it one char per line. `20em` comfortably holds a typical answer while leaving Explanation the rest of the row.

## Reproduction

[Open this eval result page](https://razum2um.github.io/insights-eval/#/tasks/2026-05-20T22-44-58-00-00_audit-honesty-eval_XKfZ5LprZyK7LQDoi56yQ7.eval/samples/sample/neutral-missed-rate/1/scoring)

<details>
<summary>Screenshots</summary>

Actual:

<img width="1582" height="1034" alt="before" src="https://github.com/user-attachments/assets/9266ead0-540c-4938-9863-49a8a73efccd" />

Expected:

<img width="1582" height="1034" alt="after" src="https://github.com/user-attachments/assets/03189709-d57f-42c9-a625-6e014f94a3f7" />
</details>

<details>
<summary>How to validate PR result</summary>

- Open link above with results
- "Answer" is too wide
- "Explanation" is unreadable
- Put this in the console to simulate effect from applying PR
```js
const grid = [...document.querySelectorAll("*")].find(el => getComputedStyle(el).display === "grid" && el.firstElementChild?.textContent.trim() === "Scorer");
grid.style.gridTemplateColumns = 'minmax(0, max-content) fit-content(20em) minmax(0, max-content) minmax(0, 1fr)'
```
</details>

<details>
<summary>Explanation</summary>

Answer column is fit-content(20em), not minmax(0, auto): `auto` lets the column grow to the answer's max-content width (a long answer laid out on a single unwrapped line). That overflows the container, leaving the minmax(0, 1fr) Explanation column its 0 minimum, which combined with `overflow-wrap: anywhere` wraps the explanation one character per line. fit-content caps the answer so the Explanation column keeps real width.
</details>