### PR TITLE
Fix transcript collapse-all to include model events (symmetry with expand-all)

### DIFF
--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -46,7 +46,11 @@ export const kCollapsibleEventTypes = [
 ];
 
 /** Event types whose *content* can be collapsed (panel-level collapse). */
-export const kContentCollapsibleEventTypes: string[] = ["state", "store"];
+export const kContentCollapsibleEventTypes: string[] = [
+  "model",
+  "state",
+  "store",
+];
 
 export type EventType =
   | SampleInitEvent


### PR DESCRIPTION
## Problem
In the transcript view, the bulk **Collapse** and **Expand** controls were asymmetric: Collapse left model events expanded while Expand collapsed/restored them.

## Cause
`ModelEventView` renders with `collapsibleContent`, so model events are individually collapsible. Expand-all clears the entire collapsed map (`{}`), so it expands everyone — including model events. But collapse-all builds its set from `collectAllCollapsibleIds`, which only collects `kCollapsibleEventTypes` (step / span / tool / subtask) and `kContentCollapsibleEventTypes` (`state`, `store`) — `"model"` was in neither list, so collapse-all skipped model events.

## Fix
Add `"model"` to `kContentCollapsibleEventTypes`. That constant is used only by collapse-all, so the change has no effect on default-collapse or anything else — it just makes collapse-all operate on the same set expand-all does.

## Test plan
- In a transcript, click Collapse: model events collapse along with steps/tools.
- Click Expand: everything (including model events) restores. The two controls are now symmetric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)