### PR TITLE
transcript: collapse same-name nested solver/agent spans

### DIFF
--- a/packages/inspect-components/src/transcript/transform/transform.test.ts
+++ b/packages/inspect-components/src/transcript/transform/transform.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { SpanBeginEvent } from "@tsmono/inspect-common/types";
+
+import { EventNode } from "../types";
+
+import { transformTree } from "./transform";
+
+const span = (
+  id: string,
+  name: string,
+  type: string,
+  depth: number,
+  children: EventNode[] = []
+): EventNode => {
+  const event = {
+    event: "span_begin",
+    id,
+    name,
+    type,
+    timestamp: "2026-01-01T00:00:00Z",
+    working_start: 0,
+  } as SpanBeginEvent;
+  const node = new EventNode(id, event, depth);
+  node.children = children;
+  return node;
+};
+
+const names = (node: EventNode): unknown =>
+  node.children.length
+    ? {
+        name: (node.event as SpanBeginEvent).name,
+        children: node.children.map(names),
+      }
+    : (node.event as SpanBeginEvent).name;
+
+describe("collapse_same_name_spans", () => {
+  it("collapses a same-named agent span nested in a solver span", () => {
+    const leaf = span("leaf", "leaf", "solver", 2);
+    const inner = span("inner", "react_agent", "agent", 1, [leaf]);
+    const outer = span("outer", "react_agent", "solver", 0, [inner]);
+
+    const [result] = transformTree([outer]);
+
+    expect(names(result!)).toEqual({ name: "react_agent", children: ["leaf"] });
+    expect(result!.children[0]?.depth).toBe(1);
+  });
+
+  it("flattens a chain of three same-named spans", () => {
+    const leaf = span("leaf", "leaf", "tool", 3);
+    const c = span("c", "react_agent", "agent", 2, [leaf]);
+    const b = span("b", "react_agent", "agent", 1, [c]);
+    const a = span("a", "react_agent", "solver", 0, [b]);
+
+    const [result] = transformTree([a]);
+
+    expect(names(result!)).toEqual({ name: "react_agent", children: ["leaf"] });
+    expect(result!.id).toBe("a");
+    expect(result!.children[0]?.depth).toBe(1);
+  });
+
+  it("collapses when the solver name is package-qualified (as_solver, running)", () => {
+    // as_solver names the solver span via registry_log_name (keeps the package
+    // prefix for non-inspect_ai packages) and the inner agent span via the
+    // unqualified registry name — so the raw strings differ by prefix.
+    const model = span("m", "model", "model", 2);
+    const inner = span("inner", "codex_cli", "agent", 1, [model]);
+    const outer = span("outer", "inspect_swe/codex_cli", "solver", 0, [inner]);
+
+    const [result] = transformTree([outer]);
+
+    expect(names(result!)).toEqual({
+      name: "inspect_swe/codex_cli",
+      children: ["model"],
+    });
+    expect(result!.children[0]?.depth).toBe(1);
+  });
+
+  it("does not collapse nested spans with different names", () => {
+    const inner = span("inner", "other_agent", "agent", 1);
+    const outer = span("outer", "react_agent", "solver", 0, [inner]);
+
+    const [result] = transformTree([outer]);
+
+    expect(names(result!)).toEqual({
+      name: "react_agent",
+      children: ["other_agent"],
+    });
+  });
+});

--- a/packages/inspect-components/src/transcript/transform/transform.ts
+++ b/packages/inspect-components/src/transcript/transform/transform.ts
@@ -148,6 +148,13 @@ const transformers = () => {
       process: (node) => skipThisNode(node),
     },
     {
+      name: "collapse_same_name_spans",
+      matches: (node) =>
+        isAgentOrSolverSpan(node) &&
+        node.children.some((child) => isSameNameSpanChild(node, child)),
+      process: (node) => collapseSameNameSpans(node),
+    },
+    {
       name: "discard_solvers_span",
       matches: (Node) =>
         Node.event.event === SPAN_BEGIN && Node.event.type === TYPE_SOLVERS,
@@ -205,6 +212,36 @@ const elevateChildNode = (
   // and more importantly we drive children / transcripts using the tree structure itself
   // and notes rather than the event.events itself)
   return targetNode as EventNode;
+};
+
+const isAgentOrSolverSpan = (node: EventNode): boolean =>
+  node.event.event === SPAN_BEGIN &&
+  (node.event.type === TYPE_SOLVER || node.event.type === TYPE_AGENT);
+
+// Strip the package prefix so a solver span (named via registry_log_name, which
+// only strips the inspect_ai/ prefix, e.g. "inspect_swe/codex_cli") matches its
+// inner agent span (named via the unqualified registry name, e.g. "codex_cli").
+const unqualifiedSpanName = (name: string): string => {
+  const slash = name.indexOf("/");
+  return slash === -1 ? name : name.slice(slash + 1);
+};
+
+const isSameNameSpanChild = (parent: EventNode, child: EventNode): boolean =>
+  isAgentOrSolverSpan(child) &&
+  parent.event.event === SPAN_BEGIN &&
+  child.event.event === SPAN_BEGIN &&
+  unqualifiedSpanName(parent.event.name) ===
+    unqualifiedSpanName(child.event.name);
+
+// Collapse a same-named agent/solver child into its parent by hoisting the
+// child's children up one level (e.g. a react_agent span nested directly
+// inside another react_agent span). Runs depth-first, so chains of any length
+// flatten into the outermost span.
+const collapseSameNameSpans = (node: EventNode): EventNode => {
+  node.children = node.children.flatMap((child) =>
+    isSameNameSpanChild(node, child) ? reduceDepth(child.children, 1) : [child]
+  );
+  return node;
 };
 
 const unwrapNode = (node: EventNode): EventNode[] => {


### PR DESCRIPTION
## Summary

Adds a `collapse_same_name_spans` transformer that flattens redundant nesting of agent/solver spans that share a name — e.g. a `react_agent` agent span nested directly inside a `react_agent` solver span. The transformer runs depth-first, so chains of any length collapse into the outermost span.

Names are compared **unqualified**, so a package-qualified solver span (named via `registry_log_name`, which only strips the `inspect_ai/` prefix — e.g. `inspect_swe/codex_cli`) matches its inner agent span (named via the unqualified registry name — e.g. `codex_cli`).

## Why

This case was previously only handled by `unwrap_agent_solver`, which matches the **closed** `[agent, state]` / `[agent, state, store]` structure and ignores names. During a *running* eval the trailing `state`/`store` events haven't been emitted yet, so that structural rule can't fire and the doubled span shows. The new transformer is the looser, name-based rule that catches it live.

## Tests

Adds `transform.test.ts` covering:
- same-named agent span nested in a solver span
- a three-level same-name chain flattening to one
- the package-qualified solver vs. unqualified agent case (`inspect_swe/codex_cli` / `codex_cli`)
- nested spans with genuinely different names are left untouched

`pnpm check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)