### PR TITLE
fix: Fix view server fetch storm when log directory is deleted or renamed

### DIFF
--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -115,11 +115,10 @@ export const LogsPanel: FC<LogsPanelProps> = ({
             .join(",") || "";
 
     if (current !== previous) {
-      // Always stop current polling first when logs change
       stopPolling();
 
       if (watchedLogs !== undefined) {
-        startPolling(watchedLogs);
+        startPolling();
       }
       previousWatchedLogs.current = watchedLogs;
     }

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -68,13 +68,12 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const { gridStateByScope, setGridState, setFilteredCount } = useLogsListing();
   const gridState = scopeKey ? gridStateByScope[scopeKey] : undefined;
 
-  const { loadLogOverviews, loadAllLogOverviews } = useLogs();
+  const { loadAllLogOverviews } = useLogs();
 
   const loading = useStore((state) => state.app.status.loading);
   const syncing = useStore((state) => state.app.status.syncing);
   const setWatchedLogs = useStore((state) => state.logsActions.setWatchedLogs);
 
-  const logPreviews = useStore((state) => state.logs.logPreviews);
   const logDetails = useStore((state) => state.logs.logDetails);
   const navigate = useNavigate();
   const internalGridRef = useRef<AgGridReact<LogListRow>>(null);
@@ -334,15 +333,8 @@ export const LogListGrid: FC<LogListGridProps> = ({
   );
 
   useEffect(() => {
-    const loadHeaders = async () => {
-      const filesToLoad = logFiles.filter((file) => !logPreviews[file.name]);
-      if (filesToLoad.length > 0) {
-        await loadLogOverviews(filesToLoad);
-      }
-      setWatchedLogs(logFiles);
-    };
-    loadHeaders();
-  }, [logFiles, loadLogOverviews, setWatchedLogs, logPreviews]);
+    setWatchedLogs(logFiles);
+  }, [logFiles, setWatchedLogs]);
 
   const applyVisibility = useApplyColumnVisibility(
     gridRef,

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -112,7 +112,7 @@ export const SamplesPanel: FC = () => {
   // Polling for updated log files.
   const { startPolling, stopPolling } = useClientEvents();
   useEffect(() => {
-    startPolling([]);
+    startPolling();
     return () => {
       stopPolling();
     };

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -406,6 +406,11 @@ export class DatabaseService {
     ]);
   }
 
+  async clearPreviewForFile(filePath: string): Promise<void> {
+    const db = this.getDb();
+    await db.log_previews.where("file_path").equals(filePath).delete();
+  }
+
   /**
    * Get cache statistics.
    */

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
+
+import { LogPreview } from "../client/api/types";
 
 import { clientEventsService } from "./clientEventsService";
 import { useLogs } from "./hooks";
@@ -12,45 +14,50 @@ const log = createLogger("Client-Events");
 export function useClientEvents() {
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
   const logPreviews = useStore((state) => state.logs.logPreviews);
+  const currentLogs = useStore((state) => state.logs.logs);
   const api = useApi();
   const { loadLogOverviews } = useLogs();
 
-  // Set up the refresh callback for the service
+  // Refs so the callback always sees the latest values without
+  // re-creating itself (which would restart polling).
+  const logPreviewsRef = useRef<Record<string, LogPreview>>(logPreviews);
+  logPreviewsRef.current = logPreviews;
+
+  const currentLogsRef = useRef<LogHandle[]>(currentLogs);
+  currentLogsRef.current = currentLogs;
+
   const refreshCallback = useCallback(
-    async (logs: LogHandle[]) => {
-      // Refresh the list of log files
-      log.debug("Refresh Log Files");
+    async (_reason: "event" | "periodic") => {
+      log.debug(`Refresh Log Files (${_reason})`);
       await syncLogs();
 
+      // Read current state *after* sync completes
+      const logs = currentLogsRef.current;
+      const previews = logPreviewsRef.current;
+
       const toRefresh: LogHandle[] = [];
-      for (const log of logs) {
-        const header = logPreviews[log.name];
+      for (const logHandle of logs) {
+        const header = previews[logHandle.name];
         if (!header || header.status === "started") {
-          toRefresh.push(log);
+          toRefresh.push(logHandle);
         }
       }
 
-      // Refresh any logFiles that are currently being watched
       if (toRefresh.length > 0) {
         log.debug(`Refreshing ${toRefresh.length} log files`, toRefresh);
         await loadLogOverviews(toRefresh);
       }
     },
-    [logPreviews, syncLogs, loadLogOverviews]
+    [syncLogs, loadLogOverviews]
   );
 
-  // Update the service's refresh callback when dependencies change
   useEffect(() => {
     clientEventsService.setRefreshCallback(refreshCallback);
   }, [refreshCallback]);
 
-  // Wrapper functions that call the service
-  const startPolling = useCallback(
-    (logs: LogHandle[]) => {
-      clientEventsService.startPolling(logs, api);
-    },
-    [api]
-  );
+  const startPolling = useCallback(() => {
+    clientEventsService.startPolling(api);
+  }, [api]);
 
   const stopPolling = useCallback(() => {
     clientEventsService.stopPolling();
@@ -60,7 +67,6 @@ export function useClientEvents() {
     clientEventsService.cleanup();
   }, []);
 
-  // Cleanup when hook unmounts
   useEffect(() => {
     return () => {
       cleanup();

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,42 +1,22 @@
 import { useCallback, useEffect } from "react";
 
-import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
 import { clientEventsService } from "./clientEventsService";
-import { useLogs } from "./hooks";
-import { storeImplementation, useApi, useStore } from "./store";
+import { useApi, useStore } from "./store";
 
 const log = createLogger("Client-Events");
 
 export function useClientEvents() {
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
   const api = useApi();
-  const { loadLogOverviews } = useLogs();
 
   const refreshCallback = useCallback(
     async (_reason: "event" | "periodic") => {
       log.debug(`Refresh Log Files (${_reason})`);
-      const currentLogs = await syncLogs();
-
-      // Read previews from the store *after* sync so we see the
-      // latest state rather than a stale closure capture.
-      const logPreviews = storeImplementation?.getState()?.logs.logPreviews;
-
-      const toRefresh: LogHandle[] = [];
-      for (const logHandle of currentLogs) {
-        const header = logPreviews?.[logHandle.name];
-        if (!header || header.status === "started") {
-          toRefresh.push(logHandle);
-        }
-      }
-
-      if (toRefresh.length > 0) {
-        log.debug(`Refreshing ${toRefresh.length} log files`, toRefresh);
-        await loadLogOverviews(toRefresh);
-      }
+      await syncLogs();
     },
-    [syncLogs, loadLogOverviews]
+    [syncLogs]
   );
 
   useEffect(() => {

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,43 +1,31 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 
 import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
-import { LogPreview } from "../client/api/types";
-
 import { clientEventsService } from "./clientEventsService";
 import { useLogs } from "./hooks";
-import { useApi, useStore } from "./store";
+import { storeImplementation, useApi, useStore } from "./store";
 
 const log = createLogger("Client-Events");
 
 export function useClientEvents() {
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
-  const logPreviews = useStore((state) => state.logs.logPreviews);
-  const currentLogs = useStore((state) => state.logs.logs);
   const api = useApi();
   const { loadLogOverviews } = useLogs();
-
-  // Refs so the callback always sees the latest values without
-  // re-creating itself (which would restart polling).
-  const logPreviewsRef = useRef<Record<string, LogPreview>>(logPreviews);
-  logPreviewsRef.current = logPreviews;
-
-  const currentLogsRef = useRef<LogHandle[]>(currentLogs);
-  currentLogsRef.current = currentLogs;
 
   const refreshCallback = useCallback(
     async (_reason: "event" | "periodic") => {
       log.debug(`Refresh Log Files (${_reason})`);
-      await syncLogs();
+      const currentLogs = await syncLogs();
 
-      // Read current state *after* sync completes
-      const logs = currentLogsRef.current;
-      const previews = logPreviewsRef.current;
+      // Read previews from the store *after* sync so we see the
+      // latest state rather than a stale closure capture.
+      const logPreviews = storeImplementation?.getState()?.logs.logPreviews;
 
       const toRefresh: LogHandle[] = [];
-      for (const logHandle of logs) {
-        const header = previews[logHandle.name];
+      for (const logHandle of currentLogs) {
+        const header = logPreviews?.[logHandle.name];
         if (!header || header.status === "started") {
           toRefresh.push(logHandle);
         }

--- a/apps/inspect/src/state/clientEventsService.ts
+++ b/apps/inspect/src/state/clientEventsService.ts
@@ -1,4 +1,3 @@
-import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
 import { ClientAPI } from "../client/api/types";
@@ -14,40 +13,30 @@ class ClientEventsService {
   private currentPolling: ReturnType<typeof createPolling> | null = null;
   private abortController: AbortController | null = null;
   private isRefreshing = false;
-  private pendingLogs = new Set<LogHandle>();
-  private onRefreshCallback: ((logs: LogHandle[]) => Promise<void>) | null =
-    null;
+  private onRefreshCallback:
+    | ((reason: "event" | "periodic") => Promise<void>)
+    | null = null;
 
-  setRefreshCallback(callback: (logs: LogHandle[]) => Promise<void>) {
+  setRefreshCallback(
+    callback: (reason: "event" | "periodic") => Promise<void>
+  ) {
     this.onRefreshCallback = callback;
   }
 
-  private async refreshPendingLogFiles() {
+  private async refreshLogFiles(reason: "event" | "periodic") {
     if (this.isRefreshing || !this.onRefreshCallback) {
       return;
     }
 
-    do {
-      try {
-        const logFiles = [...this.pendingLogs];
-        this.pendingLogs.clear();
-        this.isRefreshing = true;
-
-        // Call the refresh callback
-        await this.onRefreshCallback(logFiles);
-      } finally {
-        this.isRefreshing = false;
-      }
-    } while (this.pendingLogs.size > 0);
+    this.isRefreshing = true;
+    try {
+      await this.onRefreshCallback(reason);
+    } finally {
+      this.isRefreshing = false;
+    }
   }
 
-  private async refreshLogFiles(logs: LogHandle[]) {
-    logs.forEach((file) => this.pendingLogs.add(file));
-    await this.refreshPendingLogFiles();
-  }
-
-  startPolling(logs: LogHandle[], api: ClientAPI) {
-    // Stop any existing polling
+  startPolling(api: ClientAPI) {
     this.stopPolling();
 
     this.abortController = new AbortController();
@@ -71,11 +60,11 @@ class ClientEventsService {
         }
 
         if ((events || []).includes(kRefreshEvent)) {
-          await this.refreshLogFiles(logs);
+          await this.refreshLogFiles("event");
         }
 
         if (pollingCount++ % 10 === 0) {
-          await this.refreshLogFiles(logs);
+          await this.refreshLogFiles("periodic");
         }
 
         return true;
@@ -103,7 +92,6 @@ class ClientEventsService {
   cleanup() {
     log.debug(`Cleanup`);
     this.stopPolling();
-    this.pendingLogs.clear();
     this.onRefreshCallback = null;
   }
 }

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -358,15 +358,7 @@ export class ReplicationService {
         // Activate the current log handles
         this._applicationContext?.setLogHandles(logFiles);
 
-        // Schedule sync of missing previews or details
-        const previewTasks: LogHandle[] = [];
-        const previews = await this._database.findMissingPreviews(logFiles);
-        for (const p of previews) {
-          if (!previewTasks.find((t) => t.name === p.name)) {
-            previewTasks.push(p);
-          }
-        }
-        this.queueLogPreviews(previewTasks);
+        await this.queueMissingOrStartedPreviews(logFiles);
 
         const detailTasks: LogHandle[] = [];
         const details = await this._database.findMissingDetails(logFiles);
@@ -436,32 +428,7 @@ export class ReplicationService {
     const allLogHandles = (await this._database.readLogs()) || [];
     this._applicationContext?.setLogHandles(allLogHandles);
 
-    // Schedule any missing previews
-    const previewTasks = [...toInvalidate];
-    const previews = await this._database.findMissingPreviews(allLogHandles);
-    for (const p of previews) {
-      if (!previewTasks.find((t) => t.name === p.name)) {
-        previewTasks.push(p);
-      }
-    }
-
-    // Re-fetch previews for running evals whose mtime didn't advance
-    // past the watermark. The server's incremental response won't
-    // include them, and findMissingPreviews won't either since their
-    // preview is already cached — but the cached preview is stale.
-    const cachedPreviews = await this._database.readLogPreviews(allLogHandles);
-    for (const handle of allLogHandles) {
-      const preview = cachedPreviews[handle.name];
-      if (preview?.status === "started") {
-        if (!previewTasks.find((t) => t.name === handle.name)) {
-          this._database?.clearCacheForFile(handle.name);
-          previewTasks.push(handle);
-        }
-      }
-    }
-
-    this.queueLogPreviews(previewTasks.slice(0, 25), WorkPriority.High);
-    this.queueLogPreviews(previewTasks.slice(25), WorkPriority.Medium);
+    await this.queueMissingOrStartedPreviews(allLogHandles, toInvalidate);
 
     // Schedule detail fetching for new/changed logs
     const detailTasks = [...toInvalidate];
@@ -526,11 +493,45 @@ export class ReplicationService {
     this.updateDbStats();
   }
 
+  private async queueMissingOrStartedPreviews(
+    logHandles: LogHandle[],
+    extraHandles: LogHandle[] = [],
+    priority: WorkPriority = WorkPriority.High
+  ) {
+    if (!this._database) return;
+
+    const tasks = [...extraHandles];
+    const seen = new Set(tasks.map((t) => t.name));
+
+    const missing = await this._database.findMissingPreviews(logHandles);
+    for (const m of missing) {
+      if (!seen.has(m.name)) {
+        seen.add(m.name);
+        tasks.push(m);
+      }
+    }
+
+    const cached = await this._database.readLogPreviews(logHandles);
+    for (const handle of logHandles) {
+      if (seen.has(handle.name)) continue;
+      const preview = cached[handle.name];
+      if (preview?.status === "started") {
+        seen.add(handle.name);
+        await this._database.clearPreviewForFile(handle.name);
+        tasks.push(handle);
+      }
+    }
+
+    if (tasks.length > 0) {
+      this.queueLogPreviews(tasks.slice(0, 25), priority);
+      this.queueLogPreviews(tasks.slice(25), WorkPriority.Medium);
+    }
+  }
+
   queueLogPreviews(
     logs: LogHandle[],
     priority: WorkPriority = WorkPriority.Medium
   ) {
-    // Add to queue
     this._previewQueue.enqueue(logs, priority);
   }
 

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -444,10 +444,26 @@ export class ReplicationService {
         previewTasks.push(p);
       }
     }
+
+    // Re-fetch previews for running evals whose mtime didn't advance
+    // past the watermark. The server's incremental response won't
+    // include them, and findMissingPreviews won't either since their
+    // preview is already cached — but the cached preview is stale.
+    const cachedPreviews = await this._database.readLogPreviews(allLogHandles);
+    for (const handle of allLogHandles) {
+      const preview = cachedPreviews[handle.name];
+      if (preview?.status === "started") {
+        if (!previewTasks.find((t) => t.name === handle.name)) {
+          this._database?.clearCacheForFile(handle.name);
+          previewTasks.push(handle);
+        }
+      }
+    }
+
     this.queueLogPreviews(previewTasks.slice(0, 25), WorkPriority.High);
     this.queueLogPreviews(previewTasks.slice(25), WorkPriority.Medium);
 
-    // Schedule preview fetching for new logs
+    // Schedule detail fetching for new/changed logs
     const detailTasks = [...toInvalidate];
     const details = await this._database.findMissingDetails(allLogHandles);
     for (const d of details) {

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -227,7 +227,10 @@ export class ReplicationService {
     this._api = api;
     this._applicationContext = context;
 
-    // Preload any data
+    // Preload cached data so the UI can render immediately while
+    // sync() confirms what still exists on the server. We only push
+    // data into the store here — no fetches for missing data, since
+    // those handles haven't been validated yet.
     const logHandles = await database.readLogs();
     if (logHandles) {
       context.setLogHandles(logHandles);

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -335,6 +335,10 @@ export class ReplicationService {
           this._database?.clearCacheForFile(file.name);
         }
 
+        // Drop stale queued work before scheduling new fetches
+        this._previewQueue.clear();
+        this._detailQueue.clear();
+
         // Apply the new list
         this._applicationContext?.setLogHandles(serverLogs.files);
 
@@ -382,13 +386,18 @@ export class ReplicationService {
     const response = await this._api.get_logs(mtime, clientFileCount);
     const updatedLogs = response.files;
 
-    // Find deleted file
     if (response.response_type === "full") {
       const deletedFiles = logFiles.filter((current) => {
         return !updatedLogs.find((f) => f.name === current.name);
       });
       for (const file of deletedFiles) {
         this._database?.clearCacheForFile(file.name);
+      }
+
+      // Drop any queued fetches for files that no longer exist
+      if (deletedFiles.length > 0) {
+        this._previewQueue.clear();
+        this._detailQueue.clear();
       }
     }
 

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -394,10 +394,10 @@ export class ReplicationService {
         this._database?.clearCacheForFile(file.name);
       }
 
-      // Drop any queued fetches for files that no longer exist
       if (deletedFiles.length > 0) {
-        this._previewQueue.clear();
-        this._detailQueue.clear();
+        const deletedNames = deletedFiles.map((f) => f.name);
+        this._previewQueue.removeByIds(deletedNames);
+        this._detailQueue.removeByIds(deletedNames);
       }
     }
 

--- a/apps/inspect/src/utils/workQueue.ts
+++ b/apps/inspect/src/utils/workQueue.ts
@@ -169,6 +169,12 @@ export class WorkQueue<TInput, TOutput> {
     this.itemsById.clear();
   }
 
+  removeByIds(ids: string[]) {
+    for (const id of ids) {
+      this.itemsById.delete(id);
+    }
+  }
+
   get size() {
     return this.itemsById.size;
   }


### PR DESCRIPTION
When a log directory is deleted while the viewer is open, the client enters a cascading failure loop: stale log handles trigger
  hundreds of concurrent fetch requests that all 404, flooding the server with errors and freezing the UI.                             
   
  Root causes                                                                                                                          
                                                         
  - Stale closure in polling — ClientEventsService.startPolling captured the log handle list in its closure and kept refreshing deleted
   files on every poll cycle                             
  - Eager preview fetches before server validation — LogListGrid called loadLogOverviews for files rehydrated from IndexedDB before    
  _syncImpl confirmed they still exist, racing 25-50 requests against a deleted directory                                              
  - No queue cleanup on deletion — WorkQueue had no way to remove specific items; deleted files stayed queued with retries
  - Unhandled FileNotFoundError — only /logs/{path} caught it; other endpoints (/log-info, /log-size, /eval-set) returned 500          
  tracebacks                                                                                                                           
                                                                                                                                       
  Changes                                                                                                                              
                                                         
  Client (ts-mono):                                                                                                                    
   
  - clientEventsService.ts — Remove logs parameter from startPolling; polling no longer captures a stale handle list. Refresh callback 
  just calls syncLogs() which reads current state        
  - clientEvents.ts — Simplify refreshCallback to only call syncLogs(). The mtime-based _syncImpl already queues preview/detail fetches
   for changed files                                                                                                                   
  - replicationService.ts — Extract queueMissingOrStartedPreviews helper that finds missing previews and re-fetches status === 
  "started" previews (which may not appear in incremental sync responses due to the max-mtime watermark). Used in both the normal sync 
  path and the static-list path so neither branch silently drops live refresh
  - replicationService.ts — Use targeted removeByIds (not clear()) to drop only deleted files from work queues, preserving in-flight   
  work for files that still exist                                                                                                      
  - database/service.ts — Add clearPreviewForFile that deletes only from log_previews, not all three tables. Running evals keep their
  log handle and detail cache intact                                                                                                   
  - workQueue.ts — Add removeByIds for surgical item removal
  - LogListGrid.tsx — Remove eager loadLogOverviews on mount. startReplication preloads cached data from IndexedDB for immediate       
  render; _syncImpl queues fetches for validated files shortly after                                                                   
  - LogsPanel.tsx / SamplesPanel.tsx — Update startPolling() calls to match new signature                                                