### PR TITLE
Timeline: don't render primitive solvers as sub-agents

### DIFF
--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -819,12 +819,19 @@ function eventToNode(event: Event): TimelineEvent | TimelineSpan {
  *
  * Agent spans are:
  * - Explicit agent spans (type="agent")
- * - Solver spans (type="solver")
+ * - Solver spans that wrap a genuine agent (e.g. an @agent run via as_solver)
  * - Tool spans containing model events (tool-spawned agents)
+ *
+ * Primitive solver spans (system_message, generate, use_tools, ...) wrap no
+ * agent of their own, so they are not agent trajectories — they get unrolled
+ * into their parent rather than occupying a swimlane.
  */
 function isAgentSpan(span: SpanNode): boolean {
-  if (span.type === "agent" || span.type === "solver") {
+  if (span.type === "agent") {
     return true;
+  }
+  if (span.type === "solver") {
+    return containsAgentSpan(span);
   }
   if (
     span.type === "tool" &&
@@ -1544,7 +1551,8 @@ function classifyUtilityAgents(
  *
  * Within the agent section, spans are classified as agents or unrolled:
  * - type="agent"                → TimelineSpan (spanType="agent")
- * - type="solver"               → TimelineSpan (spanType="agent")
+ * - type="solver" wrapping agent → TimelineSpan (spanType="agent")
+ * - type="solver" (primitive)   → Unrolled into parent
  * - type="tool" + ModelEvents   → TimelineSpan (spanType="agent")
  * - ToolEvent with agent field  → TimelineSpan (spanType="agent")
  * - type="tool" (no models)     → Unrolled into parent


### PR DESCRIPTION
## Problem

A plain solver plan like `[system_message, generate]` rendered `generate` (and `system_message`) as **sub-agent swimlanes** under a synthetic `main` lane, instead of `generate` activity appearing in the `main` lane itself.

## Cause

`isAgentSpan` treated **every** `type="solver"` span as an agent trajectory. With two solver spans under `solvers`, the builder took the "multiple agent spans" path and wrapped them in a synthetic `main`, pushing each solver down a level.

## Fix

Treat a `type="solver"` span as an agent trajectory **only when it wraps a genuine agent** (`containsAgentSpan`). Primitive solvers (`system_message`, `generate`, `use_tools`, …) wrap no agent of their own, so the existing unroll machinery dissolves them into the parent rather than giving them a swimlane.

Result: a plain generate plan collapses into a single `main` lane with the model event inline. Behavior preserved for single agent-as-solver (still promoted to `main`), multiple agents (still separate lanes), and scoring.

## Testing

- `pnpm check` (lint + typecheck + format) green.
- All `inspect-components` timeline tests pass (429).

> Note: this classification is mirrored in the parent `inspect_ai` repo's Python timeline builder (`_timeline.py`); the matching change lands there separately so client- and server-built timelines stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)