### PR TITLE
Merge adjacent fork-navigator rows in transcript

### DIFF
--- a/packages/inspect-components/src/transcript/ForkNavigatorView.module.css
+++ b/packages/inspect-components/src/transcript/ForkNavigatorView.module.css
@@ -41,3 +41,12 @@
 .selected:hover {
   border-color: var(--bs-border-color);
 }
+
+.divider {
+  display: inline-block;
+  width: 1px;
+  align-self: stretch;
+  background: var(--bs-border-color);
+  opacity: 0.5;
+  margin: 2px 4px;
+}

--- a/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
+++ b/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
@@ -23,9 +23,7 @@ export const ForkNavigatorView: FC<ForkNavigatorViewProps> = ({
   const selectRow = useTimelineRowSelect();
   if (!data || data.groups.length === 0) return null;
 
-  // A group is renderable only if it offers more than the stay-on-segment
-  // pseudo-option. The previous code applied the same `length < 2` filter
-  // at the whole-nav level; we now apply it per group.
+  // Skip groups that only have the stay-on-segment pseudo-option.
   const renderable = data.groups.filter((g) => g.options.length >= 2);
   if (renderable.length === 0) return null;
 

--- a/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
+++ b/packages/inspect-components/src/transcript/ForkNavigatorView.tsx
@@ -5,7 +5,7 @@ import type { SpanBeginEvent } from "@tsmono/inspect-common/types";
 
 import styles from "./ForkNavigatorView.module.css";
 import { TranscriptIcons } from "./icons";
-import type { ForkNavData } from "./timeline/timelineEventNodes";
+import type { ForkNavData, ForkNavGroup } from "./timeline/timelineEventNodes";
 import { useTimelineRowSelect } from "./TimelineSelectContext";
 import { EventNode } from "./types";
 
@@ -21,13 +21,46 @@ export const ForkNavigatorView: FC<ForkNavigatorViewProps> = ({
   const data = (eventNode.event.metadata as Record<string, unknown> | null)
     ?.fork_nav as ForkNavData | undefined;
   const selectRow = useTimelineRowSelect();
-  if (!data || data.options.length < 2) return null;
+  if (!data || data.groups.length === 0) return null;
 
-  const { options, selectedIndex } = data;
+  // A group is renderable only if it offers more than the stay-on-segment
+  // pseudo-option. The previous code applied the same `length < 2` filter
+  // at the whole-nav level; we now apply it per group.
+  const renderable = data.groups.filter((g) => g.options.length >= 2);
+  if (renderable.length === 0) return null;
 
   return (
     <div className={clsx(styles.nav, className)}>
       <i className={clsx(TranscriptIcons.fork, styles.icon)} />
+      {renderable.map((group, gi) => (
+        <ForkNavGroupView
+          key={`${group.anchorId}-${gi}`}
+          group={group}
+          showDivider={gi > 0}
+          onSelect={(rowKey, el) => selectRow?.(rowKey, el)}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface ForkNavGroupViewProps {
+  group: ForkNavGroup;
+  showDivider: boolean;
+  onSelect: (rowKey: string, anchor: HTMLElement) => void;
+}
+
+const ForkNavGroupView: FC<ForkNavGroupViewProps> = ({
+  group,
+  showDivider,
+  onSelect,
+}) => {
+  const { options, selectedIndex } = group;
+  return (
+    <>
+      {showDivider ? (
+        <span className={styles.divider} aria-hidden="true" />
+      ) : null}
       {options.map((opt, i) => (
         <button
           key={opt.rowKey}
@@ -36,7 +69,7 @@ export const ForkNavigatorView: FC<ForkNavigatorViewProps> = ({
           onClick={(e) =>
             i === selectedIndex
               ? undefined
-              : selectRow?.(
+              : onSelect(
                   opt.rowKey,
                   e.currentTarget.closest<HTMLElement>("[data-index]") ??
                     e.currentTarget
@@ -47,6 +80,6 @@ export const ForkNavigatorView: FC<ForkNavigatorViewProps> = ({
           {opt.label}
         </button>
       ))}
-    </div>
+    </>
   );
 };

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -5,15 +5,19 @@ import type {
   CompactionEvent,
   InfoEvent,
   ModelEvent,
+  SpanBeginEvent,
 } from "@tsmono/inspect-common/types";
 
 import { TimelineEvent, TimelineSpan } from "./core";
-import { ts } from "./testHelpers";
+import { computeSwimlaneRows } from "./swimlaneRows";
+import { makeSpan, ts } from "./testHelpers";
 import {
   buildSelectionKey,
+  collectPathWithNavigators,
   computeCompactionRegions,
   getParentKeyFromBranch,
   parseSelection,
+  type ForkNavData,
 } from "./timelineEventNodes";
 
 // =============================================================================
@@ -114,15 +118,6 @@ function makeBranch(
     utility: false,
   });
 }
-
-// Placeholder reference so makeAnchor/makeBranch are "used" until the
-// collectPathWithNavigators tests land in follow-up commits.
-describe.skip("fork-nav helpers (placeholder)", () => {
-  it("references helpers", () => {
-    expect(typeof makeAnchor).toBe("function");
-    expect(typeof makeBranch).toBe("function");
-  });
-});
 
 // =============================================================================
 // parseSelection
@@ -369,5 +364,41 @@ describe("getParentKeyFromBranch", () => {
         "solvers/agent/branch-550e8400-e29b-41d4-a716-446655440000-1"
       )
     ).toBe("solvers/agent");
+  });
+});
+
+describe("collectPathWithNavigators — adjacent fork merge", () => {
+  // Root span with two back-to-back anchors and one branch off each.
+  // No non-anchor event sits between the two anchors, so the two
+  // fork-navs should collapse into a single node with two groups.
+  function rowsWithTwoAdjacentForks() {
+    const branchA1 = makeBranch("B1", "A1", 2, 3);
+    const branchA2 = makeBranch("B2", "A2", 4, 5);
+    const root = new TimelineSpan({
+      id: "root",
+      name: "Root",
+      spanType: "agent",
+      content: [makeAnchor("A1", 2), makeAnchor("A2", 3), makeModel(4, "tail")],
+      branches: [branchA1, branchA2],
+      utility: false,
+    });
+    const transcript = makeSpan("Transcript", 0, 10, 0, [root]);
+    return computeSwimlaneRows(transcript);
+  }
+
+  it("merges two anchor forks at the same parent into one fork_nav node", () => {
+    const rows = rowsWithTwoAdjacentForks();
+    const { events } = collectPathWithNavigators(rows, "root");
+
+    const forkBegins = events.filter(
+      (e): e is SpanBeginEvent =>
+        e.event === "span_begin" && e.type === "fork_nav"
+    );
+    expect(forkBegins).toHaveLength(1);
+
+    const data = (forkBegins[0]!.metadata as { fork_nav: ForkNavData })
+      .fork_nav;
+    expect(data.groups).toHaveLength(2);
+    expect(data.groups.map((g) => g.anchorId)).toEqual(["A1", "A2"]);
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -60,7 +60,11 @@ function makeTimelineEvent(
   return new TimelineEvent(event);
 }
 
-function makeAnchor(anchorId: string, sec: number): TimelineEvent {
+function makeAnchor(
+  anchorId: string,
+  sec: number,
+  spanId: string | null = null
+): TimelineEvent {
   return new TimelineEvent({
     event: "anchor",
     anchor_id: anchorId,
@@ -69,7 +73,7 @@ function makeAnchor(anchorId: string, sec: number): TimelineEvent {
     working_start: sec,
     metadata: null,
     pending: null,
-    span_id: null,
+    span_id: spanId,
     uuid: `anchor-${anchorId}`,
   } satisfies AnchorEvent);
 }
@@ -415,6 +419,31 @@ describe("collectPathWithNavigators — adjacent fork merge", () => {
         makeAnchor("A2", 5),
       ],
       branches: [branchA1, branchA2],
+      utility: false,
+    });
+    const transcript = makeSpan("Transcript", 0, 10, 0, [root]);
+    const rows = computeSwimlaneRows(transcript);
+
+    const { events } = collectPathWithNavigators(rows, "root");
+    const forkBegins = events.filter(
+      (e): e is SpanBeginEvent =>
+        e.event === "span_begin" && e.type === "fork_nav"
+    );
+    expect(forkBegins).toHaveLength(2);
+  });
+
+  it("does not merge across differing parent_ids", () => {
+    // Restart-style fork emits with parent_id = null; anchor fork emits with
+    // parent_id = stripped anchor span_id. The anchor must carry a non-null
+    // span_id so the two parent_ids differ and the merge is skipped.
+    const restartBranch = makeBranch("BR", "", 0, 1);
+    const anchorBranch = makeBranch("BA", "A1", 3, 4);
+    const root = new TimelineSpan({
+      id: "root",
+      name: "Root",
+      spanType: "agent",
+      content: [makeAnchor("A1", 2, "root")],
+      branches: [restartBranch, anchorBranch],
       utility: false,
     });
     const transcript = makeSpan("Transcript", 0, 10, 0, [root]);

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import type { CompactionEvent, InfoEvent } from "@tsmono/inspect-common/types";
+import type {
+  AnchorEvent,
+  CompactionEvent,
+  InfoEvent,
+  ModelEvent,
+} from "@tsmono/inspect-common/types";
 
-import { TimelineEvent } from "./core";
+import { TimelineEvent, TimelineSpan } from "./core";
 import { ts } from "./testHelpers";
 import {
   buildSelectionKey,
@@ -50,6 +55,74 @@ function makeTimelineEvent(
 
   return new TimelineEvent(event);
 }
+
+function makeAnchor(anchorId: string, sec: number): TimelineEvent {
+  return new TimelineEvent({
+    event: "anchor",
+    anchor_id: anchorId,
+    source: null,
+    timestamp: ts(sec).toISOString(),
+    working_start: sec,
+    metadata: null,
+    pending: null,
+    span_id: null,
+    uuid: `anchor-${anchorId}`,
+  } satisfies AnchorEvent);
+}
+
+function makeModel(sec: number, label = "m"): TimelineEvent {
+  return new TimelineEvent({
+    event: "model",
+    timestamp: ts(sec).toISOString(),
+    working_start: sec,
+    pending: null,
+    span_id: null,
+    uuid: `model-${label}-${sec}`,
+    metadata: null,
+    model: "synthetic",
+    role: null,
+    input: [],
+    tools: [],
+    tool_choice: null,
+    config: {} as ModelEvent["config"],
+    output: {} as ModelEvent["output"],
+    error: null,
+    cache: null,
+    call: null,
+    completed: ts(sec).toISOString(),
+    working_time: 0,
+    retries: null,
+    traceback: null,
+    traceback_ansi: null,
+  } as unknown as ModelEvent);
+}
+
+/** A branch span that forks from the given anchor. */
+function makeBranch(
+  name: string,
+  branchedFrom: string,
+  startSec: number,
+  _endSec: number
+): TimelineSpan {
+  return new TimelineSpan({
+    id: name.toLowerCase(),
+    name,
+    spanType: "branch",
+    content: [makeModel(startSec)],
+    branches: [],
+    branchedFrom,
+    utility: false,
+  });
+}
+
+// Placeholder reference so makeAnchor/makeBranch are "used" until the
+// collectPathWithNavigators tests land in follow-up commits.
+describe.skip("fork-nav helpers (placeholder)", () => {
+  it("references helpers", () => {
+    expect(typeof makeAnchor).toBe("function");
+    expect(typeof makeBranch).toBe("function");
+  });
+});
 
 // =============================================================================
 // parseSelection

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -401,4 +401,30 @@ describe("collectPathWithNavigators — adjacent fork merge", () => {
     expect(data.groups).toHaveLength(2);
     expect(data.groups.map((g) => g.anchorId)).toEqual(["A1", "A2"]);
   });
+
+  it("does not merge when a non-fork event sits between two anchors", () => {
+    const branchA1 = makeBranch("B1", "A1", 2, 3);
+    const branchA2 = makeBranch("B2", "A2", 6, 7);
+    const root = new TimelineSpan({
+      id: "root",
+      name: "Root",
+      spanType: "agent",
+      content: [
+        makeAnchor("A1", 2),
+        makeModel(4, "between"),
+        makeAnchor("A2", 5),
+      ],
+      branches: [branchA1, branchA2],
+      utility: false,
+    });
+    const transcript = makeSpan("Transcript", 0, 10, 0, [root]);
+    const rows = computeSwimlaneRows(transcript);
+
+    const { events } = collectPathWithNavigators(rows, "root");
+    const forkBegins = events.filter(
+      (e): e is SpanBeginEvent =>
+        e.event === "span_begin" && e.type === "fork_nav"
+    );
+    expect(forkBegins).toHaveLength(2);
+  });
 });

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -484,4 +484,39 @@ describe("collectPathWithNavigators — adjacent fork merge", () => {
     expect(data.groups[0]!.selectedIndex).toBe(0);
     expect(data.groups[1]!.selectedIndex).toBe(1);
   });
+
+  it("does not merge across segment boundaries", () => {
+    // Multi-segment path where the cut anchor has span_id=null and the
+    // selected branch opens with a restart-style fork. Both navs end up
+    // with parent_id=null, so the parent_id guard alone would merge them
+    // — the segIdx guard must prevent that.
+    const restartBranchOnB1 = makeBranch("BR", "", 4, 5);
+    const branchB1 = new TimelineSpan({
+      id: "b1",
+      name: "B1",
+      spanType: "branch",
+      content: [makeModel(3, "b1tail")],
+      branches: [restartBranchOnB1],
+      branchedFrom: "A1",
+      utility: false,
+    });
+    const root = new TimelineSpan({
+      id: "root",
+      name: "Root",
+      spanType: "agent",
+      content: [makeAnchor("A1", 2)],
+      branches: [branchB1],
+      utility: false,
+    });
+    const transcript = makeSpan("Transcript", 0, 10, 0, [root]);
+    const rows = computeFlatSwimlaneRows(transcript, { showBranches: true });
+
+    const branchRowKey = "transcript/root/branch-A1-1/branch--1";
+    const { events } = collectPathWithNavigators(rows, branchRowKey);
+    const forkBegins = events.filter(
+      (e): e is SpanBeginEvent =>
+        e.event === "span_begin" && e.type === "fork_nav"
+    );
+    expect(forkBegins).toHaveLength(2);
+  });
 });

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -9,7 +9,7 @@ import type {
 } from "@tsmono/inspect-common/types";
 
 import { TimelineEvent, TimelineSpan } from "./core";
-import { computeSwimlaneRows } from "./swimlaneRows";
+import { computeFlatSwimlaneRows, computeSwimlaneRows } from "./swimlaneRows";
 import { makeSpan, ts } from "./testHelpers";
 import {
   buildSelectionKey,
@@ -455,5 +455,33 @@ describe("collectPathWithNavigators — adjacent fork merge", () => {
         e.event === "span_begin" && e.type === "fork_nav"
     );
     expect(forkBegins).toHaveLength(2);
+  });
+
+  it("merged groups carry independent selectedIndex values", () => {
+    const branchA1 = makeBranch("B1", "A1", 2, 3);
+    const branchA2 = makeBranch("B2", "A2", 4, 5);
+    const root = new TimelineSpan({
+      id: "root",
+      name: "Root",
+      spanType: "agent",
+      content: [makeAnchor("A1", 2), makeAnchor("A2", 3), makeModel(4, "tail")],
+      branches: [branchA1, branchA2],
+      utility: false,
+    });
+    const transcript = makeSpan("Transcript", 0, 10, 0, [root]);
+    const rows = computeFlatSwimlaneRows(transcript, { showBranches: true });
+
+    const branchRowKey = "transcript/root/branch-A2-2";
+    const { events } = collectPathWithNavigators(rows, branchRowKey);
+
+    const forkBegin = events.find(
+      (e): e is SpanBeginEvent =>
+        e.event === "span_begin" && e.type === "fork_nav"
+    );
+    if (!forkBegin) throw new Error("expected a fork_nav span_begin");
+    const data = (forkBegin.metadata as { fork_nav: ForkNavData }).fork_nav;
+
+    expect(data.groups[0]!.selectedIndex).toBe(0);
+    expect(data.groups[1]!.selectedIndex).toBe(1);
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -797,9 +797,9 @@ export function collectPathWithNavigators(
       };
 
       // Collapse strictly-adjacent fork navs (same parent_id) into one row.
-      // Anchors are always hidden in the rendered transcript (see
-      // kDefaultExcludeEvents), so skip them when checking adjacency — the
-      // user perceives two fork navs separated only by anchors as adjacent.
+      // Anchors are structural markers (hidden by default) — the user
+      // perceives two fork navs separated only by anchors as adjacent — so
+      // skip them when checking adjacency.
       let i = events.length - 1;
       while (i >= 0 && events[i]!.event === "anchor") i--;
       const last = events[i];

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -633,10 +633,15 @@ export interface ForkNavOption {
   rowKey: string;
 }
 
-export interface ForkNavData {
+/** One group within a fork navigator — the options forked at a single anchor. */
+export interface ForkNavGroup {
   anchorId: string;
   options: ForkNavOption[];
   selectedIndex: number;
+}
+
+export interface ForkNavData {
+  groups: ForkNavGroup[];
 }
 
 interface PathSegment {
@@ -733,8 +738,13 @@ function emitSyntheticSpan(events: Event[], opts: SyntheticSpanOpts): void {
   } satisfies SpanEndEvent);
 }
 
-/** Outline label for a fork navigator: list children, capped to keep it short. */
-function forkNavLabel(children: ForkNavOption[]): string {
+/**
+ * Outline label for a fork navigator. Flattens all groups' child options
+ * (excluding the leading stay-on-segment entry, which is always groups[*].options[0])
+ * and caps at "first, second +N".
+ */
+function forkNavLabel(groups: ForkNavGroup[]): string {
+  const children = groups.flatMap((g) => g.options.slice(1));
   if (children.length <= 2) return children.map((c) => c.label).join(", ");
   return `${children[0]!.label} +${children.length - 1}`;
 }
@@ -775,18 +785,44 @@ export function collectPathWithNavigators(
       ];
       const isCut = anchorId === seg.cutAnchor;
       const sel = isCut ? options.findIndex((o) => o.rowKey === nextRowKey) : 0;
+      const group: ForkNavGroup = {
+        anchorId,
+        options,
+        selectedIndex: Math.max(0, sel),
+      };
+
+      // If the previous two events are a fork_nav span_begin/span_end pair
+      // with the same parent_id, append this group to that nav instead of
+      // emitting a new span pair. This collapses strictly-adjacent forks
+      // into one row.
+      const last = events[events.length - 1];
+      const prev = events[events.length - 2];
+      if (
+        last &&
+        prev &&
+        last.event === "span_end" &&
+        prev.event === "span_begin" &&
+        prev.type === "fork_nav" &&
+        last.span_id === prev.span_id &&
+        prev.parent_id === parentId
+      ) {
+        const data = (prev.metadata as { fork_nav?: ForkNavData } | null)
+          ?.fork_nav;
+        if (data) {
+          data.groups.push(group);
+          (prev as { name: string }).name = forkNavLabel(data.groups);
+          return isCut;
+        }
+      }
+
       emitSyntheticSpan(events, {
         id: `forknav-${seg.span.id}-${anchorId || "restart"}`,
-        name: forkNavLabel(children),
+        name: forkNavLabel([group]),
         type: "fork_nav",
         parentId,
         start: ts,
         metadata: {
-          fork_nav: {
-            anchorId,
-            options,
-            selectedIndex: Math.max(0, sel),
-          } satisfies ForkNavData,
+          fork_nav: { groups: [group] } satisfies ForkNavData,
         },
       });
       return isCut;

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -764,6 +764,11 @@ export function collectPathWithNavigators(
   const events: Event[] = [];
   const sourceSpans = new Map<string, TimelineSpan>();
   const path = buildPath(rows, selectedRowKey);
+  // Track which segment emitted the most recent fork-nav so navs from
+  // different segments never collapse — even if their parent_ids happen to
+  // coincide (e.g., both null when a cut anchor has a null span_id and the
+  // child segment opens with a restart-style fork).
+  let lastNavSegIdx: number | null = null;
 
   for (let segIdx = 0; segIdx < path.length; segIdx++) {
     const seg = path[segIdx]!;
@@ -800,6 +805,7 @@ export function collectPathWithNavigators(
       const last = events[i];
       const prev = events[i - 1];
       if (
+        lastNavSegIdx === segIdx &&
         last &&
         prev &&
         last.event === "span_end" &&
@@ -828,6 +834,7 @@ export function collectPathWithNavigators(
           fork_nav: { groups: [group] } satisfies ForkNavData,
         },
       });
+      lastNavSegIdx = segIdx;
       return isCut;
     };
 

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -792,8 +792,13 @@ export function collectPathWithNavigators(
       };
 
       // Collapse strictly-adjacent fork navs (same parent_id) into one row.
-      const last = events[events.length - 1];
-      const prev = events[events.length - 2];
+      // Anchors are always hidden in the rendered transcript (see
+      // kDefaultExcludeEvents), so skip them when checking adjacency — the
+      // user perceives two fork navs separated only by anchors as adjacent.
+      let i = events.length - 1;
+      while (i >= 0 && events[i]!.event === "anchor") i--;
+      const last = events[i];
+      const prev = events[i - 1];
       if (
         last &&
         prev &&

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -791,10 +791,7 @@ export function collectPathWithNavigators(
         selectedIndex: Math.max(0, sel),
       };
 
-      // If the previous two events are a fork_nav span_begin/span_end pair
-      // with the same parent_id, append this group to that nav instead of
-      // emitting a new span pair. This collapses strictly-adjacent forks
-      // into one row.
+      // Collapse strictly-adjacent fork navs (same parent_id) into one row.
       const last = events[events.length - 1];
       const prev = events[events.length - 2];
       if (
@@ -806,11 +803,12 @@ export function collectPathWithNavigators(
         last.span_id === prev.span_id &&
         prev.parent_id === parentId
       ) {
-        const data = (prev.metadata as { fork_nav?: ForkNavData } | null)
-          ?.fork_nav;
+        const data = (
+          prev.metadata as { fork_nav?: ForkNavData } | null | undefined
+        )?.fork_nav;
         if (data) {
           data.groups.push(group);
-          (prev as { name: string }).name = forkNavLabel(data.groups);
+          prev.name = forkNavLabel(data.groups);
           return isCut;
         }
       }


### PR DESCRIPTION
## Summary
- Collapse strictly-adjacent fork-navigator rows in the transcript viewer into a single row whose pills are grouped by anchor, with a thin divider between groups.
- Schema change: `ForkNavData` is now `{ groups: ForkNavGroup[] }`; the previous flat `{ anchorId, options, selectedIndex }` lives inside each group.
- Merge logic lives in `navAt` inside `collectPathWithNavigators`. Two guards prevent over-merging: a `parent_id` match (so siblings in different parent spans stay separate) and a `lastNavSegIdx` check (so navs from different path segments never collapse, even if `parent_id` happens to coincide as `null`).
- Anchors are skipped when checking adjacency since they're structural markers (hidden by default) rather than content.

## Test plan
- [x] 5 new unit tests on `collectPathWithNavigators` cover: merge fires on adjacent anchors; merge blocked by an intervening model event; merge blocked by differing `parent_id`; per-group `selectedIndex` independence; merge blocked across segment boundaries.
- [x] `pnpm check` green across the workspace (typecheck + lint + format + tests).
- [x] Manual UI verification: open a transcript with adjacent branch points and confirm a single row with multiple pill groups + divider; confirm non-adjacent forks still render as two rows; confirm outline shows a single combined entry.