### PR TITLE
Update package metadata for inspect and scout

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inspect",
+  "name": "@meridianlabs/log-viewer",
   "version": "0.0.11",
   "description": "Log viewer for inspect_ai logs.",
   "license": "MIT",
@@ -12,12 +12,9 @@
     "lib/styles",
     "lib/assets"
   ],
-  "publishConfig": {
-    "name": "@meridianlabs/log-viewer"
-  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/UKGovernmentBEIS/inspect_ai",
+    "url": "git+https://github.com/UKGovernmentBEIS/inspect_ai.git",
     "directory": "src/inspect_ai/_view/ts-mono/apps/inspect"
   },
   "scripts": {

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "Inspect Scout viewer for evaluation logs.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/meridianlabs-ai/inspect_scout.git"
+  },
   "type": "module",
   "main": "./lib/index.js",
   "module": "./lib/index.js",


### PR DESCRIPTION
Rename inspect package to @meridianlabs/log-viewer and normalize its repository URL. Add repository metadata to the scout package.