### PR TITLE
Fix stuck completed streaming samples

### DIFF
--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -98,8 +98,8 @@ export interface SegmentRef {
 
 export interface PendingSampleUrls {
   segments: SegmentRef[];
-  complete: boolean;
-  has_more: boolean;
+  complete?: boolean;
+  has_more?: boolean;
 }
 
 // Client-side types — looser than generated server types because they're

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -87,6 +87,7 @@ export interface SampleDataResponse {
   sampleData?: SampleData;
   status: "NotModified" | "NotFound" | "OK";
   has_more?: boolean;
+  complete?: boolean;
 }
 
 export interface SegmentRef {

--- a/apps/inspect/src/client/api/view-server/api-view-server.test.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { viewServerApi } from "./api-view-server";
+
+describe("viewServerApi.eval_log_sample_data_direct", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("preserves complete from pending-sample URL responses", async () => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      expect(url).toContain("/pending-sample-data-urls?");
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () =>
+          JSON.stringify({
+            segments: [],
+            complete: true,
+            has_more: false,
+          }),
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const api = viewServerApi({ apiBaseUrl: "https://viewer.test" });
+
+    const result = await api.eval_log_sample_data_direct!(
+      "log.eval",
+      "sample-1",
+      1
+    );
+
+    expect(result).toEqual({
+      status: "OK",
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+      has_more: false,
+      complete: true,
+    });
+  });
+});

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -450,6 +450,7 @@ export function viewServerApi(
       status: "OK",
       sampleData: direct.sampleData,
       has_more: direct.has_more,
+      complete: direct.complete,
     };
   };
 

