### PR TITLE
Drop redundant whole-dict scorer column for dict-shaped scorers

### DIFF
--- a/apps/inspect/src/state/scoring.ts
+++ b/apps/inspect/src/state/scoring.ts
@@ -5,43 +5,36 @@ import { LogDetails, SampleSummary } from "../client/api/types";
  * Extracts scorer information from sample summaries
  */
 const getScorersFromSamples = (samples: SampleSummary[]): ScoreLabel[] => {
-  // Collect unique score labels from all samples (scored)
+  const dictScorers = new Set<string>();
   const scoreLabelsMap = new Map<string, ScoreLabel>();
-
-  // Go through each sample and the scorers applied to it.
-  // For dictionaries, use their keys.
   for (const sample of samples) {
-    if (!sample.error && sample.scores) {
-      for (const [scorerKey, scoreValue] of Object.entries(sample.scores)) {
-        if (
-          scoreValue.value &&
-          typeof scoreValue.value === "object" &&
-          !Array.isArray(scoreValue.value)
-        ) {
-          // If it's a dictionary, extract keys from within the value
-          const valueDict = scoreValue.value as Record<string, unknown>;
-          for (const innerKey of Object.keys(valueDict)) {
-            const label = `${scorerKey}:${innerKey}`;
-            if (!scoreLabelsMap.has(label)) {
-              scoreLabelsMap.set(label, {
-                name: innerKey,
-                scorer: scorerKey,
-              });
-            }
-          }
-        } else {
-          // If it's a simple value, use the scorer key directly
-          if (!scoreLabelsMap.has(scorerKey)) {
-            scoreLabelsMap.set(scorerKey, {
-              name: scorerKey,
-              scorer: scorerKey,
-            });
+    if (sample.error || !sample.scores) continue;
+    for (const [scorerKey, scoreValue] of Object.entries(sample.scores)) {
+      if (
+        scoreValue.value &&
+        typeof scoreValue.value === "object" &&
+        !Array.isArray(scoreValue.value)
+      ) {
+        dictScorers.add(scorerKey);
+        for (const innerKey of Object.keys(
+          scoreValue.value as Record<string, unknown>
+        )) {
+          const label = `${scorerKey}:${innerKey}`;
+          if (!scoreLabelsMap.has(label)) {
+            scoreLabelsMap.set(label, { name: innerKey, scorer: scorerKey });
           }
         }
+      } else if (!scoreLabelsMap.has(scorerKey)) {
+        scoreLabelsMap.set(scorerKey, { name: scorerKey, scorer: scorerKey });
       }
     }
   }
-
+  // Drop any bare scorer-name labels that crept in from NaN/unscored
+  // samples on dict-shaped scorers — they'd render a redundant
+  // whole-dict column alongside the unpacked inner-key columns.
+  for (const scorerKey of dictScorers) {
+    scoreLabelsMap.delete(scorerKey);
+  }
   return Array.from(scoreLabelsMap.values());
 };
 


### PR DESCRIPTION
NaN/unscored samples on a dict-shaped scorer were taking the scalar branch in getScorersFromSamples and leaking a bare scorer-name label alongside the unpacked inner-key labels, producing a redundant whole-dict column rendered as a truncated key/value mini-grid.