### PR TITLE
InfoEventView: use ExpandablePanel for long content

### DIFF
--- a/packages/inspect-components/src/transcript/InfoEventView.tsx
+++ b/packages/inspect-components/src/transcript/InfoEventView.tsx
@@ -3,7 +3,7 @@ import { FC, ReactNode } from "react";
 
 import type { InfoEvent } from "@tsmono/inspect-common/types";
 import { RenderedText } from "@tsmono/inspect-components/content";
-import { JSONPanel } from "@tsmono/react/components";
+import { ExpandablePanel, JSONPanel } from "@tsmono/react/components";
 import { formatDateTime } from "@tsmono/util";
 
 import { EventPanel } from "./event/EventPanel";
@@ -43,7 +43,9 @@ export const InfoEventView: FC<InfoEventViewProps> = ({
       }
       icon={TranscriptIcons.info}
     >
-      {panels}
+      <ExpandablePanel id={`${eventNode.id}-info`} collapse={true}>
+        {panels}
+      </ExpandablePanel>
     </EventPanel>
   );
 };


### PR DESCRIPTION
## Summary

`InfoEventView` rendered its content (markdown string or JSON) directly, so very long info events blew out the transcript. This wraps the content in `ExpandablePanel` (`collapse={true}`), matching the pattern used elsewhere in the viewer for long event content (reasoning, server-tool output, compaction).

- Short content (under the panel's 15-line threshold) renders fully — no toggle shown.
- Long content starts collapsed/truncated with a "more..." toggle so users can expand/collapse it.

## Testing

- `eslint` and `prettier --check` pass on the changed file.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)