### PR TITLE
Scope SampleList view per-log; persist column widths

### DIFF
--- a/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
@@ -307,6 +307,26 @@ describe("viewToGridState", () => {
     viewToGridState(state, cols("input"));
     expect(JSON.stringify(state)).toBe(before);
   });
+
+  test("emits columnSizing for user-resized columns; skips unknown ids", () => {
+    const state = sampleState({
+      columns: [
+        { id: "input", visible: true },
+        { id: "target", visible: true },
+      ],
+      columnWidths: { input: 420, target: 180, ghost: 999 },
+    });
+    const gs = viewToGridState(state, cols("input", "target"));
+    expect(gs.columnSizing?.columnSizingModel).toEqual([
+      { colId: "input", width: 420 },
+      { colId: "target", width: 180 },
+    ]);
+  });
+
+  test("emits an empty columnSizing model when no widths are recorded", () => {
+    const gs = viewToGridState(sampleState({}), cols("input"));
+    expect(gs.columnSizing?.columnSizingModel).toEqual([]);
+  });
 });
 
 describe("gridStateToView", () => {
@@ -362,6 +382,46 @@ describe("gridStateToView", () => {
     expect(next.filters.extraColumnFilters).toEqual({
       score__missing: { type: "equals", filter: 1 },
     });
+  });
+
+  test("captures user-resized widths from columnSizing", () => {
+    const gridState: GridState = {
+      columnSizing: {
+        columnSizingModel: [
+          { colId: "input", width: 420 },
+          { colId: "tokens", width: 90 },
+        ],
+      },
+    };
+    const next = gridStateToView(baseState, gridState, cols("input", "tokens"));
+    expect(next.columnWidths).toEqual({ input: 420, tokens: 90 });
+  });
+
+  test("preserves widths under transient unknown ids", () => {
+    const prev = sampleState({
+      columns: baseState.columns,
+      columnWidths: { input: 300, score__missing: 250 },
+    });
+    const gridState: GridState = {
+      columnSizing: {
+        columnSizingModel: [{ colId: "input", width: 420 }],
+      },
+    };
+    const next = gridStateToView(prev, gridState, cols("input"));
+    expect(next.columnWidths).toEqual({ input: 420, score__missing: 250 });
+  });
+
+  test("ignores flex-only sizing entries", () => {
+    const gridState: GridState = {
+      columnSizing: {
+        columnSizingModel: [
+          { colId: "input", width: 420 },
+          { colId: "tokens", flex: 1 },
+        ],
+      },
+    };
+    const next = gridStateToView(baseState, gridState, cols("input", "tokens"));
+    expect(next.columnWidths).toEqual({ input: 420 });
   });
 });
 

--- a/apps/inspect/src/app/samples/list/samplesView.converters.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.ts
@@ -103,22 +103,22 @@ export const resolveSamplesView = (
 };
 
 // ---------------------------------------------------------------------------
-// Runtime ↔ ag-grid GridState (column-id tolerance applied at this boundary)
+// Runtime ↔ ag-grid GridState
 // ---------------------------------------------------------------------------
 
 /**
  * Project the runtime descriptor into the `GridState` ag-grid consumes.
  *
- * Column-id tolerance: any persisted reference to a column not present in
- * `availableColIds` (e.g. `score__judge__correctness` on a log without
- * that scorer) is excluded from the emitted GridState but **preserved
- * unchanged in the source descriptor**. The persisted view is never
- * mutated by a render.
+ * Column-id tolerance handles transient mismatches between a per-log
+ * descriptor and its log's columns — e.g. samples loading in stages where
+ * `allColumns` initially lacks scorer columns the user has customized.
+ * Unknown ids are excluded from the emitted GridState but preserved
+ * unchanged in the source descriptor.
  *
  * The DSL filter is intentionally *not* materialized into `filterModel`
  * here — that translation needs the live filter registry, which only
- * exists at runtime. Phase 2's `useSamplesView` layers the DSL→model
- * translation on top of this base GridState.
+ * exists at runtime. `useSamplesView` layers the DSL→model translation
+ * on top of this base GridState.
  */
 export const viewToGridState = (
   view: SamplesViewState,
@@ -133,11 +133,16 @@ export const viewToGridState = (
       availableColIds.has(colId)
     )
   );
+  const widths = view.columnWidths ?? {};
+  const columnSizingModel = Object.entries(widths)
+    .filter(([colId]) => availableColIds.has(colId))
+    .map(([colId, width]) => ({ colId, width }));
   return {
     columnVisibility: {
       hiddenColIds: knownColumns.filter((c) => !c.visible).map((c) => c.id),
     },
     columnOrder: { orderedColIds: knownColumns.map((c) => c.id) },
+    columnSizing: { columnSizingModel },
     sort: { sortModel },
     filter: { filterModel },
   };
