### PR TITLE
sample loading perf improvements

### DIFF
--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -234,70 +234,18 @@ export const clientApi = (
     return undefined;
   };
 
-  const read_eval_file_log_summary = async (log_file: string) => {
-    // If the API supports this, delegate to it
-    if (api.get_log_summary) {
-      return api.get_log_summary(log_file);
-    } else {
-      // Don't re-use the eval log file since we know these are all different log files
-      const remoteLogFile = await openRemoteLogFile(
-        api,
-        encodePathParts(log_file),
-        5
-      );
-      return remoteLogFile.readEvalBasicInfo();
-    }
-  };
-
   /**
    * Gets log headers
    */
   const get_log_summaries = async (
     log_files: string[]
   ): Promise<LogPreview[]> => {
-    const eval_files: Record<string, number> = {};
-    const json_files: Record<string, number> = {};
-    let index = 0;
-
-    // Separate files into eval_files and json_files
-    for (const file of log_files) {
-      if (isEvalFile(file)) {
-        eval_files[file] = index;
-      } else {
-        json_files[file] = index;
-      }
-      index++;
-    }
-
-    // Get the promises for eval log headers
-    const evalLogHeadersPromises = Object.keys(eval_files).map((file) =>
-      read_eval_file_log_summary(file).then((summary) => ({
-        index: eval_files[file], // Store original index
-        summary,
-      }))
-    );
-
-    // Get the promise for json log headers
-    const jsonLogHeadersPromise = api
-      .get_log_summaries(Object.keys(json_files))
-      .then((summaries) =>
-        summaries.map((summary, i) => ({
-          index: json_files[Object.keys(json_files)[i]], // Store original index
-          summary,
-        }))
-      );
-
-    // Wait for all promises to resolve
-    const summaries = await Promise.all([
-      ...evalLogHeadersPromises,
-      jsonLogHeadersPromise,
-    ]);
-
-    // Flatten the nested array and sort headers by their original index
-    const orderedSummaries = summaries.flat().sort((a, b) => a.index - b.index);
-
-    // Return only the header values in the correct order
-    return orderedSummaries.map(({ summary }) => summary);
+    // Delegate all formats to the API's batched implementation (the view
+    // server and VS Code both read .eval headers server-side; static
+    // deployments resolve from the manifest). Reading .eval headers
+    // client-side costs ~5 HTTP round-trips per file, which makes large
+    // log directories take minutes to hydrate.
+    return api.get_log_summaries(log_files);
   };
 
   const get_log_dir = async (): Promise<string | undefined> => {
@@ -487,6 +435,21 @@ export const clientApi = (
           editEtagByLog.set(log_file, result.etag);
         }
         return result;
+      }
+    ),
+    get_log_details_batch: middleware(
+      "get_log_details_batch",
+      async (log_files: string[]): Promise<(LogDetails | undefined)[]> => {
+        if (api.get_log_details_batch) {
+          try {
+            return await api.get_log_details_batch(log_files);
+          } catch {
+            // fall through to per-file reads
+          }
+        }
+        return Promise.all(
+          log_files.map((file) => get_log_details(file).catch(() => undefined))
+        );
       }
     ),
     get_log_sample: middleware("get_log_sample", get_log_sample),

