### PR TITLE
Fix live-sample follow behavior and add tool-execution progress

### DIFF
--- a/packages/inspect-components/src/chat/ChatViewVirtualList.module.css
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.module.css
@@ -6,18 +6,6 @@
 
 .generatingRow {
   display: grid;
-  grid-template-columns: auto max-content;
-  align-items: center;
-  row-gap: 0;
+  grid-template-columns: minmax(0, 1fr);
   margin-bottom: 0.75rem;
-}
-
-.generatingLabel {
-  display: flex;
-  justify-content: flex-end;
-  margin-left: 0.4em;
-}
-
-.generatingContent {
-  padding-left: 0;
 }

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -19,7 +19,10 @@ import type {
 } from "@tsmono/react/virtual";
 
 import { GeneratingIndicator } from "../indicators/GeneratingIndicator";
-import { isLivePlaceholderMessage } from "../indicators/livePlaceholder";
+import {
+  isLivePlaceholderMessage,
+  isToolExecutingMessage,
+} from "../indicators/livePlaceholder";
 
 import { ChatMessageRow, countRowBlocks } from "./ChatMessageRow";
 import styles from "./ChatViewVirtualList.module.css";
@@ -152,18 +155,29 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
             </div>
           );
         }
+        const toolExecuting =
+          running &&
+          index === lastIndex &&
+          isToolExecutingMessage(item.message, item.toolMessages.length);
         return (
-          <ChatMessageRow
-            index={index}
-            parentName={id || "chat-virtual-list"}
-            resolvedMessage={item}
-            display={display}
-            labels={labels}
-            linking={linking}
-            tools={tools}
-            maxLabelLength={maxLabelLength}
-            startNumber={rowStartNumbers[index]}
-          />
+          <>
+            <ChatMessageRow
+              index={index}
+              parentName={id || "chat-virtual-list"}
+              resolvedMessage={item}
+              display={display}
+              labels={labels}
+              linking={linking}
+              tools={tools}
+              maxLabelLength={maxLabelLength}
+              startNumber={rowStartNumbers[index]}
+            />
+            {toolExecuting ? (
+              <div className={styles.generatingRow}>
+                <GeneratingIndicator label="running" />
+              </div>
+            ) : null}
+          </>
         );
       },
       [

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -24,7 +24,6 @@ import { isLivePlaceholderMessage } from "../indicators/livePlaceholder";
 import { ChatMessageRow, countRowBlocks } from "./ChatMessageRow";
 import styles from "./ChatViewVirtualList.module.css";
 import { computeMaxLabelLength } from "./labelLength";
-import { MessageLabel } from "./MessageLabel";
 import { ResolvedMessage, resolveMessages } from "./messages";
 import { messageSearchText } from "./messageSearchText";
 import {
@@ -149,15 +148,7 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
         ) {
           return (
             <div className={styles.generatingRow}>
-              <div className={styles.generatingContent}>
-                <GeneratingIndicator />
-              </div>
-              <div
-                className={styles.generatingLabel}
-                style={{ minWidth: `${maxLabelLength ?? 3}ch` }}
-              >
-                <MessageLabel label={`${index + 1}`} />
-              </div>
+              <GeneratingIndicator />
             </div>
           );
         }

--- a/packages/inspect-components/src/indicators/GeneratingIndicator.tsx
+++ b/packages/inspect-components/src/indicators/GeneratingIndicator.tsx
@@ -4,12 +4,15 @@ import { FC } from "react";
 import styles from "./GeneratingIndicator.module.css";
 
 interface GeneratingIndicatorProps {
+  /** Activity label. Defaults to "generating". */
+  label?: string;
   /** Agentic-loop attempt number. Omits the tag when not provided. */
   attempt?: number;
   className?: string;
 }
 
 export const GeneratingIndicator: FC<GeneratingIndicatorProps> = ({
+  label = "generating",
   attempt,
   className,
 }) => {
@@ -24,7 +27,7 @@ export const GeneratingIndicator: FC<GeneratingIndicatorProps> = ({
       )}
     >
       <span className={styles.label}>
-        Generating
+        {label}
         <span className={styles.ell} aria-hidden="true">
           <i>.</i>
           <i>.</i>

--- a/packages/inspect-components/src/indicators/livePlaceholder.ts
+++ b/packages/inspect-components/src/indicators/livePlaceholder.ts
@@ -6,6 +6,17 @@ export function isLivePlaceholderMessage(message: ChatMessage): boolean {
   return !messageHasVisibleContent(message);
 }
 
+// True while an assistant message's tool calls are still executing — i.e. some
+// of its tool results have not yet come back.
+export function isToolExecutingMessage(
+  message: ChatMessage,
+  toolResultCount: number
+): boolean {
+  if (message.role !== "assistant") return false;
+  const callCount = message.tool_calls?.length ?? 0;
+  return callCount > 0 && toolResultCount < callCount;
+}
+
 function messageHasVisibleContent(message: ChatMessage): boolean {
   const content = message.content;
   if (typeof content === "string") {

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -206,7 +206,7 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
         )}
         {event.pending ? (
           <div className={clsx(styles.progress)}>
-            <GeneratingIndicator />
+            <GeneratingIndicator label="running" />
           </div>
         ) : undefined}
       </div>

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.module.css
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.module.css
@@ -28,6 +28,10 @@
   padding-bottom: 0.8rem;
 }
 
+.runningTool {
+  padding: 0 0.7em;
+}
+
 @media print {
   .node {
     break-inside: avoid;

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -14,6 +14,8 @@ import {
 import { VirtualList } from "@tsmono/react/virtual";
 import type { VirtualListHandle } from "@tsmono/react/virtual";
 
+import { GeneratingIndicator } from "../indicators/GeneratingIndicator";
+
 import { EventLabelContext } from "./EventLabelContext";
 import { eventSearchText } from "./eventText";
 import { RenderedEventNode } from "./TranscriptVirtualList";
@@ -207,6 +209,16 @@ export const TranscriptVirtualListComponent: FC<
     ]
   );
 
+  // Tools are executing when the latest model event requested tool calls that
+  // don't yet all have a (completed) tool event. Pending tool events aren't
+  // reliably streamed to the viewer, so we derive this from model events —
+  // matching each tool_call to its tool event by id.
+  const toolsRunning = useMemo(
+    () => running === true && transcriptToolsRunning(eventNodes),
+    [running, eventNodes]
+  );
+  const components = useMemo(() => ({ Footer: ToolRunningFooter }), []);
+
   if (useVirtualization) {
     return (
       <VirtualList<EventNode>
@@ -223,6 +235,8 @@ export const TranscriptVirtualListComponent: FC<
         scrollToTopOnFinish={true}
         itemSearchText={eventSearchText}
         findScope="none"
+        showProgress={toolsRunning}
+        components={components}
         onVisibleRangeChange={(range) => {
           if (visibleRangeRef) visibleRangeRef.current = range;
         }}
@@ -237,7 +251,37 @@ export const TranscriptVirtualListComponent: FC<
           });
           return row;
         })}
