### PR TITLE
Keep log list responsive during bulk sync

### DIFF
--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -1,6 +1,14 @@
 import { AgGridReact } from "ag-grid-react";
 import clsx from "clsx";
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FC,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 
 import { EvalSet } from "@tsmono/inspect-common/types";
@@ -65,6 +73,9 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   const logFiles = useLogsWithretried();
   const evalSet = useStore((state) => state.logs.evalSet);
   const logPreviews = useStore((state) => state.logs.logPreviews);
+  // Defer previews so the burst of preview flushes during initial sync
+  // can't block input — see the matching note in LogListGrid.
+  const deferredLogPreviews = useDeferredValue(logPreviews);
   const { filteredCount } = useLogsListing();
 
   const syncing = useStore((state) => state.app.status.syncing);
@@ -153,7 +164,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
             type: "file",
             url: tasksUrl(decodedPath, logDir),
             log: logFile,
-            logPreview: logPreviews[logFile.name],
+            logPreview: deferredLogPreviews[logFile.name],
           });
         }
       }
@@ -175,6 +186,23 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     const processedFolders = new Set<string>();
     const existingLogTaskIds = new Set<string>();
     let _hasRetriedLogs = false;
+
+    // Count logs under a path prefix via binary search rather than a full
+    // scan per folder (which made folder counting O(folders × logs)). Names
+    // sort into contiguous ranges, so a prefix count is two bound lookups.
+    const sortedNames = logFiles.map((f) => f.name).sort();
+    const lowerBound = (target: string): number => {
+      let lo = 0;
+      let hi = sortedNames.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (sortedNames[mid] < target) lo = mid + 1;
+        else hi = mid;
+      }
+      return lo;
+    };
+    const countWithPrefix = (prefix: string): number =>
+      lowerBound(prefix + "\uffff") - lowerBound(prefix);
 
     for (const logFile of logFiles) {
       if (logFile.task_id) {
@@ -212,7 +240,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
             type: "file",
             url: logsUrl(path, logDir),
             log: logFile,
-            logPreview: logPreviews[logFile.name],
+            logPreview: deferredLogPreviews[logFile.name],
           });
         }
       } else if (name.startsWith(dirWithSlash)) {
@@ -228,9 +256,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
             name: dirName,
             type: "folder",
             url: logsUrl(url, logDir),
-            itemCount: logFiles.filter((file) =>
-              file.name.startsWith(dirname(name))
-            ).length,
+            itemCount: countWithPrefix(dirname(name)),
           });
           processedFolders.add(dirName);
         }
@@ -252,7 +278,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     logFiles,
     currentDir,
     logDir,
