### PR TITLE
Refine scanner result header and All Scores dialog

### DIFF
--- a/apps/scout/src/app/components/ScoreValue.tsx
+++ b/apps/scout/src/app/components/ScoreValue.tsx
@@ -9,16 +9,38 @@ interface ScoreProps {
   score: JsonValue;
   className?: string | string[];
   maxRows?: number;
+  /** When false, rows beyond maxRows are hidden with no expand toggle. */
+  expandable?: boolean;
 }
 
-export const ScoreValue: FC<ScoreProps> = ({ score, className, maxRows }) => {
-  return <div className={clsx(className)}>{renderScore(score, maxRows)}</div>;
+export const ScoreValue: FC<ScoreProps> = ({
+  score,
+  className,
+  maxRows,
+  expandable = true,
+}) => {
+  return (
+    <div className={clsx(className)}>
+      {renderScore(score, maxRows, expandable)}
+    </div>
+  );
 };
 
-export const renderScore = (value: JsonValue, maxRows?: number) => {
+export const renderScore = (
+  value: JsonValue,
+  maxRows?: number,
+  expandable = true
+) => {
   if (Array.isArray(value)) {
     return value.join(", ");
   } else if (isRecord(value) && typeof value === "object") {
+    if (maxRows != null && !expandable) {
+      // Pre-slice entries so MetaDataGrid never shows its expand toggle
+      const sliced = Object.fromEntries(
+        Object.entries(value).slice(0, maxRows)
+      );
+      return <MetaDataGrid entries={sliced} />;
+    }
     return <MetaDataGrid entries={value} maxRows={maxRows} />;
   } else {
     return String(value);

--- a/apps/scout/src/app/scannerResult/AllScoresDialog.module.css
+++ b/apps/scout/src/app/scannerResult/AllScoresDialog.module.css
@@ -1,0 +1,83 @@
+.dialog > div:first-child {
+  padding: 6px 8px;
+}
+
+.dialog > div:first-child h3 {
+  font-size: 12px;
+}
+
+/* Align close button with right edge of value column */
+.dialog > div:first-child button {
+  padding: 4px 0;
+}
+
+.body {
+  margin: -16px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+
+.table thead {
+  background: var(--bs-light-bg-subtle);
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.table th {
+  text-align: left;
+  font-weight: 400;
+  font-size: var(--inspect-font-size-small);
+  color: var(--bs-secondary);
+  padding: 6px 8px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.headerContent {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sortIcon {
+  font-size: 10px;
+  margin-left: 2px;
+}
+
+/* ── Rows ────────────────────────────────────────────────────── */
+
+.table td {
+  padding: 4px 8px;
+  font-size: var(--inspect-font-size-small);
+  border-bottom: 1px dotted var(--bs-light-border-subtle);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.nameCell {
+  font-family: var(--bs-font-monospace);
+  font-size: var(--inspect-font-size-smallest);
+  color: var(--bs-secondary);
+  white-space: nowrap;
+}
+
+.valueCell {
+  color: var(--bs-body-color);
+  font-feature-settings: "tnum";
+  text-align: right;
+}
+
+.valueHeader {
+  text-align: right;
+}
+
+.valueHeader .headerContent {
+  justify-content: flex-end;
+}

--- a/apps/scout/src/app/scannerResult/AllScoresDialog.tsx
+++ b/apps/scout/src/app/scannerResult/AllScoresDialog.tsx
@@ -1,9 +1,33 @@
-import { FC } from "react";
+import clsx from "clsx";
+import { FC, useCallback, useMemo, useState } from "react";
 
 import type { JsonValue } from "@tsmono/inspect-common/types";
 import { Modal } from "@tsmono/react/components";
+import { isRecord } from "@tsmono/util";
 
-import { ScoreValue } from "../components/ScoreValue";
+import { ApplicationIcons } from "../../icons";
+
+import styles from "./AllScoresDialog.module.css";
+
+type SortColumn = "name" | "value";
+type SortDirection = "asc" | "desc";
+
+interface ScoreEntry {
+  name: string;
+  value: unknown;
+}
+
+const flattenScores = (score: JsonValue): ScoreEntry[] => {
+  if (isRecord(score) && typeof score === "object") {
+    return Object.entries(score).map(([name, value]) => ({ name, value }));
+  }
+  return [];
+};
+
+const compareValues = (a: unknown, b: unknown): number => {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return String(a ?? "").localeCompare(String(b ?? ""));
+};
 
 interface AllScoresDialogProps {
   showing: boolean;
@@ -16,9 +40,87 @@ export const AllScoresDialog: FC<AllScoresDialogProps> = ({
   setShowing,
   score,
 }) => {
+  const [sortColumn, setSortColumn] = useState<SortColumn>("name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const handleSort = useCallback(
+    (column: SortColumn) => {
+      if (sortColumn === column) {
+        setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortColumn(column);
+        setSortDirection("asc");
+      }
+    },
+    [sortColumn]
+  );
+
+  const entries = useMemo(() => flattenScores(score), [score]);
+
+  const sortedEntries = useMemo(() => {
+    const sorted = [...entries];
+    sorted.sort((a, b) => {
+      const cmp =
+        sortColumn === "name"
+          ? a.name.localeCompare(b.name)
+          : compareValues(a.value, b.value);
+      return sortDirection === "asc" ? cmp : -cmp;
+    });
+    return sorted;
+  }, [entries, sortColumn, sortDirection]);
+
+  const sortIcon = (column: SortColumn) => {
+    if (sortColumn !== column) return null;
+    return (
+      <i
+        className={clsx(
+          sortDirection === "asc"
+            ? ApplicationIcons.arrows.up
+            : ApplicationIcons.arrows.down,
+          styles.sortIcon
+        )}
+      />
+    );
+  };
+
   return (
-    <Modal show={showing} onHide={() => setShowing(false)} title="All Scores">
-      <ScoreValue score={score} />
+    <Modal
+      show={showing}
+      onHide={() => setShowing(false)}
+      title="All Scores"
+      className={styles.dialog}
+    >
+      <div className={styles.body}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th onClick={() => handleSort("name")}>
+                <span className={styles.headerContent}>
+                  Score
+                  {sortIcon("name")}
+                </span>
+              </th>
+              <th
+                className={styles.valueHeader}
+                onClick={() => handleSort("value")}
+              >
+                <span className={styles.headerContent}>
+                  Value
+                  {sortIcon("value")}
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedEntries.map((entry) => (
+              <tr key={entry.name}>
+                <td className={styles.nameCell}>{entry.name}</td>
+                <td className={styles.valueCell}>{String(entry.value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </Modal>
   );
 };

--- a/apps/scout/src/app/scannerResult/AllScoresDialog.tsx
+++ b/apps/scout/src/app/scannerResult/AllScoresDialog.tsx
@@ -1,0 +1,24 @@
+import { FC } from "react";
+
+import type { JsonValue } from "@tsmono/inspect-common/types";
+import { Modal } from "@tsmono/react/components";
+
+import { ScoreValue } from "../components/ScoreValue";
+
+interface AllScoresDialogProps {
+  showing: boolean;
+  setShowing: (showing: boolean) => void;
+  score: JsonValue;
+}
+
+export const AllScoresDialog: FC<AllScoresDialogProps> = ({
+  showing,
+  setShowing,
+  score,
+}) => {
+  return (
+    <Modal show={showing} onHide={() => setShowing(false)} title="All Scores">
+      <ScoreValue score={score} />
+    </Modal>
+  );
+};

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
@@ -1,46 +1,20 @@
 .header {
-  padding-left: 1rem;
-  padding-right: 1rem;
-  display: grid;
-  padding-bottom: 1rem;
-  padding-top: 1rem;
+  padding: 1rem 1rem;
   border-top: solid var(--bs-light-border-subtle) 1px;
-  column-gap: 1rem;
-  grid-template-rows: max-content max-content;
 }
 
-.value {
-  word-wrap: break-all;
-  overflow-wrap: break-word;
+.headerWithScore {
+  display: grid;
+  grid-template-columns: 1fr minmax(10rem, 45%);
+  gap: 1rem;
 }
 
-.oneCol {
-  grid-template-columns: minmax(0, auto);
+.metadataRegion {
+  min-width: 0;
 }
 
-.twoCol {
-  grid-template-columns: minmax(0, auto) minmax(0, auto);
-}
-
-.threeCol {
-  grid-template-columns: minmax(0, auto) minmax(0, auto) minmax(0, auto);
-}
-
-.fourCol {
-  grid-template-columns: minmax(0, auto) minmax(0, auto) minmax(0, auto) minmax(
-      0,
-      auto
-    );
-}
-
-.fiveCol {
-  grid-template-columns:
-    minmax(0, auto) minmax(0, auto) minmax(0, auto) minmax(0, auto)
-    minmax(0, auto);
-}
-
-.sixCol {
-  grid-template-columns:
-    minmax(0, auto) minmax(0, auto) minmax(0, auto) minmax(0, auto)
-    minmax(0, auto) minmax(0, auto);
+.scoreRegion {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
@@ -3,6 +3,11 @@
   border-top: solid var(--bs-light-border-subtle) 1px;
 }
 
+/* Higher specificity to beat text-size-smallest !important (source-order tie) */
+.header :global(span.text-size-smallest) {
+  font-size: inherit !important;
+}
+
 .headerWithScore {
   display: grid;
   gap: 1rem;
@@ -26,14 +31,22 @@
 }
 
 .collapsedTask {
-  font-weight: 500;
+  font-size: 0.9rem;
   white-space: nowrap;
+}
+
+/* Higher specificity to beat text-size-smallest !important (source-order tie) */
+.collapsedTask :global(span.text-size-smallest) {
+  font-size: inherit !important;
 }
 
 .collapsedSource {
   flex: 1 1 0;
   min-width: 0;
   display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
 }
 
 .collapsedDate {

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
@@ -11,3 +11,43 @@
 .metadataRegion {
   min-width: 0;
 }
+
+.collapsedBar {
+  background: var(--bs-tertiary-bg);
+  border-top: 1px solid var(--bs-border-color);
+  border-bottom: 1px solid var(--bs-border-color);
+  padding: 0.25rem 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  font-size: 0.76rem;
+  color: var(--bs-body-color);
+  min-height: 30px;
+}
+
+.collapsedTask {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.collapsedSource {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+}
+
+.collapsedDate {
+  color: var(--bs-secondary-color);
+  white-space: nowrap;
+}
+
+.collapsedMono {
+  font-family: var(--bs-font-monospace);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.dot {
+  color: var(--bs-tertiary-color);
+  flex-shrink: 0;
+}

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.module.css
@@ -5,16 +5,9 @@
 
 .headerWithScore {
   display: grid;
-  grid-template-columns: 1fr minmax(10rem, 45%);
   gap: 1rem;
 }
 
 .metadataRegion {
   min-width: 0;
-}
-
-.scoreRegion {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
 }

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -12,7 +12,6 @@ import {
 
 import { AppConfig, ScannerInput, Status } from "../../types/api-types";
 import { HeadingGrid, HeadingValue } from "../components/HeadingGrid";
-import { ScoreValue } from "../components/ScoreValue";
 import { TaskName } from "../components/TaskName";
 import { projectOrAppAliasedPath } from "../server/useAppConfig";
 import {
@@ -25,12 +24,15 @@ import {
 } from "../types";
 
 import styles from "./ScannerResultHeader.module.css";
+import { ScoreColumn } from "./ScoreColumn";
+import { SourcePath } from "./SourcePath";
 
 interface ScannerResultHeaderProps {
   scan?: Status;
   inputData?: ScannerInput;
   resultData?: ScanResultData;
   appConfig: AppConfig;
+  onShowAllScores?: () => void;
 }
 
 const labelClassName = clsx(
@@ -45,31 +47,40 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
   inputData,
   resultData,
   appConfig,
+  onShowAllScores,
 }) => {
   const headings =
     headingsForResult(appConfig, inputData, resultData, scan) ?? [];
   if (headings.length === 0) return null;
 
   const score = resultData?.transcriptScore;
-  const tabularScore = score != null && isRecord(score);
+  const hasScore = score != null;
+  const scoreGridColumns = hasScore
+    ? isRecord(score)
+      ? "minmax(0,1fr) minmax(260px, 38%)"
+      : "minmax(0,1fr) auto"
+    : undefined;
 
   return (
     <div
-      className={clsx(styles.header, tabularScore && styles.headerWithScore)}
+      className={clsx(styles.header, hasScore && styles.headerWithScore)}
+      style={
+        scoreGridColumns ? { gridTemplateColumns: scoreGridColumns } : undefined
+      }
     >
       <HeadingGrid
         headings={headings}
-        className={tabularScore ? styles.metadataRegion : undefined}
+        className={hasScore ? styles.metadataRegion : undefined}
         labelClassName={labelClassName}
         valueClassName={valueClassName}
       />
-      {tabularScore && score != null && (
-        <div className={styles.scoreRegion}>
-          <span className={labelClassName}>Score</span>
-          <span className={valueClassName}>
-            <ScoreValue score={score} maxRows={5} />
-          </span>
-        </div>
+      {hasScore && (
+        <ScoreColumn
+          score={score}
+          labelClassName={labelClassName}
+          valueClassName={valueClassName}
+          onShowAllScores={onShowAllScores}
+        />
       )}
     </div>
   );
@@ -127,7 +138,10 @@ const transcriptHeadings = (
   ];
 
   if (displaySourceUri) {
-    headings.push({ label: "Source", value: displaySourceUri });
+    headings.push({
+      label: "Source",
+      value: <SourcePath uri={displaySourceUri} />,
+    });
   }
 
   if (resultData.transcriptDate) {
@@ -138,15 +152,36 @@ const transcriptHeadings = (
   }
 
   if (resultData.transcriptAgent) {
-    headings.push({ label: "Agent", value: resultData.transcriptAgent });
+    headings.push({
+      label: "Agent",
+      value: (
+        <span style={{ fontFamily: "var(--bs-font-monospace)" }}>
+          {resultData.transcriptAgent}
+        </span>
+      ),
+    });
   }
 
   if (transcriptModel) {
-    headings.push({ label: "Model", value: transcriptModel });
+    headings.push({
+      label: "Model",
+      value: (
+        <span style={{ fontFamily: "var(--bs-font-monospace)" }}>
+          {transcriptModel}
+        </span>
+      ),
+    });
   }
 
   if (scanningModel) {
-    headings.push({ label: "Scanning Model", value: scanningModel });
+    headings.push({
+      label: "Scanning Model",
+      value: (
+        <span style={{ fontFamily: "var(--bs-font-monospace)" }}>
+          {scanningModel}
+        </span>
+      ),
+    });
   }
 
   if (resultData.transcriptLimit) {
@@ -175,17 +210,6 @@ const transcriptHeadings = (
     headings.push({
       label: "Messages",
       value: resultData.transcriptMessageCount.toString(),
-    });
-  }
-
-  // Simple (non-tabular) scores go inline; tabular scores are handled by the parent
-  if (
-    resultData.transcriptScore != null &&
-    !isRecord(resultData.transcriptScore)
-  ) {
-    headings.push({
-      label: "Score",
-      value: <ScoreValue score={resultData.transcriptScore} />,
     });
   }
 

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -24,7 +24,7 @@ import {
 } from "../types";
 
 import styles from "./ScannerResultHeader.module.css";
-import { ScoreColumn } from "./ScoreColumn";
+import { CollapsedScore, ScoreColumn } from "./ScoreColumn";
 import { SourcePath } from "./SourcePath";
 
 interface ScannerResultHeaderProps {
@@ -32,6 +32,7 @@ interface ScannerResultHeaderProps {
   inputData?: ScannerInput;
   resultData?: ScanResultData;
   appConfig: AppConfig;
+  collapsed?: boolean;
   onShowAllScores?: () => void;
 }
 
@@ -47,8 +48,66 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
   inputData,
   resultData,
   appConfig,
+  collapsed,
   onShowAllScores,
 }) => {
+  if (collapsed) {
+    if (!inputData || !isTranscriptInput(inputData) || !resultData) return null;
+
+    const sourceUri = resultData.transcriptSourceUri ?? "";
+    let resolvedSourceUrl = sourceUri;
+    if (resolvedSourceUrl && resolvedSourceUrl.startsWith("/")) {
+      resolvedSourceUrl = `file://${resolvedSourceUrl}`;
+    }
+    const displaySourceUri = projectOrAppAliasedPath(
+      appConfig,
+      resolvedSourceUrl
+    );
+    const scanningModel = scan?.spec.model?.model;
+    const score = resultData.transcriptScore;
+
+    return (
+      <div className={styles.collapsedBar}>
+        <i className="bi bi-chevron-right" />
+        <span className={styles.collapsedTask}>
+          <TaskName
+            taskSet={resultData.transcriptTaskSet}
+            taskId={resultData.transcriptTaskId}
+            taskRepeat={resultData.transcriptTaskRepeat}
+          />
+        </span>
+        {displaySourceUri && (
+          <>
+            <span className={styles.dot}>&middot;</span>
+            <span className={styles.collapsedSource}>
+              <SourcePath uri={displaySourceUri} maxLength={48} />
+            </span>
+          </>
+        )}
+        {resultData.transcriptDate && (
+          <>
+            <span className={styles.dot}>&middot;</span>
+            <span className={styles.collapsedDate}>
+              {formatDateTime(new Date(resultData.transcriptDate))}
+            </span>
+          </>
+        )}
+        {scanningModel && (
+          <>
+            <span className={styles.dot}>&middot;</span>
+            <span className={styles.collapsedMono}>{scanningModel}</span>
+          </>
+        )}
+        {score != null && (
+          <>
+            <span className={styles.dot}>&middot;</span>
+            <CollapsedScore score={score} onShowAllScores={onShowAllScores} />
+          </>
+        )}
+      </div>
+    );
+  }
+
   const headings =
     headingsForResult(appConfig, inputData, resultData, scan) ?? [];
   if (headings.length === 0) return null;

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -10,12 +10,7 @@ import {
   isRecord,
 } from "@tsmono/util";
 
-import {
-  AppConfig,
-  ScannerInput,
-  Status,
-  Transcript,
-} from "../../types/api-types";
+import { AppConfig, ScannerInput, Status } from "../../types/api-types";
 import { HeadingGrid, HeadingValue } from "../components/HeadingGrid";
 import { ScoreValue } from "../components/ScoreValue";
 import { TaskName } from "../components/TaskName";
@@ -26,6 +21,7 @@ import {
   isMessageInput,
   isMessagesInput,
   isTranscriptInput,
+  ScanResultData,
 } from "../types";
 
 import styles from "./ScannerResultHeader.module.css";
@@ -33,6 +29,7 @@ import styles from "./ScannerResultHeader.module.css";
 interface ScannerResultHeaderProps {
   scan?: Status;
   inputData?: ScannerInput;
+  resultData?: ScanResultData;
   appConfig: AppConfig;
 }
 
@@ -46,15 +43,15 @@ const valueClassName = clsx("text-size-small");
 export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
   scan,
   inputData,
+  resultData,
   appConfig,
 }) => {
-  const headings = headingsForResult(appConfig, inputData, scan) ?? [];
+  const headings =
+    headingsForResult(appConfig, inputData, resultData, scan) ?? [];
   if (headings.length === 0) return null;
 
-  // Tabular scores get their own region (same pattern as TranscriptTitle)
-  const transcript =
-    inputData && isTranscriptInput(inputData) ? inputData.input : undefined;
-  const tabularScore = transcript?.score != null && isRecord(transcript.score);
+  const score = resultData?.transcriptScore;
+  const tabularScore = score != null && isRecord(score);
 
   return (
     <div
@@ -66,11 +63,11 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
         labelClassName={labelClassName}
         valueClassName={valueClassName}
       />
-      {tabularScore && transcript?.score != null && (
+      {tabularScore && score != null && (
         <div className={styles.scoreRegion}>
           <span className={labelClassName}>Score</span>
           <span className={valueClassName}>
-            <ScoreValue score={transcript.score} maxRows={5} />
+            <ScoreValue score={score} maxRows={5} />
           </span>
         </div>
       )}
@@ -81,11 +78,12 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
 const headingsForResult = (
   appConfig: AppConfig,
   inputData?: ScannerInput,
+  resultData?: ScanResultData,
   status?: Status
 ): HeadingValue[] | undefined => {
   if (!inputData) return [];
   if (isTranscriptInput(inputData))
-    return transcriptHeadings(appConfig, inputData.input, status);
+    return transcriptHeadings(appConfig, resultData, status);
   if (isMessageInput(inputData))
     return messageHeadings(inputData.input, status);
   if (isMessagesInput(inputData)) return messagesHeadings(inputData.input);
@@ -96,14 +94,13 @@ const headingsForResult = (
 
 const transcriptHeadings = (
   appConfig: AppConfig,
-  transcript: Transcript,
+  resultData?: ScanResultData,
   status?: Status
 ): HeadingValue[] => {
-  // Source info — backwards compat with metadata
-  const sourceUri =
-    transcript.source_uri ||
-    (transcript.metadata?.log as string | undefined) ||
-    "";
+  if (!resultData) return [];
+
+  // Source info
+  const sourceUri = resultData.transcriptSourceUri ?? "";
   let resolvedSourceUrl = sourceUri;
   if (resolvedSourceUrl && resolvedSourceUrl.startsWith("/")) {
     resolvedSourceUrl = `file://${resolvedSourceUrl}`;
@@ -113,29 +110,18 @@ const transcriptHeadings = (
     resolvedSourceUrl
   );
 
-  // Model — backwards compat with metadata
-  const transcriptModel =
-    transcript.model ||
-    (transcript.metadata?.model as string | undefined) ||
-    "";
-
-  // Task — backwards compat with metadata
-  const taskSet =
-    transcript.task_set ||
-    (transcript.metadata?.task_name as string | undefined) ||
-    "";
-  const taskId =
-    transcript.task_id || (transcript.metadata?.id as string | undefined) || "";
-  const taskRepeat =
-    transcript.task_repeat || (transcript.metadata?.epoch as number) || -1;
-
+  const transcriptModel = resultData.transcriptModel ?? "";
   const scanningModel = status?.spec.model?.model;
 
   const headings: HeadingValue[] = [
     {
       label: "Task",
       value: (
-        <TaskName taskSet={taskSet} taskId={taskId} taskRepeat={taskRepeat} />
+        <TaskName
+          taskSet={resultData.transcriptTaskSet}
+          taskId={resultData.transcriptTaskId}
+          taskRepeat={resultData.transcriptTaskRepeat}
+        />
       ),
     },
   ];
@@ -144,15 +130,15 @@ const transcriptHeadings = (
     headings.push({ label: "Source", value: displaySourceUri });
   }
 
-  if (transcript.date) {
+  if (resultData.transcriptDate) {
     headings.push({
       label: "Date",
-      value: formatDateTime(new Date(transcript.date)),
+      value: formatDateTime(new Date(resultData.transcriptDate)),
     });
   }
 
-  if (transcript.agent) {
-    headings.push({ label: "Agent", value: transcript.agent });
+  if (resultData.transcriptAgent) {
+    headings.push({ label: "Agent", value: resultData.transcriptAgent });
   }
 
   if (transcriptModel) {
@@ -163,40 +149,43 @@ const transcriptHeadings = (
     headings.push({ label: "Scanning Model", value: scanningModel });
   }
 
-  if (transcript.limit) {
-    headings.push({ label: "Limit", value: transcript.limit });
+  if (resultData.transcriptLimit) {
+    headings.push({ label: "Limit", value: resultData.transcriptLimit });
   }
 
-  if (transcript.error) {
-    headings.push({ label: "Error", value: transcript.error });
+  if (resultData.transcriptError) {
+    headings.push({ label: "Error", value: resultData.transcriptError });
   }
 
-  if (transcript.total_tokens) {
+  if (resultData.transcriptTotalTokens) {
     headings.push({
       label: "Tokens",
-      value: formatNumber(transcript.total_tokens),
+      value: formatNumber(resultData.transcriptTotalTokens),
     });
   }
 
-  if (transcript.total_time) {
+  if (resultData.transcriptTotalTime) {
     headings.push({
       label: "Time",
-      value: formatTime(transcript.total_time),
+      value: formatTime(resultData.transcriptTotalTime),
     });
   }
 
-  if (transcript.message_count) {
+  if (resultData.transcriptMessageCount) {
     headings.push({
       label: "Messages",
-      value: transcript.message_count.toString(),
+      value: resultData.transcriptMessageCount.toString(),
     });
   }
 
   // Simple (non-tabular) scores go inline; tabular scores are handled by the parent
-  if (transcript.score != null && !isRecord(transcript.score)) {
+  if (
+    resultData.transcriptScore != null &&
+    !isRecord(resultData.transcriptScore)
+  ) {
     headings.push({
       label: "Score",
-      value: <ScoreValue score={transcript.score} />,
+      value: <ScoreValue score={resultData.transcriptScore} />,
     });
   }
 

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -68,7 +68,6 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
 
     return (
       <div className={styles.collapsedBar}>
-        <i className="bi bi-chevron-right" />
         <span className={styles.collapsedTask}>
           <TaskName
             taskSet={resultData.transcriptTaskSet}

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -1,8 +1,14 @@
 import clsx from "clsx";
-import { FC, ReactNode } from "react";
+import { FC } from "react";
 
 import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
 import type { EventType } from "@tsmono/inspect-components/transcript";
+import {
+  formatDateTime,
+  formatNumber,
+  formatTime,
+  isRecord,
+} from "@tsmono/util";
 
 import {
   AppConfig,
@@ -10,6 +16,8 @@ import {
   Status,
   Transcript,
 } from "../../types/api-types";
+import { HeadingGrid, HeadingValue } from "../components/HeadingGrid";
+import { ScoreValue } from "../components/ScoreValue";
 import { TaskName } from "../components/TaskName";
 import { projectOrAppAliasedPath } from "../server/useAppConfig";
 import {
@@ -28,107 +36,74 @@ interface ScannerResultHeaderProps {
   appConfig: AppConfig;
 }
 
-interface Column {
-  label: string;
-  value: ReactNode;
-  className?: string | string[];
-}
+const labelClassName = clsx(
+  "text-style-label",
+  "text-size-smallestest",
+  "text-style-secondary"
+);
+const valueClassName = clsx("text-size-small");
 
 export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
   scan,
   inputData,
   appConfig,
 }) => {
-  const columns = colsForResult(appConfig, inputData, scan) || [];
+  const headings = headingsForResult(appConfig, inputData, scan) ?? [];
+  if (headings.length === 0) return null;
+
+  // Tabular scores get their own region (same pattern as TranscriptTitle)
+  const transcript =
+    inputData && isTranscriptInput(inputData) ? inputData.input : undefined;
+  const tabularScore = transcript?.score != null && isRecord(transcript.score);
 
   return (
-    <div className={clsx(styles.header, classForCols(columns.length))}>
-      {columns.map((col) => {
-        return (
-          <div
-            key={`header-label-${col.label}`}
-            className={clsx(
-              "text-size-smallest",
-              "text-style-label",
-              "text-style-secondary",
-              styles.label,
-              col.className
-            )}
-          >
-            {col.label}
-          </div>
-        );
-      })}
-
-      {columns.map((col) => {
-        return (
-          <div
-            key={`header-val-${col.label}`}
-            className={clsx("text-size-small", styles.value, col.className)}
-          >
-            {col.value}
-          </div>
-        );
-      })}
+    <div
+      className={clsx(styles.header, tabularScore && styles.headerWithScore)}
+    >
+      <HeadingGrid
+        headings={headings}
+        className={tabularScore ? styles.metadataRegion : undefined}
+        labelClassName={labelClassName}
+        valueClassName={valueClassName}
+      />
+      {tabularScore && transcript?.score != null && (
+        <div className={styles.scoreRegion}>
+          <span className={labelClassName}>Score</span>
+          <span className={valueClassName}>
+            <ScoreValue score={transcript.score} maxRows={5} />
+          </span>
+        </div>
+      )}
     </div>
   );
 };
 
-const classForCols = (numCols: number) => {
-  return clsx(
-    numCols === 1
-      ? styles.oneCol
-      : numCols === 2
-        ? styles.twoCol
-        : numCols === 3
-          ? styles.threeCol
-          : numCols === 4
-            ? styles.fourCol
-            : numCols === 5
-              ? styles.fiveCol
-              : styles.sixCol
-  );
-};
-
-const colsForResult: (
+const headingsForResult = (
   appConfig: AppConfig,
   inputData?: ScannerInput,
   status?: Status
-) => Column[] | undefined = (appConfig, inputData, status) => {
-  if (!inputData) {
-    return [];
-  }
-  if (isTranscriptInput(inputData)) {
-    return transcriptCols(appConfig, inputData.input, status);
-  } else if (isMessageInput(inputData)) {
-    return messageCols(inputData.input, status);
-  } else if (isMessagesInput(inputData)) {
-    return messagesCols(inputData.input);
-  } else if (isEventInput(inputData)) {
-    return eventCols(inputData.input);
-  } else if (isEventsInput(inputData)) {
-    return eventsCols(inputData.input);
-  } else {
-    return [];
-  }
+): HeadingValue[] | undefined => {
+  if (!inputData) return [];
+  if (isTranscriptInput(inputData))
+    return transcriptHeadings(appConfig, inputData.input, status);
+  if (isMessageInput(inputData))
+    return messageHeadings(inputData.input, status);
+  if (isMessagesInput(inputData)) return messagesHeadings(inputData.input);
+  if (isEventInput(inputData)) return eventHeadings(inputData.input);
+  if (isEventsInput(inputData)) return eventsHeadings(inputData.input);
+  return [];
 };
 
-const transcriptCols = (
+const transcriptHeadings = (
   appConfig: AppConfig,
   transcript: Transcript,
   status?: Status
-) => {
-  // Read values from the transcript directly, falling back to metadata
-  // The metadata was previously used to store these values before they were
-  // added to the main Transcript schema (so we're doing this mainly for backwards
-  // compatibility with old scan results)
-  // Source info
+): HeadingValue[] => {
+  // Source info — backwards compat with metadata
   const sourceUri =
     transcript.source_uri ||
     (transcript.metadata?.log as string | undefined) ||
     "";
-
-  // Coerce this to a URI
   let resolvedSourceUrl = sourceUri;
   if (resolvedSourceUrl && resolvedSourceUrl.startsWith("/")) {
     resolvedSourceUrl = `file://${resolvedSourceUrl}`;
@@ -138,14 +113,13 @@ const transcriptCols = (
     resolvedSourceUrl
   );
 
-  // Model info
+  // Model — backwards compat with metadata
   const transcriptModel =
     transcript.model ||
     (transcript.metadata?.model as string | undefined) ||
     "";
-  const scanningModel = status?.spec.model?.model;
 
-  // Task information
+  // Task — backwards compat with metadata
   const taskSet =
     transcript.task_set ||
     (transcript.metadata?.task_name as string | undefined) ||
@@ -155,96 +129,120 @@ const transcriptCols = (
   const taskRepeat =
     transcript.task_repeat || (transcript.metadata?.epoch as number) || -1;
 
-  const cols: Column[] = [
+  const scanningModel = status?.spec.model?.model;
+
+  const headings: HeadingValue[] = [
     {
       label: "Task",
       value: (
         <TaskName taskSet={taskSet} taskId={taskId} taskRepeat={taskRepeat} />
       ),
     },
-    {
-      label: "Source",
-      value: displaySourceUri,
-    },
-    {
-      label: "Model",
-      value: transcriptModel,
-    },
   ];
 
-  if (status?.spec.model?.model) {
-    cols.push({
-      label: "Scanning Model",
-      value: scanningModel,
+  if (displaySourceUri) {
+    headings.push({ label: "Source", value: displaySourceUri });
+  }
+
+  if (transcript.date) {
+    headings.push({
+      label: "Date",
+      value: formatDateTime(new Date(transcript.date)),
     });
   }
 
-  return cols;
+  if (transcript.agent) {
+    headings.push({ label: "Agent", value: transcript.agent });
+  }
+
+  if (transcriptModel) {
+    headings.push({ label: "Model", value: transcriptModel });
+  }
+
+  if (scanningModel) {
+    headings.push({ label: "Scanning Model", value: scanningModel });
+  }
+
+  if (transcript.limit) {
+    headings.push({ label: "Limit", value: transcript.limit });
+  }
+
+  if (transcript.error) {
+    headings.push({ label: "Error", value: transcript.error });
+  }
+
+  if (transcript.total_tokens) {
+    headings.push({
+      label: "Tokens",
+      value: formatNumber(transcript.total_tokens),
+    });
+  }
+
+  if (transcript.total_time) {
+    headings.push({
+      label: "Time",
+      value: formatTime(transcript.total_time),
+    });
+  }
+
+  if (transcript.message_count) {
+    headings.push({
+      label: "Messages",
+      value: transcript.message_count.toString(),
+    });
+  }
+
+  // Simple (non-tabular) scores go inline; tabular scores are handled by the parent
+  if (transcript.score != null && !isRecord(transcript.score)) {
+    headings.push({
+      label: "Score",
+      value: <ScoreValue score={transcript.score} />,
+    });
+  }
+
+  return headings;
 };
 
-const messageCols = (message: ChatMessage, status?: Status) => {
-  const cols: Column[] = [
-    {
-      label: "Message ID",
-      value: message.id,
-    },
-  ];
+const messageHeadings = (
+  message: ChatMessage,
+  status?: Status
+): HeadingValue[] => {
+  const headings: HeadingValue[] = [{ label: "Message ID", value: message.id }];
 
   if (message.role === "assistant") {
-    cols.push({
-      label: "Model",
-      value: message.model,
-    });
-    cols.push({
+    headings.push({ label: "Model", value: message.model });
+    headings.push({
       label: "Tool Calls",
       value: ((message.tool_calls as []) || []).length,
     });
   } else {
-    cols.push({
-      label: "Role",
-      value: message.role,
-    });
+    headings.push({ label: "Role", value: message.role });
   }
 
   if (status?.spec.model?.model) {
-    cols.push({
+    headings.push({
       label: "Scanning Model",
       value: status.spec.model.model,
     });
   }
 
-  return cols;
+  return headings;
 };
 
-const messagesCols = (messages: ChatMessage[]): Column[] => {
-  return [
-    {
-      label: "Message Count",
-      value: messages.length,
-    },
-  ];
-};
+const messagesHeadings = (messages: ChatMessage[]): HeadingValue[] => [
+  { label: "Message Count", value: messages.length },
+];
 
-const eventCols = (event: EventType): Column[] => {
-  return [
-    {
-      label: "Event Type",
-      value: event.event,
-    },
-    {
-      label: "Timestamp",
-      value: event.timestamp
-        ? new Date(event.timestamp).toLocaleString()
-        : undefined,
-    },
-  ];
-};
+const eventHeadings = (event: EventType): HeadingValue[] => [
+  { label: "Event Type", value: event.event },
+  {
+    label: "Timestamp",
+    value: event.timestamp
+      ? new Date(event.timestamp).toLocaleString()
+      : undefined,
+  },
+];
 
-const eventsCols = (events: Event[]): Column[] => {
-  return [
-    {
-      label: "Event Count",
-      value: events.length,
-    },
-  ];
-};
+const eventsHeadings = (events: Event[]): HeadingValue[] => [
+  { label: "Event Count", value: events.length },
+];

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -3,12 +3,7 @@ import { FC } from "react";
 
 import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
 import type { EventType } from "@tsmono/inspect-components/transcript";
-import {
-  formatDateTime,
-  formatNumber,
-  formatTime,
-  isRecord,
-} from "@tsmono/util";
+import { formatDateTime, formatNumber, formatTime } from "@tsmono/util";
 
 import { AppConfig, ScannerInput, Status } from "../../types/api-types";
 import { HeadingGrid, HeadingValue } from "../components/HeadingGrid";
@@ -78,9 +73,11 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
         {displaySourceUri && (
           <>
             <span className={styles.dot}>&middot;</span>
-            <span className={styles.collapsedSource}>
-              <SourcePath uri={displaySourceUri} maxLength={48} />
-            </span>
+            <SourcePath
+              uri={displaySourceUri}
+              maxLength={Infinity}
+              className={styles.collapsedSource}
+            />
           </>
         )}
         {resultData.transcriptDate && (
@@ -113,11 +110,7 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
 
   const score = resultData?.transcriptScore;
   const hasScore = score != null;
-  const scoreGridColumns = hasScore
-    ? isRecord(score)
-      ? "minmax(0,1fr) minmax(260px, 38%)"
-      : "minmax(0,1fr) auto"
-    : undefined;
+  const scoreGridColumns = hasScore ? "minmax(0,1fr) auto" : undefined;
 
   return (
     <div

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
@@ -1,20 +1,8 @@
 .root {
   height: 100%;
   display: grid;
-  grid-template-rows: max-content max-content 1fr;
-}
-
-.scroller {
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
-}
-
-.stickyHeader {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: var(--bs-body-bg);
+  grid-template-rows: max-content max-content max-content 1fr;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .tabSet {
@@ -41,10 +29,9 @@
 .contentArea {
   display: flex;
   flex-direction: row;
-  min-height: 100%;
+  height: 100%;
+  min-height: 0;
   overflow: hidden;
-  position: relative;
-  z-index: 0;
 }
 
 .tabSetWrapper {

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
@@ -1,7 +1,7 @@
 .root {
   height: 100%;
   display: grid;
-  grid-template-rows: max-content max-content max-content 1fr;
+  grid-template-rows: max-content max-content 1fr;
 }
 
 .scroller {
@@ -34,8 +34,7 @@
 .contentArea {
   display: flex;
   flex-direction: row;
-  flex: 1;
-  min-height: 0;
+  min-height: 100%;
   overflow: hidden;
 }
 

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
@@ -43,6 +43,8 @@
   flex-direction: row;
   min-height: 100%;
   overflow: hidden;
+  position: relative;
+  z-index: 0;
 }
 
 .tabSetWrapper {

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.module.css
@@ -10,6 +10,13 @@
   overflow-y: auto;
 }
 
+.stickyHeader {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bs-body-bg);
+}
+
 .tabSet {
   border-top: solid 1px var(--bs-border-color);
   flex: 1;

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -243,6 +243,7 @@ export const ScannerResultPanel: FC = () => {
           icon={ApplicationIcons.transcript}
           onClick={handleNavigateToTranscript}
           title="View complete transcript (Shift+click to open in new tab)"
+          subtle={true}
         />
       );
     }

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -316,12 +316,7 @@ export const ScannerResultPanel: FC = () => {
           className={styles.fullHeight}
         >
           {resultData && inputData && (
-            <ResultPanel
-              resultData={resultData}
-              inputData={inputData}
-              transcriptDir={resolvedTranscriptsDir}
-              hasTranscript={!!hasTranscript}
-            />
+            <ResultPanel resultData={resultData} inputData={inputData} />
           )}
         </TabPanel>
       ) : undefined}

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -17,6 +17,7 @@ import { ApplicationIcons } from "../../icons";
 import {
   getScannerParam,
   getValidationParam,
+  openRouteInNewTab,
   transcriptRoute,
   updateValidationParam,
 } from "../../router/url";
@@ -201,7 +202,7 @@ export const ScannerResultPanel: FC = () => {
         selectedResult?.transcriptId ?? ""
       );
       if (e.shiftKey) {
-        window.open(route, "_blank");
+        openRouteInNewTab(route);
       } else {
         void navigate(route);
       }

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -15,7 +15,6 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   JSONPanel,
   LoadingBar,
-  StickyScroll,
   TabPanel,
   TabSet,
   ToolButton,
@@ -70,6 +69,17 @@ export const ScannerResultPanel: FC = () => {
   const [scoresDialogResultId, setScoresDialogResultId] = useState<
     string | undefined
   >();
+
+  // Collapse header when the scroller has been scrolled past the header
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const onScroll = () => {
+      setHeaderCollapsed(scroller.scrollTop > 0);
+    };
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => scroller.removeEventListener("scroll", onScroll);
+  }, []);
 
   // Url data
   const { scanResultUuid } = useScanRoute();
@@ -407,7 +417,7 @@ export const ScannerResultPanel: FC = () => {
         }
       />
       <div className={styles.scroller} ref={scrollRef}>
-        <StickyScroll scrollRef={scrollRef} onStickyChange={setHeaderCollapsed}>
+        <div className={styles.stickyHeader}>
           <ScannerResultHeader
             inputData={inputData}
             resultData={selectedResult}
@@ -416,7 +426,7 @@ export const ScannerResultPanel: FC = () => {
             collapsed={headerCollapsed}
             onShowAllScores={() => setScoresDialogResultId(scanResultUuid)}
           />
-        </StickyScroll>
+        </div>
         {selectedResult && (
           <div
             className={clsx(

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -66,7 +66,10 @@ const kTabIdMetadata = "Metadata";
 export const ScannerResultPanel: FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [headerCollapsed, setHeaderCollapsed] = useState(false);
-  const [showAllScores, setShowAllScores] = useState(false);
+  // Track which result's scores dialog is open — auto-resets on navigation
+  const [scoresDialogResultId, setScoresDialogResultId] = useState<
+    string | undefined
+  >();
 
   // Url data
   const { scanResultUuid } = useScanRoute();
@@ -411,7 +414,7 @@ export const ScannerResultPanel: FC = () => {
             scan={selectedScan}
             appConfig={appConfig}
             collapsed={headerCollapsed}
-            onShowAllScores={() => setShowAllScores(true)}
+            onShowAllScores={() => setScoresDialogResultId(scanResultUuid)}
           />
         </StickyScroll>
         {selectedResult && (
@@ -448,8 +451,10 @@ export const ScannerResultPanel: FC = () => {
       </div>
       {selectedResult?.transcriptScore != null && (
         <AllScoresDialog
-          showing={showAllScores}
-          setShowing={setShowAllScores}
+          showing={scoresDialogResultId === scanResultUuid}
+          setShowing={(show) =>
+            setScoresDialogResultId(show ? scanResultUuid : undefined)
+          }
           score={selectedResult.transcriptScore}
         />
       )}

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -63,22 +63,57 @@ const kTabIdTranscript = "transcript";
 const kTabIdMetadata = "Metadata";
 
 export const ScannerResultPanel: FC = () => {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const headerCollapsedRef = useRef(false);
   const [headerCollapsed, setHeaderCollapsed] = useState(false);
   // Track which result's scores dialog is open — auto-resets on navigation
   const [scoresDialogResultId, setScoresDialogResultId] = useState<
     string | undefined
   >();
 
-  // Collapse header when the scroller has been scrolled past the header
-  useEffect(() => {
-    const scroller = scrollRef.current;
-    if (!scroller) return;
-    const onScroll = () => {
-      setHeaderCollapsed(scroller.scrollTop > 0);
+  // Collapse header when any scroll container inside contentArea has scrolled.
+  // Uses a callback ref so the listener attaches when the node mounts.
+  // After collapsing, the layout shift can cause scroll containers to resize
+  // and auto-clamp scrollTop to 0, which would immediately un-collapse.
+  // A brief cooldown prevents this bounce.
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const collapsedAtRef = useRef(0);
+  const contentRef = useCallback((node: HTMLDivElement | null) => {
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    if (!node) {
+      headerCollapsedRef.current = false;
+      setHeaderCollapsed(false);
+      return;
+    }
+
+    const kScrollThreshold = 100;
+
+    const onScroll = (e: Event) => {
+      const target = e.target as Element;
+      const scrolled = target.scrollTop > kScrollThreshold;
+      if (scrolled && !headerCollapsedRef.current) {
+        // Collapsing frees vertical space (~140px). If the container's
+        // overflow is smaller than that, scrollTop will clamp to 0 after
+        // the layout shift, causing an immediate un-collapse flash.
+        const overflow = target.scrollHeight - target.clientHeight;
+        if (overflow < 150) return;
+        headerCollapsedRef.current = true;
+        collapsedAtRef.current = Date.now();
+        setHeaderCollapsed(true);
+      } else if (!scrolled && headerCollapsedRef.current) {
+        if (Date.now() - collapsedAtRef.current < 150) return;
+        const allAtTop = Array.from(node.querySelectorAll("*")).every(
+          (el) => el.scrollTop === 0
+        );
+        if (allAtTop) {
+          headerCollapsedRef.current = false;
+          setHeaderCollapsed(false);
+        }
+      }
     };
-    scroller.addEventListener("scroll", onScroll, { passive: true });
-    return () => scroller.removeEventListener("scroll", onScroll);
+    node.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    cleanupRef.current = () =>
+      node.removeEventListener("scroll", onScroll, { capture: true });
   }, []);
 
   // Url data
@@ -416,49 +451,46 @@ export const ScannerResultPanel: FC = () => {
           scanLoading || resultLoading || detailLoading || hasTranscriptLoading
         }
       />
-      <div className={styles.scroller} ref={scrollRef}>
-        <div className={styles.stickyHeader}>
-          <ScannerResultHeader
-            inputData={inputData}
-            resultData={selectedResult}
-            scan={selectedScan}
-            appConfig={appConfig}
-            collapsed={headerCollapsed}
-            onShowAllScores={() => setScoresDialogResultId(scanResultUuid)}
-          />
-        </div>
-        {selectedResult && (
-          <div
-            className={clsx(
-              styles.contentArea,
-              !validationSidebarCollapsed && styles.withValidation
-            )}
-          >
-            {validationSidebarCollapsed || !selectedResult.transcriptId ? (
-              <div className={styles.tabSetWrapper}>
+      <ScannerResultHeader
+        inputData={inputData}
+        resultData={selectedResult}
+        scan={selectedScan}
+        appConfig={appConfig}
+        collapsed={headerCollapsed}
+        onShowAllScores={() => setScoresDialogResultId(scanResultUuid)}
+      />
+      {selectedResult && (
+        <div
+          ref={contentRef}
+          className={clsx(
+            styles.contentArea,
+            !validationSidebarCollapsed && styles.withValidation
+          )}
+        >
+          {validationSidebarCollapsed || !selectedResult.transcriptId ? (
+            <div className={styles.tabSetWrapper}>
+              {renderTabSet(selectedResult)}
+            </div>
+          ) : (
+            <VscodeSplitLayout
+              className={styles.splitLayout}
+              fixedPane="end"
+              initialHandlePosition="80%"
+              minEnd="180px"
+              minStart="200px"
+            >
+              <div slot="start" className={styles.splitStart}>
                 {renderTabSet(selectedResult)}
               </div>
-            ) : (
-              <VscodeSplitLayout
-                className={styles.splitLayout}
-                fixedPane="end"
-                initialHandlePosition="80%"
-                minEnd="180px"
-                minStart="200px"
-              >
-                <div slot="start" className={styles.splitStart}>
-                  {renderTabSet(selectedResult)}
-                </div>
-                <div slot="end" className={styles.validationSidebar}>
-                  <ValidationCaseEditor
-                    transcriptId={selectedResult.transcriptId}
-                  />
-                </div>
-              </VscodeSplitLayout>
-            )}
-          </div>
-        )}
-      </div>
+              <div slot="end" className={styles.validationSidebar}>
+                <ValidationCaseEditor
+                  transcriptId={selectedResult.transcriptId}
+                />
+              </div>
+            </VscodeSplitLayout>
+          )}
+        </div>
+      )}
       {selectedResult?.transcriptScore != null && (
         <AllScoresDialog
           showing={scoresDialogResultId === scanResultUuid}

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -201,7 +201,7 @@ export const ScannerResultPanel: FC = () => {
         resolvedTranscriptsDir,
         selectedResult?.transcriptId ?? ""
       );
-      if (e.shiftKey) {
+      if (e.metaKey || e.ctrlKey) {
         openRouteInNewTab(route);
       } else {
         void navigate(route);
@@ -242,7 +242,7 @@ export const ScannerResultPanel: FC = () => {
           label="Transcript"
           icon={ApplicationIcons.transcript}
           onClick={handleNavigateToTranscript}
-          title="View complete transcript (Shift+click to open in new tab)"
+          title="View complete transcript (Cmd/Ctrl+click to open in new tab)"
           subtle={true}
         />
       );

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -2,7 +2,7 @@ import { skipToken } from "@tanstack/react-query";
 import { VscodeSplitLayout } from "@vscode-elements/react-elements";
 import { clsx } from "clsx";
 import { FC, ReactNode, useCallback, useEffect, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import {
   JSONPanel,
@@ -17,6 +17,7 @@ import { ApplicationIcons } from "../../icons";
 import {
   getScannerParam,
   getValidationParam,
+  transcriptRoute,
   updateValidationParam,
 } from "../../router/url";
 import { useStore } from "../../state/store";
@@ -191,6 +192,23 @@ export const ScannerResultPanel: FC = () => {
     setHighlightLabeled(!highlightLabeled);
   }, [highlightLabeled, setHighlightLabeled]);
 
+  const navigate = useNavigate();
+
+  const handleNavigateToTranscript = useCallback(
+    (e: React.MouseEvent) => {
+      const route = transcriptRoute(
+        resolvedTranscriptsDir,
+        selectedResult?.transcriptId ?? ""
+      );
+      if (e.shiftKey) {
+        window.open(route, "_blank");
+      } else {
+        void navigate(route);
+      }
+    },
+    [navigate, resolvedTranscriptsDir, selectedResult?.transcriptId]
+  );
+
   const tools = useMemo(() => {
     const toolButtons: ReactNode[] = [];
 
@@ -207,6 +225,23 @@ export const ScannerResultPanel: FC = () => {
           latched={!!highlightLabeled}
           onClick={toggleHighlightLabeled}
           label="Highlight Refs"
+        />
+      );
+    }
+
+    // Transcript button - navigate to full transcript view
+    const canNavigateToTranscript =
+      !!hasTranscript &&
+      resolvedTranscriptsDir.length > 0 &&
+      !!selectedResult?.transcriptId;
+    if (canNavigateToTranscript) {
+      toolButtons.push(
+        <ToolButton
+          key="transcript-navigate"
+          label="Transcript"
+          icon={ApplicationIcons.transcript}
+          onClick={handleNavigateToTranscript}
+          title="View complete transcript (Shift+click to open in new tab)"
         />
       );
     }
@@ -237,6 +272,9 @@ export const ScannerResultPanel: FC = () => {
     selectedResult,
     toggleValidationSidebar,
     validationSidebarCollapsed,
+    handleNavigateToTranscript,
+    hasTranscript,
+    resolvedTranscriptsDir,
   ]);
 
   const renderTabSet = (resultData: ScanResultData) => (

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -391,6 +391,7 @@ export const ScannerResultPanel: FC = () => {
       />
       <ScannerResultHeader
         inputData={inputData}
+        resultData={selectedResult}
         scan={selectedScan}
         appConfig={appConfig}
       />

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -1,12 +1,21 @@
 import { skipToken } from "@tanstack/react-query";
 import { VscodeSplitLayout } from "@vscode-elements/react-elements";
 import { clsx } from "clsx";
-import { FC, ReactNode, useCallback, useEffect, useMemo } from "react";
+import {
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import {
   JSONPanel,
   LoadingBar,
+  StickyScroll,
   TabPanel,
   TabSet,
   ToolButton,
@@ -36,6 +45,7 @@ import { useScansDir } from "../utils/useScansDir";
 import { useTranscriptsDir } from "../utils/useTranscriptsDir";
 import { ValidationCaseEditor } from "../validation/components/ValidationCaseEditor";
 
+import { AllScoresDialog } from "./AllScoresDialog";
 import { ErrorPanel } from "./error/ErrorPanel";
 import { InfoPanel } from "./info/InfoPanel";
 import { MetadataPanel } from "./metadata/MetadataPanel";
@@ -54,6 +64,10 @@ const kTabIdTranscript = "transcript";
 const kTabIdMetadata = "Metadata";
 
 export const ScannerResultPanel: FC = () => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [headerCollapsed, setHeaderCollapsed] = useState(false);
+  const [showAllScores, setShowAllScores] = useState(false);
+
   // Url data
   const { scanResultUuid } = useScanRoute();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -389,43 +403,55 @@ export const ScannerResultPanel: FC = () => {
           scanLoading || resultLoading || detailLoading || hasTranscriptLoading
         }
       />
-      <ScannerResultHeader
-        inputData={inputData}
-        resultData={selectedResult}
-        scan={selectedScan}
-        appConfig={appConfig}
-      />
-
-      {selectedResult && (
-        <div
-          className={clsx(
-            styles.contentArea,
-            !validationSidebarCollapsed && styles.withValidation
-          )}
-        >
-          {validationSidebarCollapsed || !selectedResult.transcriptId ? (
-            <div className={styles.tabSetWrapper}>
-              {renderTabSet(selectedResult)}
-            </div>
-          ) : (
-            <VscodeSplitLayout
-              className={styles.splitLayout}
-              fixedPane="end"
-              initialHandlePosition="80%"
-              minEnd="180px"
-              minStart="200px"
-            >
-              <div slot="start" className={styles.splitStart}>
+      <div className={styles.scroller} ref={scrollRef}>
+        <StickyScroll scrollRef={scrollRef} onStickyChange={setHeaderCollapsed}>
+          <ScannerResultHeader
+            inputData={inputData}
+            resultData={selectedResult}
+            scan={selectedScan}
+            appConfig={appConfig}
+            collapsed={headerCollapsed}
+            onShowAllScores={() => setShowAllScores(true)}
+          />
+        </StickyScroll>
+        {selectedResult && (
+          <div
+            className={clsx(
+              styles.contentArea,
+              !validationSidebarCollapsed && styles.withValidation
+            )}
+          >
+            {validationSidebarCollapsed || !selectedResult.transcriptId ? (
+              <div className={styles.tabSetWrapper}>
                 {renderTabSet(selectedResult)}
               </div>
-              <div slot="end" className={styles.validationSidebar}>
-                <ValidationCaseEditor
-                  transcriptId={selectedResult.transcriptId}
-                />
-              </div>
-            </VscodeSplitLayout>
-          )}
-        </div>
+            ) : (
+              <VscodeSplitLayout
+                className={styles.splitLayout}
+                fixedPane="end"
+                initialHandlePosition="80%"
+                minEnd="180px"
+                minStart="200px"
+              >
+                <div slot="start" className={styles.splitStart}>
+                  {renderTabSet(selectedResult)}
+                </div>
+                <div slot="end" className={styles.validationSidebar}>
+                  <ValidationCaseEditor
+                    transcriptId={selectedResult.transcriptId}
+                  />
+                </div>
+              </VscodeSplitLayout>
+            )}
+          </div>
+        )}
+      </div>
+      {selectedResult?.transcriptScore != null && (
+        <AllScoresDialog
+          showing={showAllScores}
+          setShowing={setShowAllScores}
+          score={selectedResult.transcriptScore}
+        />
       )}
     </div>
   );

--- a/apps/scout/src/app/scannerResult/ScoreColumn.module.css
+++ b/apps/scout/src/app/scannerResult/ScoreColumn.module.css
@@ -1,15 +1,18 @@
 .scoreColumn {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0;
   min-width: 0;
-  border-left: 1px solid var(--bs-border-color);
   padding-left: 1.25rem;
+}
+
+.scoreGrid {
+  margin-top: -3px;
 }
 
 .allScoresLink {
   align-self: flex-start;
-  margin-top: 0.3rem;
+  margin-top: 0.1rem;
   color: var(--bs-link-color);
   background: none;
   border: none;

--- a/apps/scout/src/app/scannerResult/ScoreColumn.module.css
+++ b/apps/scout/src/app/scannerResult/ScoreColumn.module.css
@@ -1,0 +1,31 @@
+.scoreColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+  border-left: 1px solid var(--bs-border-color);
+  padding-left: 1.25rem;
+}
+
+.allScoresLink {
+  align-self: flex-start;
+  margin-top: 0.3rem;
+  color: var(--bs-link-color);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.allScoresLink:hover {
+  text-decoration: underline;
+}
+
+.collapsedSimpleScore {
+  font-family: var(--bs-font-monospace);
+  font-size: 0.74rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}

--- a/apps/scout/src/app/scannerResult/ScoreColumn.tsx
+++ b/apps/scout/src/app/scannerResult/ScoreColumn.tsx
@@ -1,0 +1,69 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+import type { JsonValue } from "@tsmono/inspect-common/types";
+import { isRecord } from "@tsmono/util";
+
+import { ScoreValue } from "../components/ScoreValue";
+
+import styles from "./ScoreColumn.module.css";
+
+interface ScoreColumnProps {
+  score: JsonValue;
+  labelClassName?: string;
+  valueClassName?: string;
+  onShowAllScores?: () => void;
+}
+
+export const ScoreColumn: FC<ScoreColumnProps> = ({
+  score,
+  labelClassName,
+  valueClassName,
+  onShowAllScores,
+}) => {
+  const isComplex = isRecord(score);
+  const totalScores = isComplex ? Object.keys(score).length : 0;
+
+  return (
+    <div className={styles.scoreColumn}>
+      <span className={clsx(labelClassName)}>Score</span>
+      <span className={clsx(valueClassName)}>
+        <ScoreValue score={score} maxRows={5} />
+      </span>
+      {isComplex && totalScores > 5 && onShowAllScores && (
+        <button
+          type="button"
+          className={styles.allScoresLink}
+          onClick={onShowAllScores}
+        >
+          All scores ({totalScores})
+        </button>
+      )}
+    </div>
+  );
+};
+
+/** Compact inline score for the collapsed bar. */
+export const CollapsedScore: FC<{
+  score: JsonValue;
+  onShowAllScores?: () => void;
+}> = ({ score, onShowAllScores }) => {
+  const isComplex = isRecord(score);
+
+  if (isComplex) {
+    const totalScores = Object.keys(score).length;
+    return (
+      <button
+        type="button"
+        className={styles.allScoresLink}
+        onClick={onShowAllScores}
+      >
+        All scores ({totalScores})
+      </button>
+    );
+  }
+
+  return (
+    <span className={styles.collapsedSimpleScore}>Score: {String(score)}</span>
+  );
+};

--- a/apps/scout/src/app/scannerResult/ScoreColumn.tsx
+++ b/apps/scout/src/app/scannerResult/ScoreColumn.tsx
@@ -24,13 +24,19 @@ export const ScoreColumn: FC<ScoreColumnProps> = ({
   const isComplex = isRecord(score);
   const totalScores = isComplex ? Object.keys(score).length : 0;
 
+  const kMaxPreviewRows = 3;
+
   return (
     <div className={styles.scoreColumn}>
       <span className={clsx(labelClassName)}>Score</span>
-      <span className={clsx(valueClassName)}>
-        <ScoreValue score={score} maxRows={5} />
+      <span className={clsx(valueClassName, isComplex && styles.scoreGrid)}>
+        <ScoreValue
+          score={score}
+          maxRows={kMaxPreviewRows}
+          expandable={false}
+        />
       </span>
-      {isComplex && totalScores > 5 && onShowAllScores && (
+      {isComplex && totalScores > kMaxPreviewRows && onShowAllScores && (
         <button
           type="button"
           className={styles.allScoresLink}

--- a/apps/scout/src/app/scannerResult/ScoreColumn.tsx
+++ b/apps/scout/src/app/scannerResult/ScoreColumn.tsx
@@ -50,15 +50,14 @@ export const CollapsedScore: FC<{
 }> = ({ score, onShowAllScores }) => {
   const isComplex = isRecord(score);
 
-  if (isComplex) {
-    const totalScores = Object.keys(score).length;
+  if (isComplex && onShowAllScores) {
     return (
       <button
         type="button"
         className={styles.allScoresLink}
         onClick={onShowAllScores}
       >
-        All scores ({totalScores})
+        All scores ({Object.keys(score).length})
       </button>
     );
   }

--- a/apps/scout/src/app/scannerResult/SourcePath.module.css
+++ b/apps/scout/src/app/scannerResult/SourcePath.module.css
@@ -3,10 +3,12 @@
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
+  max-width: 100%;
 }
 
 .pathText {
   font-family: var(--bs-font-monospace);
+  font-size: 0.9em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/scout/src/app/scannerResult/SourcePath.module.css
+++ b/apps/scout/src/app/scannerResult/SourcePath.module.css
@@ -1,0 +1,14 @@
+.sourcePath {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.pathText {
+  font-family: var(--bs-font-monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}

--- a/apps/scout/src/app/scannerResult/SourcePath.tsx
+++ b/apps/scout/src/app/scannerResult/SourcePath.tsx
@@ -1,0 +1,27 @@
+import { FC } from "react";
+
+import { CopyButton } from "@tsmono/react/components";
+import { centerTruncate } from "@tsmono/util";
+
+import styles from "./SourcePath.module.css";
+
+interface SourcePathProps {
+  uri: string;
+  /** Maximum display length before truncation. Default 58 (≈ head 20 + ellipsis + tail 36). */
+  maxLength?: number;
+  className?: string;
+}
+
+export const SourcePath: FC<SourcePathProps> = ({
+  uri,
+  maxLength = 58,
+  className,
+}) => {
+  const display = centerTruncate(uri, maxLength);
+  return (
+    <span className={className ?? styles.sourcePath} title={uri}>
+      <span className={styles.pathText}>{display}</span>
+      <CopyButton value={uri} ariaLabel="Copy source path" />
+    </span>
+  );
+};

--- a/apps/scout/src/app/scannerResult/result/ResultBody.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultBody.tsx
@@ -1,19 +1,14 @@
 import clsx from "clsx";
-import { FC, useCallback, useRef } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { FC, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { ChatViewVirtualList } from "@tsmono/inspect-components/chat";
 import { NoContentsPanel } from "@tsmono/react/components";
 import { useScrollDirection } from "@tsmono/react/hooks";
 
-import { ApplicationIcons } from "../../../icons";
-import { transcriptRoute } from "../../../router/url";
 import { useStore } from "../../../state/store";
 import { ScannerInput } from "../../../types/api-types";
-import {
-  ColumnHeader,
-  ColumnHeaderButton,
-} from "../../components/ColumnHeader";
+import { ColumnHeader } from "../../components/ColumnHeader";
 import { TimelineEventsView } from "../../timeline/components/TimelineEventsView";
 import {
   isEventInput,
@@ -29,19 +24,11 @@ import styles from "./ResultBody.module.css";
 export interface ResultBodyProps {
   resultData: ScanResultData;
   inputData: ScannerInput;
-  transcriptDir: string;
-  hasTranscript: boolean;
 }
 
-export const ResultBody: FC<ResultBodyProps> = ({
-  resultData,
-  inputData,
-  transcriptDir,
-  hasTranscript,
-}) => {
+export const ResultBody: FC<ResultBodyProps> = ({ resultData, inputData }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
 
   // Headroom: collapse swimlanes on scroll-down, expand on scroll-up.
   const { hidden: headroomHidden, resetAnchor: headroomResetAnchor } =
@@ -53,26 +40,9 @@ export const ResultBody: FC<ResultBodyProps> = ({
 
   const highlightLabeled = useStore((state) => state.highlightLabeled);
 
-  const handleNavigateToTranscript = useCallback(() => {
-    if (transcriptDir && resultData.transcriptId) {
-      void navigate(transcriptRoute(transcriptDir, resultData.transcriptId));
-    }
-  }, [navigate, transcriptDir, resultData.transcriptId]);
-
-  // Only show the transcript button when we have both transcriptsDir and transcriptId
-  const canNavigateToTranscript =
-    hasTranscript && transcriptDir.length > 0 && resultData.transcriptId;
-  const transcriptAction = canNavigateToTranscript ? (
-    <ColumnHeaderButton
-      icon={ApplicationIcons.transcript}
-      onClick={handleNavigateToTranscript}
-      title="View complete transcript"
-    />
-  ) : undefined;
-
   return (
     <div className={clsx(styles.container, containerClass(inputData))}>
-      <ColumnHeader label="Input" actions={transcriptAction} />
+      <ColumnHeader label="Input" />
       <div ref={scrollRef} className={clsx(styles.scrollable)}>
         <InputRenderer
           resultData={resultData}

--- a/apps/scout/src/app/scannerResult/result/ResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultPanel.tsx
@@ -11,25 +11,16 @@ import { ResultSidebar } from "./ResultSidebar";
 interface ResultPanelProps {
   resultData: ScanResultData;
   inputData: ScannerInput | undefined;
-  transcriptDir: string;
-  hasTranscript: boolean;
 }
 
 export const ResultPanel: FC<ResultPanelProps> = ({
   resultData,
   inputData,
-  transcriptDir,
-  hasTranscript,
 }) => (
   <div className={clsx(styles.container, "text-size-base")}>
     <ResultSidebar inputData={inputData} resultData={resultData} />
     {inputData ? (
-      <ResultBody
-        resultData={resultData}
-        inputData={inputData}
-        transcriptDir={transcriptDir}
-        hasTranscript={hasTranscript}
-      />
+      <ResultBody resultData={resultData} inputData={inputData} />
     ) : (
       <div>No Input Available</div>
     )}

--- a/apps/scout/src/app/scannerResult/result/ResultSidebar.module.css
+++ b/apps/scout/src/app/scannerResult/result/ResultSidebar.module.css
@@ -1,6 +1,5 @@
 .sidebar {
   border-right: solid 1px var(--bs-border-color);
-  padding: 1rem;
   overflow-y: auto;
 }
 

--- a/packages/react/src/components/Modal.tsx
+++ b/packages/react/src/components/Modal.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { FC, ReactNode, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
@@ -11,6 +12,7 @@ interface ModalProps {
   title: string;
   children: ReactNode;
   footer?: ReactNode;
+  className?: string;
 }
 
 export const Modal: FC<ModalProps> = ({
@@ -20,6 +22,7 @@ export const Modal: FC<ModalProps> = ({
   title,
   children,
   footer,
+  className,
 }) => {
   const icons = useComponentIcons();
   const modalRef = useRef<HTMLDivElement>(null);
@@ -58,7 +61,7 @@ export const Modal: FC<ModalProps> = ({
     <div className={styles.backdrop} onClick={onHide}>
       <div
         ref={modalRef}
-        className={styles.modal}
+        className={clsx(styles.modal, className)}
         onClick={(e) => e.stopPropagation()}
       >
         <div className={styles.header}>


### PR DESCRIPTION
## Summary
- Refactor scanner result header with enriched transcript metadata (task, source, date, agent, model, tokens, time, messages) using `HeadingGrid` layout
- Add collapsible header that collapses to a compact bar on scroll (100px threshold with bounce prevention)
- Add `SourcePath` component with center-truncation and copy button
- Add `ScoreColumn` / `CollapsedScore` components for complex score display (3-row preview, no expand toggle)
- Replace `MetaDataGrid` in All Scores dialog with a sortable table using DataGrid-style headers and `ApplicationIcons` sort arrows
- Compact dialog header aligned edge-to-edge with table columns
- Score column takes natural width (`auto`) instead of forced 38%
- Add `className` prop to `Modal` for consumer styling overrides

## Test plan
- [x] Verify header shows all transcript metadata fields correctly
- [x] Scroll down — header collapses to compact bar after ~100px
- [x] Scroll back to top — header expands without flash/bounce
- [x] Click "All scores (N)" — dialog opens with sortable table
- [x] Click Score/Value headers to sort ascending/descending
- [x] Verify dialog title, close button, and columns align edge-to-edge
- [x] Check source path truncates with ellipsis and copy button works
- [x] Verify layout doesn't blow out with long source paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)