### PR TITLE
viewer: track inspect_ai viewer-config rename (TaskSamples*, score-panel `default`)

### DIFF
--- a/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
@@ -1,7 +1,7 @@
 import type { FilterModel, GridState } from "ag-grid-community";
 import { describe, expect, test } from "vitest";
 
-import type { SamplesView } from "@tsmono/inspect-common/types";
+import type { TaskSamplesView } from "@tsmono/inspect-common/types";
 
 import { defaultSamplesView, type SamplesViewState } from "./samplesView";
 import {
@@ -33,14 +33,13 @@ describe("liftEvalView", () => {
   });
 
   test("nullable wire fields collapse to defaults; explicit fields pass through", () => {
-    const wire: SamplesView = {
+    const wire: TaskSamplesView = {
       name: "Triage",
       columns: [
         { id: "input", visible: true },
         { id: "target", visible: false },
       ],
       sort: [{ column: "tokens", dir: "desc" }],
-      filter: "has_error",
       multiline: false,
     };
     expect(liftEvalView(wire)).toEqual({
@@ -50,7 +49,7 @@ describe("liftEvalView", () => {
         { id: "target", visible: false },
       ],
       sort: [{ colId: "tokens", dir: "desc" }],
-      filters: { dsl: "has_error", extraColumnFilters: {} },
+      filters: { dsl: "", extraColumnFilters: {} },
       multiline: false,
       compactScores: false,
       colorScalesEnabled: true,
@@ -59,7 +58,7 @@ describe("liftEvalView", () => {
   });
 
   test("missing columns / sort fall back to default (empty arrays today)", () => {
-    const wire: SamplesView = { name: "Default" };
+    const wire: TaskSamplesView = { name: "Default" };
     const lifted = liftEvalView(wire);
     expect(lifted.columns).toEqual([]);
     expect(lifted.sort).toEqual([]);
@@ -70,12 +69,15 @@ describe("liftEvalView", () => {
   });
 
   test("compact_scores wire field maps to compactScores runtime field", () => {
-    const wire: SamplesView = { name: "Triage", compact_scores: true };
+    const wire: TaskSamplesView = { name: "Triage", compact_scores: true };
     expect(liftEvalView(wire).compactScores).toBe(true);
   });
 
   test("color_scales_enabled wire field maps to colorScalesEnabled runtime field", () => {
-    const wire: SamplesView = { name: "Triage", color_scales_enabled: false };
+    const wire: TaskSamplesView = {
+      name: "Triage",
+      color_scales_enabled: false,
+    };
     expect(liftEvalView(wire).colorScalesEnabled).toBe(false);
   });
 
@@ -85,7 +87,7 @@ describe("liftEvalView", () => {
     // from a prior eval shadow the current one. Score labels are read
     // straight from the wire by `useSamplesViewScoreLabels` instead, so
     // the converter must not copy them into the runtime state.
-    const wire: SamplesView = {
+    const wire: TaskSamplesView = {
       name: "Triage",
       score_labels: { audit_situational_awareness: "Situational Awareness" },
     };
@@ -99,7 +101,7 @@ describe("liftEvalView", () => {
     // straight from the eval wire each render; the converter must not
     // copy them into the runtime state where they would survive across
     // evals.
-    const wire: SamplesView = {
+    const wire: TaskSamplesView = {
       name: "Triage",
       score_color_scales: {
         accuracy: "good-high",
@@ -128,22 +130,15 @@ describe("flattenToEvalView", () => {
       name: "Errors",
       columns: [{ id: "input", visible: true }],
       sort: [{ column: "tokens", dir: "asc" }],
-      filter: "has_error",
       multiline: false,
       compact_scores: false,
       color_scales_enabled: true,
     });
   });
-
-  test("empty dsl renders as filter: null on the wire", () => {
-    expect(
-      flattenToEvalView(sampleState({ name: "Default" })).filter
-    ).toBeNull();
-  });
 });
 
 describe("pickActiveView", () => {
-  const view: SamplesView = { name: "A" };
+  const view: TaskSamplesView = { name: "A" };
 
   test("undefined / null → undefined", () => {
     expect(pickActiveView(undefined)).toBeUndefined();
@@ -155,7 +150,7 @@ describe("pickActiveView", () => {
   });
 
   test("list returns the first entry", () => {
-    const second: SamplesView = { name: "B" };
+    const second: TaskSamplesView = { name: "B" };
     expect(pickActiveView([view, second])).toBe(view);
   });
 
@@ -165,13 +160,13 @@ describe("pickActiveView", () => {
 });
 
 describe("resolveSamplesView precedence", () => {
-  test("stored columns/sort/filter always win over eval default", () => {
+  test("stored columns/sort always win over eval default", () => {
     const stored = sampleState({
       name: "User",
       columns: [{ id: "input", visible: true }],
       sort: [{ colId: "tokens", dir: "desc" }],
     });
-    const evalDefault: SamplesView = {
+    const evalDefault: TaskSamplesView = {
       name: "Eval",
       columns: [{ id: "score", visible: true }],
     };
@@ -182,7 +177,7 @@ describe("resolveSamplesView precedence", () => {
   });
 
   test("eval default applies when no stored state is present", () => {
-    const evalDefault: SamplesView = { name: "Eval", multiline: false };
+    const evalDefault: TaskSamplesView = { name: "Eval", multiline: false };
     expect(resolveSamplesView(undefined, evalDefault)).toEqual(
       liftEvalView(evalDefault)
     );
@@ -199,7 +194,7 @@ describe("resolveSamplesView precedence", () => {
     // userOverrides is empty — so the current eval's `multiline: false`
     // should propagate through.
     const stored = sampleState({ multiline: true, userOverrides: {} });
-    const evalDefault: SamplesView = { name: "Eval", multiline: false };
+    const evalDefault: TaskSamplesView = { name: "Eval", multiline: false };
     expect(resolveSamplesView(stored, evalDefault).multiline).toBe(false);
   });
 
@@ -208,7 +203,7 @@ describe("resolveSamplesView precedence", () => {
       multiline: true,
       userOverrides: { multiline: true },
     });
-    const evalDefault: SamplesView = { name: "Eval", multiline: false };
+    const evalDefault: TaskSamplesView = { name: "Eval", multiline: false };
     expect(resolveSamplesView(stored, evalDefault).multiline).toBe(true);
   });
 
@@ -233,7 +228,7 @@ describe("resolveSamplesView precedence", () => {
       }),
     } as SamplesViewState;
     delete (legacy as Partial<SamplesViewState>).userOverrides;
-    const evalDefault: SamplesView = {
+    const evalDefault: TaskSamplesView = {
       name: "Eval",
       multiline: false,
       compact_scores: true,

--- a/apps/inspect/src/app/samples/list/samplesView.converters.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.ts
@@ -1,5 +1,5 @@
 /**
- * Pure converters between the on-the-wire `SamplesView`, the runtime
+ * Pure converters between the on-the-wire `TaskSamplesView`, the runtime
  * `SamplesViewState`, and ag-grid's `GridState`.
  *
  * No runtime imports — every function here is referentially transparent
@@ -8,7 +8,7 @@
  */
 import type { FilterModel, GridState } from "ag-grid-community";
 
-import type { SamplesView } from "@tsmono/inspect-common/types";
+import type { TaskSamplesView } from "@tsmono/inspect-common/types";
 
 import { defaultSamplesView, type SamplesViewState } from "./samplesView";
 
@@ -17,7 +17,7 @@ import { defaultSamplesView, type SamplesViewState } from "./samplesView";
 // ---------------------------------------------------------------------------
 
 /**
- * Lift a wire `SamplesView` into the runtime `SamplesViewState`.
+ * Lift a wire `TaskSamplesView` into the runtime `SamplesViewState`.
  *
  * - Nullable wire fields collapse to defaults from `defaultSamplesView()`.
  * - Sort entries map `column` → `colId` to match ag-grid naming on the
@@ -27,7 +27,7 @@ import { defaultSamplesView, type SamplesViewState } from "./samplesView";
  *   the DSL can't express.
  */
 export const liftEvalView = (
-  wire: SamplesView | undefined | null
+  wire: TaskSamplesView | undefined | null
 ): SamplesViewState => {
   const fallback = defaultSamplesView();
   if (!wire) return fallback;
@@ -39,7 +39,7 @@ export const liftEvalView = (
     sort: wire.sort
       ? wire.sort.map((s) => ({ colId: s.column, dir: s.dir ?? "asc" }))
       : fallback.sort,
-    filters: { dsl: wire.filter ?? "", extraColumnFilters: {} },
+    filters: { dsl: "", extraColumnFilters: {} },
     multiline: wire.multiline ?? fallback.multiline,
     compactScores: wire.compact_scores ?? fallback.compactScores,
     colorScalesEnabled:
@@ -53,11 +53,12 @@ export const liftEvalView = (
  * dropped — that field is TS-only and never crosses the wire. Used to
  * compare a stored view against an eval default for override detection.
  */
-export const flattenToEvalView = (state: SamplesViewState): SamplesView => ({
+export const flattenToEvalView = (
+  state: SamplesViewState
+): TaskSamplesView => ({
   name: state.name,
   columns: state.columns.map((c) => ({ id: c.id, visible: c.visible })),
   sort: state.sort.map((s) => ({ column: s.colId, dir: s.dir })),
-  filter: state.filters.dsl ? state.filters.dsl : null,
   multiline: state.multiline,
   compact_scores: state.compactScores,
   color_scales_enabled: state.colorScalesEnabled,
@@ -68,8 +69,8 @@ export const flattenToEvalView = (state: SamplesViewState): SamplesView => ({
  * For Phase 0–2 we honour only the first entry of a list.
  */
 export const pickActiveView = (
-  field: SamplesView | SamplesView[] | undefined | null
-): SamplesView | undefined => {
+  field: TaskSamplesView | TaskSamplesView[] | undefined | null
+): TaskSamplesView | undefined => {
   if (!field) return undefined;
   if (Array.isArray(field)) return field[0];
   return field;
@@ -88,7 +89,7 @@ export const pickActiveView = (
  */
 export const resolveSamplesView = (
   stored: SamplesViewState | undefined,
-  evalDefault: SamplesView | undefined | null
+  evalDefault: TaskSamplesView | undefined | null
 ): SamplesViewState => {
   if (!stored) return liftEvalView(evalDefault);
   const lifted = liftEvalView(evalDefault);
@@ -282,7 +283,7 @@ export const partitionFilterModel = (
 // ---------------------------------------------------------------------------
 
 /**
- * Pre-refactor scope state from before the SamplesView descriptor
+ * Pre-refactor scope state from before the TaskSamplesView descriptor
  * existed (gridState + columnVisibility in one bag). Kept as a converter
  * for safety; no live caller reads from this slot today — the per-log
  * refactor migrates older state via the persist `migrate` hook instead.

--- a/apps/inspect/src/app/samples/list/samplesView.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.ts
@@ -1,9 +1,9 @@
 import type { FilterModel } from "ag-grid-community";
 
 import type {
-  SamplesColumn,
-  SamplesSort,
-  SamplesView,
+  TaskSamplesColumn,
+  TaskSamplesSort,
+  TaskSamplesView,
 } from "@tsmono/inspect-common/types";
 
 /**
@@ -12,12 +12,10 @@ import type {
  * writes via `Task(viewer=ViewerConfig(task_samples_view=...))` and
  * what the eval log carries through to the frontend.
  *
- * `SamplesView.filter` is a raw DSL expression string.
- *
  * Re-exported here for convenience so SampleList code can import every
  * samples-view type from a single module.
  */
-export type { SamplesColumn, SamplesSort, SamplesView };
+export type { TaskSamplesColumn, TaskSamplesSort, TaskSamplesView };
 
 /**
  * Runtime descriptor — what the inspect app's SampleList store holds
@@ -27,7 +25,7 @@ export type { SamplesColumn, SamplesSort, SamplesView };
  *
  * `extraColumnFilters` is TS-only. It is never serialized to Python
  * and never appears on the wire; eval authors describe defaults via
- * `SamplesView.filter` (a DSL string).
+ * `TaskSamplesView.filter` (a DSL string).
  */
 export interface SamplesViewState {
   name: string;

--- a/apps/inspect/src/app/samples/list/useSamplesView.ts
+++ b/apps/inspect/src/app/samples/list/useSamplesView.ts
@@ -1,7 +1,7 @@
 import type { ColDef, GridState } from "ag-grid-community";
 import { useCallback, useEffect, useMemo } from "react";
 
-import { type SamplesView } from "@tsmono/inspect-common/types";
+import { type TaskSamplesView } from "@tsmono/inspect-common/types";
 
 import { useStore } from "../../../state/store";
 import { getFieldKey } from "../../shared/gridUtils";
@@ -19,7 +19,7 @@ import {
 /** Single subscription to the eval-author-supplied `task_samples_view`
  *  descriptor (after picking an active variant from a multi-view list).
  *  Backs every hook that reads from the wire side. */
-function useEvalDefaultSamplesView(): SamplesView | undefined {
+function useEvalDefaultSamplesView(): TaskSamplesView | undefined {
   const evalDefaultField = useStore(
     (state) =>
       state.log.selectedLogDetails?.eval.viewer?.task_samples_view ?? null
@@ -105,7 +105,7 @@ export interface UseSamplesViewResult {
 }
 
 /**
- * Window onto the SampleList scope's `SamplesView` descriptor. Resolves
+ * Window onto the SampleList scope's `TaskSamplesView` descriptor. Resolves
  * stored > eval-author default > built-in default; seeds visibility for
  * unseeded columns; folds ag-grid `GridState` updates back into the view.
  *

--- a/apps/inspect/src/app/shared/samples-grid/colorScale.ts
+++ b/apps/inspect/src/app/shared/samples-grid/colorScale.ts
@@ -1,7 +1,7 @@
 /**
  * Pure colour-scale resolver for score-cell backgrounds.
  *
- * The wire shape (from the Python `SamplesView.score_color_scales`
+ * The wire shape (from the Python `TaskSamplesView.score_color_scales`
  * field) is one of:
  *
  *   - a named palette string (numeric scores) — `"good-high"` etc.

--- a/apps/inspect/src/app/types.ts
+++ b/apps/inspect/src/app/types.ts
@@ -103,7 +103,7 @@ export interface LogsState {
         gridState?: GridState;
       };
     };
-    /** Per-log SamplesView descriptors keyed by log file path. Missing
+    /** Per-log TaskSamplesView descriptors keyed by log file path. Missing
      *  entries fall through to the eval-author default and then the
      *  built-in default — see `useSamplesView`. */
     byLog: Record<string, SamplesViewState>;

--- a/apps/inspect/src/state/hooks.test.ts
+++ b/apps/inspect/src/state/hooks.test.ts
@@ -7,6 +7,7 @@ import { ScoreView } from "../app/samples/header-v2/ViewToggle";
 
 import {
   computeLogsWithRetried,
+  readEvalScorePanelView,
   resolveScorePanelSort,
   resolveScorePanelView,
   ScorePanelSortState,
@@ -271,6 +272,38 @@ describe("resolveScorePanelView", () => {
     for (const [stored, evalDefault, count, expected] of cases) {
       expect(resolveScorePanelView(stored, evalDefault, count)).toBe(expected);
     }
+  });
+});
+
+// =============================================================================
+// readEvalScorePanelView
+//
+// The eval-author default field was renamed `view` → `default`; old logs
+// carry `view`, new logs carry `default`, and either must resolve.
+// =============================================================================
+
+describe("readEvalScorePanelView", () => {
+  it("reads the new `default` field", () => {
+    expect(readEvalScorePanelView({ default: "grid" })).toBe("grid");
+  });
+
+  it("reads the legacy `view` field from old logs", () => {
+    expect(readEvalScorePanelView({ view: "chips" })).toBe("chips");
+  });
+
+  it("prefers `default` when both are present", () => {
+    expect(readEvalScorePanelView({ default: "grid", view: "chips" })).toBe(
+      "grid"
+    );
+  });
+
+  it("returns undefined when unset, null, or empty", () => {
+    expect(readEvalScorePanelView(undefined)).toBeUndefined();
+    expect(readEvalScorePanelView(null)).toBeUndefined();
+    expect(readEvalScorePanelView({})).toBeUndefined();
+    expect(
+      readEvalScorePanelView({ default: null, view: null })
+    ).toBeUndefined();
   });
 });
 

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -108,16 +108,27 @@ export const resolveScorePanelSort = (
   evalDefault: ScorePanelSortState | undefined
 ): ScorePanelSortState => stored ?? evalDefault ?? kDefaultScorePanelSort;
 
+// The eval-author default mode was serialized under `view` and is now
+// serialized under `default`; accept either so logs from either version
+// resolve. The value is advisory, so a miss falls through to the
+// count-based default downstream.
+export const readEvalScorePanelView = (
+  panel:
+    | { default?: ScoreView | null; view?: ScoreView | null }
+    | null
+    | undefined
+): ScoreView | undefined => panel?.default ?? panel?.view ?? undefined;
+
 /**
  * Read the eval-author-declared default score-panel view from
- * `Task(viewer=ViewerConfig(sample_score_view=ScorePanelView(view=...)))`.
+ * `Task(viewer=ViewerConfig(sample_score_view=SampleScoreView(default=...)))`.
  * Returns a primitive so Zustand's reference equality is stable.
  */
 export const useEvalScorePanelView = (): ScoreView | undefined =>
-  useStore(
-    (state) =>
-      (state.log.selectedLogDetails?.eval.viewer?.sample_score_view?.view ??
-        undefined) as ScoreView | undefined
+  useStore((state) =>
+    readEvalScorePanelView(
+      state.log.selectedLogDetails?.eval.viewer?.sample_score_view
+    )
   );
 
 /**

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -72,7 +72,7 @@ export interface LogsSlice {
       visibility: Record<string, boolean>
     ) => void;
 
-    /** Persist a SamplesView descriptor for a specific log file. The
+    /** Persist a TaskSamplesView descriptor for a specific log file. The
      *  log path is captured by the caller at hook level so a navigation
      *  that races a pending effect can't redirect the write to a
      *  different log's bucket. */

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -2506,7 +2506,7 @@ export interface components {
         };
         /**
          * MetadataField
-         * @description A metadata key promoted out of metadata into a top level value.
+         * @description Identifies a field in metadata.
          */
         MetadataField: {
             /**
@@ -2890,9 +2890,9 @@ export interface components {
          * @description How the sample-header score panel should render when there are 3 or more scores.
          */
         SampleScoreView: {
+            /** Default */
+            default?: ("chips" | "grid") | null;
             sort?: components["schemas"]["SampleScoreViewSort"] | null;
-            /** View */
-            view?: ("chips" | "grid") | null;
         };
         /**
          * SampleScoreViewSort
@@ -2918,72 +2918,6 @@ export interface components {
             refresh: number;
             /** Samples */
             samples: components["schemas"]["EvalSampleSummary"][];
-        };
-        /**
-         * SamplesColumn
-         * @description A column entry in the task's Sample List view.
-         */
-        SamplesColumn: {
-            /** Id */
-            id: string;
-            /**
-             * Visible
-             * @default true
-             */
-            visible: boolean;
-        };
-        /**
-         * SamplesSort
-         * @description A single sort entry for the task's Sample List grid.
-         */
-        SamplesSort: {
-            /** Column */
-            column: string;
-            /**
-             * Dir
-             * @default asc
-             * @enum {string}
-             */
-            dir: "asc" | "desc";
-        };
-        /**
-         * SamplesView
-         * @description Default configuration for the task's Sample List grid.
-         *
-         *     Configures the list of samples shown in a task's eval-log view —
-         *     distinct from `sample_score_view`, which configures the score panel
-         *     within an individual sample's detail view.
-         *
-         *     The viewer applies `SamplesView` only when the user has not
-         *     explicitly overridden the view in their browser. User overrides
-         *     shadow the eval-author default; the resolution priority is
-         *     `user > eval default > built-in`.
-         */
-        SamplesView: {
-            /** Color Scales Enabled */
-            color_scales_enabled?: boolean | null;
-            /** Columns */
-            columns?: components["schemas"]["SamplesColumn"][] | null;
-            /** Compact Scores */
-            compact_scores?: boolean | null;
-            /** Filter */
-            filter?: string | null;
-            /** Multiline */
-            multiline?: boolean | null;
-            /** Name */
-            name: string;
-            /** Score Color Scales */
-            score_color_scales?: {
-                [key: string]: ("good-high" | "good-low" | "neutral" | "diverging") | components["schemas"]["ScoreColorScale"] | {
-                    [key: string]: "good" | "bad" | "warn" | "info" | "muted";
-                };
-            } | null;
-            /** Score Labels */
-            score_labels?: {
-                [key: string]: string;
-            } | null;
-            /** Sort */
-            sort?: components["schemas"]["SamplesSort"][] | null;
         };
         /**
          * SandboxEnvironmentSpec
@@ -3068,7 +3002,7 @@ export interface components {
         };
         /**
          * ScannerResultView
-         * @description Customizes the rendering of scanner results.
+         * @description Customizes the rendering of the sample scanner results.
          */
         ScannerResultView: {
             /** Exclude Fields */
@@ -3501,6 +3435,68 @@ export interface components {
             value?: number | null;
         };
         /**
+         * TaskSamplesColumn
+         * @description A column entry in the task's Sample List view.
+         */
+        TaskSamplesColumn: {
+            /** Id */
+            id: ("sampleStatus" | "sampleId" | "sampleUuid" | "epoch" | "input" | "target" | "answer" | "tokens" | "duration" | "retries" | "error" | "limit") | string;
+            /**
+             * Visible
+             * @default true
+             */
+            visible: boolean;
+        };
+        /**
+         * TaskSamplesSort
+         * @description A single sort entry for the task's Sample List grid.
+         */
+        TaskSamplesSort: {
+            /** Column */
+            column: ("sampleStatus" | "sampleId" | "sampleUuid" | "epoch" | "input" | "target" | "answer" | "tokens" | "duration" | "retries" | "error" | "limit") | string;
+            /**
+             * Dir
+             * @default asc
+             * @enum {string}
+             */
+            dir: "asc" | "desc";
+        };
+        /**
+         * TaskSamplesView
+         * @description Default configuration for the task's Sample List grid.
+         *
+         *     Configures the list of samples shown in a task's eval-log view.
+         *
+         *     The viewer applies `TaskSamplesView` only when the user has not
+         *     explicitly overridden the view in their browser. User overrides
+         *     shadow the eval-author default; the resolution priority is
+         *     `user > eval default > built-in`.
+         */
+        TaskSamplesView: {
+            /** Color Scales Enabled */
+            color_scales_enabled?: boolean | null;
+            /** Columns */
+            columns?: components["schemas"]["TaskSamplesColumn"][] | null;
+            /** Compact Scores */
+            compact_scores?: boolean | null;
+            /** Multiline */
+            multiline?: boolean | null;
+            /** Name */
+            name: string;
+            /** Score Color Scales */
+            score_color_scales?: {
+                [key: string]: ("good-high" | "good-low" | "neutral" | "diverging") | components["schemas"]["ScoreColorScale"] | {
+                    [key: string]: "good" | "bad" | "warn" | "info" | "muted";
+                };
+            } | null;
+            /** Score Labels */
+            score_labels?: {
+                [key: string]: string;
+            } | null;
+            /** Sort */
+            sort?: components["schemas"]["TaskSamplesSort"][] | null;
+        };
+        /**
          * TimeInterval
          * @description Fire after a wall-clock interval.
          *
@@ -3863,9 +3859,8 @@ export interface components {
          * ViewerConfig
          * @description Top-level viewer configuration.
          *
-         *     `scanner_result_view` keys are fnmatch-style glob patterns (`"*"`,
-         *     ``"audit_*"``, exact names). Pass a ScannerResultView to apply a single
-         *     configuration to every scanner.
+         *     This allows per task customization of the
+         *     Task's sample list and each sample's score and scanner result display.
          */
         ViewerConfig: {
             sample_score_view?: components["schemas"]["SampleScoreView"] | null;
@@ -3874,7 +3869,7 @@ export interface components {
                 [key: string]: components["schemas"]["ScannerResultView"];
             };
             /** Task Samples View */
-            task_samples_view?: components["schemas"]["SamplesView"] | components["schemas"]["SamplesView"][] | null;
+            task_samples_view?: components["schemas"]["TaskSamplesView"] | components["schemas"]["TaskSamplesView"][] | null;
         };
     };
     responses: never;

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -116,9 +116,9 @@ export type ScannerResultField = S["ScannerResultField"];
 export type MetadataField = S["MetadataField"];
 export type SampleScoreView = S["SampleScoreView"];
 export type SampleScoreViewSort = S["SampleScoreViewSort"];
-export type SamplesView = S["SamplesView"];
-export type SamplesColumn = S["SamplesColumn"];
-export type SamplesSort = S["SamplesSort"];
+export type TaskSamplesView = S["TaskSamplesView"];
+export type TaskSamplesColumn = S["TaskSamplesColumn"];
+export type TaskSamplesSort = S["TaskSamplesSort"];
 
 // Timeline types
 export type Timeline = S["Timeline"];


### PR DESCRIPTION
Draft. Client-side counterpart to the inspect_ai viewer-config changes (PR in `UKGovernmentBEIS/inspect_ai`). The eval log carries the viewer config as raw JSON, so these are wire-level adjustments to match the regenerated schema.

## Changes
- **Score panel `default`**: the eval-author default mode was renamed `view` → `default` in the Python schema. `readEvalScorePanelView` now reads `default` and falls back to the legacy `view`, so logs written by either version resolve. The value is advisory, so a miss falls through to the count-based default. Extracted into a pure, tested helper.
- **Wire type rename**: re-exported wire types `SamplesView`/`SamplesColumn`/`SamplesSort` → `TaskSamplesView`/`TaskSamplesColumn`/`TaskSamplesSort`, propagated to all consumers. Runtime client constructs (`SamplesViewState`, `useSamplesView`, etc.) keep their names.
- **`filter` removed**: dropped the removed `filter` field from the wire↔state converters and tests. Runtime DSL filtering (`SamplesViewState.filters`) is unaffected.
- Regenerated `generated.ts` from `inspect-openapi.json`.

## Verification
- `pnpm check` (typecheck + lint + format) green on `@meridianlabs/log-viewer` and `@tsmono/inspect-common`.
- 65 tests pass (converters + hooks), including cross-version `readEvalScorePanelView` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)