### PR TITLE
Expose useScrollDirection from the inspect-log-viewer package

### DIFF
--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -38,3 +38,11 @@ export {
 // Selection-related types
 export type { SampleSummary } from "./client/api/types";
 export type { ScoreLabel } from "./app/types";
+
+// Scroll-direction hook — used by embedders to drive their own chrome
+// collapse with the same hysteresis behaviour the viewer uses internally.
+export {
+  useScrollDirection,
+  type UseScrollDirectionOptions,
+  type UseScrollDirectionResult,
+} from "@tsmono/react/hooks";

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -1,3 +1,13 @@
+/**
+ * Public entry point for embedding the Inspect log viewer into an external application
+ * by consuming this package's **source** directly — the `<App />` component, client
+ * APIs, store initializer, and selection hooks needed to host the viewer in-process.
+ *
+ * Disclaimer: semantic versioning is NOT used. This surface evolves with the host
+ * application's needs. Consumers pinning to a revision must expect breaking changes
+ * at any time and adapt accordingly.
+ */
+
 // Main React App Component
 export { App, type AppProps } from "./app/App";
 

--- a/packages/react/src/hooks/useScrollDirection.ts
+++ b/packages/react/src/hooks/useScrollDirection.ts
@@ -10,7 +10,7 @@ import {
 const asArray = <T>(v: T | ReadonlyArray<T>): ReadonlyArray<T> =>
   Array.isArray(v) ? (v as ReadonlyArray<T>) : [v as T];
 
-interface UseScrollDirectionOptions {
+export interface UseScrollDirectionOptions {
   /** Minimum px delta before recognizing a direction change. Default: 15 */
   threshold?: number;
   /** Lock duration (ms) after a state change, matching the CSS transition.
@@ -29,7 +29,7 @@ interface UseScrollDirectionOptions {
   stayHiddenOnUpScroll?: boolean;
 }
 
-interface UseScrollDirectionResult {
+export interface UseScrollDirectionResult {
   /** True when scrolling down past threshold while scrollTop > 10px */
   hidden: boolean;
   /** Call before a programmatic scroll or layout change that will shift


### PR DESCRIPTION
## Summary

It would be very useful to be able to hook into `useScrollDirection` from outside.