### PR TITLE
Scout viewer: add prepublishOnly so npm publish ships built lib

### DIFF
--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -26,6 +26,7 @@
     "watch:dev": "NODE_ENV=development vite build --watch --mode development",
     "dev": "vite",
     "preview": "vite preview",
+    "prepublishOnly": "pnpm run build:lib",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix --max-warnings 0",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary

The official \`@meridianlabs/inspect-scout-viewer\` releases on npm ship empty: the latest 0.4.38 tarball is 2.5 KB and contains only \`package.json\` and \`README.md\`, with no \`lib/\`.

Cause: \`apps/scout/package.json\` has no \`prepublishOnly\` script, and the publish workflow in [inspect_scout](https://github.com/meridianlabs-ai/inspect_scout/blob/main/.github/workflows/npm-publish.yml) only runs \`pnpm build:lib\` for prereleases (\`if: \${{ inputs.prerelease }}\`). On the official-release path nothing builds \`apps/scout/lib/\` before \`npm publish\`, so the \`files\` field (\`["lib", "lib/styles", "lib/assets"]\`) matches nothing on disk.

Adding the `prepublishOnly` step matches the inspect_ai flow. We could also consider removing the prerelease gate in the Build library step in both modules.