### PR TITLE
fix: collapse timeline by default when only main + scoring lanes

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -360,6 +360,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     sourceSpans,
     minimapSelection,
     hasTimeline,
+    hasAgentTimeline,
     timelines,
     activeTimelineIndex,
     setActiveTimeline,
@@ -398,8 +399,14 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     ) {
       return true;
     }
-    return hasTimeline ? false : undefined;
-  }, [showSwimlanesOption, hasTimeline, regionCounts]);
+    if (hasTimeline) {
+      // Expand by default only when there's agent sub-structure to drill into.
+      // A bare main + scoring (or init) timeline has nothing to expand, so
+      // default it collapsed.
+      return hasAgentTimeline ? false : true;
+    }
+    return undefined;
+  }, [showSwimlanesOption, hasTimeline, hasAgentTimeline, regionCounts]);
 
   // ---------------------------------------------------------------------------
   // Event nodes

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -52,6 +52,40 @@ function makeModelEvent(uuid: string, startSec: number, endSec: number): Event {
   } as unknown as Event;
 }
 
+function spanBegin(
+  id: string,
+  name: string,
+  type: string | null,
+  parentId: string | null
+): Event {
+  return {
+    event: "span_begin",
+    id,
+    name,
+    type,
+    parent_id: parentId,
+    span_id: null,
+    timestamp: new Date(1705312800000).toISOString(),
+    working_start: 0,
+    pending: null,
+    uuid: null,
+    metadata: null,
+  } as unknown as Event;
+}
+
+function spanEnd(id: string): Event {
+  return {
+    event: "span_end",
+    id,
+    span_id: null,
+    timestamp: new Date(1705312800000).toISOString(),
+    working_start: 0,
+    pending: null,
+    uuid: null,
+    metadata: null,
+  } as unknown as Event;
+}
+
 function makeServerEvent(uuid: string): ServerTimelineEvent {
   return { type: "event", event: uuid };
 }
