### PR TITLE
Color tool calls in model-event views like the messages tab

### DIFF
--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -214,11 +214,16 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
     }
   }
 
-  if (useLabels) {
+  const hasTools = viewKinds.some((k) => k !== "message");
+
+  // Use the peer-block layout (which emits the `data-message-kind` bands the
+  // theme colors, and the connected blue tool-call/output card) whenever the
+  // row has tools — even with labels off, e.g. model-event views — so tool
+  // rendering matches the messages tab. Label chips still only show when
+  // `useLabels`; here they're all undefined, so none render.
+  if (useLabels || hasTools) {
     // Each row part is a peer block: the message in its role band, the tool
     // call in the blue tool box, and the tool output in a plain bordered box.
-    const hasTools = viewKinds.some((k) => k !== "message");
-
     const renderPart = (
       idx: number,
       attached?: { top?: boolean; bottom?: boolean }


### PR DESCRIPTION
## Problem

In the Messages tab, tool calls render with the colored "blue tool box" / connected-card treatment. In the **Transcript**, the same tool calls shown under a `ModelEventView` render **plain** — no colored box — even though both go through the same `ChatMessageRow` → `ToolCallView`.

## Cause

The colored treatment is driven by the theme's `[data-message-kind="tool"|"tool-result"]` rules, and `data-message-kind` is only emitted by `ChatMessageRow`'s **labeled** branch (`if (useLabels)`). `useLabels = labels?.show ?? true`. The messages tab passes no `labels` (defaults to shown) → labeled branch → colored. `ModelEventView` passes `labels={{ show: false }}` (it doesn't want the sequential numbers) → unlabeled branch → only `data-message-role`, no `data-message-kind` → no color. So tool coloring was accidentally coupled to label visibility.

## Fix

Decouple the two: use the peer-block (`data-message-kind`) layout whenever a row has tools, regardless of label visibility. Label chips stay gated on `useLabels`, so the model-event view gets the color without the numbers. Pure-text rows are unaffected (the branch only switches when the row has tool views).

## Scope

`ChatMessageRow` is shared, so this also affects other label-less `ChatView` usages that contain tools (the model-event "Messages" subtab, scout transcript/result bodies) — they now render tool calls in the colored box too, which is the intended consistency.

## Verification

- `pnpm check` passes (typecheck + lint + format, 24/24; includes scout).
- Confirmed live in the viewer: the model-event tool call now carries `data-message-kind="tool"` with the readable tool-call surface (`bg rgb(237,244,251)`) and the 3px blue left gutter, matching the messages tab. (Before: no `data-message-kind`, transparent.)

Note: in evals with **no `ToolEvent`s**, the tool *result* is rendered as a separate `tool`-role message (not collapsed into the call), so it doesn't form a connected `tool-result` band — the call is colored, the detached result stays plain. Coloring that case is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)