### PR TITLE
improve validation set creation UX with optimistic updates

### DIFF
--- a/apps/scout/src/app/server/useValidations.ts
+++ b/apps/scout/src/app/server/useValidations.ts
@@ -82,8 +82,36 @@ export const useValidationCase = (
 export const useCreateValidationSet = () => {
   const queryClient = useQueryClient();
   const api = useApi();
-  return useMutation<string, Error, CreateValidationSetRequest>({
+  return useMutation<
+    string,
+    Error,
+    CreateValidationSetRequest,
+    { previous: string[] | undefined }
+  >({
     mutationFn: (request) => api.createValidationSet(request),
+
+    onMutate: async (request) => {
+      await queryClient.cancelQueries({
+        queryKey: validationQueryKeys.sets(),
+      });
+      const previous = queryClient.getQueryData<string[]>(
+        validationQueryKeys.sets()
+      );
+      if (previous) {
+        queryClient.setQueryData(validationQueryKeys.sets(), [
+          ...previous,
+          request.path,
+        ]);
+      }
+      return { previous };
+    },
+
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(validationQueryKeys.sets(), context.previous);
+      }
+    },
+
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: validationQueryKeys.sets(),

--- a/apps/scout/src/app/validation/components/ValidationCaseEditor.module.css
+++ b/apps/scout/src/app/validation/components/ValidationCaseEditor.module.css
@@ -75,13 +75,9 @@
 }
 
 .saveStatusContainer {
-  position: fixed;
-  bottom: 0.1rem;
-  right: 0.1rem;
+  margin-top: auto;
   padding: 0.25rem 0.5rem;
-  background-color: var(--bs-body-bg);
-  border-radius: var(--bs-border-radius);
-  max-width: 175px;
+  text-align: right;
   line-height: 1.3;
   pointer-events: none;
   transition: opacity 300ms ease-in-out;

--- a/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
@@ -473,6 +473,7 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
               onSelect={handleValidationSetSelect}
               allowCreate={true}
               onCreate={(name) => void handleCreateSet(name)}
+              createPending={createSetMutation.isPending}
               appConfig={config}
             />
             {createError && (

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
@@ -26,6 +26,9 @@ interface ValidationSetSelectorProps {
   allowCreate?: boolean;
   onCreate?: (name: string) => void;
 
+  /** Whether a create operation is currently in progress */
+  createPending?: boolean;
+
   /** Project directory path for displaying full file path in create modal */
   appConfig?: AppConfig;
 }
@@ -42,6 +45,7 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
   autoSize = false,
   allowCreate = false,
   onCreate,
+  createPending = false,
   appConfig,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -336,9 +340,9 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
             <button
               className={`${styles.modalButton} ${styles.modalButtonPrimary}`}
               onClick={handleCreateSubmit}
-              disabled={!newSetName.trim()}
+              disabled={!newSetName.trim() || createPending}
             >
-              Create
+              {createPending ? "Creating..." : "Create"}
             </button>
           </>
         }


### PR DESCRIPTION
- Apply optimistic update in useCreateValidationSet so the new set appears immediately, with rollback on error
- Disable the Create button and show "Creating..." while the mutation is pending
- Reflow the save status indicator inline instead of fixed-positioning it