@@ -145,13 +150,15 @@ export const viewToGridState = (
 
 /**
  * Fold a fresh ag-grid `GridState` back into the runtime descriptor,
- * preserving any unknown-id references from `prev` so they re-engage when
- * the user navigates back to a log that has those columns.
+ * preserving any unknown-id references from `prev`. Unknown ids occur
+ * during transient column-load mismatches (e.g. user refreshes a log,
+ * a write fires before scorer columns reappear); preservation keeps the
+ * user's customizations alive across those frames.
  *
- * Note: this updates `columns`, `sort`, and `filters.extraColumnFilters`.
- * The `dsl` half of `filters` is the responsibility of the caller — it
- * comes from a different signal (the toolbar text) and is partitioned
- * via `partitionFilterModel`.
+ * Updates `columns`, `sort`, and `filters.extraColumnFilters`. The `dsl`
+ * half of `filters` is the responsibility of the caller — it comes from
+ * a different signal (the toolbar text) and is partitioned via
+ * `partitionFilterModel`.
  */
 export const gridStateToView = (
   prev: SamplesViewState,
@@ -181,6 +188,21 @@ export const gridStateToView = (
     )
   );
 
+  // Widths: capture fresh values for known columns and preserve any
+  // recorded under transient unknown ids (samples still loading).
+  // Flex-only entries (no `width`) don't represent a user resize.
+  const prevWidths = prev.columnWidths ?? {};
+  const knownWidths: Record<string, number> = {};
+  for (const entry of gridState.columnSizing?.columnSizingModel ?? []) {
+    if (availableColIds.has(entry.colId) && typeof entry.width === "number") {
+      knownWidths[entry.colId] = entry.width;
+    }
+  }
+  const unknownWidths = Object.fromEntries(
+    Object.entries(prevWidths).filter(([colId]) => !availableColIds.has(colId))
+  );
+  const mergedWidths = { ...unknownWidths, ...knownWidths };
+
   return {
     ...prev,
     columns: [...knownColumns, ...unknownColumns],
@@ -189,6 +211,8 @@ export const gridStateToView = (
       dsl: prev.filters.dsl,
       extraColumnFilters: { ...knownExtras, ...unknownExtras },
     },
+    columnWidths:
+      Object.keys(mergedWidths).length > 0 ? mergedWidths : undefined,
   };
 };
 
