### PR TITLE
Show backed-up files in CheckpointEventView

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -3200,8 +3200,12 @@ export interface components {
          *     from restic's backup summary — see :class:`ResticBackupSummary`.
          */
         SnapshotDetails: {
+            /** Additional Files */
+            additional_files?: number | null;
             /** Duration Ms */
             duration_ms: number;
+            /** Files */
+            files?: string[] | null;
             /** Size Bytes */
             size_bytes: number;
             /** Snapshot Id */

--- a/packages/inspect-components/src/transcript/CheckpointEventView.module.css
+++ b/packages/inspect-components/src/transcript/CheckpointEventView.module.css
@@ -23,3 +23,19 @@
 .indented {
   padding-left: 1.5em;
 }
+
+.files {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1em;
+  font-family: var(--bs-font-monospace);
+}
+
+.file {
+  overflow-wrap: anywhere;
+}
+
+.fileOverflow {
+  font-style: italic;
+  opacity: 0.7;
+}

--- a/packages/inspect-components/src/transcript/CheckpointEventView.tsx
+++ b/packages/inspect-components/src/transcript/CheckpointEventView.tsx
@@ -29,6 +29,29 @@ const SizeAndDuration: FC<{ size_bytes: number; duration_ms: number }> = ({
   </>
 );
 
+const Files: FC<{
+  files?: string[] | null;
+  additionalFiles?: number | null;
+}> = ({ files, additionalFiles }) => {
+  if (!files || files.length === 0) {
+    return null;
+  }
+  return (
+    <LabeledValue label="Files" layout="column">
+      <div className={styles.files}>
+        {files.map((file) => (
+          <div key={file} className={styles.file}>
+            {file}
+          </div>
+        ))}
+        {additionalFiles ? (
+          <div className={styles.fileOverflow}>+{additionalFiles} more</div>
+        ) : null}
+      </div>
+    </LabeledValue>
+  );
+};
+
 export const CheckpointEventView: FC<CheckpointEventViewProps> = ({
   eventNode,
   className,
@@ -59,6 +82,10 @@ export const CheckpointEventView: FC<CheckpointEventViewProps> = ({
             size_bytes={details.size_bytes}
             duration_ms={details.duration_ms}
           />
+          <Files
+            files={details.files}
+            additionalFiles={details.additional_files}
+          />
         </div>
       </div>
     );
@@ -74,6 +101,10 @@ export const CheckpointEventView: FC<CheckpointEventViewProps> = ({
                 <SizeAndDuration
                   size_bytes={details.size_bytes}
                   duration_ms={details.duration_ms}
+                />
+                <Files
+                  files={details.files}
+                  additionalFiles={details.additional_files}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Display the optional list of files captured in a checkpoint snapshot in `CheckpointEventView`
- Show a `+N more` overflow indicator when the snapshot includes more files than are listed
- Add `files` and `additional_files` fields to the generated `SnapshotDetails` type

## Changes
- `SnapshotDetails` (generated types): new optional `files: string[] | null` and `additional_files: number | null`
- New `Files` subcomponent rendering a monospace, column-layout file list with overflow handling
- Wired into both render paths of `CheckpointEventView`