--- a/apps/inspect/src/client/api/static-http/api-static-http.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.ts
@@ -170,20 +170,6 @@ function staticHttpApiForLog(logInfo: {
     get_log_bytes: async (log_file: string, start: number, end: number) => {
       return await fetchRange(log_file, start, end);
     },
-    get_log_summary: async (log_file: string) => {
-      const manifest = await getManifest();
-      if (manifest) {
-        const manifestAbs: Record<string, LogPreview> = {};
-        Object.keys(manifest).forEach((key) => {
-          manifestAbs[joinURI(log_dir || "", key)] = manifest[key];
-        });
-        const header = manifestAbs[log_file];
-        if (header) {
-          return header;
-        }
-      }
-      throw new Error(`Unable to load eval log header for ${log_file}`);
-    },
     get_log_summaries: async (files: string[]) => {
       if (files.length === 0) {
         return [];

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -204,8 +204,13 @@ export interface LogViewAPI {
     start: number,
     end: number
   ) => Promise<Uint8Array>;
-  get_log_summary?: (log_file: string) => Promise<LogPreview>;
   get_log_summaries: (log_files: string[]) => Promise<LogPreview[]>;
+  // Batched header + sample summaries (one entry per requested file,
+  // undefined for files that could not be read). When available it avoids
+  // opening each log archive over multiple range requests.
+  get_log_details_batch?: (
+    log_files: string[]
+  ) => Promise<(LogDetails | undefined)[]>;
   log_message: (log_file: string, message: string) => Promise<void>;
   download_file: (
     filename: string,
@@ -290,6 +295,9 @@ export interface ClientAPI {
 
   get_log_summaries: (log_files: string[]) => Promise<LogPreview[]>;
   get_log_details: (log_file: string, cached?: boolean) => Promise<LogDetails>;
+  get_log_details_batch: (
+    log_files: string[]
+  ) => Promise<(LogDetails | undefined)[]>;
 
   // Sample retrieval
   get_log_sample: (

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -14,6 +14,7 @@ import {
   EditLogResult,
   EvalHeader,
   LogContents,
+  LogDetails,
   LogPreview,
   LogViewAPI,
   PendingSampleResponse,
@@ -21,6 +22,7 @@ import {
   PendingSampleUrls,
   SampleData,
   SampleDataResponse,
+  SampleSummary,
   UserInfo,
 } from "../types";
 
@@ -234,18 +236,94 @@ export function viewServerApi(
       `/log-bytes/${encodeURIComponent(file)}?start=${start}&end=${end}`
     );
 
-  const get_log_summaries = async (files: string[]) => {
-    const params = new URLSearchParams();
+  // Keep batched GET query strings comfortably under common request-line
+  // limits (proxies often cap at 8KB) by splitting on encoded length.
+  const MAX_BATCH_QUERY_CHARS = 6000;
+  const chunkFilesByQueryLength = (files: string[]): string[][] => {
+    const chunks: string[][] = [];
+    let current: string[] = [];
+    let currentLength = 0;
     for (const file of files) {
-      params.append("file", file);
+      const paramLength = encodeURIComponent(file).length + 6; // "&file="
+      if (
+        current.length > 0 &&
+        currentLength + paramLength > MAX_BATCH_QUERY_CHARS
+      ) {
+        chunks.push(current);
+        current = [];
+        currentLength = 0;
+      }
+      current.push(file);
+      currentLength += paramLength;
     }
-    const result = await requestApi.fetchString(
-      "GET",
-      `/log-headers?${params.toString()}`
-    );
-    const logHeaders: EvalHeader[] = result.parsed;
-    return logHeaders.map(toLogPreview);
+    if (current.length > 0) {
+      chunks.push(current);
+    }
+    return chunks;
   };
+
+  // Fetch a per-file batched endpoint, chunking the file list to keep each
+  // request's query string bounded. Results concatenate in input order.
+  const fetchFileBatches = async <TItem, TResult>(
+    endpoint: string,
+    files: string[],
+    mapItems: (items: TItem[]) => TResult[]
+  ): Promise<TResult[]> => {
+    const results = await Promise.all(
+      chunkFilesByQueryLength(files).map(async (chunk) => {
+        const params = new URLSearchParams();
+        for (const file of chunk) {
+          params.append("file", file);
+        }
+        const result = await requestApi.fetchString(
+          "GET",
+          `${endpoint}?${params.toString()}`
+        );
+        return mapItems(result.parsed as TItem[]);
+      })
+    );
+    return results.flat();
+  };
+
+  const get_log_summaries = async (files: string[]) =>
+    fetchFileBatches("/log-headers", files, (headers: EvalHeader[]) =>
+      headers.map(toLogPreview)
+    );
+
+  const get_log_details_batch = async (
+    files: string[]
+  ): Promise<(LogDetails | undefined)[]> =>
+    fetchFileBatches(
+      "/log-details",
+      files,
+      (
+        items: ({
+          header: EvalHeader;
+          sample_summaries: SampleSummary[];
+        } | null)[]
+      ) =>
+        // Pick fields explicitly rather than spreading: the server header
+        // is a full EvalLog and carries fields LogDetails doesn't declare
+        // (e.g. reductions, invalidated) that would otherwise leak into
+        // IndexedDB. Same pattern as toLogPreview and readLogSummary.
+        items.map((item) =>
+          item
+            ? {
+                version: item.header.version,
+                status: item.header.status,
+                eval: item.header.eval,
+                plan: item.header.plan,
+                results: item.header.results,
+                stats: item.header.stats,
+                error: item.header.error,
+                tags: item.header.tags,
+                metadata: item.header.metadata,
+                log_updates: item.header.log_updates,
+                sampleSummaries: item.sample_summaries ?? [],
+              }
+            : undefined
+        )
+    );
 
   const log_message = async (
     log_file: string,
@@ -545,6 +623,7 @@ export function viewServerApi(
     get_log_info,
     get_log_bytes,
     get_log_summaries,
+    get_log_details_batch,
     log_message,
     download_file,
     download_log,

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -11,12 +11,10 @@ import { asyncJsonParseBytes } from "../../utils/json-worker";
 import {
   EvalHeader,
   LogDetails,
-  LogPreview,
   LogViewAPI,
   ProgressCallback,
   SampleSummary,
 } from "../api/types";
-import { toLogPreview } from "../utils/type-utils";
 
 import {
   CentralDirectoryEntry,
@@ -45,7 +43,6 @@ export class SampleNotFoundError extends Error {
   }
 }
 export interface RemoteLogFile {
-  readEvalBasicInfo: () => Promise<LogPreview>;
   readLogSummary: () => Promise<LogDetails>;
   readSample: (
     sampleId: string,
@@ -253,11 +250,6 @@ export const openRemoteLogFile = async (
     }
   };
 
-  const readEvalBasicInfo = async (): Promise<LogPreview> => {
-    const header = await readHeader();
-    return toLogPreview(header);
-  };
-
   /**
    * Reads individual summary files when summaries.json is not available.
    */
@@ -309,7 +301,6 @@ export const openRemoteLogFile = async (
   };
 
   return {
-    readEvalBasicInfo,
     readLogSummary: async () => {
       const [header, sampleSummaries] = await Promise.all([
         readHeader(),

--- a/apps/inspect/src/state/samplePolling.ts
+++ b/apps/inspect/src/state/samplePolling.ts
@@ -447,9 +447,13 @@ function processEvents(
     // Identify if this event id already has an event in the event list
     const existingIndex = pollingState.eventMapping[eventData.event_id];
 
-    // Resolve attachments within this event
-    const withAttachments = resolveAttachments<Event>(
-      eventData.event,
+    // Resolve pool refs for model events
+    const withPoolRefs = resolvePoolRefs(eventData.event, pollingState);
+
+    // Resolve attachments after pool expansion: a single pass covers both
+    // the event itself and any attachment:// URIs inside pool entries.
+    const resolvedEvent = resolveAttachments<Event>(
+      withPoolRefs,
       pollingState.attachments,
       (attachmentId: string) => {
         const snapshot = {
@@ -467,16 +471,6 @@ function processEvents(
         }
         console.warn(`Unable to resolve attachment ${attachmentId}`, snapshot);
       }
-    );
-
-    // Resolve pool refs for model events
-    const withPoolRefs = resolvePoolRefs(withAttachments, pollingState);
-
-    // Resolve attachments again after pool expansion, since pool entries
-    // may contain attachment:// URIs that weren't visible before expansion.
-    const resolvedEvent = resolveAttachments<Event>(
-      withPoolRefs,
-      pollingState.attachments
     );
 
     if (existingIndex !== undefined) {

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -32,7 +32,7 @@ export class ReplicationService {
 
   // The work queues
   private _previewQueue: WorkQueue<LogHandle, LogPreview>;
-  private _detailQueue: WorkQueue<LogHandle, LogDetails>;
+  private _detailQueue: WorkQueue<LogHandle, LogDetails | undefined>;
   private _processingCount: number;
 
   // Track sync requests (so we wait on already running requests before syncing again)
@@ -63,7 +63,7 @@ export class ReplicationService {
     this._previewQueue = new WorkQueue<LogHandle, LogPreview>({
       name: "Log-Preview-Queue",
       concurrency: 2,
-      batchSize: 6,
+      batchSize: 24,
       processingDelay: 20,
       onProcessingChanged: this.processingChanged,
       getId: (log) => log.name,
@@ -91,35 +91,34 @@ export class ReplicationService {
       },
     });
 
-    this._detailQueue = new WorkQueue<LogHandle, LogDetails>({
+    this._detailQueue = new WorkQueue<LogHandle, LogDetails | undefined>({
       name: "Log-Detail-Queue",
-      concurrency: 10,
-      batchSize: 1,
+      concurrency: 4,
+      batchSize: 12,
       processingDelay: 0,
       onProcessingChanged: this.processingChanged,
       getId: (log) => log.name,
       worker: async (logHandles: LogHandle[]) => {
         if (!this._api) throw new Error("API not available");
 
-        const details = await Promise.all(
-          logHandles.map(async (log) => {
-            try {
-              const result = await this._api!.get_log_details(log.name);
-              return result;
-            } catch {
-              return undefined;
-            }
-          })
+        // Batched fetch keeps results aligned with inputs (undefined for
+        // unreadable files) so onComplete can match details[i] to inputs[i].
+        // The ClientAPI wrapper never rejects here — a failed batch request
+        // falls back to per-file reads — so a transient error degrades to
+        // undefined entries rather than dropping the whole batch.
+        return this._api.get_log_details_batch(
+          logHandles.map((log) => log.name)
         );
-
-        const allResults = details.filter((d) => d !== undefined);
-        return allResults;
       },
-      onComplete: async (details: LogDetails[], inputs: LogHandle[]) => {
+      onComplete: async (
+        details: (LogDetails | undefined)[],
+        inputs: LogHandle[]
+      ) => {
         // Add to pending batch
         inputs.forEach((log, i) => {
-          if (details[i]) {
-            this._pendingDetailUpdates[log.name] = details[i];
+          const detail = details[i];
+          if (detail) {
+            this._pendingDetailUpdates[log.name] = detail;
           }
         });
 

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -174,6 +174,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/log-details": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Api Log Details
+         * @description Batched header + sample summaries.
+         *
+         *     Returns one item per requested file (None for files that could not
+         *     be read) so the client can hydrate log details without opening each
+         *     log archive over multiple range requests. Authorization and mapping
+         *     failures fail the whole request (same contract as /log-headers).
+         */
+        get: operations["api_log_details_log_details_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/log-dir": {
         parameters: {
             query?: never;
@@ -2362,6 +2387,15 @@ export interface components {
              */
             type: "llm";
         };
+        /**
+         * LogDetailsItem
+         * @description Header plus sample summaries for a single log file.
+         */
+        LogDetailsItem: {
+            header: components["schemas"]["EvalLog"];
+            /** Sample Summaries */
+            sample_summaries: components["schemas"]["EvalSampleSummary"][];
+        };
         /** LogDirResponse */
         LogDirResponse: {
             /** Log Dir */
@@ -4153,6 +4187,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": boolean;
+                };
+            };
+        };
+    };
+    api_log_details_log_details_get: {
+        parameters: {
+            query?: {
+                file?: string[];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": (components["schemas"]["LogDetailsItem"] | null)[];
                 };
             };
         };


### PR DESCRIPTION
Hydrate log listing via batched server endpoints (125s -> 23s for 1418 logs)

- get_log_summaries delegates all formats to the API's batched endpoint (view server and VS Code read .eval headers server-side; static deployments resolve from the manifest); the per-file client-side zip path and get_log_summary are deleted as dead code, converging with the unmerged upstream fix (inspect_ai faber/remote-performance, 0064b921d)
- new LogViewAPI.get_log_details_batch backed by the view server's new /log-details endpoint (header + sample summaries, undefined for unreadable files), with per-file fallback for APIs without it (VS Code)
- replication detail queue batches 12 (was 1), preview batches 24 (was 6)
- batched GET query strings chunked at ~6KB for request-line limits
- polling: resolve attachments once per event (after pool expansion) instead of twice


- ^^ the measurements are by Claude Fable 5 itself, I just smoke-tested in browser and Cursor extension with local log and s3, didn't notice any bugs, everything feels 10x faster subjectively, and the code looks reasonable when manually reviewed
- API changes in: https://github.com/UKGovernmentBEIS/inspect_ai/pull/4210