### PR TITLE
Viewer: drive log listing via React Query (multi-log-dir PR 1/3)

### DIFF
--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -15,7 +15,7 @@ import "@tsmono/theme/base";
 import "@tsmono/theme/vscode";
 import "./App.css";
 
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ClipboardJS from "clipboard";
 import { FC, useCallback, useEffect, useLayoutEffect } from "react";
@@ -33,6 +33,7 @@ import { ClientAPI, HostMessage } from "../client/api/types.ts";
 import { inspectStateHooks } from "../state/componentStateAdapter";
 import { queryClient } from "../state/queryClient.ts";
 import { ApiProvider, useApi, useStore } from "../state/store.ts";
+import { logListingQueryKey, useLogListing } from "../state/useLogListing.ts";
 import {
   SETTINGS_STORAGE_KEY,
   useUserSettings,
@@ -112,7 +113,10 @@ const AppContent: FC = () => {
   const setInitialState = useStore((state) => state.appActions.setInitialState);
   const setLoading = useStore((state) => state.appActions.setLoading);
 
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const ensureReplicationReady = useStore(
+    (state) => state.logsActions.ensureReplicationReady
+  );
+  const queryClient = useQueryClient();
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
   const setLogDir = useStore((state) => state.logsActions.setLogDir);
   const setLogFiles = useStore((state) => state.logsActions.setLogHandles);
@@ -122,6 +126,12 @@ const AppContent: FC = () => {
 
   const loadLog = useStore((state) => state.logActions.syncLog);
   const pollLog = useStore((state) => state.logActions.pollLog);
+
+  useLogListing(logDir);
+
+  useEffect(() => {
+    void ensureReplicationReady();
+  }, [ensureReplicationReady]);
 
   // Load a specific log
   useEffect(() => {
@@ -201,7 +211,9 @@ const AppContent: FC = () => {
               api.open_log_file(e.data.url, e.data.log_dir);
             }
           } else {
-            syncLogs();
+            queryClient.invalidateQueries({
+              queryKey: logListingQueryKey(logDir),
+            });
           }
           break;
         }
@@ -213,7 +225,7 @@ const AppContent: FC = () => {
       logDir,
       setSelectedLogFile,
       api,
-      syncLogs,
+      queryClient,
       rehydrated,
     ]
   );
@@ -263,14 +275,7 @@ const AppContent: FC = () => {
     };
 
     loadLogsAndState();
-  }, [
-    setLogDir,
-    setLogFiles,
-    setSelectedLogFile,
-    initLogDir,
-    syncLogs,
-    onMessage,
-  ]);
+  }, [setLogDir, setLogFiles, setSelectedLogFile, initLogDir, onMessage]);
 
   return (
     <ComponentIconProvider icons={componentIcons}>

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -15,7 +15,7 @@ import "@tsmono/theme/base";
 import "@tsmono/theme/vscode";
 import "./App.css";
 
-import { QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ClipboardJS from "clipboard";
 import { FC, useCallback, useEffect, useLayoutEffect } from "react";
@@ -33,7 +33,7 @@ import { ClientAPI, HostMessage } from "../client/api/types.ts";
 import { inspectStateHooks } from "../state/componentStateAdapter";
 import { queryClient } from "../state/queryClient.ts";
 import { ApiProvider, useApi, useStore } from "../state/store.ts";
-import { logListingQueryKey, useLogListing } from "../state/useLogListing.ts";
+import { useLogListing, useRefreshLogListing } from "../state/useLogListing.ts";
 import {
   SETTINGS_STORAGE_KEY,
   useUserSettings,
@@ -116,7 +116,7 @@ const AppContent: FC = () => {
   const ensureReplicationReady = useStore(
     (state) => state.logsActions.ensureReplicationReady
   );
-  const queryClient = useQueryClient();
+  const refreshLogListing = useRefreshLogListing();
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
   const setLogDir = useStore((state) => state.logsActions.setLogDir);
   const setLogFiles = useStore((state) => state.logsActions.setLogHandles);
@@ -211,9 +211,7 @@ const AppContent: FC = () => {
               api.open_log_file(e.data.url, e.data.log_dir);
             }
           } else {
-            queryClient.invalidateQueries({
-              queryKey: logListingQueryKey(logDir),
-            });
+            void refreshLogListing();
           }
           break;
         }
@@ -225,7 +223,7 @@ const AppContent: FC = () => {
       logDir,
       setSelectedLogFile,
       api,
-      queryClient,
+      refreshLogListing,
       rehydrated,
     ]
   );

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -15,13 +15,12 @@ import "@tsmono/theme/base";
 import "@tsmono/theme/vscode";
 import "./App.css";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ClipboardJS from "clipboard";
 import { FC, useCallback, useEffect, useLayoutEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 
-import { defaultRetry } from "@tsmono/react";
 import {
   ComponentIconProvider,
   ComponentIcons,
@@ -32,6 +31,7 @@ import { basename, dirname } from "@tsmono/util";
 
 import { ClientAPI, HostMessage } from "../client/api/types.ts";
 import { inspectStateHooks } from "../state/componentStateAdapter";
+import { queryClient } from "../state/queryClient.ts";
 import { ApiProvider, useApi, useStore } from "../state/store.ts";
 import {
   SETTINGS_STORAGE_KEY,
@@ -42,11 +42,6 @@ import { isUri } from "../utils/uri.ts";
 import { ApplicationIcons } from "./appearance/icons.ts";
 import { AppRouter } from "./routing/AppRouter.tsx";
 import { useAppConfigAsync } from "./server/useAppConfig.ts";
-
-// app-config (and future server data) flow through this client.
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: defaultRetry } },
-});
 
 const componentIcons: ComponentIcons = {
   chevronDown: ApplicationIcons.chevron.down,

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { FC, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -5,6 +6,7 @@ import { kLogViewSamplesTabId } from "../../constants";
 import { useSampleSummaries } from "../../state/hooks";
 import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
+import { logListingQueryKey } from "../../state/useLogListing";
 import { usePollSample } from "../../state/usePollSample";
 import { useLogSampleNavigation } from "../routing/sampleNavigation";
 import {
@@ -21,7 +23,7 @@ import { isSingleFileMode } from "../singleFileMode";
  * This is shown when navigating to /logs/path/to/file.eval/samples/sample/id/epoch
  *
  * This component handles:
- * - Log loading (initLogDir, setSelectedLogFile, syncLogs)
+ * - Log loading (initLogDir, setSelectedLogFile, listing invalidation)
  * - Sample selection and loading (useLoadSample, usePollSample)
  * - Navigation state via useLogSampleNavigation (respects log filters)
  *
@@ -55,7 +57,8 @@ export const LogSampleDetailView: FC = () => {
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
   );
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const queryClient = useQueryClient();
+  const logDir = useStore((s) => s.logs.logDir);
   const selectSample = useStore((state) => state.logActions.selectSample);
 
   // Fall back to state for VSCode restored state scenario
@@ -80,8 +83,10 @@ export const LogSampleDetailView: FC = () => {
         // Set the selected log file
         setSelectedLogFile(routeLogPath);
 
-        // Sync logs to ensure we have the latest data
-        void syncLogs();
+        // Refresh the listing to ensure we have the latest data
+        void queryClient.invalidateQueries({
+          queryKey: logListingQueryKey(logDir),
+        });
 
         // Select the sample
         const targetEpoch = parseInt(routeEpoch, 10);
@@ -100,7 +105,8 @@ export const LogSampleDetailView: FC = () => {
     routeEpoch,
     initLogDir,
     setSelectedLogFile,
-    syncLogs,
+    queryClient,
+    logDir,
     selectSample,
   ]);
 

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { FC, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -6,7 +5,7 @@ import { kLogViewSamplesTabId } from "../../constants";
 import { useSampleSummaries } from "../../state/hooks";
 import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
-import { logListingQueryKey } from "../../state/useLogListing";
+import { useRefreshLogListing } from "../../state/useLogListing";
 import { usePollSample } from "../../state/usePollSample";
 import { useLogSampleNavigation } from "../routing/sampleNavigation";
 import {
@@ -57,8 +56,7 @@ export const LogSampleDetailView: FC = () => {
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
   );
-  const queryClient = useQueryClient();
-  const logDir = useStore((s) => s.logs.logDir);
+  const refreshLogListing = useRefreshLogListing();
   const selectSample = useStore((state) => state.logActions.selectSample);
 
   // Fall back to state for VSCode restored state scenario
@@ -84,9 +82,7 @@ export const LogSampleDetailView: FC = () => {
         setSelectedLogFile(routeLogPath);
 
         // Refresh the listing to ensure we have the latest data
-        void queryClient.invalidateQueries({
-          queryKey: logListingQueryKey(logDir),
-        });
+        void refreshLogListing();
 
         // Select the sample
         const targetEpoch = parseInt(routeEpoch, 10);
@@ -105,8 +101,7 @@ export const LogSampleDetailView: FC = () => {
     routeEpoch,
     initLogDir,
     setSelectedLogFile,
-    queryClient,
-    logDir,
+    refreshLogListing,
     selectSample,
   ]);
 

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { FC, useEffect, useLayoutEffect } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
@@ -10,7 +9,7 @@ import {
 } from "../../state/hooks";
 import { useUnloadLog } from "../../state/log";
 import { useStore } from "../../state/store";
-import { logListingQueryKey } from "../../state/useLogListing";
+import { useRefreshLogListing } from "../../state/useLogListing";
 import {
   baseUrl,
   logSamplesUrl,
@@ -108,8 +107,7 @@ export const LogViewContainer: FC = () => {
   }, [initialState, evalSpec, clearInitialState, navigate, prefix]);
 
   const prevLogPath = usePrevious<string | undefined>(logPath);
-  const queryClient = useQueryClient();
-  const logDir = useStore((s) => s.logs.logDir);
+  const refreshLogListing = useRefreshLogListing();
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
 
   // Clear the previous eval's data before paint when the route changes, so the
@@ -135,14 +133,12 @@ export const LogViewContainer: FC = () => {
       if (logPath) {
         await initLogDir();
         setSelectedLogFile(logPath);
-        void queryClient.invalidateQueries({
-          queryKey: logListingQueryKey(logDir),
-        });
+        void refreshLogListing();
       }
     };
 
     loadLogFromPath();
-  }, [logPath, setSelectedLogFile, initLogDir, queryClient, logDir]);
+  }, [logPath, setSelectedLogFile, initLogDir, refreshLogListing]);
 
   return <LogViewLayout />;
 };

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { FC, useEffect, useLayoutEffect } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
@@ -9,6 +10,7 @@ import {
 } from "../../state/hooks";
 import { useUnloadLog } from "../../state/log";
 import { useStore } from "../../state/store";
