### PR TITLE
Scout viewer: include bootstrap CSS in library build

### DIFF
--- a/apps/scout/src/App.tsx
+++ b/apps/scout/src/App.tsx
@@ -1,6 +1,9 @@
 import { createContext, FC, useEffect, useMemo } from "react";
 import { RouterProvider } from "react-router-dom";
 
+import "@vscode/codicons/dist/codicon.css";
+import "bootstrap-icons/font/bootstrap-icons.css";
+import "bootstrap/dist/css/bootstrap.min.css";
 import "prismjs";
 import "prismjs/components/prism-bash";
 import "prismjs/components/prism-clike";

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -2,10 +2,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRoot } from "react-dom/client";
 
-import "@vscode/codicons/dist/codicon.css";
-import "bootstrap-icons/font/bootstrap-icons.css";
-import "bootstrap/dist/css/bootstrap.min.css";
-
 import { defaultRetry } from "@tsmono/react";
 import { getVscodeApi } from "@tsmono/util";
 


### PR DESCRIPTION
## Summary

The scout viewer's published library CSS (`lib/styles/index.css`) is missing the Bootstrap base rules its own components rely on. Consumers that don't *also* pull in a sibling viewer's CSS (the Hawk scan-viewer page is an example) end up rendering with unstyled `.btn`, `.nav`, `.nav-link`, `.container`, etc.

The cause is that `apps/scout/src/main.tsx` is where `bootstrap`, `bootstrap-icons`, and `@vscode/codicons` are imported, but `main.tsx` is the standalone-app HTML entry — it isn't re-exported from `src/index.ts` (the library entry only re-exports `App`). So the library build never sees those CSS imports and drops them from `lib/styles/index.css`. Move the three imports to the top of `App.tsx`, mirroring the pattern already used in `apps/inspect/src/app/App.tsx`. Both builds (library and standalone app) now include Bootstrap in their CSS output (lib CSS grows from ~10.5k → ~13.5k lines, with the full `.btn { --bs-btn-*: …; display: inline-block; … }` etc.).