### PR TITLE
Show sample-limit (operator cancel) event in swimlane views

### DIFF
--- a/packages/inspect-components/src/transcript/InterruptEventView.tsx
+++ b/packages/inspect-components/src/transcript/InterruptEventView.tsx
@@ -33,7 +33,10 @@ export const InterruptEventView: FC<InterruptEventViewProps> = ({
   className,
 }) => {
   const event = eventNode.event;
-  const title = SOURCE_TITLES[event.source];
+  const baseTitle = SOURCE_TITLES[event.source];
+  const title = event.timestamp
+    ? `${baseTitle} — ${formatDateTime(new Date(event.timestamp))}`
+    : baseTitle;
   const detail = INTERRUPTED_DESCRIPTIONS[event.interrupted];
 
   return (
@@ -42,9 +45,6 @@ export const InterruptEventView: FC<InterruptEventViewProps> = ({
       title={title}
       icon={TranscriptIcons.interrupt}
       className={className}
-      subTitle={
-        event.timestamp ? formatDateTime(new Date(event.timestamp)) : undefined
-      }
     >
       <div className={clsx("text-size-smaller")}>{detail}</div>
     </EventPanel>

--- a/packages/inspect-components/src/transcript/ModelEventView.module.css
+++ b/packages/inspect-components/src/transcript/ModelEventView.module.css
@@ -50,6 +50,19 @@
   margin: 0.5em 0;
 }
 
+.cancelled {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  color: var(--bs-secondary-color);
+  padding: 0.5em;
+  border: 1px solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  white-space: pre-wrap;
+  font-size: var(--inspect-font-size-smaller);
+  margin: 0.5em 0;
+}
+
 .showAllLink {
   text-align: center;
   padding: 0.5em 0 0.7em;

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -22,7 +22,7 @@ import { attemptDurationSec } from "./event/attemptDuration";
 import { EventPanel } from "./event/EventPanel";
 import { EventSection } from "./event/EventSection";
 import { RetryChip } from "./event/RetryChip";
-import { formatTiming, formatTitle } from "./event/utils";
+import { formatTiming, formatTitle, isCancelError } from "./event/utils";
 import { TranscriptIcons } from "./icons";
 import styles from "./ModelEventView.module.css";
 import { retryAttemptKey } from "./timeline/retryGrouping";
@@ -57,7 +57,10 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     attempts?.find((a) => retryAttemptKey(a) === selectedAttemptKey) ??
     successEvent;
   const event = selectedEvent;
-  const isFailed = !!event.error;
+  // An operator/limit/system cancel stamps a sentinel on `error`, but it isn't
+  // a genuine failure — surface it as "Cancelled", not a red "FAILED" error.
+  const isCancelled = isCancelError(event.error);
+  const isFailed = !!event.error && !isCancelled;
 
   const totalUsage = event.output?.usage?.total_tokens;
   const callTime = event.output?.time;
@@ -115,13 +118,15 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   const [showAllMessages, setShowAllMessages] = useState(false);
 
   const summaryMessages = useMemo(() => {
-    // Filter the synthetic empty-assistant placeholder only while the
-    // event is in flight — once it completes, the same predicate would
-    // also drop legitimate tool_use-only outputs, since
-    // isLivePlaceholderMessage treats those as "no visible content".
-    const outputs = event.pending
-      ? (outputMessages || []).filter((m) => !isLivePlaceholderMessage(m))
-      : outputMessages || [];
+    // Filter the synthetic empty-assistant placeholder while the event is in
+    // flight, or when it was cancelled (the interrupted generation produced no
+    // real output) — otherwise the same predicate would drop legitimate
+    // tool_use-only outputs, since isLivePlaceholderMessage treats those as
+    // "no visible content".
+    const outputs =
+      event.pending || isCancelled
+        ? (outputMessages || []).filter((m) => !isLivePlaceholderMessage(m))
+        : outputMessages || [];
     return showAllMessages
       ? [...event.input, ...outputs]
       : [...userMessages, ...outputs];
@@ -129,6 +134,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     showAllMessages,
     event.input,
     event.pending,
+    isCancelled,
     outputMessages,
     userMessages,
   ]);
@@ -145,7 +151,9 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
 
   const titleString = isFailed
     ? `${panelTitle} · FAILED${formatFailureTime(event)}`
-    : formatTitle(panelTitle, totalUsage, callTime);
+    : isCancelled
+      ? `${panelTitle} · Cancelled${formatFailureTime(event)}`
+      : formatTitle(panelTitle, totalUsage, callTime);
 
   const turnLabel = context?.turnInfo
     ? `turn ${context.turnInfo.turnNumber}/${context.turnInfo.totalTurns}`
@@ -204,7 +212,12 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
           }}
           labels={summaryLabels}
         />
-        {event.error ? (
+        {isCancelled ? (
+          <div className={styles.cancelled}>
+            <i className={TranscriptIcons.cancel} />
+            <span>{event.error}</span>
+          </div>
+        ) : event.error ? (
           <EventSection title="Error">
             <div className={styles.error}>{event.error}</div>
           </EventSection>

--- a/packages/inspect-components/src/transcript/SampleLimitEventView.tsx
+++ b/packages/inspect-components/src/transcript/SampleLimitEventView.tsx
@@ -5,6 +5,7 @@ import type {
   EvalSampleLimit,
   SampleLimitEvent,
 } from "@tsmono/inspect-common/types";
+import { formatDateTime } from "@tsmono/util";
 
 import { EventPanel } from "./event/EventPanel";
 import { TranscriptIcons } from "./icons";
@@ -31,7 +32,7 @@ export const SampleLimitEventView: FC<SampleLimitEventViewProps> = ({
       case "token":
         return "Token Limit Exceeded";
       case "operator":
-        return "Operator Canceled";
+        return "Operator Cancelled";
       case "working":
         return "Execution Time Limit Exceeded";
       case "cost":
@@ -58,7 +59,10 @@ export const SampleLimitEventView: FC<SampleLimitEventViewProps> = ({
     }
   };
 
-  const title = resolve_title(eventNode.event.type);
+  const baseTitle = resolve_title(eventNode.event.type);
+  const title = eventNode.event.timestamp
+    ? `${baseTitle} — ${formatDateTime(new Date(eventNode.event.timestamp))}`
+    : baseTitle;
   const icon = resolve_icon(eventNode.event.type);
 
   return (

--- a/packages/inspect-components/src/transcript/event/utils.test.ts
+++ b/packages/inspect-components/src/transcript/event/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isCancelError } from "./utils";
+
+describe("isCancelError", () => {
+  it("recognizes the cancel sentinels", () => {
+    expect(isCancelError("Cancelled by operator")).toBe(true);
+    expect(isCancelError("Cancelled by limit")).toBe(true);
+    expect(isCancelError("Cancelled by system")).toBe(true);
+  });
+
+  it("treats genuine errors and empty values as failures", () => {
+    expect(isCancelError("Connection reset by peer")).toBe(false);
+    expect(isCancelError("")).toBe(false);
+    expect(isCancelError(null)).toBe(false);
+    expect(isCancelError(undefined)).toBe(false);
+  });
+});

--- a/packages/inspect-components/src/transcript/event/utils.ts
+++ b/packages/inspect-components/src/transcript/event/utils.ts
@@ -13,6 +13,19 @@ const sampleLimitTitles: Record<string, string> = {
   cost: "Cost Limit Exceeded",
 };
 
+// Sentinel strings stamped on `ModelEvent.error` when an in-flight generate
+// call is cancelled rather than failing. Mirrors Python's `CANCEL_ERRORS`
+// (inspect_ai.event._model) — fixed strings so they round-trip through the log.
+const cancelErrors = new Set([
+  "Cancelled by operator",
+  "Cancelled by limit",
+  "Cancelled by system",
+]);
+
+/** True when a model error is a cancel sentinel (not a genuine failure). */
+export const isCancelError = (error?: string | null): boolean =>
+  !!error && cancelErrors.has(error);
+
 const approvalDecisionLabels: Record<string, string> = {
   approve: "Approved",
   reject: "Rejected",

--- a/packages/inspect-components/src/transcript/icons.ts
+++ b/packages/inspect-components/src/transcript/icons.ts
@@ -6,6 +6,7 @@
 export const TranscriptIcons = {
   agent: "bi bi-grid",
   approve: "bi bi-shield",
+  cancel: "bi bi-x-circle",
   checkpoint: "bi bi-bookmark-check-fill",
   approvals: {
     approve: "bi bi-shield-check",

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -1736,6 +1736,21 @@ export function buildTimeline(events: Event[]): Timeline {
   const hasPhaseSpans =
     topSpans.has("init") || topSpans.has("solvers") || topSpans.has("scorers");
 
+  // Top-level items that don't belong to a phase span — e.g. a SampleLimitEvent
+  // (span_id=null) recorded when an eval is interrupted. The phase-span branch
+  // below partitions events strictly by init/solvers/scorers, so these would
+  // otherwise be dropped from the tree and stay invisible in swimlane views
+  // (ts-mono#178). The no-phase-spans branch already keeps them via
+  // buildAgentFromTree(tree).
+  const orphanNodes = hasPhaseSpans
+    ? tree
+        .filter(
+          (item) => !(isSpanNode(item) && topSpans.get(item.name) === item)
+        )
+        .map(treeItemToNode)
+        .filter((n): n is TimelineEvent | TimelineSpan => n !== null)
+    : [];
+
   let root: TimelineSpan;
 
   if (hasPhaseSpans) {
@@ -1833,6 +1848,15 @@ export function buildTimeline(events: Event[]): Timeline {
         spanType: null,
       });
     }
+  }
+
+  // Slot orphan top-level events into the root chronologically. Root content is
+  // already in timestamp order and JS sort is stable, so existing items keep
+  // their relative order and orphans land at the right point.
+  if (orphanNodes.length > 0) {
+    root.content = [...root.content, ...orphanNodes].sort(
+      (a, b) => a.startTime().getTime() - b.startTime().getTime()
+    );
   }
 
   return { name: "Default", description: "", root };

--- a/packages/inspect-components/src/transcript/timeline/sampleLifecycleEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/sampleLifecycleEvents.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for top-level sample-lifecycle events (ts-mono#178).
+ *
+ * A `SampleLimitEvent` (e.g. an operator interrupt) is recorded with
+ * `span_id=null` — it belongs to no agent span. When the transcript has the
+ * usual init/solvers/scorers phase spans, `buildTimeline` previously consumed
+ * only those spans and dropped any top-level orphan event, making the event
+ * invisible in swimlane views. It must instead land in the root span's content.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { buildTimeline, TimelineEvent, type TimelineSpan } from "./core";
+
+let clock = 0;
+function ts(): string {
+  clock += 1;
+  return new Date(Date.UTC(2026, 0, 1, 0, 0, clock)).toISOString();
+}
+
+const base = () => ({
+  uuid: null,
+  timestamp: ts(),
+  working_start: 0,
+  pending: false,
+  metadata: null,
+});
+
+function spanBegin(
+  id: string,
+  name: string,
+  type: string | null,
+  parentId: string | null
+): Event {
+  return {
+    ...base(),
+    event: "span_begin",
+    id,
+    name,
+    type,
+    parent_id: parentId,
+    span_id: null,
+  } as unknown as Event;
+}
+
+function spanEnd(id: string): Event {
+  return {
+    ...base(),
+    event: "span_end",
+    id,
+    span_id: null,
+  } as unknown as Event;
+}
+
+function modelTurn(spanId: string): Event {
+  return {
+    ...base(),
+    event: "model",
+    model: "mockllm/model",
+    completed: ts(),
+    span_id: spanId,
+    input: [{ role: "user", content: "go" }],
+    output: {
+      choices: [
+        { message: { role: "assistant", content: "ok" }, stop_reason: "stop" },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1 },
+    },
+  } as unknown as Event;
+}
+
+function sampleLimitEvent(): Event {
+  return {
+    ...base(),
+    event: "sample_limit",
+    type: "operator",
+    message: "Sample completed: interrupted by operator",
+    limit: null,
+    span_id: null,
+  } as unknown as Event;
+}
+
+/** Recursively collect the underlying Events from a span's content tree. */
+function collectEvents(span: TimelineSpan): Event[] {
+  const out: Event[] = [];
+  for (const item of span.content) {
+    if (item instanceof TimelineEvent) {
+      out.push(item.event);
+    } else {
+      out.push(...collectEvents(item));
+    }
+  }
+  return out;
+}
+
+describe("top-level sample-lifecycle events", () => {
+  // A normal eval transcript: init/solvers/scorers phase spans, then an
+  // operator-interrupt SampleLimitEvent at the top level (span_id=null).
+  const events: Event[] = [
+    spanBegin("init", "init", "init", null),
+    spanEnd("init"),
+    spanBegin("solvers", "solvers", "solvers", null),
+    modelTurn("solvers"),
+    spanEnd("solvers"),
+    sampleLimitEvent(),
+  ];
+
+  const timeline = buildTimeline(events);
+
+  it("includes the sample_limit event in the timeline tree", () => {
+    const collected = collectEvents(timeline.root);
+    expect(collected.some((e) => e.event === "sample_limit")).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #178.

## Problem

A `SampleLimitEvent` (e.g. an operator interrupt) is recorded with `span_id=null` — it belongs to no agent span. It rendered fine in no-swimlane mode but was **invisible whenever swimlanes were active**.

Root cause is in `buildTimeline`: for a normal eval (which has `init`/`solvers`/`scorers` phase spans), the phase-span path partitioned events strictly by those three spans and silently dropped any top-level orphan event. The no-phase-spans path (`buildAgentFromTree`) already kept such orphans, so the two paths were inconsistent.

## Fix

`buildTimeline` now collects top-level items that don't belong to a phase span and merges them into the root span's content **chronologically** (root content is already timestamp-ordered and JS sort is stable, so existing items keep their order and orphans slot into place). The `sample_limit` event lands in the root ("main") swimlane row — the natural place for a sample-lifecycle event — and renders in both swimlane and no-swimlane modes.

## Display refinements

With the event now visible, three near-duplicate representations of a cancel were showing. Aligned their display:

- **`ModelEventView`** — an operator/limit/system cancel stamps a sentinel on `error`, but it isn't a genuine failure. A new `isCancelError()` (mirroring Python's `CANCEL_ERRORS`) recognizes it; the call now reads as **`· Cancelled`** in a muted grey box with a circular-x icon instead of a red **`· FAILED`** error, and the empty-assistant placeholder is filtered from the cancelled summary view.
- **`InterruptEventView` / `SampleLimitEventView`** — show the event timestamp in the title after an em dash.

## Tests

- `sampleLifecycleEvents.test.ts` — regression test asserting the top-level `sample_limit` event appears in the timeline tree when phase spans are present (fails before the fix).
- `event/utils.test.ts` — unit coverage for `isCancelError`.
- Full suite: 422 passing / 2 skipped. `pnpm check` clean (typecheck + lint + format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)