### PR TITLE
Sample message/transcript placeholders + steady streaming

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -270,6 +270,15 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     [sampleUrlBuilder, urlLogPath, urlSampleId, urlEpoch]
   );
 
+  // Stable option objects so memoized ChatMessageRow rows don't re-render on
+  // every streaming poll just because these were fresh literals each render.
+  const chatDisplay = useMemo(() => ({ indented: true, formatDateTime }), []);
+  const chatLinking = useMemo(
+    () => ({ enabled: isHostedEnvironment(), getMessageUrl }),
+    [getMessageUrl]
+  );
+  const chatTools = useMemo(() => ({ callStyle: "complete" as const }), []);
+
   const sampleUsages = usageViewsForSample(`${baseId}-${id}`, sample, evalSpec);
   const sampleMetadatas = metadataViewsForSample(
     `${baseId}-${id}`,
@@ -660,17 +669,11 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                   messages={sampleMessages}
                   initialMessageId={sampleDetailNavigation.message}
                   offsetTop={stickyOffsetTop}
-                  display={{
-                    indented: true,
-                    formatDateTime,
-                  }}
-                  linking={{
-                    enabled: isHostedEnvironment(),
-                    getMessageUrl: getMessageUrl,
-                  }}
+                  display={chatDisplay}
+                  linking={chatLinking}
                   onNativeFindChanged={setNativeFind}
                   scrollRef={scrollRef}
-                  tools={{ callStyle: "complete" }}
+                  tools={chatTools}
                   running={running}
                   className={styles.fullWidth}
                 />

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -43,6 +43,8 @@ import {
 import { SampleScansSidebar } from "../scans/SampleScansSidebar";
 import { useMakeCiteUrl } from "../scans/scanReferences";
 
+import { useTranscriptFilter } from "./hooks";
+
 interface TranscriptPanelProps {
   id: string;
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -106,6 +108,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
   const filteredEventTypes = useStore(
     (state) => state.sample.eventFilter.filteredTypes
   );
+  const { isDefaultFilter } = useTranscriptFilter();
 
   // ---------------------------------------------------------------------------
   // Store-backed timeline selection adapters
@@ -484,10 +487,13 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
           : undefined
       }
       emptyText={
-        filteredEventTypes.length > 0
-          ? "The currently applied filter hides all events."
-          : undefined
+        running && isDefaultFilter
+          ? "Sample is starting"
+          : filteredEventTypes.length > 0
+            ? "The currently applied filter hides all events."
+            : undefined
       }
+      emptyBusy={running && isDefaultFilter}
     />
   );
 });

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, ReactNode } from "react";
+import { FC, memo, ReactNode } from "react";
 
 import type { ChatMessageTool } from "@tsmono/inspect-common/types";
 import type { MarkdownReference } from "@tsmono/react/components";
