### PR TITLE
fix: outline virtualization stalls on long transcripts

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -863,6 +863,24 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   // Use getBoundingClientRect().height — this matches what's actually on
   // screen (clientHeight can report slightly different values depending on
   // scrollbar / box-sizing quirks).
+  // Capture the outline's own scroll container (the StickyScroll div, which
+  // has overflow-y:auto) into state so the outline's Virtuoso can use it as
+  // its scroll parent. Resolving into state (rather than reading a ref during
+  // render) guarantees a re-render once the element mounts. Also mirror it
+  // into the optional external ref callers pass for wheel forwarding.
+  const [outlineScrollEl, setOutlineScrollEl] = useState<HTMLDivElement | null>(
+    null
+  );
+  const handleOutlineScrollRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      setOutlineScrollEl(el);
+      if (outlineScrollRef) {
+        outlineScrollRef.current = el;
+      }
+    },
+    [outlineScrollRef]
+  );
+
   const [scrollerHeight, setScrollerHeight] = useState<number>(0);
   useEffect(() => {
     const el = scrollRef.current;
@@ -984,7 +1002,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
             {outline && (
               <>
                 <StickyScroll
-                  ref={outlineScrollRef}
+                  ref={handleOutlineScrollRef}
                   scrollRef={scrollRef}
                   className={styles.outline}
                   offsetTop={effectiveOffsetTop}
@@ -1018,6 +1036,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                         eventNodes={eventNodes}
                         defaultCollapsedIds={defaultCollapsedIds}
                         scrollRef={scrollRef}
+                        outlineScrollEl={outlineScrollEl}
                         running={running}
                         agentName={
                           outline.name ??

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
@@ -37,6 +37,10 @@ interface TranscriptOutlineProps {
   running?: boolean;
   className?: string;
   scrollRef?: RefObject<HTMLDivElement | null>;
+  /** The element that actually scrolls the outline (its own overflow
+   *  container). Used as Virtuoso's scroll parent so virtualization tracks
+   *  the outline's internal scroll rather than the shared main scroller. */
+  outlineScrollEl?: HTMLDivElement | null;
   style?: CSSProperties;
   /** Name of the agent/subagent currently being displayed. Shown as a static header. */
   agentName?: string;
@@ -92,6 +96,7 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
   running,
   className,
   scrollRef,
+  outlineScrollEl,
   style,
   agentName,
   onHasNodesChange,
@@ -305,8 +310,7 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
       )}
       <Virtuoso
         ref={listHandle}
-        // eslint-disable-next-line react-hooks/refs -- Virtuoso accepts undefined for customScrollParent
-        customScrollParent={scrollRef?.current ? scrollRef.current : undefined}
+        customScrollParent={outlineScrollEl ?? undefined}
         id={id}
         data={[...outlineNodeList, EventPaddingNode]}
         defaultItemHeight={50}


### PR DESCRIPTION
## Problem

For very long transcript outlines, the outline cut off after ~45 items and never rendered more as the user scrolled — as if the virtualizer wasn't detecting scroll.

## Root cause

The outline's `Virtuoso` used the **shared main scroll container** (`scrollRef`) as its `customScrollParent`. But the outline lives inside its own scroll container — the `StickyScroll` `.outline` div, which has `overflow-y: auto` + a capped `max-height` and scrolls internally when taller than the viewport.

Because the two were decoupled, scrolling inside a tall outline never changed the main container's `scrollTop`, so Virtuoso received no scroll event and never materialized rows beyond the window it rendered on mount.

This is the same class of bug the `VirtualList` wrapper already documents ("the first trackpad swipe goes to the wrong scroll ancestor").

## Fix

- `TranscriptLayout` captures the outline's own scroll element (the `.outline` `StickyScroll` div) into state via a callback ref, and passes it down to `TranscriptOutline`.
- `TranscriptOutline` uses that element as Virtuoso's `customScrollParent`, so virtualization tracks the outline's internal scroll.
- The main `scrollRef` is still used for scroll-tracking (highlighting the outline item matching the transcript position) and click-to-navigate.

Resolving the element into state guarantees a re-render once it mounts, and also covers consumers that don't pass the optional external `outlineScrollRef`.

## Testing

- `pnpm check` passes (typecheck, lint, format across all packages).
- Verified manually in the viewer: long outlines now scroll and continuously materialize rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)