### PR TITLE
SamplesPanel/LogList: completed column, sample-limits aggregation, column reorder

### DIFF
--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -186,6 +186,20 @@ export const LogListGrid: FC<LogListGridProps> = ({
         sampleErrors = details.sampleSummaries.filter((s) => s.error).length;
       }
 
+      // Distinct limit types across samples in this task, comma-joined.
+      // Empty when no sample ended with a limit. Sorted for stable
+      // text-filtering and predictable display order.
+      let sampleLimits: string | undefined;
+      if (details?.sampleSummaries) {
+        const limits = new Set<string>();
+        for (const s of details.sampleSummaries) {
+          if (s.limit) limits.add(s.limit);
+        }
+        if (limits.size > 0) {
+          sampleLimits = Array.from(limits).sort().join(", ");
+        }
+      }
+
       const row: LogListRow = {
         id: item.id,
         name: item.name,
@@ -223,6 +237,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         tags: details?.tags,
         percentCompleted,
         sampleErrors,
+        sampleLimits,
         errorMessage: details?.error?.message,
       };
 

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -631,6 +631,19 @@ export const useLogListColumns = (
         },
       },
       {
+        field: "sampleLimits",
+        headerName: "Sample Limits",
+        initialWidth: 140,
+        minWidth: 80,
+        sortable: true,
+        filter: true,
+        resizable: true,
+        cellRenderer: (params: ICellRendererParams<LogListRow>) => {
+          if (!params.value) return <EmptyCell />;
+          return <div>{params.value}</div>;
+        },
+      },
+      {
         field: "errorMessage",
         headerName: "Error",
         initialWidth: 300,
@@ -825,6 +838,7 @@ export const useLogListColumns = (
         "completedSamples",
         "percentCompleted",
         "sampleErrors",
+        "sampleLimits",
         "totalTokens",
         "duration",
         "errorMessage",
@@ -860,6 +874,16 @@ export const useLogListColumns = (
     return allCols;
   }, [scorerMap, mode]);
 
+  // Auto-promote `sampleLimits` to default-visible when any in-scope log
+  // has a sample that ended with a limit.
+  const hasSampleLimits = useMemo(() => {
+    for (const [logName, details] of Object.entries(logDetails)) {
+      if (scopePrefix && !logName.startsWith(scopePrefix)) continue;
+      if (details.sampleSummaries?.some((s) => s.limit)) return true;
+    }
+    return false;
+  }, [logDetails, scopePrefix]);
+
   // Default hidden columns per mode
   const defaultHiddenFields = useMemo(() => {
     const hidden = new Set<string>();
@@ -880,9 +904,10 @@ export const useLogListColumns = (
     // New columns default to hidden in both views
     hidden.add("percentCompleted");
     hidden.add("sampleErrors");
+    if (!hasSampleLimits) hidden.add("sampleLimits");
     hidden.add("errorMessage");
     return hidden;
-  }, [mode]);
+  }, [mode, hasSampleLimits]);
 
   // Determine whether a column belongs to the active scores view mode. Base
   // columns (neither prefix) always match. Per-scorer and by-metric columns