+        {toolsRunning ? <ToolRunningFooter /> : null}
       </div>
     );
   }
 };
+
+const ToolRunningFooter: FC = () => (
+  <div className={styles.runningTool}>
+    <GeneratingIndicator label="running" />
+  </div>
+);
+
+// True when the most recent model event requested tool calls that don't all
+// have a completed tool event yet (i.e. a tool is still executing).
+function transcriptToolsRunning(eventNodes: EventNode[]): boolean {
+  let lastModelIdx = -1;
+  for (let i = eventNodes.length - 1; i >= 0; i--) {
+    if (eventNodes[i]?.event.event === "model") {
+      lastModelIdx = i;
+      break;
+    }
+  }
+  if (lastModelIdx === -1) return false;
+  const modelEvent = eventNodes[lastModelIdx]!.event;
+  if (modelEvent.event !== "model" || modelEvent.pending) return false;
+  const toolCalls = modelEvent.output.choices[0]?.message.tool_calls ?? [];
+  if (toolCalls.length === 0) return false;
+  const completedToolIds = new Set<string>();
+  for (let i = lastModelIdx + 1; i < eventNodes.length; i++) {
+    const ev = eventNodes[i]!.event;
+    if (ev.event === "tool" && !ev.pending) completedToolIds.add(ev.id);
+  }
+  return toolCalls.some((call) => !completedToolIds.has(call.id));
+}

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -274,6 +274,13 @@ export function VirtualList<T>({
         if (stickyHeaderOffset) el.scrollTop -= stickyHeaderOffset;
         hasInitialScrolledRef.current = true;
         release();
+      } else if (followOutput && live) {
+        // Auto-following a live sample: the follow effect owns the scroll
+        // position (pins to bottom). Commit the one-shot guard so this effect
+        // stops re-firing and resetting scrollTop to 0 on every new event —
+        // which would otherwise fight follow until the user scrolled manually.
+        hasInitialScrolledRef.current = true;
+        release();
       } else if (snapshot) {
         // Restore from snapshot unless the user has already scrolled this
         // list (e.g. snapshot rehydrated late and they reached for the wheel
@@ -308,6 +315,8 @@ export function VirtualList<T>({
     stickyHeaderOffset,
     contentTotal,
     data.length,
+    followOutput,
+    live,
     getRestoreSnapshot,
     getScrollElement,
     toSpacerScroll,

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -30,6 +30,16 @@ import { useVirtualListState } from "./use-virtual-list-state";
 import styles from "./VirtualList.module.css";
 
 const BOTTOM_THRESHOLD_PX = 30;
+const USER_INTERACTION_WINDOW_MS = 400;
+const SCROLL_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+]);
 const SMOOTH_SCROLL_MAX_S = 10;
 const PERSIST_DEBOUNCE_MS = 250;
 const DEFAULT_ITEM_HEIGHT_PX = 400;
@@ -108,6 +118,22 @@ export function VirtualList<T>({
   );
   const isAutoScrollingRef = useRef(false);
 
+  // Follow is toggled ONLY by user-initiated scrolling. Programmatic
+  // auto-follow scrolls and content-growth reflow also emit scroll events, but
+  // inferring user intent from scroll-position deltas is unreliable while the
+  // bottom is a moving target during streaming. So we instead gate on real
+  // input events (wheel / touch / pointer-drag / scroll keys).
+  const userInteractingRef = useRef(false);
+  const pointerDownRef = useRef(false);
+  const interactTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const noteUserInteraction = useCallback(() => {
+    userInteractingRef.current = true;
+    if (interactTimerRef.current) clearTimeout(interactTimerRef.current);
+    interactTimerRef.current = setTimeout(() => {
+      userInteractingRef.current = false;
+    }, USER_INTERACTION_WINDOW_MS);
+  }, []);
+
   useEffect(() => {
     if (followOutput === null) setFollowOutput(!!live);
   }, [followOutput, live, setFollowOutput]);
@@ -131,10 +157,12 @@ export function VirtualList<T>({
   ]);
 
   const handleScroll = useRafThrottle(() => {
-    if (isAutoScrollingRef.current) return;
     if (!live) return;
     const el = getScrollElement();
     if (!el) return;
+    // Ignore scroll events not caused by user input (programmatic auto-follow,
+    // content-growth reflow) — they must never flip follow state.
+    if (!userInteractingRef.current && !pointerDownRef.current) return;
     const atBottom =
       el.scrollHeight - el.scrollTop <= el.clientHeight + BOTTOM_THRESHOLD_PX;
     if (atBottom && !followOutput) setFollowOutput(true);
@@ -147,6 +175,37 @@ export function VirtualList<T>({
     el.addEventListener("scroll", handleScroll);
     return () => el.removeEventListener("scroll", handleScroll);
   }, [getScrollElement, handleScroll]);
+
+  useEffect(() => {
+    const el = getScrollElement();
+    if (!el) return;
+    const onWheel = () => noteUserInteraction();
+    const onTouchMove = () => noteUserInteraction();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (SCROLL_KEYS.has(e.key)) noteUserInteraction();
+    };
+    const onPointerDown = () => {
+      pointerDownRef.current = true;
+      noteUserInteraction();
+    };
+    const onPointerUp = () => {
+      pointerDownRef.current = false;
+    };
+    el.addEventListener("wheel", onWheel, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: true });
+    el.addEventListener("keydown", onKeyDown);
+    el.addEventListener("pointerdown", onPointerDown, { passive: true });
+    window.addEventListener("pointerup", onPointerUp, { passive: true });
+    window.addEventListener("pointercancel", onPointerUp, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("keydown", onKeyDown);
+      el.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [getScrollElement, noteUserInteraction]);
 
   const contentTotal = virtualizer.getTotalSize();
   useEffect(() => {
@@ -302,6 +361,10 @@ export function VirtualList<T>({
       if (persistTimerRef.current) {
         clearTimeout(persistTimerRef.current);
         persistTimerRef.current = null;
+      }
+      if (interactTimerRef.current) {
+        clearTimeout(interactTimerRef.current);
+        interactTimerRef.current = null;
       }
     },
     []


### PR DESCRIPTION
Fixes a set of regressions and gaps in the running-sample views after the virtuoso → TanStack Virtual migration.

## Follow behavior (transcript)
- **Keep running samples pinned to the bottom.** The virtual list inferred "user scrolled away" from scroll-position deltas, but during streaming the bottom is a moving target (content-growth reflow grows `scrollHeight` after the auto-follow scroll, and rAF-throttled scroll events lag the programmatic scrolls). Both made the at-bottom check read false and disable follow after a few events. Follow toggling is now gated on real user input (wheel / touch / pointer-drag / scroll keys); programmatic auto-follow and reflow-driven scroll events can no longer flip follow state. Restores the behavior react-virtuoso's `followOutput` provided.
- **Follow from first navigation when events start empty.** Opening a running sample whose events are initially all filtered out, the no-snapshot branch of the initial-scroll effect reset `scrollTop` to 0 on every new event, fighting auto-follow until the user scrolled manually. When auto-following a live sample we now cede scroll position to the follow effect. Affected both transcript and messages views.

## Generating / tool-execution indicators
- **Messages view generating placeholder** is now full width and unnumbered (was rendered with an incorrect `index + 1` label inside a content-sized grid).
- **Tool-execution progress in both views.** While a tool executes (model issued `tool_calls`, results not yet returned) neither view showed progress. Added a `label` prop to `GeneratingIndicator`, a full-width "running" bar under the last assistant message while its tool calls await results, and a synthesized trailing "running" footer in the transcript (derived from the latest model event's tool_calls matched to completed tool events by id — robust to parallel calls and not dependent on transient pending events that aren't reliably streamed to the viewer).

## Test plan
- Open a running sample; transcript stays pinned to the bottom as events stream; scrolling up detaches and scrolling back re-engages follow.
- Open a running sample whose events are initially filtered; once events appear it follows without a manual scroll. Same in the messages view.
- While the model generates: "generating…"; while a tool runs: "running…" in both views.
- Finished sample opens at the top; deep-linking to an event still lands on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)