+import { logListingQueryKey } from "../../state/useLogListing";
 import {
   baseUrl,
   logSamplesUrl,
@@ -106,7 +108,8 @@ export const LogViewContainer: FC = () => {
   }, [initialState, evalSpec, clearInitialState, navigate, prefix]);
 
   const prevLogPath = usePrevious<string | undefined>(logPath);
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const queryClient = useQueryClient();
+  const logDir = useStore((s) => s.logs.logDir);
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
 
   // Clear the previous eval's data before paint when the route changes, so the
@@ -132,12 +135,14 @@ export const LogViewContainer: FC = () => {
       if (logPath) {
         await initLogDir();
         setSelectedLogFile(logPath);
-        void syncLogs();
+        void queryClient.invalidateQueries({
+          queryKey: logListingQueryKey(logDir),
+        });
       }
     };
 
     loadLogFromPath();
-  }, [logPath, setSelectedLogFile, initLogDir, syncLogs]);
+  }, [logPath, setSelectedLogFile, initLogDir, queryClient, logDir]);
 
   return <LogViewLayout />;
 };

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from "@tanstack/react-query";
 import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
@@ -29,7 +28,7 @@ import {
 import { useSampleData } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import { useLoadSample } from "../../../state/useLoadSample";
-import { logListingQueryKey } from "../../../state/useLogListing";
+import { useRefreshLogListing } from "../../../state/useLogListing";
 import { usePollSample } from "../../../state/usePollSample";
 import { formatDateTime, formatTime } from "../../../utils/format";
 import { useLogRouteParams } from "../../routing/url";
@@ -58,8 +57,7 @@ export const SamplePrintView: FC = () => {
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
   );
-  const queryClient = useQueryClient();
-  const logDir = useStore((s) => s.logs.logDir);
+  const refreshLogListing = useRefreshLogListing();
   const selectSample = useStore((state) => state.logActions.selectSample);
 
   useEffect(() => {
@@ -67,9 +65,7 @@ export const SamplePrintView: FC = () => {
       if (logPath && sampleId && epoch) {
         await initLogDir();
         setSelectedLogFile(logPath);
-        void queryClient.invalidateQueries({
-          queryKey: logListingQueryKey(logDir),
-        });
+        void refreshLogListing();
 
         const targetEpoch = parseInt(epoch, 10);
         if (!isNaN(targetEpoch)) {
@@ -84,8 +80,7 @@ export const SamplePrintView: FC = () => {
     epoch,
     initLogDir,
     setSelectedLogFile,
-    queryClient,
-    logDir,
+    refreshLogListing,
     selectSample,
   ]);
 

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
@@ -28,6 +29,7 @@ import {
 import { useSampleData } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import { useLoadSample } from "../../../state/useLoadSample";
+import { logListingQueryKey } from "../../../state/useLogListing";
 import { usePollSample } from "../../../state/usePollSample";
 import { formatDateTime, formatTime } from "../../../utils/format";
 import { useLogRouteParams } from "../../routing/url";
@@ -56,7 +58,8 @@ export const SamplePrintView: FC = () => {
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
   );
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const queryClient = useQueryClient();
+  const logDir = useStore((s) => s.logs.logDir);
   const selectSample = useStore((state) => state.logActions.selectSample);
 
   useEffect(() => {
@@ -64,7 +67,9 @@ export const SamplePrintView: FC = () => {
       if (logPath && sampleId && epoch) {
         await initLogDir();
         setSelectedLogFile(logPath);
-        void syncLogs();
+        void queryClient.invalidateQueries({
+          queryKey: logListingQueryKey(logDir),
+        });
 
         const targetEpoch = parseInt(epoch, 10);
         if (!isNaN(targetEpoch)) {
@@ -79,7 +84,8 @@ export const SamplePrintView: FC = () => {
     epoch,
     initLogDir,
     setSelectedLogFile,
-    syncLogs,
+    queryClient,
+    logDir,
     selectSample,
   ]);
 

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,22 +1,27 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 
 import { createLogger } from "@tsmono/util";
 
 import { clientEventsService } from "./clientEventsService";
 import { useApi, useStore } from "./store";
+import { logListingQueryKey } from "./useLogListing";
 
 const log = createLogger("Client-Events");
 
 export function useClientEvents() {
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const queryClient = useQueryClient();
+  const logDir = useStore((state) => state.logs.logDir);
   const api = useApi();
 
   const refreshCallback = useCallback(
     async (_reason: "event" | "periodic") => {
       log.debug(`Refresh Log Files (${_reason})`);
-      await syncLogs();
+      await queryClient.invalidateQueries({
+        queryKey: logListingQueryKey(logDir),
+      });
     },
-    [syncLogs]
+    [queryClient, logDir]
   );
 
   useEffect(() => {

--- a/apps/inspect/src/state/clientEvents.ts
+++ b/apps/inspect/src/state/clientEvents.ts
@@ -1,27 +1,23 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 
 import { createLogger } from "@tsmono/util";
 
 import { clientEventsService } from "./clientEventsService";
-import { useApi, useStore } from "./store";
-import { logListingQueryKey } from "./useLogListing";
+import { useApi } from "./store";
+import { useRefreshLogListing } from "./useLogListing";
 
 const log = createLogger("Client-Events");
 
 export function useClientEvents() {
-  const queryClient = useQueryClient();
-  const logDir = useStore((state) => state.logs.logDir);
+  const refreshLogListing = useRefreshLogListing();
   const api = useApi();
 
   const refreshCallback = useCallback(
     async (_reason: "event" | "periodic") => {
       log.debug(`Refresh Log Files (${_reason})`);
-      await queryClient.invalidateQueries({
-        queryKey: logListingQueryKey(logDir),
-      });
+      await refreshLogListing();
     },
-    [queryClient, logDir]
+    [refreshLogListing]
   );
 
   useEffect(() => {

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -599,7 +599,9 @@ export const useSamplePopover = (id: string) => {
 
 export const useLogs = () => {
   // Loading logs and eval set info
-  const syncLogs = useStore((state) => state.logsActions.syncLogs);
+  const ensureReplicationReady = useStore(
+    (state) => state.logsActions.ensureReplicationReady
+  );
   const syncEvalSetInfo = useStore(
     (state) => state.logsActions.syncEvalSetInfo
   );
@@ -608,12 +610,15 @@ export const useLogs = () => {
   const loadLogs = useCallback(
     async (logPath?: string) => {
       // load in parallel to display Show Retried Logs button as soon as we know current directory is an eval set without awaiting all logs
-      await Promise.all([syncEvalSetInfo(logPath), syncLogs()]).catch((e) => {
+      await Promise.all([
+        syncEvalSetInfo(logPath),
+        ensureReplicationReady(),
+      ]).catch((e) => {
         log.error("Error loading logs", e);
         setLoading(false, e as Error);
       });
     },
-    [syncLogs, setLoading, syncEvalSetInfo]
+    [ensureReplicationReady, setLoading, syncEvalSetInfo]
   );
 
   // Loading overviews

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -18,7 +18,9 @@ import {
 import { DatabaseService } from "../client/database";
 import { isUri, join } from "../utils/uri";
 
+import { queryClient } from "./queryClient";
 import { StoreState } from "./store";
+import { logListingQueryKey } from "./useLogListing";
 
 const log = createLogger("Log Slice");
 
@@ -37,7 +39,7 @@ export interface LogsSlice {
     // Fetch or update logs
     initLogDir: () => Promise<string | undefined>;
     ensureReplication: () => Promise<void>;
-    syncLogs: () => Promise<LogHandle[]>;
+    ensureReplicationReady: () => Promise<void>;
 
     setSelectedLogFile: (logFile: string) => void;
     clearSelectedLogFile: () => void;
@@ -264,10 +266,10 @@ export const createLogsSlice = (
       ensureReplication: async () => {
         const state = get();
         if (state.logs.logDir) {
-          await state.logsActions.syncLogs();
+          await state.logsActions.ensureReplicationReady();
         }
       },
-      syncLogs: async () => {
+      ensureReplicationReady: async () => {
         const databaseService = get().databaseService;
         get().appActions.setLoading(true);
 
@@ -313,7 +315,7 @@ export const createLogsSlice = (
             if (!get().app.status.error) {
               get().appActions.setLoading(false);
             }
-            return [];
+            return;
           }
 
           // Activate the database for this log directory
@@ -377,8 +379,18 @@ export const createLogsSlice = (
 
         get().appActions.setLoading(false);
 
-        // Sync
-        return (await get().replicationService?.sync(initDatabase)) || [];
+        // On first init, startReplication already preloaded cached handles.
+        // On warm re-entry (same dir) nothing preloaded this call, so refresh
+        // handles from cache here; the useLogListing hook owns the server fetch.
+        if (!initDatabase) {
+          await get().replicationService?.preloadFromCache();
+        }
+
+        // Replication is wired up now; (re)fetch the listing — covers the case
+        // where useLogListing's initial query ran before startReplication.
+        void queryClient.invalidateQueries({
+          queryKey: logListingQueryKey(get().logs.logDir),
+        });
       },
       syncEvalSetInfo: async (logPath?: string) => {
         const info = await api.get_eval_set(logPath);
@@ -403,7 +415,10 @@ export const createLogsSlice = (
 
         if (!isInFileList) {
           if (state.replicationService?.isReplicating() && !isSingleFileMode) {
-            await state.logsActions.syncLogs();
+            await state.logsActions.ensureReplicationReady();
+            await queryClient.refetchQueries({
+              queryKey: logListingQueryKey(get().logs.logDir),
+            });
             const logHandle = get().logs.logs.find((val: { name: string }) =>
               val.name.endsWith(logFile)
             );

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -20,7 +20,7 @@ import { isUri, join } from "../utils/uri";
 
 import { queryClient } from "./queryClient";
 import { StoreState } from "./store";
-import { logListingQueryKey } from "./useLogListing";
+import { logListingQueryFilter } from "./useLogListing";
 
 const log = createLogger("Log Slice");
 
@@ -388,9 +388,7 @@ export const createLogsSlice = (
 
         // Replication is wired up now; (re)fetch the listing — covers the case
         // where useLogListing's initial query ran before startReplication.
-        void queryClient.invalidateQueries({
-          queryKey: logListingQueryKey(get().logs.logDir),
-        });
+        void queryClient.invalidateQueries(logListingQueryFilter);
       },
       syncEvalSetInfo: async (logPath?: string) => {
         const info = await api.get_eval_set(logPath);
@@ -416,9 +414,7 @@ export const createLogsSlice = (
         if (!isInFileList) {
           if (state.replicationService?.isReplicating() && !isSingleFileMode) {
             await state.logsActions.ensureReplicationReady();
-            await queryClient.refetchQueries({
-              queryKey: logListingQueryKey(get().logs.logDir),
-            });
+            await queryClient.refetchQueries(logListingQueryFilter);
             const logHandle = get().logs.logs.find((val: { name: string }) =>
               val.name.endsWith(logFile)
             );

--- a/apps/inspect/src/state/queryClient.ts
+++ b/apps/inspect/src/state/queryClient.ts
@@ -1,0 +1,8 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { defaultRetry } from "@tsmono/react";
+
+// defaultRetry must stay the global default — the app-config query depends on it.
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: defaultRetry } },
+});

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -1,11 +1,11 @@
-import { LogHandle } from "@tsmono/inspect-common";
+import { LogFilesResponse, LogHandle } from "@tsmono/inspect-common";
 import { throttle } from "@tsmono/util";
 
 import { ClientAPI, LogDetails, LogPreview } from "../../client/api/types";
 import { DatabaseService } from "../../client/database";
 import { WorkPriority, WorkQueue } from "../../utils/workQueue";
 
-import { computeInvalidations, computeSyncCursor } from "./syncCursor";
+import { computeInvalidations } from "./syncCursor";
 
 export interface ApplicationContext {
   setLogHandles: (logs: LogHandle[]) => void;
@@ -36,10 +36,6 @@ export class ReplicationService {
   private _previewQueue: WorkQueue<LogHandle, LogPreview>;
   private _detailQueue: WorkQueue<LogHandle, LogDetails>;
   private _processingCount: number;
-
-  // Track sync requests (so we wait on already running requests before syncing again)
-  private _pendingSync: Promise<LogHandle[]> | null = null;
-  private _syncQueued: boolean = false;
 
   // Batched DB updates
   private _pendingPreviewUpdates: Record<string, LogPreview> = {};
@@ -260,128 +256,29 @@ export class ReplicationService {
     return !!this._api && !!this._database && !!this._applicationContext;
   }
 
-  public async sync(progress?: boolean): Promise<LogHandle[]> {
-    // If sync is running and another is already queued, just wait for the queued one
-    if (this._pendingSync && this._syncQueued) {
-      return this._pendingSync;
-    }
-
-    // If sync is running but none queued, queue this one
-    if (this._pendingSync) {
-      this._syncQueued = true;
-      await this._pendingSync;
-      this._syncQueued = false;
-      // After pending completes, run one more sync
-      return this.sync(progress);
-    }
-
-    // No sync running, execute immediately
-    this._pendingSync = this._syncImpl(progress);
-
-    try {
-      return await this._pendingSync;
-    } finally {
-      this._pendingSync = null;
-    }
-  }
-
-  private async _syncImpl(progress?: boolean): Promise<LogHandle[]> {
+  // Apply a server listing fetched by the caller (the useLogListing hook).
+  // Owns diffing, cache invalidation, persisting the handle list, and queueing
+  // preview/detail work. Returns the merged handle list now in the database.
+  public async applyServerListing(
+    response: LogFilesResponse,
+    logFiles: LogHandle[]
+  ): Promise<LogHandle[]> {
     if (!this._database) {
       throw new Error("No database available for replication.");
     }
-
-    if (!this._api) {
-      throw new Error("No API available for replication.");
-    }
-
     if (!this._applicationContext) {
-      throw new Error("No replication context available for replication.");
+      throw new Error("No replication context available.");
     }
 
-    if (progress) {
-      this._applicationContext.setLoading(true);
-    }
-
-    // First query the list of logs
-    const logFiles = (await this._database.readLogs()) || [];
-    const { mtime, clientFileCount, staticList } = computeSyncCursor(logFiles);
-    if (staticList) {
-      // There is no mtime data which means sync isn't possible
-      // check to ensure the file list hasn't changed (in which
-      // we will invlidate the whole thing)
-      const serverLogs = await this._api.get_logs(0, 0);
-      let invalidate = false;
-      if (serverLogs.files.length !== logFiles.length) {
-        // Quick check - if they're differing lengths, invalidate.
-        invalidate = true;
-      } else {
-        // Slower check - see if _any_ files are different
-        const localLogNames = new Set(logFiles.map((f) => f.name));
-        for (const serverLog of serverLogs.files) {
-          if (!localLogNames.has(serverLog.name)) {
-            invalidate = true;
-            break;
-          }
-        }
-      }
-
-      if (invalidate) {
-        // Invalidate everything
-        for (const file of logFiles) {
-          this._database?.clearCacheForFile(file.name);
-        }
-
-        // Drop stale queued work before scheduling new fetches
-        this._previewQueue.clear();
-        this._detailQueue.clear();
-
-        // Apply the new list
-        this._applicationContext?.setLogHandles(serverLogs.files);
-
-        // Schedule sync of missing previews or details
-        this.queueLogDetails(serverLogs.files);
-        this.queueLogPreviews(serverLogs.files);
-
-        if (progress) {
-          this._applicationContext.setLoading(false);
-        }
-
-        return serverLogs.files;
-      } else {
-        // Activate the current log handles
-        this._applicationContext?.setLogHandles(logFiles);
-
-        await this.queueMissingOrStartedPreviews(logFiles);
-
-        const detailTasks: LogHandle[] = [];
-        const details = await this._database.findMissingDetails(logFiles);
-        for (const d of details) {
-          if (!detailTasks.find((t) => t.name === d.name)) {
-            detailTasks.push(d);
-          }
-        }
-        this.queueLogDetails(detailTasks);
-
-        if (progress) {
-          this._applicationContext.setLoading(false);
-        }
-
-        return logFiles;
-      }
-    }
-
-    // Fetch the updated list of logs from the server
-    const response = await this._api.get_logs(mtime, clientFileCount);
     const updatedLogs = response.files;
 
     if (response.response_type === "full") {
-      const deletedFiles = logFiles.filter((current) => {
-        return !updatedLogs.find((f) => f.name === current.name);
-      });
+      const deletedFiles = logFiles.filter(
+        (current) => !updatedLogs.find((f) => f.name === current.name)
+      );
       for (const file of deletedFiles) {
         this._database?.clearCacheForFile(file.name);
       }
-
       if (deletedFiles.length > 0) {
         const deletedNames = deletedFiles.map((f) => f.name);
         this._previewQueue.removeByIds(deletedNames);
@@ -390,22 +287,17 @@ export class ReplicationService {
     }
 
     const toInvalidate = computeInvalidations(updatedLogs, logFiles);
-
-    // Invalidate summaries and overviews for deleted or updated files
     toInvalidate
       .map((file) => file.name)
       .map((name) => this._database?.clearCacheForFile(name));
 
-    // Cache the current list of files
     await this._database.writeLogs(updatedLogs);
 
-    // Update the log handles in the application state
     const allLogHandles = (await this._database.readLogs()) || [];
     this._applicationContext?.setLogHandles(allLogHandles);
 
     await this.queueMissingOrStartedPreviews(allLogHandles, toInvalidate);
 
-    // Schedule detail fetching for new/changed logs
     const detailTasks = [...toInvalidate];
     const details = await this._database.findMissingDetails(allLogHandles);
     for (const d of details) {
@@ -415,11 +307,16 @@ export class ReplicationService {
     }
     this.queueLogDetails(detailTasks, WorkPriority.High);
 
-    if (progress) {
-      this._applicationContext.setLoading(false);
-    }
-
     return allLogHandles;
+  }
+
+  // Warm-reentry preload; the useLogListing hook owns the server fetch.
+  public async preloadFromCache(): Promise<LogHandle[]> {
+    if (!this._database || !this._applicationContext) return [];
+    const logFiles = (await this._database.readLogs()) || [];
+    this._applicationContext.setLogHandles(logFiles);
+    await this.queueMissingOrStartedPreviews(logFiles);
+    return logFiles;
   }
 
   public async loadLogPreviews(context: {
@@ -510,12 +407,10 @@ export class ReplicationService {
     this._previewQueue.enqueue(logs, priority);
   }
 
-  private count = 0;
   queueLogDetails(
     logs: LogHandle[],
     priority: WorkPriority = WorkPriority.Medium
   ) {
-    this.count = this.count + logs.length;
     // Add to queue (deduplicated by name)
     this._detailQueue.enqueue(logs, priority);
   }

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -5,6 +5,8 @@ import { ClientAPI, LogDetails, LogPreview } from "../../client/api/types";
 import { DatabaseService } from "../../client/database";
 import { WorkPriority, WorkQueue } from "../../utils/workQueue";
 
+import { computeInvalidations, computeSyncCursor } from "./syncCursor";
+
 export interface ApplicationContext {
   setLogHandles: (logs: LogHandle[]) => void;
   getSelectedLog: () => LogHandle | undefined;
@@ -302,16 +304,7 @@ export class ReplicationService {
 
     // First query the list of logs
     const logFiles = (await this._database.readLogs()) || [];
-    let mtime = 0;
-    let clientFileCount = 0;
-    if (logFiles && logFiles.length > 0) {
-      mtime = Math.max(...logFiles.map((file) => file.mtime || 0));
-      clientFileCount = logFiles.length;
-    }
-
-    // If there are logFiles, but no mtime, then no sync is possible
-    // this is just a static list.
-    const staticList = logFiles.length > 0 && mtime === 0;
+    const { mtime, clientFileCount, staticList } = computeSyncCursor(logFiles);
     if (staticList) {
       // There is no mtime data which means sync isn't possible
       // check to ensure the file list hasn't changed (in which
@@ -396,25 +389,7 @@ export class ReplicationService {
       }
     }
 
-    // Make a list of the files in current files that are missing
-    // from the files we just loaded or which have a lower mtime
-    // than the file in the files list.
-    const toInvalidate = updatedLogs.filter((remoteLog) => {
-      const localCopy = logFiles.find((f) => f.name === remoteLog.name);
-
-      // There isn't a local copy, so it's new
-      if (!localCopy) {
-        return true;
-      }
-
-      // If there is a local copy, but the remote mtime is newer, invalidate
-      if (remoteLog.mtime && localCopy.mtime) {
-        return remoteLog.mtime > localCopy.mtime;
-      }
-
-      // times are missing, so assume it's changed
-      return true;
-    });
+    const toInvalidate = computeInvalidations(updatedLogs, logFiles);
 
     // Invalidate summaries and overviews for deleted or updated files
     toInvalidate

--- a/apps/inspect/src/state/sync/syncCursor.test.ts
+++ b/apps/inspect/src/state/sync/syncCursor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { LogHandle } from "@tsmono/inspect-common/types";
+
+import { computeInvalidations, computeSyncCursor } from "./syncCursor";
+
+const log = (name: string, mtime: number | null): LogHandle => ({
+  name,
+  task: null,
+  task_id: null,
+  mtime,
+});
+
+describe("computeSyncCursor", () => {
+  it("returns a zero cursor for an empty list", () => {
+    expect(computeSyncCursor([])).toEqual({
+      mtime: 0,
+      clientFileCount: 0,
+      staticList: false,
+    });
+  });
+
+  it("uses the max mtime and the file count", () => {
+    const logs = [log("a.eval", 100), log("b.eval", 250)];
+    expect(computeSyncCursor(logs)).toEqual({
+      mtime: 250,
+      clientFileCount: 2,
+      staticList: false,
+    });
+  });
+
+  it("flags a static list when files exist but no mtimes are present", () => {
+    const logs = [log("a.eval", null), log("b.eval", null)];
+    expect(computeSyncCursor(logs)).toEqual({
+      mtime: 0,
+      clientFileCount: 2,
+      staticList: true,
+    });
+  });
+
+  it("is not static when at least one file has an mtime", () => {
+    const logs = [log("a.eval", null), log("b.eval", 300)];
+    expect(computeSyncCursor(logs)).toEqual({
+      mtime: 300,
+      clientFileCount: 2,
+      staticList: false,
+    });
+  });
+});
+
+describe("computeInvalidations", () => {
+  it("treats a remote log with no local copy as new", () => {
+    expect(
+      computeInvalidations([log("a.eval", 100)], []).map((l) => l.name)
+    ).toEqual(["a.eval"]);
+  });
+
+  it("invalidates when the remote mtime is newer than local", () => {
+    expect(
+      computeInvalidations([log("a.eval", 200)], [log("a.eval", 100)]).map(
+        (l) => l.name
+      )
+    ).toEqual(["a.eval"]);
+  });
+
+  it("does not invalidate when local is current", () => {
+    expect(
+      computeInvalidations([log("a.eval", 100)], [log("a.eval", 100)])
+    ).toEqual([]);
+  });
+
+  it("invalidates when either mtime is missing", () => {
+    expect(
+      computeInvalidations([log("a.eval", null)], [log("a.eval", 100)]).map(
+        (l) => l.name
+      )
+    ).toEqual(["a.eval"]);
+  });
+
+  it("invalidates when the local mtime is missing but the remote has one", () => {
+    expect(
+      computeInvalidations([log("a.eval", 200)], [log("a.eval", null)]).map(
+        (l) => l.name
+      )
+    ).toEqual(["a.eval"]);
+  });
+});

--- a/apps/inspect/src/state/sync/syncCursor.ts
+++ b/apps/inspect/src/state/sync/syncCursor.ts
@@ -8,10 +8,10 @@ export interface SyncCursor {
 
 // staticList = files cached but no mtimes: incremental sync is impossible, so the caller must force a full fetch.
 export function computeSyncCursor(logFiles: LogHandle[]): SyncCursor {
-  let mtime = 0;
-  if (logFiles.length > 0) {
-    mtime = Math.max(...logFiles.map((file) => file.mtime || 0));
-  }
+  const mtime = logFiles.reduce(
+    (max, file) => Math.max(max, file.mtime || 0),
+    0
+  );
   return {
     mtime,
     clientFileCount: logFiles.length,

--- a/apps/inspect/src/state/sync/syncCursor.ts
+++ b/apps/inspect/src/state/sync/syncCursor.ts
@@ -1,0 +1,35 @@
+import { LogHandle } from "@tsmono/inspect-common/types";
+
+export interface SyncCursor {
+  mtime: number;
+  clientFileCount: number;
+  staticList: boolean;
+}
+
+// staticList = files cached but no mtimes: incremental sync is impossible, so the caller must force a full fetch.
+export function computeSyncCursor(logFiles: LogHandle[]): SyncCursor {
+  let mtime = 0;
+  if (logFiles.length > 0) {
+    mtime = Math.max(...logFiles.map((file) => file.mtime || 0));
+  }
+  return {
+    mtime,
+    clientFileCount: logFiles.length,
+    staticList: logFiles.length > 0 && mtime === 0,
+  };
+}
+
+// A missing mtime on either side can't be compared, so treat it as changed (invalidate).
+export function computeInvalidations(
+  remoteLogs: LogHandle[],
+  localLogs: LogHandle[]
+): LogHandle[] {
+  return remoteLogs.filter((remoteLog) => {
+    const localCopy = localLogs.find((f) => f.name === remoteLog.name);
+    if (!localCopy) return true;
+    if (remoteLog.mtime && localCopy.mtime) {
+      return remoteLog.mtime > localCopy.mtime;
+    }
+    return true;
+  });
+}

--- a/apps/inspect/src/state/useLogListing.test.ts
+++ b/apps/inspect/src/state/useLogListing.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LogFilesResponse, LogHandle } from "@tsmono/inspect-common/types";
+
+import { fetchAndApplyListing } from "./useLogListing";
+
+const handle = (name: string, mtime: number): LogHandle => ({
+  name,
+  task: null,
+  task_id: null,
+  mtime,
+});
+
+describe("fetchAndApplyListing", () => {
+  it("fetches with the cached cursor and applies the response", async () => {
+    const cached = [handle("a.eval", 100)];
+    const response: LogFilesResponse = {
+      response_type: "incremental",
+      files: [handle("a.eval", 100), handle("b.eval", 200)],
+    };
+    const get_logs = vi.fn().mockResolvedValue(response);
+    const applyServerListing = vi.fn().mockResolvedValue(response.files);
+
+    const result = await fetchAndApplyListing({
+      api: { get_logs } as any,
+      replication: { applyServerListing, isReplicating: () => true } as any,
+      readCachedLogs: async () => cached,
+    });
+
+    // cursor from cached: mtime=100, count=1 (not static)
+    expect(get_logs).toHaveBeenCalledWith(100, 1);
+    expect(applyServerListing).toHaveBeenCalledWith(response, cached);
+    expect(result).toEqual(response.files);
+  });
+
+  it("forces a full fetch (count 0) for a static list", async () => {
+    const cached = [handle("a.eval", 0), handle("b.eval", 0)];
+    const response: LogFilesResponse = {
+      response_type: "full",
+      files: cached,
+    };
+    const get_logs = vi.fn().mockResolvedValue(response);
+    const applyServerListing = vi.fn().mockResolvedValue(response.files);
+
+    await fetchAndApplyListing({
+      api: { get_logs } as any,
+      replication: { applyServerListing, isReplicating: () => true } as any,
+      readCachedLogs: async () => cached,
+    });
+
+    // static list (files, no mtimes) -> get_logs(0, 0) forces a full response
+    expect(get_logs).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("returns an empty list when there is no replication context", async () => {
+    const get_logs = vi.fn();
+    const result = await fetchAndApplyListing({
+      api: { get_logs } as any,
+      replication: undefined,
+      readCachedLogs: async () => [],
+    });
+    expect(result).toEqual([]);
+    expect(get_logs).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the replication service is not yet wired up", async () => {
+    const get_logs = vi.fn();
+    const result = await fetchAndApplyListing({
+      api: { get_logs } as any,
+      replication: {
+        applyServerListing: vi.fn(),
+        isReplicating: () => false,
+      } as any,
+      readCachedLogs: async () => [],
+    });
+    expect(result).toEqual([]);
+    expect(get_logs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/inspect/src/state/useLogListing.ts
+++ b/apps/inspect/src/state/useLogListing.ts
@@ -1,3 +1,6 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
 import { LogHandle } from "@tsmono/inspect-common/types";
 import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
 import { AsyncData } from "@tsmono/util";
@@ -34,6 +37,17 @@ export async function fetchAndApplyListing(
 
 export function logListingQueryKey(logDir: string | undefined) {
   return ["log-files", logDir ?? "__default__"] as const;
+}
+
+// Prefix filter: TanStack does partial matching, so ["log-files"] hits any ["log-files", dir].
+export const logListingQueryFilter = { queryKey: ["log-files"] } as const;
+
+export function useRefreshLogListing(): () => Promise<void> {
+  const queryClient = useQueryClient();
+  return useCallback(
+    () => queryClient.invalidateQueries(logListingQueryFilter),
+    [queryClient]
+  );
 }
 
 // Mirrors useAppConfigAsync (app/server/useAppConfig.ts).

--- a/apps/inspect/src/state/useLogListing.ts
+++ b/apps/inspect/src/state/useLogListing.ts
@@ -1,0 +1,57 @@
+import { LogHandle } from "@tsmono/inspect-common/types";
+import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
+import { AsyncData } from "@tsmono/util";
+
+import { ClientAPI } from "../client/api/types";
+
+import { useApi, useStore } from "./store";
+import { ReplicationService } from "./sync/replicationService";
+import { computeSyncCursor } from "./sync/syncCursor";
+
+export interface FetchAndApplyDeps {
+  api: ClientAPI;
+  replication: ReplicationService | undefined | null;
+  readCachedLogs: () => Promise<LogHandle[]>;
+}
+
+export async function fetchAndApplyListing(
+  deps: FetchAndApplyDeps
+): Promise<LogHandle[]> {
+  const { api, replication, readCachedLogs } = deps;
+  // The service instance always exists; only fetch once startReplication has
+  // wired it up. Premature runs (query mounts before setup) no-op; the
+  // ensureReplicationReady tail invalidation re-runs this once ready.
+  if (!replication || !replication.isReplicating()) return [];
+  const cached = await readCachedLogs();
+  const { mtime, clientFileCount, staticList } = computeSyncCursor(cached);
+  // A static list has no mtimes; fetch with a zero count to force a full
+  // response the apply step can diff against.
+  const response = staticList
+    ? await api.get_logs(0, 0)
+    : await api.get_logs(mtime, clientFileCount);
+  return replication.applyServerListing(response, cached);
+}
+
+export function logListingQueryKey(logDir: string | undefined) {
+  return ["log-files", logDir ?? "__default__"] as const;
+}
+
+// Mirrors useAppConfigAsync (app/server/useAppConfig.ts).
+export function useLogListing(
+  logDir: string | undefined
+): AsyncData<LogHandle[]> {
+  const api = useApi();
+  const replication = useStore((state) => state.replicationService);
+  const databaseService = useStore((state) => state.databaseService);
+
+  return useAsyncDataFromQuery({
+    queryKey: logListingQueryKey(logDir),
+    queryFn: () =>
+      fetchAndApplyListing({
+        api,
+        replication,
+        readCachedLogs: async () => (await databaseService?.readLogs()) || [],
+      }),
+    staleTime: Infinity,
+  });
+}


### PR DESCRIPTION
## Summary

First PR of a 3-PR effort to support multiple log directories in the viewer. This PR is **single-directory only**; it lays the React Query foundation that the multi-dir merge (PR 2) and individual-log loading (PR 3) build on.

It moves the log-directory **listing** fetch + refresh out of the imperative Zustand `syncLogs()` path into a declarative React Query hook, leaving the replication engine to own only diffing/caching/queueing.

- **Extract shared `QueryClient`** into `state/queryClient.ts` (preserves the existing `retry: defaultRetry` global default), exported so non-React store actions can invalidate.
- **Extract pure helpers** `computeSyncCursor` / `computeInvalidations` from the old `_syncImpl` (unit-tested).
- **`ReplicationService.applyServerListing(response, logFiles)`** now owns the post-fetch diff/cache/queue; the `api.get_logs` fetch is removed from the service (both call sites) and `sync()`/`_syncImpl()`/the `_pendingSync` in-flight dedup are gone. Added `preloadFromCache()` for warm re-entry.
- **`useLogListing(logDir)`** (mirrors the existing `useAppConfigAsync`): `useAsyncDataFromQuery` with `staleTime: Infinity`; its query fn fetches via `api.get_logs` and applies via `applyServerListing`. Guarded on `replication.isReplicating()` so it no-ops until `startReplication` has wired up.
- **Migrated all 8 imperative `syncLogs()` callers** to React Query invalidation: component sites use `useQueryClient()`; store actions use the exported `queryClient` (`setSelectedLogFile` awaits a `refetchQueries` so a deep-linked log resolves). `syncLogs` renamed to `ensureReplicationReady` (setup-only, returns `void`); it invalidates the listing once setup completes.

Refetch-loop safety: the query key is `["log-files", logDir]` (the mtime cursor is read inside the query fn at call time, not in the key) + `staleTime: Infinity`.

## Test Plan

- [x] `pnpm check` (typecheck + lint + prettier) green
- [x] `pnpm vitest run` — 411 tests pass (incl. new `syncCursor` and `useLogListing` unit tests)
- [x] Manual: list loads (cold + warm cache); refreshes on a running eval; deep-link to a not-yet-listed log resolves; no refetch loop in React Query devtools; reliable load across reloads (startup race fixed)

## Notes

- Reviews so far were automated; this PR is open for human + CI review.
- Out of scope (later PRs): multiple directories / merged listing + `/app-config` `log_dirs` handshake (PR 2); moving individual-log detail loading onto React Query (PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)