@@ -37,7 +37,7 @@ interface ChatMessageRowProps {
 /**
  * Renders the ChatMessage component.
  */
-export const ChatMessageRow: FC<ChatMessageRowProps> = ({
+export const ChatMessageRow = memo(function ChatMessageRow({
   index,
   parentName,
   resolvedMessage,
@@ -48,7 +48,7 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
   linking,
   tools,
   startNumber,
-}) => {
+}: ChatMessageRowProps) {
   const highlightUserMessage = display?.highlightUserMessage ?? true;
   const showLabels = labels?.show ?? true;
   const labelValues = labels?.messageLabels;
@@ -302,7 +302,38 @@ export const ChatMessageRow: FC<ChatMessageRowProps> = ({
       );
     });
   }
-};
+}, chatMessageRowEqual);
+
+// Shallow-compare every prop by reference EXCEPT `resolvedMessage`: compare
+// that one through the wrapper to its `message`/`toolMessages` references,
+// because `resolveMessages` recreates the wrapper each call even when the
+// underlying turn is unchanged (so default memo would never hit). Iterating
+// the keys keeps this exhaustive by construction — a future prop is covered by
+// the generic `===` branch without editing this function. Callers must pass
+// stable option objects (and never mutate a message in place) for it to hit;
+// the actively-streaming turn gets a fresh message ref each poll, so it still
+// re-renders.
+function chatMessageRowEqual(
+  prev: ChatMessageRowProps,
+  next: ChatMessageRowProps
+): boolean {
+  const keys = Object.keys(prev) as (keyof ChatMessageRowProps)[];
+  if (keys.length !== Object.keys(next).length) return false;
+  for (const key of keys) {
+    if (key === "resolvedMessage") {
+      const a = prev.resolvedMessage;
+      const b = next.resolvedMessage;
+      if (a.message !== b.message) return false;
+      if (a.toolMessages.length !== b.toolMessages.length) return false;
+      if (!a.toolMessages.every((t, i) => t === b.toolMessages[i])) {
+        return false;
+      }
+    } else if (prev[key] !== next[key]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 const resolveToolMessage = (toolMessage?: ChatMessageTool): ContentTool[] => {
   if (!toolMessage || toolMessage.error) {

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -199,10 +199,10 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
     // message event arrives), and a finished one may be empty (e.g. an early
     // error, or messages cleared due to size limits).
     if (collapsedMessages.length === 0) {
-      return (
-        <NoContentsPanel
-          text={running ? "Waiting for messages…" : "No messages"}
-        />
+      return running ? (
+        <NoContentsPanel text="Waiting for messages" busy />
+      ) : (
+        <NoContentsPanel text="No messages" />
       );
     }
 

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import type { ChatMessage } from "@tsmono/inspect-common/types";
+import { NoContentsPanel } from "@tsmono/react/components";
 import { useListKeyboardNavigation } from "@tsmono/react/hooks";
 import { VirtualList } from "@tsmono/react/virtual";
 import type {
@@ -192,6 +193,18 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
         rowStartNumbers,
       ]
     );
+
+    // Show a placeholder instead of a blank tab when there's nothing to
+    // render: a running sample may have no messages yet (before its first
+    // message event arrives), and a finished one may be empty (e.g. an early
+    // error, or messages cleared due to size limits).
+    if (collapsedMessages.length === 0) {
+      return (
+        <NoContentsPanel
+          text={running ? "Waiting for messages…" : "No messages"}
+        />
+      );
+    }
 
     return (
       <VirtualList<ResolvedMessage>

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -183,6 +183,8 @@ export interface TranscriptLayoutProps {
 
   /** Text shown when no events match the current filter. Pass null to disable empty state. */
   emptyText?: string | null;
+  /** Render the empty state as an in-progress placeholder (animated, no icon). */
+  emptyBusy?: boolean;
   className?: string;
 }
 
@@ -304,6 +306,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   rightPaneScrollRef,
   eventNodeContext,
   emptyText = "No events match the current filter",
+  emptyBusy,
   className,
 }) => {
   // ---------------------------------------------------------------------------
@@ -1109,7 +1112,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                 eventNodeContext={mergedEventNodeContext}
               />
             ) : emptyText !== null ? (
-              <NoContentsPanel text={emptyText} />
+              <NoContentsPanel text={emptyText} busy={emptyBusy} />
             ) : null}
             {rightPane && (
               <>

--- a/packages/react/src/components/NoContentsPanel.module.css
+++ b/packages/react/src/components/NoContentsPanel.module.css
@@ -10,3 +10,38 @@
   grid-template-columns: max-content max-content;
   column-gap: 0.3em;
 }
+
+.ellipsis {
+  display: inline-flex;
+}
+
+.ellipsis i {
+  font-style: normal;
+  animation: ncp-ellipsis 1.5s ease-in-out infinite both;
+}
+
+.ellipsis i:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.ellipsis i:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes ncp-ellipsis {
+  0%,
+  80%,
+  100% {
+    opacity: 0.22;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ellipsis i {
+    animation: none;
+    opacity: 0.55;
+  }
+}

--- a/packages/react/src/components/NoContentsPanel.tsx
+++ b/packages/react/src/components/NoContentsPanel.tsx
@@ -7,16 +7,31 @@ import styles from "./NoContentsPanel.module.css";
 interface NoContentsPanelProps {
   text: string;
   icon?: string;
+  /** In-progress state: drop the icon and animate a trailing ellipsis. */
+  busy?: boolean;
 }
 
-export const NoContentsPanel: FC<NoContentsPanelProps> = ({ text, icon }) => {
+export const NoContentsPanel: FC<NoContentsPanelProps> = ({
+  text,
+  icon,
+  busy,
+}) => {
   const icons = useComponentIcons();
 
   return (
     <div className={clsx(styles.panel)}>
       <div className={clsx(styles.container, "text-size-smaller")}>
-        <i className={icon ?? icons.noSamples} />
-        <div>{text}</div>
+        {!busy && <i className={icon ?? icons.noSamples} />}
+        <div>
+          {text}
+          {busy && (
+            <span className={clsx(styles.ellipsis)} aria-hidden="true">
+              <i>.</i>
+              <i>.</i>
+              <i>.</i>
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Three related improvements to the running-sample experience. Each is a separate commit.

## 1. Placeholder for an empty messages list
The Messages tab rendered nothing when a sample had no messages, leaving a blank tab. Show `NoContentsPanel` instead: "Waiting for messages" while the sample is running (no message events yet) and "No messages" otherwise (e.g. an early error or messages cleared for size).

## 2. Animated starting placeholders + transcript starting text
- Transcript tab: show "Sample is starting" instead of the filter-hides-all message when a running sample's only events are default-excluded (`sample_init`/`state`/etc.).
- `NoContentsPanel` gains a `busy` mode that drops the cross-out icon and animates a trailing ellipsis (same staggered fade as `GeneratingIndicator`, with a reduced-motion fallback); threaded through `TranscriptLayout` as `emptyBusy`.
- Both running placeholders ("Waiting for messages", "Sample is starting") use `busy` — animated, no icon. Non-running empty states are unchanged.

## 3. Stop re-rendering unchanged message rows during streaming
The Messages tab rebuilt every visible row on each streaming poll (a poll recreates the messages array and `resolveMessages` mints fresh wrappers, and `ChatMessageRow` was unmemoized), making the list jumpy as a running sample streamed in.
- Memoize `ChatMessageRow` with a comparator that compares *through* the wrapper to the underlying `message`/`toolMessages` refs (stable across polls for unchanged turns). It iterates prop keys, so it stays exhaustive as props are added.
- Memoize the `display`/`linking`/`tools` option objects in `SampleDisplay` so the memo isn't busted by fresh literals each render.

Only the actively-streaming turn re-renders now; the rest stay put.

## Verification
- `pnpm check` passes (typecheck + lint + format, 24/24; includes scout).
- Placeholders and steadier streaming confirmed in the running viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)