### PR TITLE
feat: add task_id and task_repeat to validation case types

### DIFF
--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -485,6 +485,12 @@ export const ScannerResultPanel: FC = () => {
               <div slot="end" className={styles.validationSidebar}>
                 <ValidationCaseEditor
                   transcriptId={selectedResult.transcriptId}
+                  taskId={
+                    selectedResult.transcriptTaskId != null
+                      ? String(selectedResult.transcriptTaskId)
+                      : undefined
+                  }
+                  taskRepeat={selectedResult.transcriptTaskRepeat}
                 />
               </div>
             </VscodeSplitLayout>

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -562,7 +562,11 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
             {tabSetContent}
           </div>
           <div slot="end" className={styles.validationSidebar}>
-            <ValidationCaseEditor transcriptId={transcript.transcript_id} />
+            <ValidationCaseEditor
+              transcriptId={transcript.transcript_id}
+              taskId={transcript.task_id}
+              taskRepeat={transcript.task_repeat}
+            />
           </div>
         </VscodeSplitLayout>
       ) : (

--- a/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
@@ -58,11 +58,15 @@ import { ValidationSplitSelector } from "./ValidationSplitSelector";
 
 interface ValidationCaseEditorProps {
   transcriptId: string;
+  taskId?: string | null;
+  taskRepeat?: number | null;
   className?: string | string[];
 }
 
 export const ValidationCaseEditor: FC<ValidationCaseEditorProps> = ({
   transcriptId,
+  taskId,
+  taskRepeat,
   className,
 }) => {
   const [searchParams] = useSearchParams();
@@ -153,6 +157,8 @@ export const ValidationCaseEditor: FC<ValidationCaseEditorProps> = ({
             <ValidationCaseEditorComponent
               key={validatedSetUri}
               transcriptId={transcriptId}
+              taskId={taskId}
+              taskRepeat={taskRepeat}
               validationSets={setsData}
               editorValidationSetUri={validatedSetUri}
               validationCase={caseData}
@@ -170,6 +176,8 @@ type ValidationType = "target" | "labels";
 
 interface ValidationCaseEditorComponentProps {
   transcriptId: string;
+  taskId?: string | null;
+  taskRepeat?: number | null;
   validationSets: string[];
   editorValidationSetUri?: string;
   validationCase?: ValidationCase | null;
@@ -179,6 +187,8 @@ interface ValidationCaseEditorComponentProps {
 
 const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
   transcriptId,
+  taskId,
+  taskRepeat,
   validationSets,
   editorValidationSetUri,
   validationCase: caseData,
@@ -294,6 +304,10 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
         labels: updatedCase.labels,
         predicate: updatedCase.predicate,
         split: updatedCase.split,
+        task_id: updatedCase.task_id ?? (taskId !== null ? taskId : undefined),
+        task_repeat:
+          updatedCase.task_repeat ??
+          (taskRepeat !== null ? taskRepeat : undefined),
       };
 
       setSaveStatus("saving");
@@ -319,6 +333,8 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
       caseData,
       queryClient,
       updateValidationCaseMutation,
+      taskId,
+      taskRepeat,
     ]
   );
 

--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -918,10 +918,11 @@ export interface components {
         };
         /**
          * BudgetPercent
-         * @description Fire at percentage milestones of a named budget. Not yet implemented (Phase 5).
+         * @description Fire on each ``percent``-percent slice of the active ``budget``.
          *
-         *     Example: ``BudgetPercent(budget="cost", percent=10)`` fires at 10%, 20%, …
-         *     of the ``cost_limit`` configured on the task or sample.
+         *     ``percent`` is in 0..100. With ``percent=25``, the trigger fires
+         *     at ~25% / 50% / 75% / 100% of the relevant limit's usage. Has no
+         *     effect when no limit is set for the chosen budget.
          */
         BudgetPercent: {
             /**
@@ -989,7 +990,7 @@ export interface components {
              */
             role: "assistant";
             /** Source */
-            source?: ("input" | "generate") | null;
+            source?: ("input" | "generate" | "operator") | null;
             /** Tool Calls */
             tool_calls?: components["schemas"]["ToolCall"][] | null;
         };
@@ -1013,7 +1014,7 @@ export interface components {
              */
             role: "system";
             /** Source */
-            source?: ("input" | "generate") | null;
+            source?: ("input" | "generate" | "operator") | null;
         };
         /**
          * ChatMessageTool
@@ -1038,7 +1039,7 @@ export interface components {
              */
             role: "tool";
             /** Source */
-            source?: ("input" | "generate") | null;
+            source?: ("input" | "generate" | "operator") | null;
             /** Tool Call Id */
             tool_call_id?: string | null;
         };
@@ -1062,9 +1063,69 @@ export interface components {
              */
             role: "user";
             /** Source */
-            source?: ("input" | "generate") | null;
+            source?: ("input" | "generate" | "operator") | null;
             /** Tool Call Id */
             tool_call_id?: string[] | null;
+        };
+        /**
+         * CheckpointEvent
+         * @description A successful checkpoint commit.
+         *
+         *     Emitted by the checkpointer immediately after the per-checkpoint
+         *     sidecar JSON is written — see working.md §8a. Carries the full
+         *     sidecar payload flattened into top-level fields (via multiple
+         *     inheritance from :class:`CheckpointDetails`), so a consumer of
+         *     ``transcript().events`` (or the ``.eval`` log) reads
+         *     ``event.checkpoint_id`` / ``event.trigger`` / ``event.host`` etc.
+         *     directly — same data as someone reading
+         *     ``<sample>/ckpt-NNNNN.json`` from disk.
+         */
+        CheckpointEvent: {
+            /** Checkpoint Id */
+            checkpoint_id: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Duration Ms */
+            duration_ms: number;
+            /**
+             * Event
+             * @default checkpoint
+             * @constant
+             */
+            event: "checkpoint";
+            host: components["schemas"]["SnapshotDetails"];
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Pending */
+            pending?: boolean | null;
+            /** Sandboxes */
+            sandboxes: {
+                [key: string]: components["schemas"]["SnapshotDetails"];
+            };
+            /** Size Bytes */
+            size_bytes: number;
+            /** Span Id */
+            span_id?: string | null;
+            /** Timestamp */
+            timestamp: string;
+            /**
+             * Trigger
+             * @enum {string}
+             */
+            trigger: "time" | "turn" | "manual" | "token" | "cost" | "budget";
+            /** Turn */
+            turn: number;
+            /** Uuid */
+            uuid?: string | null;
+            /** Working Start */
+            working_start: number;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * CheckpointSampleConfig
@@ -1089,7 +1150,7 @@ export interface components {
                 [key: string]: string[];
             } | null;
             /** Trigger */
-            trigger?: components["schemas"]["TimeInterval"] | components["schemas"]["TurnInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | "manual" | null;
+            trigger?: components["schemas"]["Manual"] | components["schemas"]["TurnInterval"] | components["schemas"]["TimeInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | null;
         };
         /**
          * CompactionEvent
@@ -1342,7 +1403,12 @@ export interface components {
         };
         /**
          * CostInterval
-         * @description Fire every $N spent. Not yet implemented (Phase 5).
+         * @description Fire every ``every`` dollars of sample-level cost.
+         *
+         *     Sample total cost is read from
+         *     :func:`inspect_ai.model.sample_total_cost`; the trigger fires
+         *     each time the running total crosses another ``every``-dollar
+         *     boundary since the last fire.
          */
         CostInterval: {
             /** Every */
@@ -1778,6 +1844,61 @@ export interface components {
             working_start: number;
         };
         /**
+         * InterruptEvent
+         * @description Records that an agent's turn or sample was cut short.
+         *
+         *     Emitted in three cases:
+         *
+         *     - ``source="user_cancel"`` — an ACP client (e.g. an editor or TUI)
+         *       called ``session/cancel`` while a turn was in flight.
+         *     - ``source="limit"`` — a sample-level limit (tokens, time, cost,
+         *       messages) tripped during execution.
+         *     - ``source="system"`` — the eval is shutting down for an external
+         *       reason and is cancelling active samples.
+         *
+         *     The ``interrupted`` field records what was running at the moment
+         *     the cancel reached the cancel scope. ``interrupted_tool_call_id``
+         *     and ``interrupted_model_event_id`` give cross-references when
+         *     applicable so downstream consumers can correlate this event with
+         *     the in-flight ``ToolEvent`` or ``ModelEvent``.
+         */
+        InterruptEvent: {
+            /**
+             * Event
+             * @default interrupt
+             * @constant
+             */
+            event: "interrupt";
+            /**
+             * Interrupted
+             * @enum {string}
+             */
+            interrupted: "generate" | "tool_call" | "between_turns";
+            /** Interrupted Model Event Id */
+            interrupted_model_event_id?: string | null;
+            /** Interrupted Tool Call Id */
+            interrupted_tool_call_id?: string | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Pending */
+            pending?: boolean | null;
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "user_cancel" | "limit" | "system";
+            /** Span Id */
+            span_id?: string | null;
+            /** Timestamp */
+            timestamp: string;
+            /** Uuid */
+            uuid?: string | null;
+            /** Working Start */
+            working_start: number;
+        };
+        /**
          * InvalidationTopic
          * @enum {string}
          */
@@ -2018,6 +2139,14 @@ export interface components {
             content: components["schemas"]["Logprob"][];
         };
         /**
+         * Manual
+         * @description No-op trigger spec.
+         *
+         *     The engine's ``tick()`` always returns ``None`` for this spec —
+         *     fires happen only through explicit ``cp.checkpoint()`` calls.
+         */
+        Manual: Record<string, never>;
+        /**
          * MessageFormatOptions
          * @description Message formatting options for controlling message content display.
          *
@@ -2051,7 +2180,7 @@ export interface components {
                 [key: string]: string;
             } | null;
             /** Events */
-            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
+            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
             events_data?: components["schemas"]["EventsData"] | null;
             /** Messages */
             messages: (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[];
@@ -2942,7 +3071,7 @@ export interface components {
          */
         ScannerInputResponse: {
             /** Input */
-            input: components["schemas"]["Transcript"] | components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"] | (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[] | components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"] | (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[] | components["schemas"]["Timeline"] | components["schemas"]["Timeline"][];
+            input: components["schemas"]["Transcript"] | components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"] | (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[] | components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"] | (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[] | components["schemas"]["Timeline"] | components["schemas"]["Timeline"][];
             input_data?: components["schemas"]["EventsData"] | null;
             /**
              * Input Type
@@ -3206,6 +3335,23 @@ export interface components {
             result: components["schemas"]["Result"];
         };
         /**
+         * SnapshotDetails
+         * @description Per-backup stats captured in the sidecar.
+         *
+         *     One per repo (host repo + one per active sandbox repo). Values come
+         *     from restic's backup summary — see :class:`ResticBackupSummary`.
+         */
+        SnapshotDetails: {
+            /** Duration Ms */
+            duration_ms: number;
+            /** Size Bytes */
+            size_bytes: number;
+            /** Snapshot Id */
+            snapshot_id: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * SpanBeginEvent
          * @description Mark the beginning of a transcript span.
          */
@@ -3431,7 +3577,10 @@ export interface components {
         };
         /**
          * TimeInterval
-         * @description Fire every N of wall-clock time.
+         * @description Fire after a wall-clock interval.
+         *
+         *     The engine fires when at least ``every`` has elapsed since the
+         *     last fire (or since the session opened, for the first fire).
          */
         TimeInterval: {
             /**
@@ -3510,7 +3659,12 @@ export interface components {
         };
         /**
          * TokenInterval
-         * @description Fire every N tokens generated. Not yet implemented (Phase 5).
+         * @description Fire every ``every`` tokens of sample-level usage.
+         *
+         *     Sample total tokens are read from
+         *     :func:`inspect_ai.model.sample_total_tokens`; the trigger fires
+         *     each time the running total crosses another ``every``-token
+         *     boundary since the last fire.
          */
         TokenInterval: {
             /** Every */
@@ -3562,7 +3716,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "unknown" | "output_limit";
+            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "unknown" | "output_limit";
         };
         /**
          * ToolCallView
@@ -3735,7 +3889,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Events */
-            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
+            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
             /** Limit */
             limit?: string | null;
             /** Message Count */
@@ -3862,7 +4016,14 @@ export interface components {
         };
         /**
          * TurnInterval
-         * @description Fire every N agent turns.
+         * @description Fire after every ``every`` agent turns of work.
+         *
+         *     The very first ``tick()`` call marks the boundary *before* turn 1
+         *     has run — agents place ``cp.tick()`` at the top of their loop, so
+         *     the opening tick stands between "no turn yet" and "turn 1." That
+         *     boundary is informational and doesn't count toward the threshold;
+         *     otherwise ``every=1`` would fire an empty checkpoint on the
+         *     opening tick.
          */
         TurnInterval: {
             /** Every */

--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -918,11 +918,10 @@ export interface components {
         };
         /**
          * BudgetPercent
-         * @description Fire on each ``percent``-percent slice of the active ``budget``.
+         * @description Fire at percentage milestones of a named budget. Not yet implemented (Phase 5).
          *
-         *     ``percent`` is in 0..100. With ``percent=25``, the trigger fires
-         *     at ~25% / 50% / 75% / 100% of the relevant limit's usage. Has no
-         *     effect when no limit is set for the chosen budget.
+         *     Example: ``BudgetPercent(budget="cost", percent=10)`` fires at 10%, 20%, …
+         *     of the ``cost_limit`` configured on the task or sample.
          */
         BudgetPercent: {
             /**
@@ -990,7 +989,7 @@ export interface components {
              */
             role: "assistant";
             /** Source */
-            source?: ("input" | "generate" | "operator") | null;
+            source?: ("input" | "generate") | null;
             /** Tool Calls */
             tool_calls?: components["schemas"]["ToolCall"][] | null;
         };
@@ -1014,7 +1013,7 @@ export interface components {
              */
             role: "system";
             /** Source */
-            source?: ("input" | "generate" | "operator") | null;
+            source?: ("input" | "generate") | null;
         };
         /**
          * ChatMessageTool
@@ -1039,7 +1038,7 @@ export interface components {
              */
             role: "tool";
             /** Source */
-            source?: ("input" | "generate" | "operator") | null;
+            source?: ("input" | "generate") | null;
             /** Tool Call Id */
             tool_call_id?: string | null;
         };
@@ -1063,69 +1062,9 @@ export interface components {
              */
             role: "user";
             /** Source */
-            source?: ("input" | "generate" | "operator") | null;
+            source?: ("input" | "generate") | null;
             /** Tool Call Id */
             tool_call_id?: string[] | null;
-        };
-        /**
-         * CheckpointEvent
-         * @description A successful checkpoint commit.
-         *
-         *     Emitted by the checkpointer immediately after the per-checkpoint
-         *     sidecar JSON is written — see working.md §8a. Carries the full
-         *     sidecar payload flattened into top-level fields (via multiple
-         *     inheritance from :class:`CheckpointDetails`), so a consumer of
-         *     ``transcript().events`` (or the ``.eval`` log) reads
-         *     ``event.checkpoint_id`` / ``event.trigger`` / ``event.host`` etc.
-         *     directly — same data as someone reading
-         *     ``<sample>/ckpt-NNNNN.json`` from disk.
-         */
-        CheckpointEvent: {
-            /** Checkpoint Id */
-            checkpoint_id: number;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Duration Ms */
-            duration_ms: number;
-            /**
-             * Event
-             * @default checkpoint
-             * @constant
-             */
-            event: "checkpoint";
-            host: components["schemas"]["SnapshotDetails"];
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Pending */
-            pending?: boolean | null;
-            /** Sandboxes */
-            sandboxes: {
-                [key: string]: components["schemas"]["SnapshotDetails"];
-            };
-            /** Size Bytes */
-            size_bytes: number;
-            /** Span Id */
-            span_id?: string | null;
-            /** Timestamp */
-            timestamp: string;
-            /**
-             * Trigger
-             * @enum {string}
-             */
-            trigger: "time" | "turn" | "manual" | "token" | "cost" | "budget";
-            /** Turn */
-            turn: number;
-            /** Uuid */
-            uuid?: string | null;
-            /** Working Start */
-            working_start: number;
-        } & {
-            [key: string]: unknown;
         };
         /**
          * CheckpointSampleConfig
@@ -1150,7 +1089,7 @@ export interface components {
                 [key: string]: string[];
             } | null;
             /** Trigger */
-            trigger?: components["schemas"]["Manual"] | components["schemas"]["TurnInterval"] | components["schemas"]["TimeInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | null;
+            trigger?: components["schemas"]["TimeInterval"] | components["schemas"]["TurnInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | "manual" | null;
         };
         /**
          * CompactionEvent
@@ -1403,12 +1342,7 @@ export interface components {
         };
         /**
          * CostInterval
-         * @description Fire every ``every`` dollars of sample-level cost.
-         *
-         *     Sample total cost is read from
-         *     :func:`inspect_ai.model.sample_total_cost`; the trigger fires
-         *     each time the running total crosses another ``every``-dollar
-         *     boundary since the last fire.
+         * @description Fire every $N spent. Not yet implemented (Phase 5).
          */
         CostInterval: {
             /** Every */
@@ -1844,61 +1778,6 @@ export interface components {
             working_start: number;
         };
         /**
-         * InterruptEvent
-         * @description Records that an agent's turn or sample was cut short.
-         *
-         *     Emitted in three cases:
-         *
-         *     - ``source="user_cancel"`` — an ACP client (e.g. an editor or TUI)
-         *       called ``session/cancel`` while a turn was in flight.
-         *     - ``source="limit"`` — a sample-level limit (tokens, time, cost,
-         *       messages) tripped during execution.
-         *     - ``source="system"`` — the eval is shutting down for an external
-         *       reason and is cancelling active samples.
-         *
-         *     The ``interrupted`` field records what was running at the moment
-         *     the cancel reached the cancel scope. ``interrupted_tool_call_id``
-         *     and ``interrupted_model_event_id`` give cross-references when
-         *     applicable so downstream consumers can correlate this event with
-         *     the in-flight ``ToolEvent`` or ``ModelEvent``.
-         */
-        InterruptEvent: {
-            /**
-             * Event
-             * @default interrupt
-             * @constant
-             */
-            event: "interrupt";
-            /**
-             * Interrupted
-             * @enum {string}
-             */
-            interrupted: "generate" | "tool_call" | "between_turns";
-            /** Interrupted Model Event Id */
-            interrupted_model_event_id?: string | null;
-            /** Interrupted Tool Call Id */
-            interrupted_tool_call_id?: string | null;
-            /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
-            /** Pending */
-            pending?: boolean | null;
-            /**
-             * Source
-             * @enum {string}
-             */
-            source: "user_cancel" | "limit" | "system";
-            /** Span Id */
-            span_id?: string | null;
-            /** Timestamp */
-            timestamp: string;
-            /** Uuid */
-            uuid?: string | null;
-            /** Working Start */
-            working_start: number;
-        };
-        /**
          * InvalidationTopic
          * @enum {string}
          */
@@ -2139,14 +2018,6 @@ export interface components {
             content: components["schemas"]["Logprob"][];
         };
         /**
-         * Manual
-         * @description No-op trigger spec.
-         *
-         *     The engine's ``tick()`` always returns ``None`` for this spec —
-         *     fires happen only through explicit ``cp.checkpoint()`` calls.
-         */
-        Manual: Record<string, never>;
-        /**
          * MessageFormatOptions
          * @description Message formatting options for controlling message content display.
          *
@@ -2180,7 +2051,7 @@ export interface components {
                 [key: string]: string;
             } | null;
             /** Events */
-            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
+            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
             events_data?: components["schemas"]["EventsData"] | null;
             /** Messages */
             messages: (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[];
@@ -3071,7 +2942,7 @@ export interface components {
          */
         ScannerInputResponse: {
             /** Input */
-            input: components["schemas"]["Transcript"] | components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"] | (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[] | components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"] | (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[] | components["schemas"]["Timeline"] | components["schemas"]["Timeline"][];
+            input: components["schemas"]["Transcript"] | components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"] | (components["schemas"]["ChatMessageSystem"] | components["schemas"]["ChatMessageUser"] | components["schemas"]["ChatMessageAssistant"] | components["schemas"]["ChatMessageTool"])[] | components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"] | (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[] | components["schemas"]["Timeline"] | components["schemas"]["Timeline"][];
             input_data?: components["schemas"]["EventsData"] | null;
             /**
              * Input Type
@@ -3335,23 +3206,6 @@ export interface components {
             result: components["schemas"]["Result"];
         };
         /**
-         * SnapshotDetails
-         * @description Per-backup stats captured in the sidecar.
-         *
-         *     One per repo (host repo + one per active sandbox repo). Values come
-         *     from restic's backup summary — see :class:`ResticBackupSummary`.
-         */
-        SnapshotDetails: {
-            /** Duration Ms */
-            duration_ms: number;
-            /** Size Bytes */
-            size_bytes: number;
-            /** Snapshot Id */
-            snapshot_id: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /**
          * SpanBeginEvent
          * @description Mark the beginning of a transcript span.
          */
@@ -3577,10 +3431,7 @@ export interface components {
         };
         /**
          * TimeInterval
-         * @description Fire after a wall-clock interval.
-         *
-         *     The engine fires when at least ``every`` has elapsed since the
-         *     last fire (or since the session opened, for the first fire).
+         * @description Fire every N of wall-clock time.
          */
         TimeInterval: {
             /**
@@ -3659,12 +3510,7 @@ export interface components {
         };
         /**
          * TokenInterval
-         * @description Fire every ``every`` tokens of sample-level usage.
-         *
-         *     Sample total tokens are read from
-         *     :func:`inspect_ai.model.sample_total_tokens`; the trigger fires
-         *     each time the running total crosses another ``every``-token
-         *     boundary since the last fire.
+         * @description Fire every N tokens generated. Not yet implemented (Phase 5).
          */
         TokenInterval: {
             /** Every */
@@ -3716,7 +3562,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "unknown" | "output_limit";
+            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "unknown" | "output_limit";
         };
         /**
          * ToolCallView
@@ -3889,7 +3735,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Events */
-            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CheckpointEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["InterruptEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
+            events: (components["schemas"]["SampleInitEvent"] | components["schemas"]["SampleLimitEvent"] | components["schemas"]["SandboxEvent"] | components["schemas"]["StateEvent"] | components["schemas"]["StoreEvent"] | components["schemas"]["ModelEvent"] | components["schemas"]["ToolEvent"] | components["schemas"]["AnchorEvent"] | components["schemas"]["ApprovalEvent"] | components["schemas"]["BranchEvent"] | components["schemas"]["CompactionEvent"] | components["schemas"]["InputEvent"] | components["schemas"]["ScoreEvent"] | components["schemas"]["ScoreEditEvent"] | components["schemas"]["ErrorEvent"] | components["schemas"]["LoggerEvent"] | components["schemas"]["InfoEvent"] | components["schemas"]["SpanBeginEvent"] | components["schemas"]["SpanEndEvent"] | components["schemas"]["StepEvent"] | components["schemas"]["SubtaskEvent"])[];
             /** Limit */
             limit?: string | null;
             /** Message Count */
@@ -4016,14 +3862,7 @@ export interface components {
         };
         /**
          * TurnInterval
-         * @description Fire after every ``every`` agent turns of work.
-         *
-         *     The very first ``tick()`` call marks the boundary *before* turn 1
-         *     has run — agents place ``cp.tick()`` at the top of their loop, so
-         *     the opening tick stands between "no turn yet" and "turn 1." That
-         *     boundary is informational and doesn't count toward the threshold;
-         *     otherwise ``every=1`` would fire an empty checkpoint on the
-         *     opening tick.
+         * @description Fire every N agent turns.
          */
         TurnInterval: {
             /** Every */
@@ -4071,6 +3910,10 @@ export interface components {
             /** Split */
             split?: string | null;
             target?: components["schemas"]["JsonValue"] | null;
+            /** Task Id */
+            task_id?: string | null;
+            /** Task Repeat */
+            task_repeat?: number | null;
         };
         /**
          * ValidationCaseRequest
@@ -4088,6 +3931,10 @@ export interface components {
             /** Split */
             split?: string | null;
             target?: components["schemas"]["JsonValue"] | null;
+            /** Task Id */
+            task_id?: string | null;
+            /** Task Repeat */
+            task_repeat?: number | null;
         };
         /**
          * ValidationEntry


### PR DESCRIPTION
## Summary
- Regenerate TypeScript types from updated OpenAPI schema — `ValidationCase` and `ValidationCaseRequest` now include optional `task_id` and `task_repeat` fields
- Thread `task_id` / `task_repeat` from transcript context through `ValidationCaseEditor` to upsert requests
- Pass metadata from both `TranscriptBody` and `ScannerResultPanel` call sites

## Context
Companion PR to meridianlabs-ai/inspect_scout (Python model, API, and schema changes).

## Test plan
- [ ] Verify `pnpm typecheck` passes (pre-existing e2e error is unrelated)
- [ ] Open a transcript, create a validation case — verify `task_id` and `task_repeat` appear in the CSV/JSON file
- [ ] Edit an existing case — verify metadata is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)