### PR TITLE
Fix logsSlice loading counter: always call setLoading in syncLogs

### DIFF
--- a/apps/inspect/e2e/error-state.spec.ts
+++ b/apps/inspect/e2e/error-state.spec.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse, delay } from "msw";
+import { delay, http, HttpResponse } from "msw";
 
 import { expect, test } from "./fixtures/app";
 

--- a/apps/inspect/e2e/error-state.spec.ts
+++ b/apps/inspect/e2e/error-state.spec.ts
@@ -1,11 +1,3 @@
-/**
- * E2E tests for error state display in the log-list grid.
- *
- * Covers two scenarios:
- * 1. A plain server 500 replaces the grid with an ErrorPanel.
- * 2. A slow 500 exercises the full ActivityBar → "Loading" → ErrorPanel → idle
- *    sequence, which only works when syncLogs always calls setLoading(true).
- */
 import { http, HttpResponse, delay } from "msw";
 
 import { expect, test } from "./fixtures/app";
@@ -27,7 +19,7 @@ test.describe("Server error state", () => {
     await page.goto("/");
 
     // The ErrorPanel should appear with the error message
-    const errorPanel = page.locator("[class*='errorPanel']");
+    const errorPanel = page.locator("[data-testid='error-panel']");
     await expect(errorPanel).toBeVisible({ timeout: 10_000 });
 
     // The AG Grid should NOT be visible
@@ -50,7 +42,7 @@ test.describe("Server error state", () => {
     );
 
     await page.goto("/");
-    const errorPanel = page.locator("[class*='errorPanel']");
+    const errorPanel = page.locator("[data-testid='error-panel']");
     await expect(errorPanel).toBeVisible({ timeout: 10_000 });
 
     // Second load: restore default (empty success)
@@ -63,6 +55,7 @@ test.describe("Server error state", () => {
     // Navigate away and back to trigger a fresh load
     await page.goto("/");
     await expect(errorPanel).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(".ag-root")).toBeVisible({ timeout: 10_000 });
   });
 
   test("shows ActivityBar, Loading..., then ErrorPanel after a delayed 500", async ({
@@ -104,7 +97,7 @@ test.describe("Server error state", () => {
     await expect(page.getByText("Loading")).toBeVisible();
 
     // After the delayed 500 resolves the error panel must appear
-    await expect(page.locator("[class*='errorPanel']")).toBeVisible({
+    await expect(page.locator("[data-testid='error-panel']")).toBeVisible({
       timeout: 10_000,
     });
 

--- a/apps/inspect/e2e/error-state.spec.ts
+++ b/apps/inspect/e2e/error-state.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E tests for error state display in the log-list grid.
+ *
+ * Covers two scenarios:
+ * 1. A plain server 500 replaces the grid with an ErrorPanel.
+ * 2. A slow 500 exercises the full ActivityBar → "Loading" → ErrorPanel → idle
+ *    sequence, which only works when syncLogs always calls setLoading(true).
+ */
+import { http, HttpResponse, delay } from "msw";
+
+import { expect, test } from "./fixtures/app";
+
+test.describe("Server error state", () => {
+  test("shows ErrorPanel when /api/log-files returns 500", async ({
+    page,
+    network,
+  }) => {
+    network.use(
+      http.get("*/api/log-files*", () => {
+        return HttpResponse.json(
+          { error: "Internal Server Error: database connection failed" },
+          { status: 500 }
+        );
+      })
+    );
+
+    await page.goto("/");
+
+    // The ErrorPanel should appear with the error message
+    const errorPanel = page.locator("[class*='errorPanel']");
+    await expect(errorPanel).toBeVisible({ timeout: 10_000 });
+
+    // The AG Grid should NOT be visible
+    const grid = page.locator(".ag-root");
+    await expect(grid).not.toBeVisible();
+  });
+
+  test("clears error and shows grid on successful retry", async ({
+    page,
+    network,
+  }) => {
+    // First load: server error
+    network.use(
+      http.get("*/api/log-files*", () => {
+        return HttpResponse.json(
+          { error: "Internal Server Error" },
+          { status: 500 }
+        );
+      })
+    );
+
+    await page.goto("/");
+    const errorPanel = page.locator("[class*='errorPanel']");
+    await expect(errorPanel).toBeVisible({ timeout: 10_000 });
+
+    // Second load: restore default (empty success)
+    network.use(
+      http.get("*/api/log-files*", () => {
+        return HttpResponse.json({ files: [], response_type: "full" });
+      })
+    );
+
+    // Navigate away and back to trigger a fresh load
+    await page.goto("/");
+    await expect(errorPanel).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows ActivityBar, Loading..., then ErrorPanel after a delayed 500", async ({
+    page,
+    network,
+  }) => {
+    network.use(
+      // Provide a valid log root so initLogDir succeeds and the replication
+      // path is entered. Without this, /api/logs fails with ECONNREFUSED and
+      // the error arrives before the loading state is ever set.
+      http.get("*/api/logs*", () => {
+        return HttpResponse.json({ log_dir: "/home/test/logs" });
+      }),
+
+      // Slow 500 on the log-files endpoint so the loading indicators are
+      // visible for long enough to be asserted.
+      http.get("*/api/log-files*", async () => {
+        await delay(1000);
+        return HttpResponse.json(
+          { error: "Internal Server Error" },
+          { status: 500 }
+        );
+      })
+    );
+
+    await page.goto("/");
+
+    // ActivityBar must animate while the request is in-flight.
+    // The inner animated div is a child of [role='progressbar']; its presence
+    // signals animating=true. toBeEmpty() only checks text content so we
+    // target the child directly.
+    const activityBarChild = page
+      .locator("[role='progressbar']")
+      .first()
+      .locator("> div");
+    await expect(activityBarChild).toBeVisible({ timeout: 5_000 });
+
+    // Grid loading overlay should be visible while loading=1
+    await expect(page.getByText("Loading")).toBeVisible();
+
+    // After the delayed 500 resolves the error panel must appear
+    await expect(page.locator("[class*='errorPanel']")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // And the ActivityBar must have stopped (child div gone)
+    await expect(activityBarChild).not.toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -4,7 +4,7 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { EvalSet } from "@tsmono/inspect-common/types";
-import { ProgressBar } from "@tsmono/react/components";
+import { ErrorPanel, ProgressBar } from "@tsmono/react/components";
 import { useProperty } from "@tsmono/react/hooks";
 import { dirname, isInDirectory } from "@tsmono/util";
 
@@ -68,6 +68,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   const { filteredCount } = useLogsListing();
 
   const syncing = useStore((state) => state.app.status.syncing);
+  const error = useStore((state) => state.app.status.error);
 
   const watchedLogs = useStore((state) => state.logs.listing.watchedLogs);
   const navigate = useNavigate();
@@ -425,32 +426,39 @@ export const LogsPanel: FC<LogsPanelProps> = ({
         onScoresViewModeChange={setScoresViewMode}
       />
 
-      <>
-        <div className={clsx(styles.list, "text-size-smaller")}>
-          <LogListGrid
-            items={logItems}
-            currentPath={currentDir}
-            scopeKey={scopeKey}
-            gridRef={gridRef}
-            mode={mode}
-          />
-        </div>
-        <LogListFooter
-          itemCount={logItems.length}
-          filteredCount={filteredCount}
-          progressText={syncing ? "Syncing data" : undefined}
-          progressBar={
-            progress.total !== progress.complete ? (
-              <ProgressBar
-                min={0}
-                max={progress.total}
-                value={progress.complete}
-                width="100px"
-              />
-            ) : undefined
-          }
+      {error ? (
+        <ErrorPanel
+          title="Error"
+          error={{ message: error.message, stack: error.stack }}
         />
-      </>
+      ) : (
+        <>
+          <div className={clsx(styles.list, "text-size-smaller")}>
+            <LogListGrid
+              items={logItems}
+              currentPath={currentDir}
+              scopeKey={scopeKey}
+              gridRef={gridRef}
+              mode={mode}
+            />
+          </div>
+          <LogListFooter
+            itemCount={logItems.length}
+            filteredCount={filteredCount}
+            progressText={syncing ? "Syncing data" : undefined}
+            progressBar={
+              progress.total !== progress.complete ? (
+                <ProgressBar
+                  min={0}
+                  max={progress.total}
+                  value={progress.complete}
+                  width="100px"
+                />
+              ) : undefined
+            }
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -271,10 +271,7 @@ export const createLogsSlice = (
       },
       syncLogs: async () => {
         const databaseService = get().databaseService;
-        const useProgress = !!databaseService?.getDatabaseHandle();
-        if (useProgress) {
-          get().appActions.setLoading(true);
-        }
+        get().appActions.setLoading(true);
 
         // Determine the log directory
         const logDir = await get().logsActions.initLogDir();
@@ -304,16 +301,18 @@ export const createLogsSlice = (
               return databaseService;
             } catch (e) {
               console.log(e);
-              if (useProgress) {
-                get().appActions.setLoading(false, e as Error);
-              }
+              get().appActions.setLoading(false, e as Error);
               return;
             }
           };
 
-          // Don't enable syncing if there is no log directory
+          // Don't enable syncing if there is no log directory.
+          // initLogDir may have already called setLoading(false, e) via its own
+          // catch block; the counter is clamped at zero so the extra decrement
+          // here is safe, and we avoid overwriting a non-null error by only
+          // calling setLoading(false) when no error was already recorded.
           if (!logDir || isSingleFileMode) {
-            if (useProgress) {
+            if (!get().app.status.error) {
               get().appActions.setLoading(false);
             }
             return [];
@@ -378,9 +377,7 @@ export const createLogsSlice = (
           );
         }
 
-        if (useProgress) {
-          get().appActions.setLoading(false);
-        }
+        get().appActions.setLoading(false);
 
         // Sync
         return (await get().replicationService?.sync(initDatabase)) || [];

--- a/packages/react/src/components/ErrorPanel.tsx
+++ b/packages/react/src/components/ErrorPanel.tsx
@@ -21,7 +21,10 @@ export const ErrorPanel: FC<ErrorPanelProps> = ({ title, error }) => {
   const stack = error.stack;
 
   return (
-    <div className={clsx(styles.errorPanel, styles.centeredFlex)}>
+    <div
+      data-testid="error-panel"
+      className={clsx(styles.errorPanel, styles.centeredFlex)}
+    >
       <div className={clsx(styles.heading, styles.centeredFlex)}>
         <div>
           <i className={clsx(icons.error, styles.errorIcon)}></i>


### PR DESCRIPTION
## Summary

- `syncLogs` gated all `setLoading` calls behind `useProgress` (`!!databaseService?.getDatabaseHandle()`), which is false whenever there is no database service (e.g. the MSW test environment, and any lightweight deployment without a DatabaseService). This meant the loading counter stayed at 0 throughout a fetch — the ActivityBar never animated and errors from `sync()` were never surfaced to the UI.
- Remove `useProgress` entirely. `setLoading(true)` is now called unconditionally at the top of `syncLogs`; every exit path calls `setLoading(false[, error])`.
- The `!logDir` early-return path now checks `get().app.status.error` before calling `setLoading(false)` to avoid overwriting an error already recorded by `initLogDir`'s own catch block.

## Regression test

`apps/inspect/e2e/error-state.spec.ts` — new test: **"shows ActivityBar, Loading..., then ErrorPanel after a delayed 500"**

Uses `msw`'s `delay()` to hold the `/api/log-files` response for 1 second, then returns a 500. Asserts:
1. `[role='progressbar'] > div` becomes visible (ActivityBar animating)
2. `getByText("Loading")` is visible (grid loading overlay)
3. `[class*='errorPanel']` appears after the delay
4. `[role='progressbar'] > div` disappears (ActivityBar stops)

This test would time out on `main` without the `setLoading` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)