--- a/apps/inspect/src/app/log-list/grid/columns/types.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/types.ts
@@ -26,6 +26,7 @@ export interface LogListRow {
   tags?: string[];
   percentCompleted?: number;
   sampleErrors?: number;
+  sampleLimits?: string;
   errorMessage?: string;
   [key: string]: any; // For dynamic score columns
 }

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -246,15 +246,25 @@ export const SamplesPanel: FC = () => {
   // prior directory isn't. Pure: state mutations live in the effects
   // below.
   const initialState = useMemo<GridState | undefined>(() => {
-    if (
-      previousSamplesPath !== undefined &&
-      previousSamplesPath !== samplesPath
-    ) {
-      const result = { ...gridState };
-      delete result?.filter;
-      return result;
+    const base =
+      previousSamplesPath !== undefined && previousSamplesPath !== samplesPath
+        ? (() => {
+            const result = { ...gridState };
+            delete result?.filter;
+            return result;
+          })()
+        : gridState;
+
+    // Default sort: completed desc when nothing is persisted. Once the
+    // user changes it, the new sort gets persisted into gridState and
+    // takes over from here.
+    if (!base?.sort?.sortModel?.length) {
+      return {
+        ...base,
+        sort: { sortModel: [{ colId: "completed_at", sort: "desc" }] },
+      };
     }
-    return gridState;
+    return base;
   }, [previousSamplesPath, samplesPath, gridState]);
 
   useEffect(() => {
@@ -308,7 +318,7 @@ export const SamplesPanel: FC = () => {
           error: sample.error,
           limit: sample.limit,
           retries: sample.retries,
-          completed: sample.completed ?? false,
+          completed: sample.completed,
           tokens,
           duration: sample.total_time ?? undefined,
         };

--- a/apps/inspect/src/app/samples/status/sampleStatus.tsx
+++ b/apps/inspect/src/app/samples/status/sampleStatus.tsx
@@ -17,7 +17,10 @@ export const sampleStatus = (
   if (error) {
     return errorType(error) === "CancelledError" ? "cancelled" : "error";
   }
-  return completed ? "ok" : "running";
+  // Only an explicit `false` indicates running. Omitted/undefined is
+  // treated as completed: older logs (pre-Apr 2025) and stale buffer
+  // entries may lack the field but represent finished samples.
+  return completed === false ? "running" : "ok";
 };
 
 export const isCancelled = (sample: SampleSummary | EvalSample): boolean => {

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -411,33 +411,10 @@ export function buildSampleColumns(
         : formatTime(params.value),
   });
 
-  // SCORE COLUMNS
-  cols.push(...buildScoreColumns(ctx));
-
-  // OPTIONAL columns — present in selector, default-visible only when data
-  // exists. Initial visibility is seeded by `useSampleGridState`.
-  if (multiLog) {
-    cols.push({
-      colId: "created",
-      field: "created",
-      headerName: "Eval Created",
-      initialWidth: 140,
-      minWidth: 80,
-      maxWidth: 160,
-      sortable: true,
-      filter: true,
-      resizable: true,
-      cellDataType: "date",
-      filterValueGetter: (params: ValueGetterParams<SampleRow>) => {
-        if (!params.data?.created) return undefined;
-        const d = new Date(params.data.created);
-        return new Date(d.getFullYear(), d.getMonth(), d.getDate());
-      },
-      valueFormatter: (params: ValueFormatterParams<SampleRow>) =>
-        params.value ? formatDateTime(new Date(params.value)) : "",
-    });
-  }
-
+  // OPTIONAL columns kept before scores so a scrolling user sees
+  // halted/limited/retried-sample signals without scrolling past the
+  // (often wide) score-column block. Default visibility is seeded by
+  // `useSampleGridState`.
   cols.push(
     {
       colId: "error",
@@ -499,6 +476,31 @@ export function buildSampleColumns(
         params.data?.retries ?? params.data?.data?.retries,
     }
   );
+
+  // SCORE COLUMNS
+  cols.push(...buildScoreColumns(ctx));
+
+  if (multiLog) {
+    cols.push({
+      colId: "created",
+      field: "created",
+      headerName: "Eval Created",
+      initialWidth: 140,
+      minWidth: 80,
+      maxWidth: 160,
+      sortable: true,
+      filter: true,
+      resizable: true,
+      cellDataType: "date",
+      filterValueGetter: (params: ValueGetterParams<SampleRow>) => {
+        if (!params.data?.created) return undefined;
+        const d = new Date(params.data.created);
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+      },
+      valueFormatter: (params: ValueFormatterParams<SampleRow>) =>
+        params.value ? formatDateTime(new Date(params.value)) : "",
+    });
+  }
 
   // Phantom spacer at the right end — only in compact mode. Compact
   // mode's rotated labels extend ~92px past the rightmost score

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -191,6 +191,28 @@ export function buildSampleColumns(
         resizable: true,
         valueFormatter: (params: ValueFormatterParams<SampleRow>) =>
           filename(params.value),
+      },
+      {
+        colId: "completed_at",
+        headerName: "Completed",
+        initialWidth: 140,
+        minWidth: 80,
+        maxWidth: 160,
+        sortable: true,
+        filter: true,
+        resizable: true,
+        cellDataType: "date",
+        valueGetter: (params: ValueGetterParams<SampleRow>) =>
+          params.data?.data?.completed_at ?? undefined,
+        filterValueGetter: (params: ValueGetterParams<SampleRow>) => {
+          const v = params.data?.data?.completed_at;
+          if (!v) return undefined;
+          const d = new Date(v);
+          return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+        },
+        valueFormatter: (params: ValueFormatterParams<SampleRow>) =>
+          params.value ? formatDateTime(new Date(params.value)) : "",
+        comparator: comparators.date,
       }
     );
   }
@@ -398,10 +420,10 @@ export function buildSampleColumns(
     cols.push({
       colId: "created",
       field: "created",
-      headerName: "Created",
-      initialWidth: 130,
+      headerName: "Eval Created",
+      initialWidth: 140,
       minWidth: 80,
-      maxWidth: 140,
+      maxWidth: 160,
       sortable: true,
       filter: true,
       resizable: true,


### PR DESCRIPTION
## Summary

- **SamplesPanel (cross-log)**: new **Completed** column (`sample.completed_at`) between Log File and Id, default visible, default sort desc (via initialState so user changes still persist). Renamed existing "Created" → "Eval Created" (it's `eval.created`, not per-sample).
- **sampleStatus**: only `completed === false` renders as running. Older logs (pre-Apr 2025) and stale buffer entries that omit the field no longer mis-render as running.
- **LogList (Tasks/Folders)**: new **Sample Limits** column, comma-joined sorted distinct `EvalSampleSummary.limit` values per task. Auto-promotes to default-visible when any in-scope log has a limit-halted sample (scoped to the same `scopePrefix` the scorer-column discovery uses).
- **SamplesGrid column order**: Error / Limit / Retries now sit before the score-column block in both single-log SampleList and cross-log SamplesPanel — halted/limited/retried signals are visible without horizontally scrolling past the (often wide) scores.

<img width="1212" height="281" alt="Screenshot 2026-05-27 at 7 37 26 PM" src="https://github.com/user-attachments/assets/5cb4088e-3115-481f-bcd6-df19fc96d037" />

<img width="1226" height="478" alt="Screenshot 2026-05-27 at 7 40 56 PM" src="https://github.com/user-attachments/assets/6b9785f9-39f2-4771-a1b6-c17053228d2c" />


<img width="1225" height="459" alt="Screenshot 2026-05-27 at 7 41 07 PM" src="https://github.com/user-attachments/assets/24ecf88b-60b6-4ded-babc-d63c79b6d261" />


## Test plan

- [x] Cross-log Samples view (`/#/samples/`): Completed column visible by default, sorted desc; user-cleared sort persists across reload.
- [x] Old eval logs (no `completed` field on summaries) render with the correct sample status icon, not "running" pulsing dots.
- [x] Tasks view: Sample Limits column appears automatically when any task in the current scope has a sample with a `limit`; comma-joined list of distinct types is displayed.
- [x] Folders view (descending into a subfolder): the Sample Limits column auto-promotes based only on that subfolder's logs.
- [x] Per-task SampleList: Error / Limit / Retries appear before scoring columns; Eval Created (multiLog-only) stays at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)