@@ -156,6 +190,51 @@ describe("useTranscriptTimeline", () => {
 
     // A single event with no child spans — no meaningful timeline
     expect(result.current.hasTimeline).toBe(false);
+  });
+
+  it("reports hasAgentTimeline false for a main + scoring transcript", () => {
+    // init/solvers/scorers phases with no agent sub-structure: the only
+    // child lanes are lifecycle phases (init/scoring), nothing to expand.
+    const phaseEvents: Event[] = [
+      spanBegin("init", "init", "init", null),
+      makeModelEvent("init-1", 0, 1),
+      spanEnd("init"),
+      spanBegin("solvers", "solvers", "solvers", null),
+      makeModelEvent("solve-1", 1, 3),
+      spanEnd("solvers"),
+      spanBegin("scorers", "scorers", "scorers", null),
+      makeModelEvent("score-1", 3, 4),
+      spanEnd("scorers"),
+    ];
+    const { result } = renderHook(() =>
+      useTranscriptTimeline({ events: phaseEvents })
+    );
+
+    expect(result.current.hasTimeline).toBe(true);
+    expect(result.current.hasAgentTimeline).toBe(false);
+  });
+
+  it("reports hasAgentTimeline true when agent sub-lanes exist", () => {
+    const agentEvents: Event[] = [
+      spanBegin("solvers", "solvers", "solvers", null),
+      makeModelEvent("solve-1", 0, 1),
+      spanBegin("a1", "agent_one", "agent", "solvers"),
+      makeModelEvent("a1-1", 1, 2),
+      spanEnd("a1"),
+      spanBegin("a2", "agent_two", "agent", "solvers"),
+      makeModelEvent("a2-1", 2, 3),
+      spanEnd("a2"),
+      spanEnd("solvers"),
+      spanBegin("scorers", "scorers", "scorers", null),
+      makeModelEvent("score-1", 3, 4),
+      spanEnd("scorers"),
+    ];
+    const { result } = renderHook(() =>
+      useTranscriptTimeline({ events: agentEvents })
+    );
+
+    expect(result.current.hasTimeline).toBe(true);
+    expect(result.current.hasAgentTimeline).toBe(true);
   });
 
   it("returns timelines array with server-provided timeline", () => {

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -27,7 +27,7 @@ import {
   rowHasEvents,
   type RowLayout,
 } from "../swimlaneLayout";
-import { isSingleSpan, type SwimlaneRow } from "../swimlaneRows";
+import { getAgents, isSingleSpan, type SwimlaneRow } from "../swimlaneRows";
 import {
   collectPathWithNavigators,
   collectRawEvents,
@@ -52,6 +52,11 @@ import {
 } from "./useTimeline";
 import { useTimelinesArray } from "./useTimelinesArray";
 
+// Phase lanes synthesized from the eval lifecycle (init/scoring) rather than
+// agent activity. A timeline whose only child lanes are phases has no agent
+// sub-structure to drill into, so it shouldn't auto-expand.
+const PHASE_SPAN_TYPES = new Set(["init", "scorers"]);
+
 const emptySourceSpans: ReadonlyMap<string, TimelineSpan> = new Map();
 const emptyHighlightedKeys: ReadonlyMap<string, number> = new Map();
 
@@ -74,6 +79,9 @@ export interface TranscriptTimelineResult {
   minimapSelection: MinimapSelection | undefined;
   /** Whether the timeline has meaningful structure (non-empty root with children). */
   hasTimeline: boolean;
+  /** Whether the timeline has agent sub-structure worth expanding (a child lane
+   *  beyond the lifecycle phases init/scoring). */
+  hasAgentTimeline: boolean;
   /** All available timelines (may be 1 or more). */
   timelines: Timeline[];
   /** Index of the currently active timeline. */
@@ -329,6 +337,17 @@ export function useTranscriptTimeline(
     ) ||
       timeline.root.branches.length > 0);
 
+  // True when the timeline has agent sub-structure worth expanding — i.e. a
+  // child lane that isn't just a lifecycle phase (init/scoring). A bare
+  // main + scoring transcript is effectively flat and defaults to collapsed.
+  const hasAgentTimeline = visibleRows.some((row) => {
+    if (row.depth < 1) return false;
+    const rowSpan = row.spans[0];
+    if (!rowSpan) return false;
+    const span = getAgents(rowSpan)[0];
+    return !!span && !PHASE_SPAN_TYPES.has(span.spanType ?? "");
+  });
+
   // Compute the agent name for the outline header.
   // When a swimlane row is selected, show its name; otherwise show the root.
   const selectedRowName = useMemo(() => {
@@ -349,6 +368,7 @@ export function useTranscriptTimeline(
     sourceSpans,
     minimapSelection,
     hasTimeline,
+    hasAgentTimeline,
     timelines,
     activeTimelineIndex,
     setActiveTimeline,


### PR DESCRIPTION
## Problem

A transcript whose only swimlanes are the **main** lane plus lifecycle phase lanes (**init**/**scoring**) was expanded by default in the timeline. There's no agent sub-structure to drill into, so it should default to collapsed.

The default expand/collapse state is driven by `swimlanesDefaultCollapsed` in `TranscriptLayout`, which force-expands (`false`) whenever `hasTimeline` is true. But `hasTimeline` becomes true as soon as the root `main` lane has *any* child span — including the synthesized `scoring`/`init` phase spans — so a bare solver+scorer transcript was treated as a real, expandable timeline.

## Fix

Add a `hasAgentTimeline` signal in `useTranscriptTimeline` that is true only when a child lane is something other than a lifecycle phase (`init`/`scoring`). `swimlanesDefaultCollapsed` now expands by default only when `hasAgentTimeline` is true; a main + scoring/init-only timeline defaults to collapsed.

A user's explicit expand/collapse choice still takes precedence (the persisted `swimlanesCollapsed` preference is unchanged).

## Tests

- `useTranscriptTimeline.test.ts`: main + scoring → `hasAgentTimeline=false`; multi-agent → `hasAgentTimeline=true`.
- All timeline tests pass; `pnpm check` (typecheck + lint + format) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)