@@ -258,11 +282,10 @@ export const partitionFilterModel = (
 // ---------------------------------------------------------------------------
 
 /**
- * Pre-refactor `samplesListState.byScope.logViewSamples` shape. After
- * the refactor lands, persisted state from before that point can still
- * appear (transient host storage may retain a pre-refactor object). We
- * read it via `legacyToView` and write the new shape back on the next
- * user action.
+ * Pre-refactor scope state from before the SamplesView descriptor
+ * existed (gridState + columnVisibility in one bag). Kept as a converter
+ * for safety; no live caller reads from this slot today — the per-log
+ * refactor migrates older state via the persist `migrate` hook instead.
  */
 export interface LegacyScopeState {
   columnVisibility?: Record<string, boolean>;

--- a/apps/inspect/src/app/samples/list/samplesView.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.ts
@@ -76,6 +76,13 @@ export interface SamplesViewState {
     compactScores?: boolean;
     colorScalesEnabled?: boolean;
   };
+  /**
+   * User-resized pixel widths keyed by column id. Sparse — only columns
+   * the user has actually resized appear here; others fall through to
+   * the column def's initialWidth. Per-log via `samplesListState.byLog`,
+   * so widths from one log don't bleed into another.
+   */
+  columnWidths?: Record<string, number>;
 }
 
 /**

--- a/apps/inspect/src/app/samples/list/useSamplesView.ts
+++ b/apps/inspect/src/app/samples/list/useSamplesView.ts
@@ -28,10 +28,13 @@ function useEvalDefaultSamplesView(): SamplesView | undefined {
 }
 
 /** Single subscription + resolution; backs every hook that needs a
- *  field off the resolved view. */
+ *  field off the resolved view. Reads the per-log bucket keyed by the
+ *  currently-selected log file so customizations don't bleed across logs
+ *  with different scorers / eval config. */
 function useResolvedSamplesView(): SamplesViewState {
-  const stored = useStore(
-    (state) => state.logs.samplesListState.byScope.logViewSamples.view
+  const logFile = useStore((state) => state.logs.selectedLogFile);
+  const stored = useStore((state) =>
+    logFile ? state.logs.samplesListState.byLog[logFile] : undefined
   );
   const evalDefault = useEvalDefaultSamplesView();
   return useMemo(
@@ -119,8 +122,20 @@ export function useSamplesView<TRow>(
 
   const evalDefault = useEvalDefaultSamplesView();
   const view = useResolvedSamplesView();
-  const setSampleListView = useStore(
+  const logFile = useStore((state) => state.logs.selectedLogFile);
+  const setSampleListViewAction = useStore(
     (state) => state.logsActions.setSampleListView
+  );
+
+  // Bind the log file at hook level so a pending effect from log A's
+  // render can't redirect a write into log B's bucket if navigation
+  // races the effect.
+  const setSampleListView = useCallback(
+    (next: SamplesViewState) => {
+      if (!logFile) return;
+      setSampleListViewAction(logFile, next);
+    },
+    [logFile, setSampleListViewAction]
   );
 
   const availableColIds = useMemo(() => {

--- a/apps/inspect/src/app/types.ts
+++ b/apps/inspect/src/app/types.ts
@@ -93,19 +93,20 @@ export interface LogsState {
     detailsCount: number;
   };
   samplesListState: {
-    // Asymmetric: samplesPanel keeps the pre-refactor shape; logViewSamples
-    // is now driven by the SamplesView descriptor. See design/samples-view.md.
+    // samplesPanel is cross-log by nature (lists samples from many logs in
+    // a directory); it keeps the single-bucket shape. The single-log view
+    // (logViewSamples) is keyed per log file so user customizations in one
+    // log don't bleed into another with different scorers / eval config.
     byScope: {
       samplesPanel: {
         columnVisibility: Record<string, boolean>;
         gridState?: GridState;
       };
-      logViewSamples: {
-        // undefined = no user override; useSamplesView falls through to
-        // the eval-author default and then the built-in default.
-        view?: SamplesViewState;
-      };
     };
+    /** Per-log SamplesView descriptors keyed by log file path. Missing
+     *  entries fall through to the eval-author default and then the
+     *  built-in default — see `useSamplesView`. */
+    byLog: Record<string, SamplesViewState>;
     displayedSamples?: Array<DisplayedSample>;
     previousSamplesPath?: string;
   };

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -67,7 +67,11 @@ export interface LogsSlice {
       visibility: Record<string, boolean>
     ) => void;
 
-    setSampleListView: (view: SamplesViewState) => void;
+    /** Persist a SamplesView descriptor for a specific log file. The
+     *  log path is captured by the caller at hook level so a navigation
+     *  that races a pending effect can't redirect the write to a
+     *  different log's bucket. */
+    setSampleListView: (logFile: string, view: SamplesViewState) => void;
 
     setDisplayedSamples: (samples: Array<DisplayedSample>) => void;
     clearDisplayedSamples: () => void;
@@ -95,8 +99,8 @@ const initialState: LogsState = {
   samplesListState: {
     byScope: {
       samplesPanel: { columnVisibility: {} },
-      logViewSamples: {},
     },
+    byLog: {},
   },
   showRetriedLogs: false,
 };
@@ -125,14 +129,9 @@ export const createLogsSlice = (
           if (realPrev && realNew) {
             state.logs.samplesListState.byScope.samplesPanel.gridState =
               undefined;
-            // SampleList: keep columns + multiline (general preferences);
-            // reset only filter + sort, which reference log-specific values.
-            const view =
-              state.logs.samplesListState.byScope.logViewSamples.view;
-            if (view) {
-              view.filters = { dsl: "", extraColumnFilters: {} };
-              view.sort = [];
-            }
+            // SampleList per-log state survives the dir change — each log
+            // still owns its own bucket via `byLog[logFile]`. No need to
+            // reset filters/sort here.
             // listing.gridStateByScope keys are old logDir paths.
             state.logs.listing.gridStateByScope = {};
           }
@@ -188,9 +187,9 @@ export const createLogsSlice = (
           state.logs.samplesListState.byScope[scope].gridState = undefined;
         });
       },
-      setSampleListView: (view: SamplesViewState) => {
+      setSampleListView: (logFile: string, view: SamplesViewState) => {
         set((state) => {
-          state.logs.samplesListState.byScope.logViewSamples.view = view;
+          state.logs.samplesListState.byLog[logFile] = view;
         });
       },
       setDisplayedSamples: (samples: Array<DisplayedSample>) => {

--- a/apps/inspect/src/state/store.ts
+++ b/apps/inspect/src/state/store.ts
@@ -177,7 +177,7 @@ export const initializeStore = (
               logs: state.logs,
               sample: state.sample,
             }) as unknown as StoreState,
-          version: 3,
+          version: 4,
           onRehydrateStorage: (state: StoreState) => {
             return (hydrationState, error) => {
               handleRehydrate(state);

--- a/design/samples-view.md
+++ b/design/samples-view.md
@@ -22,7 +22,7 @@ This is distinct from `sample_score_view` (also under `ViewerConfig`), which con
 
 ## Scope (Phase 0–2)
 
-- The descriptor is owned by `SampleList` (`apps/inspect/src/app/samples/list/SampleList.tsx`, single-log scope `logViewSamples`).
+- The descriptor is owned by `SampleList` (`apps/inspect/src/app/samples/list/SampleList.tsx`). Runtime state is keyed **per log file** in `samplesListState.byLog[logFile]` so different logs (with different scorer columns / eval config) don't share customizations.
 - `SamplesGrid` (`apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx`) is a dumb-ish ag-grid renderer used by both `SampleList` and `SamplesPanel`. It does not own the descriptor; in Phase 2 it grows a single optional prop `multiline?: boolean`.
 - `SamplesPanel` (cross-log dataframe view, scope `samplesPanel`) is **out of scope**. It can adopt the descriptor in a follow-on, but its persisted state shape is unchanged here.
 
@@ -144,10 +144,10 @@ Mirrors the existing `resolveScorePanelSort` pattern in [`apps/inspect/src/state
 
 ## Column-id instability tolerance
 
-Score columns include scorer + metric (`score__<scorer>__<metric>`). A view recorded against one log may reference columns that don't exist in another. The boundary contract:
+Per-log scoping means a log's descriptor only references columns from that log, so cross-log mismatches are gone. The unknown-id tolerance in `viewToGridState` / `gridStateToView` is now a defence against **transient** mismatches within a single log — e.g. log details streaming in stages where `allColumns` initially lacks scorer columns the user has already customized.
 
-- Read time: `viewToGridState(view, availableColIds)` excludes unknown ids from the `GridState` it hands ag-grid. The persisted descriptor is **not** mutated. When the user navigates to a log that does have those columns, references re-engage automatically.
-- Same rule for sort entries naming missing columns and `extraColumnFilters` keyed on missing columns.
+- Read time: `viewToGridState(view, availableColIds)` excludes unknown ids from the `GridState` it hands ag-grid. The persisted descriptor is **not** mutated.
+- Write time: `gridStateToView(prev, gs, availableColIds)` preserves unknown-id references from `prev` so a write that fires during a partial-load doesn't erase user customizations.
 
 ## `selectedScores` adapter
 
@@ -155,11 +155,11 @@ Score columns include scorer + metric (`score__<scorer>__<metric>`). A view reco
 
 ## Persistence
 
-The store's `persist` middleware in [`apps/inspect/src/state/store.ts`](../apps/inspect/src/state/store.ts) uses host-injected `ClientStorage`. Persistence is transient (used in the VSCode extension to survive tab backgrounding), not long-lived localStorage. There is no formal versioned migrator — the read boundary in Phase 2 will handle the legacy `byScope.logViewSamples = { columnVisibility, gridState }` shape gracefully via a `legacyToView(slot, dslFilter): SamplesViewState` helper, and the first user write replaces it with the new `{ view }` shape.
+The store's `persist` middleware in [`apps/inspect/src/state/store.ts`](../apps/inspect/src/state/store.ts) uses host-injected `ClientStorage`. Persistence is transient (used in the VSCode extension to survive tab backgrounding), not long-lived localStorage. The `version` bump from 3 → 4 (per-log refactor) drops mismatched-version state on rehydrate; backgrounded windows rebuild state on first use.
 
 ## logDir change behavior
 
-In Phase 2, navigating to a different log directory will keep `view.columns` and `view.multiline` for `logViewSamples` and reset only `view.filters` and `view.sort`. Today the entire `gridState` is wiped; the narrowing preserves column choices and row layout (general preferences) while still clearing log-specific filter/sort state. SamplesPanel scope behavior is unchanged.
+Per-log scoping means a logDir change doesn't have to reset SampleList state — each log keeps its own `byLog[logFile]` bucket. The action only resets `samplesPanel.gridState` (cross-log) and the listing's cross-scope grid state. SamplesPanel scope behavior is unchanged.
 
 ## What is explicitly NOT in this descriptor
 


### PR DESCRIPTION
Replaces the single shared `byScope.logViewSamples` bucket with `byLog: Record<logFile, SamplesViewState>` so customizations in one log no longer shadow another log's eval-author config or its distinct column set (e.g. different scorers).

- `setSampleListView` now takes an explicit log file so a pending effect from log A's render can't redirect a write into log B's bucket on navigation.
- `useResolvedSamplesView` resolves per `selectedLogFile`.
- `setLogDir` no longer wipes filter/sort — per-log state isolates cross-dir changes naturally.
- Column widths join the descriptor; round-tripped through ag-grid's `columnSizing.columnSizingModel` so resize survives the grid → transcript → back navigation.
- Persist version bumped 3 → 4 to drop mismatched single-bucket state on rehydrate (transient VSCode-backgrounded-window state).
- Unknown-id tolerance in the converters now defends against transient within-log column-load mismatches rather than cross-log mismatches.