-    logPreviews,
+    deferredLogPreviews,
     showRetriedLogs,
   ]);
 

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -16,6 +16,7 @@ import {
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -25,9 +26,11 @@ import { useNavigate } from "react-router-dom";
 
 import { useProperty } from "@tsmono/react/hooks";
 
+import { LogDetails } from "../../../client/api/types";
 import { FindBandUI } from "../../../components/FindBandUI";
 import { useLogs, useLogsListing } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
+import { useKeyedMemo } from "../../shared/useKeyedMemo";
 
 import "../../shared/agGrid";
 
@@ -58,6 +61,139 @@ interface LogListGridProps {
   mode?: LogListMode;
 }
 
+type LogListItem = FileLogItem | FolderLogItem | PendingTaskItem;
+
+const detailsForItem = (
+  item: LogListItem,
+  logDetails: Record<string, LogDetails>
+): LogDetails | undefined =>
+  item.type === "file" && item.log ? logDetails[item.log.name] : undefined;
+
+const buildLogListRow = (
+  item: LogListItem,
+  details: LogDetails | undefined
+): LogListRow => {
+  const preview = item.type === "file" ? item.logPreview : undefined;
+
+  // Compute total tokens across all models
+  let totalTokens: number | undefined;
+  if (details?.stats?.model_usage) {
+    totalTokens = 0;
+    for (const usage of Object.values(details.stats.model_usage)) {
+      totalTokens += usage.total_tokens;
+    }
+  }
+
+  // Compute duration in seconds
+  let duration: number | undefined;
+  if (details?.stats?.started_at && details?.stats?.completed_at) {
+    const start = new Date(details.stats.started_at).getTime();
+    const end = new Date(details.stats.completed_at).getTime();
+    if (start && end && end > start) {
+      duration = (end - start) / 1000;
+    }
+  }
+
+  // Format task args. Prefer `task_args_passed` (the args the user
+  // actually supplied at the call site) over `task_args` (which
+  // would also include defaulted values).
+  const taskArgsSource =
+    details?.eval?.task_args_passed ?? details?.eval?.task_args;
+  let taskArgs: string | undefined;
+  if (taskArgsSource) {
+    const entries = Object.entries(taskArgsSource);
+    if (entries.length > 0) {
+      taskArgs = entries
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join(", ");
+    }
+  }
+
+  // Percent of samples completed
+  let percentCompleted: number | undefined;
+  const total = details?.results?.total_samples;
+  const completed = details?.results?.completed_samples;
+  if (total && total > 0 && completed !== undefined) {
+    percentCompleted = (completed / total) * 100;
+  }
+
+  // Count of sample errors
+  let sampleErrors: number | undefined;
+  if (details?.sampleSummaries) {
+    sampleErrors = details.sampleSummaries.filter((s) => s.error).length;
+  }
+
+  // Distinct limit types across samples in this task, comma-joined.
+  // Empty when no sample ended with a limit. Sorted for stable
+  // text-filtering and predictable display order.
+  let sampleLimits: string | undefined;
+  if (details?.sampleSummaries) {
+    const limits = new Set<string>();
+    for (const s of details.sampleSummaries) {
+      if (s.limit) limits.add(s.limit);
+    }
+    if (limits.size > 0) {
+      sampleLimits = Array.from(limits).sort().join(", ");
+    }
+  }
+
+  const row: LogListRow = {
+    id: item.id,
+    name: item.name,
+    displayIndex:
+      item.type === "file" || item.type === "pending-task"
+        ? item.displayIndex
+        : undefined,
+    type: item.type,
+    url: item.url,
+    task: item.type === "file" ? preview?.task : item.name,
+    model:
+      item.type === "file"
+        ? preview?.model
+        : item.type === "pending-task"
+          ? item.model
+          : undefined,
+    modelRoles:
+      item.type === "file" ? (preview?.model_roles ?? undefined) : undefined,
+    score: preview?.primary_metric?.value,
+    status: preview?.status,
+    completedAt: preview?.completed_at,
+    itemCount: item.type === "folder" ? item.itemCount : undefined,
+    log: item.type === "file" ? item.log : undefined,
+    path: item.type === "file" ? item.name : undefined,
+    totalSamples: details?.results?.total_samples,
+    completedSamples: details?.results?.completed_samples,
+    sandbox: details?.eval?.sandbox?.type,
+    totalTokens,
+    duration,
+    taskFile: details?.eval?.task_file ?? undefined,
+    taskArgs,
+    taskArgsRaw: taskArgsSource ?? undefined,
+    tags: details?.tags,
+    percentCompleted,
+    sampleErrors,
+    sampleLimits,
+    errorMessage: details?.error?.message,
+  };
+
+  // Add individual scorer columns from results. Key by (scorer, metric)
+  // so distinct scorers emitting the same metric name each get their own
+  // column. Reducer is omitted from the key: `reducer=null` (default,
+  // silently mean) and `reducer="mean"` (explicit) should land in the
+  // same column since the underlying computation is identical.
+  if (details?.results?.scores) {
+    for (const evalScore of details.results.scores) {
+      if (evalScore.metrics) {
+        for (const [metricName, metric] of Object.entries(evalScore.metrics)) {
+          row[`score_${evalScore.name}/${metricName}`] = metric.value;
+        }
+      }
+    }
+  }
+
+  return row;
+};
+
 export const LogListGrid: FC<LogListGridProps> = ({
   items,
   currentPath,
@@ -75,6 +211,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const setWatchedLogs = useStore((state) => state.logsActions.setWatchedLogs);
 
   const logDetails = useStore((state) => state.logs.logDetails);
+  // Defer the detail map so a burst of detail flushes during initial sync
+  // can't block click/scroll input — the grid renders from the prior value
+  // and catches up when the main thread is idle.
+  const deferredLogDetails = useDeferredValue(logDetails);
   const navigate = useNavigate();
   const internalGridRef = useRef<AgGridReact<LogListRow>>(null);
   const gridRef = externalGridRef ?? internalGridRef;
@@ -129,137 +269,29 @@ export const LogListGrid: FC<LogListGridProps> = ({
     gridContainerRef.current?.focus();
   }, []);
 
-  const data: LogListRow[] = useMemo(() => {
-    return items.map((item) => {
-      const preview = item.type === "file" ? item.logPreview : undefined;
-      const details =
-        item.type === "file" && item.log
-          ? logDetails[item.log.name]
-          : undefined;
-
-      // Compute total tokens across all models
-      let totalTokens: number | undefined;
-      if (details?.stats?.model_usage) {
-        totalTokens = 0;
-        for (const usage of Object.values(details.stats.model_usage)) {
-          totalTokens += usage.total_tokens;
-        }
-      }
-
-      // Compute duration in seconds
-      let duration: number | undefined;
-      if (details?.stats?.started_at && details?.stats?.completed_at) {
-        const start = new Date(details.stats.started_at).getTime();
-        const end = new Date(details.stats.completed_at).getTime();
-        if (start && end && end > start) {
-          duration = (end - start) / 1000;
-        }
-      }
-
-      // Format task args. Prefer `task_args_passed` (the args the user
-      // actually supplied at the call site) over `task_args` (which
-      // would also include defaulted values).
-      const taskArgsSource =
-        details?.eval?.task_args_passed ?? details?.eval?.task_args;
-      let taskArgs: string | undefined;
-      if (taskArgsSource) {
-        const entries = Object.entries(taskArgsSource);
-        if (entries.length > 0) {
-          taskArgs = entries
-            .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-            .join(", ");
-        }
-      }
-
-      // Percent of samples completed
-      let percentCompleted: number | undefined;
-      const total = details?.results?.total_samples;
-      const completed = details?.results?.completed_samples;
-      if (total && total > 0 && completed !== undefined) {
-        percentCompleted = (completed / total) * 100;
-      }
-
-      // Count of sample errors
-      let sampleErrors: number | undefined;
-      if (details?.sampleSummaries) {
-        sampleErrors = details.sampleSummaries.filter((s) => s.error).length;
-      }
-
-      // Distinct limit types across samples in this task, comma-joined.
-      // Empty when no sample ended with a limit. Sorted for stable
-      // text-filtering and predictable display order.
-      let sampleLimits: string | undefined;
-      if (details?.sampleSummaries) {
-        const limits = new Set<string>();
-        for (const s of details.sampleSummaries) {
-          if (s.limit) limits.add(s.limit);
-        }
-        if (limits.size > 0) {
-          sampleLimits = Array.from(limits).sort().join(", ");
-        }
-      }
-
-      const row: LogListRow = {
-        id: item.id,
-        name: item.name,
-        displayIndex:
-          item.type === "file" || item.type === "pending-task"
-            ? item.displayIndex
-            : undefined,
-        type: item.type,
-        url: item.url,
-        task: item.type === "file" ? preview?.task : item.name,
-        model:
-          item.type === "file"
-            ? preview?.model
-            : item.type === "pending-task"
-              ? item.model
-              : undefined,
-        modelRoles:
-          item.type === "file"
-            ? (preview?.model_roles ?? undefined)
-            : undefined,
-        score: preview?.primary_metric?.value,
-        status: preview?.status,
-        completedAt: preview?.completed_at,
-        itemCount: item.type === "folder" ? item.itemCount : undefined,
-        log: item.type === "file" ? item.log : undefined,
-        path: item.type === "file" ? item.name : undefined,
-        totalSamples: details?.results?.total_samples,
-        completedSamples: details?.results?.completed_samples,
-        sandbox: details?.eval?.sandbox?.type,
-        totalTokens,
-        duration,
-        taskFile: details?.eval?.task_file ?? undefined,
-        taskArgs,
-        taskArgsRaw: taskArgsSource ?? undefined,
-        tags: details?.tags,
-        percentCompleted,
-        sampleErrors,
-        sampleLimits,
-        errorMessage: details?.error?.message,
-      };
-
-      // Add individual scorer columns from results. Key by (scorer, metric)
-      // so distinct scorers emitting the same metric name each get their own
-      // column. Reducer is omitted from the key: `reducer=null` (default,
-      // silently mean) and `reducer="mean"` (explicit) should land in the
-      // same column since the underlying computation is identical.
-      if (details?.results?.scores) {
-        for (const evalScore of details.results.scores) {
-          if (evalScore.metrics) {
-            for (const [metricName, metric] of Object.entries(
-              evalScore.metrics
-            )) {
-              row[`score_${evalScore.name}/${metricName}`] = metric.value;
-            }
-          }
-        }
-      }
-
-      return row;
-    });
-  }, [items, logDetails]);
+  // Reuse the prior row object for any item whose display inputs (preview,
+  // details, structural fields) are unchanged. AG-Grid's immutable diff then
+  // leaves those rows' DOM untouched, so a sync flush mid-click can't replace
+  // the node under the pointer and swallow the click — and only changed rows
+  // get the expensive per-row rebuild. Keyed on store references (which stay
+  // stable across flushes for unchanged logs) rather than the `item` object,
+  // so it works even though `items` is rebuilt each flush upstream.
+  const data: LogListRow[] = useKeyedMemo(
+    items,
+    (item) => item.id,
+    (item) => [
+      item.id,
+      item.type,
+      item.url,
+      item.name,
+      item.displayIndex,
+      item.type === "file" ? item.logPreview : undefined,
+      item.type === "folder" ? item.itemCount : undefined,
+      item.type === "pending-task" ? item.model : undefined,
+      detailsForItem(item, deferredLogDetails),
+    ],
+    (item) => buildLogListRow(item, detailsForItem(item, deferredLogDetails))
+  );
 
   const handleRowClick = useCallback(
     (e: RowClickedEvent<LogListRow>) => {

--- a/apps/inspect/src/app/shared/useKeyedMemo.ts
+++ b/apps/inspect/src/app/shared/useKeyedMemo.ts
@@ -1,0 +1,55 @@
+import { useRef } from "react";
+
+const shallowEqual = (
+  a: readonly unknown[],
+  b: readonly unknown[]
+): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+};
+
+/**
+ * Map a list to derived values, reusing the prior output object for any item
+ * whose per-item deps are unchanged.
+ *
+ * `useMemo` is all-or-nothing: any dep change rebuilds every element, handing
+ * a consumer (e.g. AG-Grid) all-new identities and forcing a full refresh.
+ * This keeps a per-key cache so only the items that actually changed get a new
+ * object — the rest keep reference identity. Reuse is gated on `itemDeps`, so
+ * the cache must be pure: same deps must always yield the same value.
+ *
+ * The list is re-walked on every render; reuse keeps that cheap (a shallow dep
+ * compare per item, builds only on change). The returned array keeps the same
+ * reference when nothing changed, so consumers that key off its identity (deps
+ * arrays, AG-Grid's rowData diff) don't re-run on unrelated renders.
+ */
+export function useKeyedMemo<S, T>(
+  source: readonly S[],
+  getKey: (item: S) => string,
+  itemDeps: (item: S) => readonly unknown[],
+  build: (item: S) => T
+): T[] {
+  const cacheRef = useRef(
+    new Map<string, { deps: readonly unknown[]; value: T }>()
+  );
+  const resultRef = useRef<T[]>([]);
+
+  const prev = cacheRef.current;
+  const next = new Map<string, { deps: readonly unknown[]; value: T }>();
+  let changed = source.length !== resultRef.current.length;
+  const result = source.map((item, i) => {
+    const key = getKey(item);
+    const deps = itemDeps(item);
+    const hit = prev.get(key);
+    const value = hit && shallowEqual(hit.deps, deps) ? hit.value : build(item);
+    next.set(key, { deps, value });
+    if (!changed && resultRef.current[i] !== value) changed = true;
+    return value;
+  });
+  cacheRef.current = next;
+  if (changed) resultRef.current = result;
+  return resultRef.current;
+}

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -53,11 +53,11 @@ export class ReplicationService {
     this._throttledUpdateDbStats = throttle(() => this.updateDbStats(), 1000);
     this._throttledFlushPreviewBatch = throttle(
       () => this.flushPreviewBatch(),
-      100
+      250
     );
     this._throttledFlushDetailBatch = throttle(
       () => this.flushDetailBatch(),
-      100
+      250
     );
 
     this._previewQueue = new WorkQueue<LogHandle, LogPreview>({


### PR DESCRIPTION
## Problem

On first load of a large log directory, the log list pegs the main thread and **drops clicks** while sync streams in. Two root causes, one shared mechanism:

- Every store flush (~10/sec) rebuilt the *entire* row dataset with all-new object identities, so AG-Grid refreshed **every** row each flush — O(N) synchronous work per flush.
- Because the row DOM was rebuilt on each flush, a flush landing between mousedown and click replaced the node under the pointer, so the trailing `click` hit a stale node and `onRowClicked` never fired (the same failure mode already documented in `SamplesGrid`).

## Changes

- **`useDeferredValue`** on the preview/detail maps so update bursts render at non-urgent priority and don't block click/scroll input.
- **New `useKeyedMemo` hook** + keying the grid's `data` on *store references* (which stay stable across flushes for unchanged logs) rather than the intermediate `item` object. Unchanged rows keep object identity, so AG-Grid's immutable diff refreshes only the rows that actually changed and leaves stable rows' DOM — and clicks — intact. The hook also returns a stable array reference when nothing changed, so consumers that key off its identity don't re-run on unrelated renders.
- **Flush throttle 100ms → 250ms** in the replication service.
- **Folder `itemCount`**: replaced the O(folders × logs) per-folder scan with a binary search over a once-sorted name list (exact `startsWith` semantics preserved).

## Testing

- `pnpm check` passes (typecheck + lint + format).
- Manually verified against a large log dir: CPU settles and clicks/scroll stay responsive throughout the download.

Known residuals (not addressed here): clicking a row that is *itself* actively streaming, or live re-sort reordering a row mid-click, can still drop that specific click — fixable later by buffering flushes while the pointer is down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)