### PR TITLE
sample loading - more targeted perf improvement

### DIFF
--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -255,6 +255,18 @@ export const clientApi = (
   const get_log_summaries = async (
     log_files: string[]
   ): Promise<LogPreview[]> => {
+    // Prefer the API's batched endpoint for all formats: reading .eval
+    // headers client-side costs ~5 HTTP round-trips per file, which makes
+    // large log directories take minutes to hydrate.
+    try {
+      const summaries = await api.get_log_summaries(log_files);
+      if (summaries.length === log_files.length) {
+        return summaries;
+      }
+    } catch {
+      // fall through to per-file reads
+    }
+
     const eval_files: Record<string, number> = {};
     const json_files: Record<string, number> = {};
     let index = 0;

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -63,7 +63,7 @@ export class ReplicationService {
     this._previewQueue = new WorkQueue<LogHandle, LogPreview>({
       name: "Log-Preview-Queue",
       concurrency: 2,
-      batchSize: 6,
+      batchSize: 24,
       processingDelay: 20,
       onProcessingChanged: this.processingChanged,
       getId: (log) => log.name,
@@ -93,7 +93,7 @@ export class ReplicationService {
 
     this._detailQueue = new WorkQueue<LogHandle, LogDetails>({
       name: "Log-Detail-Queue",
-      concurrency: 10,
+      concurrency: 24,
       batchSize: 1,
       processingDelay: 0,
       onProcessingChanged: this.processingChanged,


### PR DESCRIPTION
smaller version of https://github.com/meridianlabs-ai/ts-mono/pull/316 with only the biggest impact

Batch log listing header reads through the existing /log-headers endpoint

get_log_summaries read .eval headers client-side (~5 HTTP round-trips per file: log-info, EOCD, central directory, header.json); route all formats through the API's existing batched endpoint instead, with the per-file path kept as fallback. Also retune replication queues (preview batch 6 -> 24, detail concurrency 10 -> 24).

Measured together with the inspect_ai /log-bytes and filename-parse fixes on a 1418-file local log dir: full listing hydration 125s -> 54s, and sample loads no longer compete with the background sync (127MB transcript 45s -> 4.4s).