### PR TITLE
Add optional copy button to MetaDataGrid and RecordTree

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -145,6 +145,7 @@ export const TaskTab: FC<TaskTabProps> = ({
                 key={`plan-md-task`}
                 className={"text-size-small"}
                 entries={taskInformation}
+                options={{ copyButton: true }}
               />
 
               <MetaDataGrid
@@ -157,6 +158,7 @@ export const TaskTab: FC<TaskTabProps> = ({
                   ),
                   ["Duration"]: totalDuration,
                 }}
+                options={{ copyButton: true }}
               />
             </div>
           </CardBody>
@@ -171,6 +173,7 @@ export const TaskTab: FC<TaskTabProps> = ({
               <RecordTree
                 id={`early-stopping-metadata`}
                 record={earlyStopping.metadata}
+                copyButton={true}
               />
             </CardBody>
           </Card>

--- a/apps/inspect/src/app/plan/PlanCard.tsx
+++ b/apps/inspect/src/app/plan/PlanCard.tsx
@@ -68,6 +68,7 @@ export const PlanCard: FC<PlanCardProps> = ({
                 id={"plan-md-metadata"}
                 record={metadata}
                 scrollRef={scrollRef}
+                copyButton={true}
               />
             ) : (
               <div className={clsx("text-size-smaller", styles.emptyMetadata)}>

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -954,6 +954,7 @@ const metadataViewsForSample = (
             record={invalidationRecord}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
+            copyButton={true}
           />
         </CardBody>
       </Card>
@@ -970,6 +971,7 @@ const metadataViewsForSample = (
             record={sample?.metadata as Record<string, unknown>}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
+            copyButton={true}
           />
         </CardBody>
       </Card>
@@ -987,6 +989,7 @@ const metadataViewsForSample = (
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
             processStore={true}
+            copyButton={true}
           />
         </CardBody>
       </Card>

--- a/apps/scout/src/app/scan/info/ScanInfo.tsx
+++ b/apps/scout/src/app/scan/info/ScanInfo.tsx
@@ -86,7 +86,11 @@ const ScanMetadataCard: FC<ScanMetadataCardProps> = ({
 
   return (
     <InfoCard title={"Metadata"} className={className}>
-      <RecordTree id="scan-metadata" record={selectedScan.spec.metadata} />
+      <RecordTree
+        id="scan-metadata"
+        record={selectedScan.spec.metadata}
+        copyButton={true}
+      />
     </InfoCard>
   );
 };

--- a/apps/scout/src/app/scannerResult/info/InfoPanel.tsx
+++ b/apps/scout/src/app/scannerResult/info/InfoPanel.tsx
@@ -54,6 +54,7 @@ export const InfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
                 <RecordTree
                   id={`scan-metadata-${resultData?.identifier}`}
                   record={resultData?.scanMetadata || {}}
+                  copyButton={true}
                 />
               </CardBody>
             </Card>
@@ -116,6 +117,7 @@ export const TranscriptInfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
           total_time: resultData?.transcriptTotalTime,
           total_tokens: resultData?.transcriptTotalTokens,
         }}
+        options={{ copyButton: true }}
       />
     </div>
   );

--- a/apps/scout/src/app/scannerResult/metadata/MetadataPanel.tsx
+++ b/apps/scout/src/app/scannerResult/metadata/MetadataPanel.tsx
@@ -31,6 +31,7 @@ export const MetadataPanel: FC<MetadataPanelProps> = ({ resultData }) => {
               <RecordTree
                 id={`result-metadata-${resultData.identifier}`}
                 record={resultData.metadata || {}}
+                copyButton={true}
               />
             </CardBody>
           </Card>

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -494,7 +494,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
             id="transcript-metadata-grid"
             entries={transcript.metadata || {}}
             className={clsx(styles.metadata)}
-            options={{ striped: true }}
+            options={{ striped: true, copyButton: true }}
           />
         </div>
       </TabPanel>
@@ -519,7 +519,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
           id="transcript-info-grid"
           entries={infoData}
           className={clsx(styles.metadata)}
-          options={{ striped: true }}
+          options={{ striped: true, copyButton: true }}
         />
       </div>
     </TabPanel>

--- a/packages/inspect-components/src/chat/ChatMessage.tsx
+++ b/packages/inspect-components/src/chat/ChatMessage.tsx
@@ -212,6 +212,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
               record={message.metadata}
               id={`${id}-metadata`}
               defaultExpandLevel={0}
+              copyButton={true}
             />
           </LabeledValue>
         ) : (

--- a/packages/inspect-components/src/chat/content-data/CompactionData.tsx
+++ b/packages/inspect-components/src/chat/content-data/CompactionData.tsx
@@ -33,6 +33,7 @@ export const CompactionData: FC<{
         id={`${id}-compacted-content-metadata`}
         className={styles.grid}
         entries={compactionMetadata}
+        options={{ copyButton: true }}
       />
     );
   }

--- a/packages/inspect-components/src/content/MetaDataGrid.test.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ComponentIconProvider,
+  ComponentIcons,
+  ComponentNavigationProvider,
+} from "@tsmono/react/components";
+import {
+  ComponentStateHooks,
+  ComponentStateProvider,
+} from "@tsmono/react/state";
+
+import { MetaDataGrid } from "./MetaDataGrid";
+
+const icons: ComponentIcons = {
+  chevronDown: "icon-chevron-down",
+  chevronUp: "icon-chevron-up",
+  clearText: "icon-clear-text",
+  close: "icon-close",
+  code: "icon-code",
+  confirm: "icon-confirm",
+  copy: "icon-copy",
+  error: "icon-error",
+  menu: "icon-menu",
+  next: "icon-next",
+  noSamples: "icon-no-samples",
+  play: "icon-play",
+  previous: "icon-previous",
+  toggleRight: "icon-toggle-right",
+};
+
+const stateHooks: ComponentStateHooks = {
+  useValue: (_id, _prop, defaultValue) => defaultValue,
+  useSetValue: () => () => {},
+  useRemoveValue: () => () => {},
+  useEntries: () => undefined,
+  useRemoveAll: () => () => {},
+  useRemoveByPrefix: () => () => {},
+};
+
+const renderGrid = (
+  entries: Record<string, unknown>,
+  options?: { copyButton?: boolean }
+) =>
+  render(
+    <ComponentStateProvider hooks={stateHooks}>
+      <ComponentIconProvider icons={icons}>
+        <ComponentNavigationProvider navigation={{ navigate: () => {} }}>
+          <MetaDataGrid id="test-grid" entries={entries} options={options} />
+        </ComponentNavigationProvider>
+      </ComponentIconProvider>
+    </ComponentStateProvider>
+  );
+
+describe("MetaDataGrid copy button", () => {
+  const writeText = vi.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders no copy buttons by default", () => {
+    renderGrid({ name: "value" });
+    expect(screen.queryByRole("button", { name: /copy/i })).toBeNull();
+  });
+
+  it("copies string values verbatim", async () => {
+    renderGrid({ name: "hello world" }, { copyButton: true });
+    const button = screen.getByRole("button", { name: "Copy name" });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("hello world");
+    });
+  });
+
+  it("copies non-string scalars as strings", async () => {
+    renderGrid({ count: 42 }, { copyButton: true });
+    fireEvent.click(screen.getByRole("button", { name: "Copy count" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("42");
+    });
+  });
+
+  it("copies array values as pretty-printed JSON", async () => {
+    renderGrid({ items: [1, 2] }, { copyButton: true });
+    fireEvent.click(screen.getByRole("button", { name: "Copy items" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(JSON.stringify([1, 2], null, 2));
+    });
+  });
+
+  it("renders copy buttons in nested group rows", async () => {
+    renderGrid({ group: { inner: "nested value" } }, { copyButton: true });
+    fireEvent.click(screen.getByRole("button", { name: "Copy inner" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("nested value");
+    });
+  });
+
+  it("renders no copy button for _html escape rows", () => {
+    renderGrid(
+      { custom: { _html: <span>bespoke</span> } },
+      { copyButton: true }
+    );
+    expect(screen.queryByRole("button", { name: /copy/i })).toBeNull();
+  });
+});

--- a/packages/inspect-components/src/content/MetaDataGrid.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.tsx
@@ -1,8 +1,9 @@
 import clsx from "clsx";
 import { CSSProperties, FC, useState } from "react";
 
-import { MarkdownReference } from "@tsmono/react/components";
+import { CopyButton, MarkdownReference } from "@tsmono/react/components";
 
+import { copyValueText } from "./copyText";
 import styles from "./MetadataGrid.module.css";
 import { RenderedContent } from "./RenderedContent";
 
@@ -19,6 +20,7 @@ interface MetadataGridProps {
     plain?: boolean;
     striped?: boolean;
     previewRefsOnHover?: boolean;
+    copyButton?: boolean;
   };
 }
 
@@ -84,7 +86,9 @@ export const MetaDataGrid: FC<MetadataGridProps> = ({
       style={depth === 0 ? style : undefined}
     >
       {visibleScalars.length > 0 && (
-        <div className={styles.rows}>
+        <div
+          className={clsx(styles.rows, options?.copyButton && styles.rowsCopy)}
+        >
           {visibleScalars.map((entry, index) => {
             const entryId = `${baseId}-value-${index}`;
             return (
@@ -110,6 +114,14 @@ export const MetaDataGrid: FC<MetadataGridProps> = ({
                     )}
                   />
                 </div>
+                {options?.copyButton && !hasHtmlEscape(entry.value) ? (
+                  <div className={styles.copyCell}>
+                    <CopyButton
+                      value={copyValueText(entry.value)}
+                      ariaLabel={`Copy ${entry.name}`}
+                    />
+                  </div>
+                ) : undefined}
               </div>
             );
           })}

--- a/packages/inspect-components/src/content/MetadataGrid.module.css
+++ b/packages/inspect-components/src/content/MetadataGrid.module.css
@@ -74,6 +74,31 @@
   color: var(--bs-success-text-emphasis, #198754);
 }
 
+/* ── Copy button (opt-in via copyButton option) ──────────────── */
+
+.rowsCopy {
+  grid-template-columns: auto 1fr max-content;
+}
+
+/* Wrapper carries the hover reveal so CopyButton's own opacity
+   styles still apply unchanged inside it. */
+.copyCell {
+  opacity: 0;
+  justify-self: end;
+  align-self: center;
+  transition: opacity 0.2s;
+}
+
+.copyCell button {
+  padding: 0;
+  line-height: 1;
+}
+
+.row:hover .copyCell,
+.copyCell:focus-within {
+  opacity: 1;
+}
+
 /* ── Sections (nested objects promoted to titled groups) ──────── */
 
 .group {

--- a/packages/inspect-components/src/content/RecordTree.module.css
+++ b/packages/inspect-components/src/content/RecordTree.module.css
@@ -10,6 +10,30 @@
   border-bottom: solid 1px var(--bs-border-color);
 }
 
+/* Copy button column (opt-in via copyButton prop) */
+
+.keyPairCopy {
+  grid-template-columns: max-content auto max-content;
+}
+
+/* Wrapper carries the hover reveal so CopyButton's own opacity
+   styles still apply unchanged inside it. */
+.copyCell {
+  opacity: 0;
+  justify-self: end;
+  transition: opacity 0.2s;
+}
+
+.copyCell button {
+  padding: 0;
+  line-height: 1;
+}
+
+.keyPairContainer:hover .copyCell,
+.copyCell:focus-within {
+  opacity: 1;
+}
+
 .key {
   display: grid;
   grid-template-columns: 1em auto;

--- a/packages/inspect-components/src/content/RecordTree.test.tsx
+++ b/packages/inspect-components/src/content/RecordTree.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ComponentIconProvider,
+  ComponentIcons,
+} from "@tsmono/react/components";
+import {
+  ComponentStateHooks,
+  ComponentStateProvider,
+} from "@tsmono/react/state";
+
+import { RecordTree } from "./RecordTree";
+
+const icons: ComponentIcons = {
+  chevronDown: "icon-chevron-down",
+  chevronUp: "icon-chevron-up",
+  clearText: "icon-clear-text",
+  close: "icon-close",
+  code: "icon-code",
+  confirm: "icon-confirm",
+  copy: "icon-copy",
+  error: "icon-error",
+  menu: "icon-menu",
+  next: "icon-next",
+  noSamples: "icon-no-samples",
+  play: "icon-play",
+  previous: "icon-previous",
+  toggleRight: "icon-toggle-right",
+};
+
+const stateHooks: ComponentStateHooks = {
+  useValue: (_id, _prop, defaultValue) => defaultValue,
+  useSetValue: () => () => {},
+  useRemoveValue: () => () => {},
+  useEntries: () => undefined,
+  useRemoveAll: () => () => {},
+  useRemoveByPrefix: () => () => {},
+};
+
+const renderTree = (
+  record: Record<string, unknown>,
+  props?: { copyButton?: boolean; defaultExpandLevel?: number }
+) =>
+  render(
+    <ComponentStateProvider hooks={stateHooks}>
+      <ComponentIconProvider icons={icons}>
+        <RecordTree id="test-tree" record={record} {...props} />
+      </ComponentIconProvider>
+    </ComponentStateProvider>
+  );
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe("RecordTree copy button", () => {
+  const writeText = vi.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders no copy buttons by default", () => {
+    renderTree({ name: "value" });
+    expect(screen.queryByRole("button", { name: /copy/i })).toBeNull();
+  });
+
+  it("copies leaf string values verbatim", async () => {
+    renderTree({ name: "hello world" }, { copyButton: true });
+    const button = screen.getByRole("button", { name: "Copy name" });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("hello world");
+    });
+  });
+
+  it("copies leaf number values as strings", async () => {
+    renderTree({ count: 42 }, { copyButton: true });
+    fireEvent.click(screen.getByRole("button", { name: "Copy count" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("42");
+    });
+  });
+
+  it("copies collapsed subtrees as pretty-printed JSON", async () => {
+    renderTree(
+      { nested: { a: 1, b: "two" } },
+      { copyButton: true, defaultExpandLevel: 0 }
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Copy nested" }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        JSON.stringify({ a: 1, b: "two" }, null, 2)
+      );
+    });
+  });
+
+  it("renders no copy button for expanded parent rows", () => {
+    renderTree(
+      { nested: { a: 1 }, leaf: "x" },
+      { copyButton: true, defaultExpandLevel: 2 }
+    );
+    expect(screen.queryByRole("button", { name: "Copy nested" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy a" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy leaf" })).toBeTruthy();
+  });
+});

--- a/packages/inspect-components/src/content/RecordTree.tsx
+++ b/packages/inspect-components/src/content/RecordTree.tsx
@@ -10,11 +10,12 @@ import {
 } from "react";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 
-import { ExpandablePanel } from "@tsmono/react/components";
+import { CopyButton, ExpandablePanel } from "@tsmono/react/components";
 import { useCollapsibleIds } from "@tsmono/react/hooks";
 
 import { useVirtuosoState } from "../virtuoso/useVirtuosoState";
 
+import { copyValueText } from "./copyText";
 import { useContentIcons } from "./IconsContext";
 import { resolveStoreKeys } from "./record_processors/store";
 import { RecordProcessor } from "./record_processors/types";
@@ -31,6 +32,7 @@ interface RecordTreeProps {
   defaultExpandLevel?: number;
   processStore?: boolean;
   useBorders?: boolean;
+  copyButton?: boolean;
 }
 
 /**
@@ -44,6 +46,7 @@ export const RecordTree: FC<RecordTreeProps> = ({
   defaultExpandLevel = 1,
   processStore = false,
   useBorders = true,
+  copyButton = false,
 }) => {
   const icons = useContentIcons();
 
@@ -162,11 +165,15 @@ export const RecordTree: FC<RecordTreeProps> = ({
       return null;
     }
 
+    const showValue =
+      item.value !== null && (!item.hasChildren || item.isCollapsed);
+
     return (
       <div
         key={item.id}
         className={clsx(
           styles.keyPairContainer,
+          copyButton && styles.keyPairCopy,
           index < items.length - 1 && useBorders
             ? styles.keyPairBordered
             : undefined,
@@ -205,7 +212,7 @@ export const RecordTree: FC<RecordTreeProps> = ({
           <pre className={clsx(styles.pre)}>{item.key}:</pre>
         </div>
         <div>
-          {item.value !== null && (!item.hasChildren || item.isCollapsed) ? (
+          {showValue ? (
             <ExpandablePanel
               id={`${id}-collapse-${item.id}`}
               collapse={true}
@@ -223,6 +230,14 @@ export const RecordTree: FC<RecordTreeProps> = ({
             </ExpandablePanel>
           ) : undefined}
         </div>
+        {copyButton && showValue ? (
+          <div className={styles.copyCell}>
+            <CopyButton
+              value={copyValueText(item.rawValue)}
+              ariaLabel={`Copy ${item.key}`}
+            />
+          </div>
+        ) : undefined}
       </div>
     );
   };
@@ -279,6 +294,9 @@ interface MetadataItem {
   id: string;
   key: string;
   value: string | number | boolean | null;
+  /** Original (untruncated) value backing this row — objects and arrays
+   *  keep their full subtree here while `value` holds the display label. */
+  rawValue: unknown;
   depth: number;
   hasChildren: boolean;
   childCount?: number;
@@ -346,6 +364,7 @@ const processNodeRecursive = (
       id,
       key,
       value: value === undefined ? null : value,
+      rawValue: value,
       depth,
       hasChildren: false,
       isCollapsed: false,
@@ -388,6 +407,7 @@ const processNodeRecursive = (
     id,
     key,
     value: displayValue,
+    rawValue: value,
     depth,
     hasChildren: processChildren,
     childCount,

--- a/packages/inspect-components/src/content/copyText.ts
+++ b/packages/inspect-components/src/content/copyText.ts
@@ -1,0 +1,32 @@
+/**
+ * Plain-text form of a metadata value for clipboard copy.
+ *
+ * Strings copy verbatim; other scalars use their string form; objects
+ * and arrays copy as pretty-printed JSON.
+ */
+export const copyValueText = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "function"
+  ) {
+    return value.toString();
+  }
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+  // Circular structures (or exotic objects JSON can't represent) have no
+  // sensible text form — copy an empty string rather than "[object Object]".
+  try {
+    return JSON.stringify(value, null, 2) ?? "";
+  } catch {
+    return "";
+  }
+};

--- a/packages/inspect-components/src/transcript/CompactionEventView.tsx
+++ b/packages/inspect-components/src/transcript/CompactionEventView.tsx
@@ -40,7 +40,11 @@ export const CompactionEventView: FC<CompactionEventViewProps> = ({
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={TranscriptIcons.compaction}
     >
-      <MetaDataGrid entries={data} className={styles.panel} />
+      <MetaDataGrid
+        entries={data}
+        className={styles.panel}
+        options={{ copyButton: true }}
+      />
     </EventPanel>
   );
 };

--- a/packages/inspect-components/src/transcript/SampleInitEventView.tsx
+++ b/packages/inspect-components/src/transcript/SampleInitEventView.tsx
@@ -102,6 +102,7 @@ export const SampleInitEventView: FC<SampleInitEventViewProps> = ({
           data-name="Metadata"
           className={styles.metadata}
           entries={event.sample.metadata}
+          options={{ copyButton: true }}
         />
       ) : (
         ""

--- a/packages/inspect-components/src/transcript/ScoreEditEventView.tsx
+++ b/packages/inspect-components/src/transcript/ScoreEditEventView.tsx
@@ -122,6 +122,7 @@ export const ScoreEditEventView: FC<ScoreEditEventViewProps> = ({
               record={event.edit.metadata || {}}
               className={styles.metadataTree}
               defaultExpandLevel={0}
+              copyButton={true}
             />
           </div>
         ) : undefined}

--- a/packages/inspect-components/src/transcript/ScoreEventView.tsx
+++ b/packages/inspect-components/src/transcript/ScoreEventView.tsx
@@ -71,6 +71,7 @@ export const ScoreEventView: FC<ScoreEventViewProps> = ({
             record={event.score.metadata}
             className={styles.metadataTree}
             defaultExpandLevel={0}
+            copyButton={true}
           />
         </div>
       ) : undefined}

--- a/packages/scout-components/src/scanner-result-detail/Metadata.tsx
+++ b/packages/scout-components/src/scanner-result-detail/Metadata.tsx
@@ -87,6 +87,7 @@ export const MetadataValue: FC<MetadataValueProps> = ({
             id={`metadata-${id}`}
             record={record}
             useBorders={false}
+            copyButton={true}
           />
         );
       }
@@ -95,6 +96,7 @@ export const MetadataValue: FC<MetadataValueProps> = ({
           id={`metadata-${id}`}
           record={value as Record<string, unknown>}
           useBorders={false}
+          copyButton={true}
         />
       );
     }


### PR DESCRIPTION
## Summary

Adds an opt-in copy button to value rows in `MetaDataGrid` and `RecordTree`. Off by default; enabled via `options.copyButton` on `MetaDataGrid` (propagates into nested section grids) and the `copyButton` prop on `RecordTree`.

- The button sits in a new right-edge grid column on each value row, revealed on row hover or keyboard focus (CSS-only opacity transition, following the existing `ChatMessage` hover-reveal pattern). Reuses the shared `CopyButton` from `@tsmono/react/components`, so the confirm-checkmark feedback comes for free.
- Copy semantics (`content/copyText.ts`): strings verbatim, other scalars as their string form, objects/arrays as pretty-printed JSON.
- Collapsed `RecordTree` nodes copy their full JSON subtree rather than the `Object(n)` display label (a new `rawValue` field on tree items carries the original value).
- Rows with no rendered value get no button: expanded `RecordTree` parents, and `_html` escape rows in `MetaDataGrid`.

## Screenshots

Hovering the `dataset` row in `MetaDataGrid`:

![MetaDataGrid with copy button on hovered row](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/refs/heads/assets/metadata-copy-button/metadata-grid-hover.png)

Hovering the `model` row in `RecordTree`:

![RecordTree with copy button on hovered row](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/refs/heads/assets/metadata-copy-button/record-tree-hover.png)

(Screenshots live on the orphan branch `assets/metadata-copy-button` — delete it after merge.)

## Testing

- 11 new tests in `MetaDataGrid.test.tsx` / `RecordTree.test.tsx` (written first, watched fail): default-off, copy semantics per value type, JSON subtree copy, no-button rows.
- `inspect-components`: 448 passed / 2 skipped; lint, typecheck, prettier clean; monorepo-wide `turbo typecheck` 8/8.
- Hover reveal and right-edge placement verified in a live browser (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Enabled at pure-metadata call sites

The second commit turns the button on wherever user/log-supplied metadata dicts are displayed (both apps plus shared event views): sample **Metadata / Store / Invalidation** cards, eval/task metadata, message metadata, score & score-edit metadata, compaction metadata, early-stopping metadata, scan/scanner-result metadata, and the **Task Info / Transcript Info** cards (IDs are handy to copy; `_html` rows like revision links get no button by design).

Deliberately left off: the print view, score-value table cells, the outline popover, and config/args displays. The component default remains `false`.