--- a/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
@@ -68,8 +68,8 @@ describe("fetchPendingSampleDataDirect", () => {
           { id: 2, member_name: "m2", direct_url: "https://example/seg-2" },
           { id: 3, member_name: "m3", direct_url: "https://example/seg-3" },
         ],
-        complete: false,
-        has_more: false,
+        complete: true,
+        has_more: true,
       });
 
       const result = await fetchPendingSampleDataDirect(
@@ -81,6 +81,8 @@ describe("fetchPendingSampleDataDirect", () => {
       );
 
       expect(result).toBeDefined();
+      expect(result!.complete).toBe(true);
+      expect(result!.has_more).toBe(true);
       expect(result!.sampleData.events.map((e) => e.id)).toEqual([
         0, 10, 20, 30,
       ]);
@@ -130,10 +132,10 @@ describe("fetchPendingSampleDataDirect", () => {
     expect(result).toBeUndefined();
   });
 
-  test("returns has_more from the URL manifest on the empty-segments short-circuit", async () => {
+  test("returns metadata from the URL manifest on the empty-segments short-circuit", async () => {
     const getUrls = vi.fn().mockResolvedValue({
       segments: [],
-      complete: false,
+      complete: true,
       has_more: true,
     });
 
@@ -146,6 +148,7 @@ describe("fetchPendingSampleDataDirect", () => {
     );
 
     expect(result).toBeDefined();
+    expect(result!.complete).toBe(true);
     expect(result!.has_more).toBe(true);
     expect(result!.sampleData).toEqual({
       events: [],
@@ -155,11 +158,9 @@ describe("fetchPendingSampleDataDirect", () => {
     });
   });
 
-  test("returns complete from the URL manifest on the empty-segments short-circuit", async () => {
+  test("defaults missing complete and has_more fields to false on the empty-segments short-circuit", async () => {
     const getUrls = vi.fn().mockResolvedValue({
       segments: [],
-      complete: true,
-      has_more: false,
     });
 
     const result = await fetchPendingSampleDataDirect(
@@ -171,57 +172,7 @@ describe("fetchPendingSampleDataDirect", () => {
     );
 
     expect(result).toBeDefined();
-    expect(result!.complete).toBe(true);
+    expect(result!.complete).toBe(false);
     expect(result!.has_more).toBe(false);
-    expect(result!.sampleData).toEqual({
-      events: [],
-      attachments: [],
-      message_pool: [],
-      call_pool: [],
-    });
-  });
-
-  test("returns complete from the URL manifest after segment downloads", async () => {
-    const realFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn(async () => {
-      const body = new TextEncoder().encode(
-        JSON.stringify({
-          events: [],
-          attachments: [],
-          message_pool: [],
-          call_pool: [],
-        })
-      );
-      return {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        arrayBuffer: async () => body.buffer,
-      } as unknown as Response;
-    }) as typeof fetch;
-
-    const getUrls = vi.fn().mockResolvedValue({
-      segments: [
-        { id: 0, member_name: "m0", direct_url: "https://example/seg-0" },
-      ],
-      complete: true,
-      has_more: false,
-    });
-
-    try {
-      const result = await fetchPendingSampleDataDirect(
-        getUrls,
-        "log.eval",
-        "sample1",
-        0,
-        {}
-      );
-
-      expect(result).toBeDefined();
-      expect(result!.complete).toBe(true);
-      expect(result!.has_more).toBe(false);
-    } finally {
-      globalThis.fetch = realFetch;
-    }
   });
 });

--- a/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
@@ -154,4 +154,74 @@ describe("fetchPendingSampleDataDirect", () => {
       call_pool: [],
     });
   });
+
+  test("returns complete from the URL manifest on the empty-segments short-circuit", async () => {
+    const getUrls = vi.fn().mockResolvedValue({
+      segments: [],
+      complete: true,
+      has_more: false,
+    });
+
+    const result = await fetchPendingSampleDataDirect(
+      getUrls,
+      "log.eval",
+      "sample1",
+      0,
+      {}
+    );
+
+    expect(result).toBeDefined();
+    expect(result!.complete).toBe(true);
+    expect(result!.has_more).toBe(false);
+    expect(result!.sampleData).toEqual({
+      events: [],
+      attachments: [],
+      message_pool: [],
+      call_pool: [],
+    });
+  });
+
+  test("returns complete from the URL manifest after segment downloads", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      const body = new TextEncoder().encode(
+        JSON.stringify({
+          events: [],
+          attachments: [],
+          message_pool: [],
+          call_pool: [],
+        })
+      );
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        arrayBuffer: async () => body.buffer,
+      } as unknown as Response;
+    }) as typeof fetch;
+
+    const getUrls = vi.fn().mockResolvedValue({
+      segments: [
+        { id: 0, member_name: "m0", direct_url: "https://example/seg-0" },
+      ],
+      complete: true,
+      has_more: false,
+    });
+
+    try {
+      const result = await fetchPendingSampleDataDirect(
+        getUrls,
+        "log.eval",
+        "sample1",
+        0,
+        {}
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.complete).toBe(true);
+      expect(result!.has_more).toBe(false);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
 });

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -72,8 +72,8 @@ export const fetchPendingSampleDataDirect = async (
         message_pool: [],
         call_pool: [],
       },
-      has_more: urls.has_more,
-      complete: urls.complete,
+      has_more: urls.has_more === true,
+      complete: urls.complete === true,
     };
   }
 
@@ -95,8 +95,8 @@ export const fetchPendingSampleDataDirect = async (
   };
   return {
     sampleData: applyCursorFilter(out, cursors),
-    has_more: urls.has_more,
-    complete: urls.complete,
+    has_more: urls.has_more === true,
+    complete: urls.complete === true,
   };
 };
 

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -24,6 +24,7 @@ export type GetPendingSampleDataUrls = (
 export interface DirectPendingResult {
   sampleData: SampleData;
   has_more: boolean;
+  complete: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ export const fetchPendingSampleDataDirect = async (
         call_pool: [],
       },
       has_more: urls.has_more,
+      complete: urls.complete,
     };
   }
 
@@ -94,6 +96,7 @@ export const fetchPendingSampleDataDirect = async (
   return {
     sampleData: applyCursorFilter(out, cursors),
     has_more: urls.has_more,
+    complete: urls.complete,
   };
 };
 

--- a/apps/inspect/src/state/samplePolling.test.ts
+++ b/apps/inspect/src/state/samplePolling.test.ts
@@ -87,9 +87,86 @@ describe("samplePolling helpers", () => {
 
     expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
   });
+
+  it("finalizes when the pending buffer reports complete", () => {
+    const response: SampleDataResponse = {
+      status: "OK",
+      complete: true,
+      has_more: false,
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    };
+
+    expect(shouldFinalizeStreamingSample(response, false)).toBe(true);
+  });
+
+  it("does not finalize a complete pending sample while more chunks remain", () => {
+    const response: SampleDataResponse = {
+      status: "OK",
+      complete: true,
+      has_more: true,
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    };
+
+    expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
+  });
 });
 
 describe("createSamplePolling", () => {
+  it("loads the completed sample when the pending buffer reports complete", async () => {
+    const completedSample = createEvalSample("sample-1");
+    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+      status: "OK",
+      complete: true,
+      has_more: false,
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    } satisfies SampleDataResponse);
+    const getLogSample = vi.fn().mockResolvedValue(completedSample);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: { selectedLogDetails: { sampleSummaries: [] } },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    polling.startPolling("log.eval", createSummary("sample-1"));
+    await flushPromises();
+
+    expect(getLogSample).toHaveBeenCalledWith("log.eval", "sample-1", 1);
+    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
+    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+  });
+
   it("does not let duplicate streamed pool rows shift refs", async () => {
     const inputSystem = chatMessage("input-system", "system", "Input system");
     const inputUser = chatMessage("input-user", "user", "Input user");

--- a/apps/inspect/src/state/samplePolling.test.ts
+++ b/apps/inspect/src/state/samplePolling.test.ts
@@ -167,6 +167,51 @@ describe("createSamplePolling", () => {
     expect(sampleActions.setSampleError).not.toHaveBeenCalled();
   });
 
+  it("keeps streaming when buffer-complete sample is not flushed to the eval yet", async () => {
+    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+      status: "OK",
+      complete: true,
+      has_more: false,
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    } satisfies SampleDataResponse);
+    const getLogSample = vi.fn().mockResolvedValue(undefined);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      api: {
+        get_log_sample_data: getLogSampleData,
+        get_log_sample: getLogSample,
+      },
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: { selectedLogDetails: { sampleSummaries: [] } },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store);
+    polling.startPolling("log.eval", createSummary("sample-1"));
+    await flushPromises();
+    polling.stopPolling();
+
+    expect(getLogSample).toHaveBeenCalledWith("log.eval", "sample-1", 1);
+    expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
+    expect(sampleActions.setSampleStatus).not.toHaveBeenCalledWith("error");
+    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+  });
+
   it("does not let duplicate streamed pool rows shift refs", async () => {
     const inputSystem = chatMessage("input-system", "system", "Input system");
     const inputUser = chatMessage("input-user", "user", "Input user");

--- a/apps/inspect/src/state/samplePolling.test.ts
+++ b/apps/inspect/src/state/samplePolling.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StoreApi, UseBoundStore } from "zustand";
 
 import { EvalSample } from "@tsmono/inspect-common/types";
@@ -30,15 +30,20 @@ beforeEach(() => {
 });
 
 describe("samplePolling helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const emptySampleData = {
+    events: [],
+    attachments: [],
+    message_pool: [],
+    call_pool: [],
+  };
+
   it("treats empty sample-data payloads as no-op updates", () => {
-    expect(
-      hasSampleDataUpdates({
-        events: [],
-        attachments: [],
-        message_pool: [],
-        call_pool: [],
-      })
-    ).toBe(false);
+    expect(hasSampleDataUpdates(emptySampleData)).toBe(false);
   });
 
   it("detects sample-data deltas across all streamed collections", () => {
@@ -88,87 +93,144 @@ describe("samplePolling helpers", () => {
     expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
   });
 
-  it("finalizes when the pending buffer reports complete", () => {
-    const response: SampleDataResponse = {
-      status: "OK",
-      complete: true,
-      has_more: false,
-      sampleData: {
-        events: [],
-        attachments: [],
-        message_pool: [],
-        call_pool: [],
+  it.each([
+    ["missing response", undefined, true, false],
+    ["not found response", { status: "NotFound" }, true, false],
+    ["not modified incomplete log", { status: "NotModified" }, false, false],
+    ["not modified completed log", { status: "NotModified" }, true, true],
+    [
+      "complete response with empty data",
+      {
+        status: "OK",
+        complete: true,
+        has_more: false,
+        sampleData: emptySampleData,
       },
-    };
-
-    expect(shouldFinalizeStreamingSample(response, false)).toBe(true);
-  });
-
-  it("does not finalize a complete pending sample while more chunks remain", () => {
-    const response: SampleDataResponse = {
-      status: "OK",
-      complete: true,
-      has_more: true,
-      sampleData: {
-        events: [],
-        attachments: [],
-        message_pool: [],
-        call_pool: [],
+      false,
+      true,
+    ],
+    [
+      "complete response with more chunks",
+      {
+        status: "OK",
+        complete: true,
+        has_more: true,
+        sampleData: emptySampleData,
       },
-    };
-
-    expect(shouldFinalizeStreamingSample(response, false)).toBe(false);
+      false,
+      false,
+    ],
+    [
+      "complete response with data updates",
+      {
+        status: "OK",
+        complete: true,
+        has_more: false,
+        sampleData: {
+          ...emptySampleData,
+          events: [
+            {
+              id: 1,
+              event_id: "event-1",
+              sample_id: "sample-1",
+              epoch: 1,
+              event: {} as any,
+            },
+          ],
+        },
+      },
+      false,
+      false,
+    ],
+  ] satisfies Array<
+    [string, SampleDataResponse | undefined, boolean | undefined, boolean]
+  >)("returns %s = %s", (_name, response, completedInLog, expected) => {
+    expect(shouldFinalizeStreamingSample(response, completedInLog)).toBe(
+      expected
+    );
   });
 });
 
 describe("createSamplePolling", () => {
-  it("loads the completed sample when the pending buffer reports complete", async () => {
-    const completedSample = createEvalSample("sample-1");
-    const getLogSampleData = vi.fn().mockResolvedValueOnce({
-      status: "OK",
-      complete: true,
-      has_more: false,
-      sampleData: {
-        events: [],
-        attachments: [],
-        message_pool: [],
-        call_pool: [],
-      },
-    } satisfies SampleDataResponse);
-    const getLogSample = vi.fn().mockResolvedValue(completedSample);
-
-    const sampleActions = {
-      setSelectedSample: vi.fn(),
-      setSampleStatus: vi.fn(),
-      setSampleError: vi.fn(),
-      setRunningEvents: vi.fn(),
-    };
-
-    const state = {
-      api: {
-        get_log_sample_data: getLogSampleData,
-        get_log_sample: getLogSample,
-      },
-      sample: { runningEvents: [] },
-      sampleActions,
-      log: { selectedLogDetails: { sampleSummaries: [] } },
-    } as unknown as StoreState;
-    const store = {
-      getState: () => state,
-    } as unknown as UseBoundStore<StoreApi<StoreState>>;
-
-    const polling = createSamplePolling(store);
-    polling.startPolling("log.eval", createSummary("sample-1"));
-    await flushPromises();
-
-    expect(getLogSample).toHaveBeenCalledWith("log.eval", "sample-1", 1);
-    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
-    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
-    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it("keeps streaming when buffer-complete sample is not flushed to the eval yet", async () => {
-    const getLogSampleData = vi.fn().mockResolvedValueOnce({
+  it("keeps polling until a buffer-complete sample is flushed to the eval", async () => {
+    vi.useFakeTimers();
+
+    const completedSample = createEvalSample("sample-1");
+    const completePendingResponse = {
+      status: "OK",
+      complete: true,
+      has_more: false,
+      sampleData: {
+        events: [],
+        attachments: [],
+        message_pool: [],
+        call_pool: [],
+      },
+    } satisfies SampleDataResponse;
+    mockApi.get_log_sample_data.mockResolvedValue(completePendingResponse);
+    mockApi.get_log_sample
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(completedSample);
+
+    const sampleActions = {
+      setSelectedSample: vi.fn(),
+      setSampleStatus: vi.fn(),
+      setSampleError: vi.fn(),
+      setRunningEvents: vi.fn(),
+    };
+
+    const state = {
+      sample: { runningEvents: [] },
+      sampleActions,
+      log: { selectedLogDetails: { sampleSummaries: [] } },
+    } as unknown as StoreState;
+    const store = {
+      getState: () => state,
+    } as unknown as UseBoundStore<StoreApi<StoreState>>;
+
+    const polling = createSamplePolling(store, api);
+    polling.startPolling("log.eval", createSummary("sample-1"));
+    await flushPromises();
+
+    expect(mockApi.get_log_sample).toHaveBeenCalledTimes(1);
+    expect(mockApi.get_log_sample).toHaveBeenCalledWith(
+      "log.eval",
+      "sample-1",
+      1
+    );
+    expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("streaming");
+    expect(sampleActions.setSampleStatus).not.toHaveBeenCalledWith("error");
+    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+    expect(sampleActions.setRunningEvents).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(mockApi.get_log_sample_data).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() =>
+      expect(mockApi.get_log_sample).toHaveBeenCalledTimes(2)
+    );
+
+    expect(mockApi.get_log_sample_data).toHaveBeenCalledTimes(2);
+    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
+    expect(sampleActions.setRunningEvents).toHaveBeenCalledWith([]);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockApi.get_log_sample_data).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps polling after a transient buffer-complete sample load error", async () => {
+    vi.useFakeTimers();
+
+    const completedSample = createEvalSample("sample-1");
+    mockApi.get_log_sample_data.mockResolvedValue({
       status: "OK",
       complete: true,
       has_more: false,
@@ -179,7 +241,9 @@ describe("createSamplePolling", () => {
         call_pool: [],
       },
     } satisfies SampleDataResponse);
-    const getLogSample = vi.fn().mockResolvedValue(undefined);
+    mockApi.get_log_sample
+      .mockRejectedValueOnce(new Error("temporary read failure"))
+      .mockResolvedValueOnce(completedSample);
 
     const sampleActions = {
       setSelectedSample: vi.fn(),
@@ -189,10 +253,6 @@ describe("createSamplePolling", () => {
     };
 
     const state = {
-      api: {
-        get_log_sample_data: getLogSampleData,
-        get_log_sample: getLogSample,
-      },
       sample: { runningEvents: [] },
       sampleActions,
       log: { selectedLogDetails: { sampleSummaries: [] } },
@@ -201,14 +261,22 @@ describe("createSamplePolling", () => {
       getState: () => state,
     } as unknown as UseBoundStore<StoreApi<StoreState>>;
 
-    const polling = createSamplePolling(store);
+    const polling = createSamplePolling(store, api);
     polling.startPolling("log.eval", createSummary("sample-1"));
     await flushPromises();
-    polling.stopPolling();
 
-    expect(getLogSample).toHaveBeenCalledWith("log.eval", "sample-1", 1);
-    expect(sampleActions.setSelectedSample).not.toHaveBeenCalled();
+    expect(mockApi.get_log_sample).toHaveBeenCalledTimes(1);
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("streaming");
     expect(sampleActions.setSampleStatus).not.toHaveBeenCalledWith("error");
+    expect(sampleActions.setSampleError).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.waitFor(() =>
+      expect(mockApi.get_log_sample).toHaveBeenCalledTimes(2)
+    );
+
+    expect(sampleActions.setSelectedSample).toHaveBeenCalledTimes(1);
+    expect(sampleActions.setSampleStatus).toHaveBeenCalledWith("ok");
     expect(sampleActions.setSampleError).not.toHaveBeenCalled();
   });
 

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -127,12 +127,10 @@ export function createSamplePolling(
         return false;
       }
 
-      const loadCompletedSample = async (message: string) => {
-        // A 404 from the server means that this sample has been flushed to the
-        // main eval file. We also take the same path when the log summary says
-        // the sample is complete but the buffer only returns empty deltas.
-        stopPollingTimer();
-
+      const loadCompletedSample = async (
+        message: string,
+        options: { missingSampleIsError: boolean }
+      ): Promise<PollingCallbackResult> => {
         try {
           log.debug(message);
           // The closure-captured `summary` is the stub {id, epoch} from
@@ -157,28 +155,37 @@ export function createSamplePolling(
           }
 
           if (sample) {
+            stopPollingTimer();
             const migratedSample = resolveSample(sample);
 
             sampleActions.setSelectedSample(migratedSample, logFile);
             sampleActions.setSampleStatus("ok");
             sampleActions.setRunningEvents([]);
-          } else {
-            sampleActions.setSampleStatus("error");
-            sampleActions.setSampleError(
-              new Error("Unable to load sample - an unknown error occurred")
-            );
-            sampleActions.setRunningEvents([]);
+            return false;
           }
+
+          if (!options.missingSampleIsError) {
+            sampleActions.setSampleStatus("streaming");
+            return true;
+          }
+
+          stopPollingTimer();
+          sampleActions.setSampleStatus("error");
+          sampleActions.setSampleError(
+            new Error("Unable to load sample - an unknown error occurred")
+          );
+          sampleActions.setRunningEvents([]);
+          return false;
         } catch (e) {
           if (localAbort.signal.aborted) {
             return false;
           }
+          stopPollingTimer();
           sampleActions.setSampleError(e as Error);
           sampleActions.setSampleStatus("error");
           sampleActions.setRunningEvents([]);
+          return false;
         }
-
-        return false;
       };
 
       // Snapshot cursors before the call so we can detect progress below.
@@ -202,18 +209,23 @@ export function createSamplePolling(
 
       if (sampleDataResponse?.status === "NotFound") {
         return await loadCompletedSample(
-          `LOADING COMPLETED SAMPLE AFTER FLUSH: ${summary.id}-${summary.epoch}`
+          `LOADING COMPLETED SAMPLE AFTER FLUSH: ${summary.id}-${summary.epoch}`,
+          { missingSampleIsError: true }
         );
       }
 
-      if (
-        shouldFinalizeStreamingSample(
-          sampleDataResponse,
-          hasCompletedLogSummary(store.getState(), summary.id, summary.epoch)
-        )
-      ) {
+      const completedInLog = hasCompletedLogSummary(
+        store.getState(),
+        summary.id,
+        summary.epoch
+      );
+      if (shouldFinalizeStreamingSample(sampleDataResponse, completedInLog)) {
+        const completedByPendingBuffer = sampleDataResponse?.complete === true;
         return await loadCompletedSample(
-          `LOADING COMPLETED SAMPLE AFTER SUMMARY UPDATE: ${summary.id}-${summary.epoch}`
+          completedByPendingBuffer
+            ? `LOADING COMPLETED SAMPLE AFTER BUFFER COMPLETE: ${summary.id}-${summary.epoch}`
+            : `LOADING COMPLETED SAMPLE AFTER SUMMARY UPDATE: ${summary.id}-${summary.epoch}`,
+          { missingSampleIsError: !completedByPendingBuffer }
         );
       }
 

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -370,16 +370,20 @@ export const hasSampleDataUpdates = (sampleData?: SampleData) => {
 export const shouldFinalizeStreamingSample = (
   sampleDataResponse: SampleDataResponse | undefined,
   completedInLog: boolean | undefined
-) => {
-  if (!completedInLog || !sampleDataResponse) {
+): boolean => {
+  if (!sampleDataResponse || sampleDataResponse.status !== "OK") {
     return false;
   }
 
-  return (
-    sampleDataResponse.status === "NotModified" ||
-    (sampleDataResponse.status === "OK" &&
-      !hasSampleDataUpdates(sampleDataResponse.sampleData))
-  );
+  if (sampleDataResponse.has_more === true) {
+    return false;
+  }
+
+  if (!completedInLog && sampleDataResponse.complete !== true) {
+    return false;
+  }
+
+  return !hasSampleDataUpdates(sampleDataResponse.sampleData);
 };
 
 const resetPollingState = (state: PollingState) => {

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -180,6 +180,12 @@ export function createSamplePolling(
           if (localAbort.signal.aborted) {
             return false;
           }
+
+          if (!options.missingSampleIsError) {
+            sampleActions.setSampleStatus("streaming");
+            return true;
+          }
+
           stopPollingTimer();
           sampleActions.setSampleError(e as Error);
           sampleActions.setSampleStatus("error");
@@ -383,7 +389,15 @@ export const shouldFinalizeStreamingSample = (
   sampleDataResponse: SampleDataResponse | undefined,
   completedInLog: boolean | undefined
 ): boolean => {
-  if (!sampleDataResponse || sampleDataResponse.status !== "OK") {
+  if (!sampleDataResponse) {
+    return false;
+  }
+
+  if (sampleDataResponse.status === "NotModified") {
+    return completedInLog === true;
+  }
+
+  if (sampleDataResponse.status !== "OK") {
     return false;
   }
 

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -131,6 +131,19 @@ export function createSamplePolling(
         message: string,
         options: { missingSampleIsError: boolean }
       ): Promise<PollingCallbackResult> => {
+        const keepStreaming = (): PollingCallbackResult => {
+          sampleActions.setSampleStatus("streaming");
+          return true;
+        };
+
+        const failLoad = (error: Error): PollingCallbackResult => {
+          stopPollingTimer();
+          sampleActions.setSampleError(error);
+          sampleActions.setSampleStatus("error");
+          sampleActions.setRunningEvents([]);
+          return false;
+        };
+
         try {
           log.debug(message);
           // The closure-captured `summary` is the stub {id, epoch} from
@@ -165,32 +178,22 @@ export function createSamplePolling(
           }
 
           if (!options.missingSampleIsError) {
-            sampleActions.setSampleStatus("streaming");
-            return true;
+            return keepStreaming();
           }
 
-          stopPollingTimer();
-          sampleActions.setSampleStatus("error");
-          sampleActions.setSampleError(
+          return failLoad(
             new Error("Unable to load sample - an unknown error occurred")
           );
-          sampleActions.setRunningEvents([]);
-          return false;
         } catch (e) {
           if (localAbort.signal.aborted) {
             return false;
           }
 
           if (!options.missingSampleIsError) {
-            sampleActions.setSampleStatus("streaming");
-            return true;
+            return keepStreaming();
           }
 
-          stopPollingTimer();
-          sampleActions.setSampleError(e as Error);
-          sampleActions.setSampleStatus("error");
-          sampleActions.setRunningEvents([]);
-          return false;
+          return failLoad(e as Error);
         }
       };
 


### PR DESCRIPTION
## Summary
Completed pending samples can stay in the streaming state when the pending buffer has no new rows but the broader log summary has not caught up yet. This PR carries the pending-buffer completion signal through the direct segment URL path and uses it to finalize only after the final chunk is drained, while retrying safely if the completed sample is not readable from the `.eval` file yet.

This intentionally leaves proxy and VS Code live-viewing metadata unchanged; those transports do not currently receive `complete` / `has_more` and would need a separate protocol update.