### PR TITLE
fix embedded scout in hawk

### DIFF
--- a/apps/scout/src/app/components/Navbar.module.css
+++ b/apps/scout/src/app/components/Navbar.module.css
@@ -17,6 +17,17 @@
   max-width: 100%;
 }
 
+/* The `right` slot holds inline controls (e.g. the scanner-result prev/next
+   navigator and the theme toggle). Without an explicit layout its children are
+   block-level and stack onto a second row; keep them on one line. */
+.right {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .leftButtons {
   display: flex;
   gap: 0.4rem;

--- a/apps/scout/src/app/hooks/useEnsureVisibleScannerResults.ts
+++ b/apps/scout/src/app/hooks/useEnsureVisibleScannerResults.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { useStore } from "../../state/store";
+
 import { useScanResultSummaries } from "./useScanResultSummaries";
 import { useScanRoute } from "./useScanRoute";
 import { useSelectedScanDataframe } from "./useSelectedScanDataframe";

--- a/apps/scout/src/app/hooks/useEnsureVisibleScannerResults.ts
+++ b/apps/scout/src/app/hooks/useEnsureVisibleScannerResults.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+
+import { useStore } from "../../state/store";
+import { useScanResultSummaries } from "./useScanResultSummaries";
+import { useScanRoute } from "./useScanRoute";
+import { useSelectedScanDataframe } from "./useSelectedScanDataframe";
+
+/**
+ * Ensure `visibleScannerResults` is populated when a scanner-result page is
+ * opened directly (deep link or page reload).
+ *
+ * `visibleScannerResults` is normally written only by ScannerResultsList, which
+ * renders under the scan-list route (ScanPanel). On a direct result URL the
+ * router renders ScannerResultPanel instead, so that list never mounts and the
+ * store keeps its empty default — which leaves ScannerResultNav with no items
+ * to page through and hides it entirely (ScannerResultPanel gates the nav on
+ * `visibleScannerResults.length > 0`).
+ *
+ * This seeds the store from the active scan's summaries the same way the list
+ * does, but only while it's empty, so it never overrides the list view's
+ * filtered/sorted set during in-app navigation.
+ */
+export const useEnsureVisibleScannerResults = (): void => {
+  const { scanResultUuid } = useScanRoute();
+  const { data: columnTable } = useSelectedScanDataframe();
+  const { data: summaries } = useScanResultSummaries(columnTable);
+
+  const isPopulated = useStore(
+    (state) => state.visibleScannerResults.length > 0
+  );
+  const setVisibleScannerResults = useStore(
+    (state) => state.setVisibleScannerResults
+  );
+  const setVisibleScannerResultsCount = useStore(
+    (state) => state.setVisibleScannerResultsCount
+  );
+
+  useEffect(() => {
+    if (isPopulated || summaries.length === 0) {
+      return;
+    }
+    // Only seed once the loaded summaries actually contain the result we're
+    // viewing. On a cold deep link `useSelectedScanDataframe` briefly resolves
+    // for the DEFAULT scanner before the URL `?scanner=` param syncs into the
+    // store, so summaries may belong to the wrong scanner; seeding those would
+    // be locked in by the `isPopulated` guard and page through the wrong list.
+    // The current result only appears in its own scanner's summaries.
+    if (
+      scanResultUuid &&
+      !summaries.some((summary) => summary.identifier === scanResultUuid)
+    ) {
+      return;
+    }
+    setVisibleScannerResults(summaries);
+    setVisibleScannerResultsCount(summaries.length);
+  }, [
+    isPopulated,
+    scanResultUuid,
+    summaries,
+    setVisibleScannerResults,
+    setVisibleScannerResultsCount,
+  ]);
+};

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../router/url";
 import { useStore } from "../../state/store";
 import { ScansNavbar } from "../components/ScansNavbar";
+import { useEnsureVisibleScannerResults } from "../hooks/useEnsureVisibleScannerResults";
 import { useScanRoute } from "../hooks/useScanRoute";
 import { useSelectedScan } from "../hooks/useSelectedScan";
 import { useSelectedScanResultData } from "../hooks/useSelectedScanResultData";
@@ -119,6 +120,10 @@ export const ScannerResultPanel: FC = () => {
   // Url data
   const { scanResultUuid } = useScanRoute();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  // Seed the prev/next navigator list when this page is opened directly
+  // (deep link / reload) and the scan-list view never mounted to populate it.
+  useEnsureVisibleScannerResults();
 
   // Required server data
   const { loading: scanLoading, data: selectedScan } = useSelectedScan();


### PR DESCRIPTION
* avoid double-height header when rendering theme toggle icon:
  <img width="3839" height="1499" alt="image" src="https://github.com/user-attachments/assets/4adffc5c-e6a5-457c-96e9-f45359fabeb0" />
* render epoch selector in the header after page reload