### PR TITLE
Use shared eslint rules

### DIFF
--- a/apps/inspect/e2e/chat-virtualization.spec.ts
+++ b/apps/inspect/e2e/chat-virtualization.spec.ts
@@ -19,11 +19,14 @@ import {
 const LOG_FILE = "test-virtual.json";
 
 function generateMessages(count: number): ChatMessage[] {
-  return Array.from({ length: count }, (_, i) => ({
-    role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
-    content: `message-${i}`,
-    source: i % 2 === 0 ? "input" : "generate",
-  }));
+  return Array.from(
+    { length: count },
+    (_, i): ChatMessage => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `message-${i}`,
+      source: i % 2 === 0 ? "input" : "generate",
+    })
+  );
 }
 
 async function openSample(

--- a/apps/inspect/e2e/fixtures/test-data.ts
+++ b/apps/inspect/e2e/fixtures/test-data.ts
@@ -100,7 +100,7 @@ export function createEvalSample(overrides: {
     input: overrides.messages
       .filter((m) => m.role === "user")
       .map((m) => m.content)
-      .join("\n") as string,
+      .join("\n"),
     output: createModelOutput(
       typeof lastAssistant?.content === "string"
         ? lastAssistant.content

--- a/apps/inspect/eslint.config.mjs
+++ b/apps/inspect/eslint.config.mjs
@@ -7,7 +7,6 @@ export default tseslint.config(
   {
     ignores: [
       "libs/",
-      "preact/",
       "dist/",
       "lib/",
       "node_modules/",

--- a/apps/inspect/eslint.config.mjs
+++ b/apps/inspect/eslint.config.mjs
@@ -50,7 +50,15 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-return": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
       "@typescript-eslint/require-await": "off",
       "react/display-name": "off",
     },

--- a/apps/inspect/eslint.config.mjs
+++ b/apps/inspect/eslint.config.mjs
@@ -1,41 +1,59 @@
-import pluginJs from "@eslint/js";
-import reactHooks from "eslint-plugin-react-hooks";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default [
+import reactConfig from "@tsmono/eslint-config/react";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "libs/",
+      "preact/",
+      "dist/",
+      "lib/",
+      "node_modules/",
+      "playwright-report/",
+      "test-results/",
+      "*.config.?s",
+      "*.config.cjs",
+      "src/types/log.d.ts",
+    ],
+  },
+  ...reactConfig,
   {
     languageOptions: {
       globals: {
         ...globals.browser,
         ...globals.node,
         __VIEW_SERVER_API_URL__: "readonly",
+        __DEV_WATCH__: "readonly",
+        __LOGGING_FILTER__: "readonly",
+      },
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["*.config.js", "*.config.ts", "*.config.cjs"],
+        },
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },
-  pluginJs.configs.recommended,
-  {
-    ignores: ["libs/**", "preact/**", "dist/**", "src/types/log.d.ts"],
-  },
-  // Add TypeScript support with customized rules for all files
+  // Legacy code overrides — disabled rules that haven't been fixed yet
   {
     files: ["**/*.{ts,tsx}"],
-    languageOptions: {
-      parser: tseslint.parser,
-      parserOptions: {
-        project: "./tsconfig.json",
-      },
-    },
-    plugins: {
-      "react-hooks": reactHooks,
-    },
     rules: {
-      // React Hooks rules
-      "react-hooks/rules-of-hooks": "warn",
-      "react-hooks/exhaustive-deps": "warn",
-
-      // These are disabled because we didn't have time to fix them, not because they are bad rules
       "no-unused-vars": "off",
+      "@typescript-eslint/no-base-to-string": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-floating-promises": "off",
+      "@typescript-eslint/no-misused-promises": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/require-await": "off",
+      "react/display-name": "off",
     },
-  },
-];
+  }
+);

--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -54,6 +54,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.1",
+    "@tsmono/eslint-config": "workspace:*",
     "@tsmono/prettier-config": "workspace:*",
     "@types/bootstrap": "^5.2.11",
     "@types/clipboard": "^2.0.10",

--- a/apps/inspect/src/@types/asciicinema-player.d.ts
+++ b/apps/inspect/src/@types/asciicinema-player.d.ts
@@ -1,6 +1,6 @@
 declare module "asciinema-player" {
   export const create: (
-    src: string | Object,
+    src: string | object,
     el: HTMLElement,
     opts: {
       cols?: number;
@@ -20,7 +20,7 @@ declare module "asciinema-player" {
       terminalFontSize?: string;
       terminalFontFamily?: string;
       terminalLineHeight?: string;
-      logger?: Object;
+      logger?: object;
     }
   ) => any;
 }

--- a/apps/inspect/src/@types/prism.d.ts
+++ b/apps/inspect/src/@types/prism.d.ts
@@ -1,4 +1,4 @@
-declare var Prism: {
+declare let Prism: {
   languages: any;
   highlight(contents: any, tokens: any, type: any): string;
   highlightElement(

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -64,7 +64,8 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   const { loadLogs } = useLogs();
   const gridRef = useRef<AgGridReact<LogListRow>>(null);
   const [showColumnSelector, setShowColumnSelector] = useState(false);
-  const columnButtonRef = useRef<HTMLButtonElement>(null);
+  const [columnButtonEl, setColumnButtonEl] =
+    useState<HTMLButtonElement | null>(null);
 
   const showRetriedLogs = useUserSettings((state) => state.showRetriedLogs);
   const setShowRetriedLogs = useUserSettings(
@@ -77,7 +78,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // Defer previews so the burst of preview flushes during initial sync
   // can't block input — see the matching note in LogListGrid.
   const deferredLogPreviews = useDeferredValue(logPreviews);
-  const { filteredCount } = useLogsListing();
+  const { filteredCount, gridStateByScope } = useLogsListing();
 
   const syncing = useStore((state) => state.app.status.syncing);
   const error = useStore((state) => state.app.status.error);
@@ -376,8 +377,14 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     }
   };
 
-  const filterModel = gridRef.current?.api?.getFilterModel() || {};
-  const filteredFields = Object.keys(filterModel);
+  // Derived from the store's persisted grid state (kept fresh by the
+  // grid's onStateUpdated) rather than read off the grid api during
+  // render — the api read only appeared live because unrelated renders
+  // happened to coincide with filter changes.
+  const scopeGridState = scopeKey ? gridStateByScope[scopeKey] : undefined;
+  const filteredFields = Object.keys(
+    scopeGridState?.filter?.filterModel ?? {}
+  );
   const hasFilter = filteredFields.length > 0;
 
   useEffect(() => {
@@ -422,7 +429,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
 
         <NavbarButton
           key="choose-columns"
-          ref={columnButtonRef}
+          ref={setColumnButtonEl}
           label="Columns"
           icon={ApplicationIcons.columns}
           dropdown
@@ -445,7 +452,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
         columns={pickerColumns}
         visibility={visibility}
         onVisibilityChange={handleColumnVisibilityChange}
-        positionEl={columnButtonRef.current}
+        positionEl={columnButtonEl}
         filteredFields={filteredFields}
         scoresHeading="Metrics"
         groupableScores

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -382,9 +382,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // render — the api read only appeared live because unrelated renders
   // happened to coincide with filter changes.
   const scopeGridState = scopeKey ? gridStateByScope[scopeKey] : undefined;
-  const filteredFields = Object.keys(
-    scopeGridState?.filter?.filterModel ?? {}
-  );
+  const filteredFields = Object.keys(scopeGridState?.filter?.filterModel ?? {});
   const hasFilter = filteredFields.length > 0;
 
   useEffect(() => {

--- a/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
+++ b/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
@@ -39,7 +39,7 @@ export const ViewerOptionsPopover: FC<ViewerOptionsPopoverProps> = ({
     setClearMessage(null);
 
     try {
-      await replicationService.clearData();
+      replicationService.clearData();
       setClearMessage("Database cleared successfully");
       setTimeout(() => setClearMessage(null), 3000);
     } catch (error) {

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -216,8 +216,18 @@ export const LogListGrid: FC<LogListGridProps> = ({
   // and catches up when the main thread is idle.
   const deferredLogDetails = useDeferredValue(logDetails);
   const navigate = useNavigate();
-  const internalGridRef = useRef<AgGridReact<LogListRow>>(null);
-  const gridRef = externalGridRef ?? internalGridRef;
+  const gridRef = useRef<AgGridReact<LogListRow>>(null);
+  // Bridge the grid instance to the optional external ref while keeping a
+  // true local ref. A conditional `external ?? internal` expression isn't
+  // recognized as a ref by the React Compiler, which would force
+  // `gridRef.current` into every callback's inferred dependencies.
+  const attachGridRef = useCallback(
+    (instance: AgGridReact<LogListRow> | null) => {
+      gridRef.current = instance;
+      if (externalGridRef) externalGridRef.current = instance;
+    },
+    [externalGridRef]
+  );
   const gridContainerRef = useRef<HTMLDivElement>(null);
 
   // Find functionality state - store row IDs instead of IRowNode references to avoid memory leaks
@@ -318,7 +328,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         }
       }
     },
-    [navigate, gridRef]
+    [navigate]
   );
 
   const handleOpenRow = useCallback(
@@ -336,25 +346,22 @@ export const LogListGrid: FC<LogListGridProps> = ({
     [navigate]
   );
 
-  const handleKeyDown = useMemo(
-    () =>
-      createGridKeyboardHandler<LogListRow>({
-        gridRef,
-        onOpenRow: handleOpenRow,
-      }),
-    [gridRef, handleOpenRow]
-  );
-
+  // The handler is created inside the effect because it closes over the
+  // grid ref, which render-phase code must not touch.
   useEffect(() => {
     const gridElement = gridContainerRef.current;
     if (!gridElement) return;
 
+    const handleKeyDown = createGridKeyboardHandler<LogListRow>({
+      gridRef,
+      onOpenRow: handleOpenRow,
+    });
     gridElement.addEventListener("keydown", handleKeyDown);
 
     return () => {
       gridElement.removeEventListener("keydown", handleKeyDown);
     };
-  }, [handleKeyDown]);
+  }, [handleOpenRow]);
 
   const handleCellMouseDown = useCallback(
     (_e: CellMouseDownEvent<LogListRow>) => {
@@ -408,7 +415,14 @@ export const LogListGrid: FC<LogListGridProps> = ({
 
   const maxColCount = useRef(0);
 
-  const resizeGridColumns = useRef(createGridColumnResizer(gridRef)).current;
+  // Lazily created on first use: creating it during render would pass the
+  // grid ref into non-React code, and the single instance must survive
+  // re-renders so the debounce timer isn't reset.
+  const resizerRef = useRef<(() => void) | null>(null);
+  const resizeGridColumns = useCallback(() => {
+    resizerRef.current ??= createGridColumnResizer(gridRef);
+    resizerRef.current();
+  }, []);
 
   // Resize grid columns when columns prop changes (e.g., when columns are hidden/unhidden)
   useEffect(() => {
@@ -486,7 +500,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         }
       }
     },
-    [data, columns, gridRef]
+    [data, columns]
   );
 
   const goToMatch = useCallback(
@@ -504,7 +518,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
         node.setSelected(true, true);
       }
     },
-    [matchIds, gridRef]
+    [matchIds]
   );
 
   const handleInputKeyDown = useCallback(
@@ -536,13 +550,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
       document.removeEventListener("keydown", handleFindKeyDown, true);
   }, [closeFind, showFind]);
 
+  // performSearch handles the empty term by clearing match state, so a
+  // single call covers both the search and reset paths.
   useEffect(() => {
-    if (findTerm) {
-      performSearch(findTerm);
-    } else {
-      setMatchIds([]);
-      setCurrentMatchIndex(0);
-    }
+    performSearch(findTerm);
   }, [findTerm, performSearch]);
 
   return (
@@ -572,7 +583,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
           // slate. AG-Grid's `initialState` is one-shot at mount, so a key
           // change is the cleanest way to reset everything declaratively.
           key={scopeKey ?? "pending"}
-          ref={gridRef}
+          ref={attachGridRef}
           rowData={data}
           animateRows={false}
           suppressColumnMoveAnimation={true}

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -84,7 +84,7 @@ export const LogView: FC = () => {
     const refs: RefObject<HTMLElement | null>[] = [];
     for (const key of Object.keys(tabs)) {
       const ref = tabs[key].scrollRef;
-      if (ref) refs.push(ref as RefObject<HTMLElement | null>);
+      if (ref) refs.push(ref);
     }
     return refs;
     // The set of tab refs is stable within a session — recompute only when

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -80,6 +80,7 @@ export const LogView: FC = () => {
     json: jsonTabConfig,
   };
 
+  const tabKeys = Object.keys(tabs).join(",");
   const scrollRefs = useMemo(() => {
     const refs: RefObject<HTMLElement | null>[] = [];
     for (const key of Object.keys(tabs)) {
@@ -90,7 +91,7 @@ export const LogView: FC = () => {
     // The set of tab refs is stable within a session — recompute only when
     // the tab keys change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [Object.keys(tabs).join(",")]);
+  }, [tabKeys]);
 
   const { hidden: titleCollapsed } = useScrollDirection(scrollRefs, {
     stayHiddenOnUpScroll: true,

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -1,12 +1,8 @@
-import { FC, useEffect, useLayoutEffect } from "react";
+import { FC, useEffect, useLayoutEffect, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import { kLogViewSamplesTabId } from "../../constants";
-import {
-  useEvalSpec,
-  usePrevious,
-  useSampleSummaries,
-} from "../../state/hooks";
+import { useEvalSpec, useSampleSummaries } from "../../state/hooks";
 import { useUnloadLog } from "../../state/log";
 import { useStore } from "../../state/store";
 import {
@@ -105,7 +101,7 @@ export const LogViewContainer: FC = () => {
     }
   }, [initialState, evalSpec, clearInitialState, navigate, prefix]);
 
-  const prevLogPath = usePrevious<string | undefined>(logPath);
+  const prevLogPathRef = useRef<string | undefined>(undefined);
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
 
@@ -113,11 +109,13 @@ export const LogViewContainer: FC = () => {
   // old eval doesn't flash while the new one loads. A useEffect would run after
   // the browser has already painted the stale eval.
   useLayoutEffect(() => {
+    const prevLogPath = prevLogPathRef.current;
+    prevLogPathRef.current = logPath;
     if (prevLogPath && logPath && logPath !== prevLogPath) {
       clearSelectedSample();
       clearSelectedLogSummary();
     }
-  }, [logPath, prevLogPath, clearSelectedSample, clearSelectedLogSummary]);
+  }, [logPath, clearSelectedSample, clearSelectedLogSummary]);
 
   // Sync the workspace tab from the URL synchronously. Kept separate from
   // the async log-loading effect below so a tab click can't race with a

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -61,7 +61,7 @@ import { RunningNoSamples } from "./RunningNoSamples.tsx";
 interface SamplesTabExtraProps {
   showColumnSelector: boolean;
   setShowColumnSelector: (showing: boolean) => void;
-  columnButtonRef: RefObject<HTMLButtonElement | null>;
+  columnButtonEl: HTMLButtonElement | null;
 }
 
 // Individual hook for Samples tab
@@ -82,7 +82,8 @@ export const useSamplesTabConfig = (
   // Column-selector state lives here so the tools toolbar can host the
   // trigger button while the popover is rendered inside SamplesTab.
   const [showColumnSelector, setShowColumnSelector] = useState(false);
-  const columnButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [columnButtonEl, setColumnButtonEl] =
+    useState<HTMLButtonElement | null>(null);
   const handleToggleColumnSelector = useCallback(() => {
     setShowColumnSelector((p) => !p);
   }, []);
@@ -101,7 +102,7 @@ export const useSamplesTabConfig = (
         scrollRef,
         showColumnSelector,
         setShowColumnSelector,
-        columnButtonRef,
+        columnButtonEl,
       },
       tools: () =>
         !samplesDescriptor
@@ -122,7 +123,7 @@ export const useSamplesTabConfig = (
                 samplesAvailable && (
                   <NavbarButton
                     key="choose-columns"
-                    ref={columnButtonRef}
+                    ref={setColumnButtonEl}
                     label="Columns"
                     icon={ApplicationIcons.columns}
                     dropdown
@@ -132,11 +133,11 @@ export const useSamplesTabConfig = (
                 ),
               ],
     };
-    // `scrollRef`, `columnButtonRef`, and `setShowColumnSelector` are
-    // intentionally omitted — refs and React state setters have stable
-    // identity across renders, so including them only churns the memo
-    // without changing behavior. If `componentProps` ever gains a
-    // non-stable value, add it to the deps list.
+    // `scrollRef` and `setShowColumnSelector` are intentionally omitted —
+    // refs and React state setters have stable identity across renders, so
+    // including them only churns the memo without changing behavior. If
+    // `componentProps` ever gains a non-stable value, add it to the deps
+    // list.
   }, [
     evalStatus,
     refreshLog,
@@ -144,6 +145,7 @@ export const useSamplesTabConfig = (
     streamSamples,
     totalSampleCount,
     showColumnSelector,
+    columnButtonEl,
     handleToggleColumnSelector,
   ]);
 };
@@ -158,7 +160,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   scrollRef,
   showColumnSelector,
   setShowColumnSelector,
-  columnButtonRef,
+  columnButtonEl,
 }) => {
   const sampleSummaries = useFilteredSamples();
   const selectedLogDetails = useStore((state) => state.log.selectedLogDetails);
@@ -402,7 +404,9 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   const setFilter = useStore((state) => state.logActions.setFilter);
   const currentFilter = useStore((state) => state.log.filter);
   const currentFilterRef = useRef(currentFilter);
-  currentFilterRef.current = currentFilter;
+  useEffect(() => {
+    currentFilterRef.current = currentFilter;
+  }, [currentFilter]);
 
   /** Parse `text` and project it to the FilterModel the column UI
    *  should be holding — `{}` for empty or non-round-trippable text. */
@@ -549,7 +553,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
           columns={allColumns}
           visibility={visibilityForGrid}
           onVisibilityChange={handleVisibilityChange}
-          positionEl={columnButtonRef.current}
+          positionEl={columnButtonEl}
           filteredFields={filteredFields}
           scoresHeading="Scores"
           onResetToDefault={resetColumns}

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -173,7 +173,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
         ? undefined
         : typeof limit === "number"
           ? limit
-          : (limit[1]) - (limit[0]);
+          : limit[1] - limit[0];
     return (
       (limitCount || selectedLogDetails?.eval.dataset.samples || 0) *
       (selectedLogDetails?.eval.config.epochs || 0)
@@ -361,7 +361,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
         input: inputString(sample.input).join(" "),
         target: Array.isArray(sample.target)
           ? sample.target.join(", ")
-          : (sample.target),
+          : sample.target,
         error: sample.error,
         limit: sample.limit,
         retries: sample.retries,
@@ -442,7 +442,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
     const api = sampleListHandle.current?.api;
     if (!api) return;
     const desired = filterModelFromText(currentFilter);
-    const current: FilterModel = (api.getFilterModel() ?? {});
+    const current: FilterModel = api.getFilterModel() ?? {};
     // Preserve current model entries that the synthesizer would have
     // skipped — they live only in the column UI and must not be wiped
     // by a text-driven update. Entries the user can express in text

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -171,7 +171,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
         ? undefined
         : typeof limit === "number"
           ? limit
-          : (limit[1] as number) - (limit[0] as number);
+          : (limit[1]) - (limit[0]);
     return (
       (limitCount || selectedLogDetails?.eval.dataset.samples || 0) *
       (selectedLogDetails?.eval.config.epochs || 0)
@@ -359,7 +359,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
         input: inputString(sample.input).join(" "),
         target: Array.isArray(sample.target)
           ? sample.target.join(", ")
-          : (sample.target as string | undefined),
+          : (sample.target),
         error: sample.error,
         limit: sample.limit,
         retries: sample.retries,
@@ -438,7 +438,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
     const api = sampleListHandle.current?.api;
     if (!api) return;
     const desired = filterModelFromText(currentFilter);
-    const current: FilterModel = (api.getFilterModel() ?? {}) as FilterModel;
+    const current: FilterModel = (api.getFilterModel() ?? {});
     // Preserve current model entries that the synthesizer would have
     // skipped — they live only in the column UI and must not be wiped
     // by a text-driven update. Entries the user can express in text
@@ -469,7 +469,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
     const state = cols.flatMap((c) => {
       const colId = c.getColId();
       if (!colId.startsWith("score_")) return [];
-      const w = c.getColDef().initialWidth as number | undefined;
+      const w = c.getColDef().initialWidth;
       return w === undefined ? [] : [{ colId, width: w, flex: null }];
     });
     if (state.length > 0) api.applyColumnState({ state });

--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -186,7 +186,7 @@ export const TaskTab: FC<TaskTabProps> = ({
               <MetaDataGrid
                 key={`plan-md-task-args`}
                 className={"text-size-small"}
-                entries={task_args as Record<string, unknown>}
+                entries={task_args}
               />
             </CardBody>
           </Card>

--- a/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
@@ -165,24 +165,37 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  // Captures the most recently added key so a layout effect can scroll
-  // the new row into view and focus its value textarea once it's in
-  // the DOM. Reset to null after handling.
-  const [pendingFocusKey, setPendingFocusKey] = useState<string | null>(null);
+  // Captures the most recently added key so an effect can scroll the
+  // new row into view and focus its value textarea once it's in the
+  // DOM. A ref (not state): it never needs to trigger a render — the
+  // entries update from addKey re-runs the focus effect below.
+  const pendingFocusKeyRef = useRef<string | null>(null);
 
+  // Reset local state whenever the dialog opens (or the underlying log
+  // changes its metadata out from under us). Render-adjust rather than
+  // an effect so the reset is scheduled before anything paints.
+  const [prevReset, setPrevReset] = useState({ showing, initialEntries });
+  if (
+    prevReset.showing !== showing ||
+    prevReset.initialEntries !== initialEntries
+  ) {
+    setPrevReset({ showing, initialEntries });
+    if (showing) {
+      setEntries(initialEntries);
+      setRemoved([]);
+      setNewKey("");
+      setNewType("string");
+      setAuthor("");
+      setReason("");
+      setSubmitting(false);
+      setError(undefined);
+    }
+  }
+
+  // On open, prefill Author from the server's best-effort identity (git
+  // user.name → OS login). Same pattern as EditTagsDialog.
   useEffect(() => {
     if (!showing) return;
-    setEntries(initialEntries);
-    setRemoved([]);
-    setNewKey("");
-    setNewType("string");
-    setAuthor("");
-    setReason("");
-    setSubmitting(false);
-    setError(undefined);
-
-    // Prefill Author from the server's best-effort identity (git
-    // user.name → OS login). Same pattern as EditTagsDialog.
     let cancelled = false;
     if (api?.get_user_info) {
       api
@@ -257,7 +270,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
     setNewType("string");
     // Trigger a scroll-into-view + focus on the freshly inserted row
     // once it's in the DOM (handled by the effect below).
-    setPendingFocusKey(k);
+    pendingFocusKeyRef.current = k;
   };
 
   // Scroll the just-added row into view and focus its textarea so the
@@ -266,7 +279,9 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
   // taking a ref so we don't need to thread a ref handler through
   // every MetaRow.
   useEffect(() => {
+    const pendingFocusKey = pendingFocusKeyRef.current;
     if (pendingFocusKey == null) return;
+    pendingFocusKeyRef.current = null;
     const selector = `[data-meta-key="${CSS.escape(pendingFocusKey)}"]`;
     const row = document.querySelector<HTMLElement>(selector);
     const textarea = row?.querySelector<HTMLTextAreaElement>("textarea");
@@ -276,8 +291,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
       textarea.scrollIntoView({ behavior: "smooth", block: "nearest" });
       textarea.focus();
     }
-    setPendingFocusKey(null);
-  }, [pendingFocusKey]);
+  }, [entries]);
 
   const handleNewKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {

--- a/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
@@ -39,19 +39,27 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
   const [error, setError] = useState<string | undefined>();
 
   // Reset local state whenever the dialog opens (or the underlying log
-  // changes its tags out from under us). On open, also fetch the
-  // server-side identity (git user.name → OS login) so the user doesn't
-  // have to retype themselves for every edit. The fetch is best-effort —
-  // a missing endpoint or empty result simply leaves the field blank.
+  // changes its tags out from under us). Render-adjust rather than an
+  // effect so the reset is scheduled before anything paints.
+  const [prevReset, setPrevReset] = useState({ showing, currentTags });
+  if (prevReset.showing !== showing || prevReset.currentTags !== currentTags) {
+    setPrevReset({ showing, currentTags });
+    if (showing) {
+      setTags(currentTags);
+      setPending("");
+      setAuthor("");
+      setReason("");
+      setError(undefined);
+      setSubmitting(false);
+    }
+  }
+
+  // On open, fetch the server-side identity (git user.name → OS login)
+  // so the user doesn't have to retype themselves for every edit. The
+  // fetch is best-effort — a missing endpoint or empty result simply
+  // leaves the field blank.
   useEffect(() => {
     if (!showing) return;
-    setTags(currentTags);
-    setPending("");
-    setAuthor("");
-    setReason("");
-    setError(undefined);
-    setSubmitting(false);
-
     let cancelled = false;
     if (api?.get_user_info) {
       api

--- a/apps/inspect/src/app/log-view/title-view/ModelRolesView.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ModelRolesView.tsx
@@ -13,16 +13,16 @@ interface ModelRolesViewProps {
  * Renders the Navbar
  */
 export const ModelRolesView: FC<ModelRolesViewProps> = ({ roles }) => {
-  roles = roles || {};
+  const modelRoles = roles || {};
 
   // Render as a single line if there is only a single
   // model role
-  const singleLine = Object.keys(roles).length !== 1;
+  const singleLine = Object.keys(modelRoles).length !== 1;
 
   // Render a layout of model roles
-  const modelEls = Object.keys(roles).map((key) => {
+  const modelEls = Object.keys(modelRoles).map((key) => {
     const role = key;
-    const roleData = roles[role];
+    const roleData = modelRoles[role];
     const model = roleData.model;
     return (
       <div

--- a/apps/inspect/src/app/log-view/title-view/SecondaryBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/SecondaryBar.tsx
@@ -228,7 +228,7 @@ const ParamSummary: FC<ParamSummaryProps> = ({ params }) => {
     if (Array.isArray(val) || typeof val === "object") {
       return `${key}: ${JSON.stringify(val)}`;
     } else {
-      return `${key}: ${val}`;
+      return `${key}: ${String(val)}`;
     }
   });
   if (paraValues.length > 0) {

--- a/apps/inspect/src/app/log-view/title-view/TagStrip.tsx
+++ b/apps/inspect/src/app/log-view/title-view/TagStrip.tsx
@@ -62,20 +62,18 @@ export const TagStrip: FC<TagStripProps> = ({
   // loop on unrelated re-renders. `selectedLogDetails.tags` is a
   // fresh array after every refresh, so reference equality is a
   // reliable change signal here.
-  const lastTagsRef = useRef<string[]>(tags);
+  const [lastTags, setLastTags] = useState<string[]>(tags);
   // The overflow pill only makes sense when there's also an Edit pill
   // to anchor it. Without edit, we let chips wrap normally.
   const enableCollapse = collapseOnWrap && showEdit;
 
-  // Whenever the tag set changes, restart from "all visible". This
-  // runs *during* commit, before the trim effect below, so trimming
-  // always measures against the full set first.
-  if (lastTagsRef.current !== tags) {
-    lastTagsRef.current = tags;
+  // Whenever the tag set changes, restart from "all visible". This is
+  // the render-adjust pattern: the update is scheduled before the trim
+  // effect below runs, so trimming always measures against the full
+  // set first.
+  if (lastTags !== tags) {
+    setLastTags(tags);
     if (visibleCount !== tags.length) {
-      // Schedule a state update; this render returns with the old
-      // count, but the immediately-following render has the reset
-      // value and the trim effect re-measures.
       setVisibleCount(tags.length);
     }
   }
@@ -95,6 +93,10 @@ export const TagStrip: FC<TagStripProps> = ({
     const tops = new Set<number>();
     for (const k of kids) tops.add(k.offsetTop);
     if (tops.size > MAX_ROWS && visibleCount > 0) {
+      // DOM measurement can only happen after layout, so this
+      // measure-and-converge loop genuinely needs setState in a layout
+      // effect; it terminates because visibleCount strictly decreases.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setVisibleCount((c) => Math.max(0, c - 1));
     }
   }, [enableCollapse, visibleCount, tags, showEdit]);

--- a/apps/inspect/src/app/navbar/ApplicationNavbar.tsx
+++ b/apps/inspect/src/app/navbar/ApplicationNavbar.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useMemo, useRef } from "react";
+import { FC, ReactNode, useMemo, useState } from "react";
 
 import {
   ThemeToggle,
@@ -31,7 +31,7 @@ export const ApplicationNavbar: FC<ApplicationNavbarProps> = ({
   showActivity = "log",
   breadcrumbsEnabled,
 }) => {
-  const optionsRef = useRef<HTMLButtonElement>(null);
+  const [optionsEl, setOptionsEl] = useState<HTMLButtonElement | null>(null);
   const themePreference = useUserSettings((s) => s.themePreference);
   const setThemePreference = useUserSettings((s) => s.setThemePreference);
   const isDark = useResolvedIsDark(themePreference);
@@ -73,10 +73,10 @@ export const ApplicationNavbar: FC<ApplicationNavbarProps> = ({
         <ViewerOptionsButton
           showing={isShowing}
           setShowing={setShowing}
-          ref={optionsRef}
+          ref={setOptionsEl}
         />
         <ViewerOptionsPopover
-          positionEl={optionsRef.current}
+          positionEl={optionsEl}
           showing={isShowing}
           setShowing={setShowing}
         />

--- a/apps/inspect/src/app/plan/ModelCard.tsx
+++ b/apps/inspect/src/app/plan/ModelCard.tsx
@@ -67,7 +67,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
                   Object.keys(modelInfo.config).length > 0 ? (
                     <MetaDataGrid
                       entries={
-                        modelInfo.config as any as Record<string, unknown>
+                        modelInfo.config
                       }
                     />
                   ) : (
@@ -79,7 +79,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
                 <div className="text-size-small">
                   {Object.keys(modelInfo.args).length > 0 ? (
                     <MetaDataGrid
-                      entries={modelInfo.args as any as Record<string, unknown>}
+                      entries={modelInfo.args}
                     />
                   ) : (
                     noneEl

--- a/apps/inspect/src/app/plan/ModelCard.tsx
+++ b/apps/inspect/src/app/plan/ModelCard.tsx
@@ -65,11 +65,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
                 <div className="text-size-small">
                   {modelInfo.config &&
                   Object.keys(modelInfo.config).length > 0 ? (
-                    <MetaDataGrid
-                      entries={
-                        modelInfo.config
-                      }
-                    />
+                    <MetaDataGrid entries={modelInfo.config} />
                   ) : (
                     noneEl
                   )}
@@ -78,9 +74,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
                 <div className={clsx("text-style-label")}>Args</div>
                 <div className="text-size-small">
                   {Object.keys(modelInfo.args).length > 0 ? (
-                    <MetaDataGrid
-                      entries={modelInfo.args}
-                    />
+                    <MetaDataGrid entries={modelInfo.args} />
                   ) : (
                     noneEl
                   )}

--- a/apps/inspect/src/app/plan/PlanDetailView.tsx
+++ b/apps/inspect/src/app/plan/PlanDetailView.tsx
@@ -71,7 +71,7 @@ export const PlanDetailView: FC<PlanDetailViewProps> = ({
             key={key}
             name={key}
             scores={scorers[key].scores}
-            params={scorers[key].params as Record<string, unknown>}
+            params={scorers[key].params}
           />
         );
       });

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -320,7 +320,7 @@ export const SamplesPanel: FC = () => {
           input: inputString(sample.input).join("\n"),
           target: Array.isArray(sample.target)
             ? sample.target.join(", ")
-            : (sample.target),
+            : sample.target,
           error: sample.error,
           limit: sample.limit,
           retries: sample.retries,

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -106,7 +106,8 @@ export const SamplesPanel: FC = () => {
 
   const gridRef = useRef<AgGridReact<SampleRow>>(null);
   const [showColumnSelector, setShowColumnSelector] = useState(false);
-  const columnButtonRef = useRef<HTMLButtonElement>(null);
+  const [columnButtonEl, setColumnButtonEl] =
+    useState<HTMLButtonElement | null>(null);
 
   const logDetails = useStore((state) => state.logs.logDetails);
 
@@ -441,7 +442,7 @@ export const SamplesPanel: FC = () => {
         )}
         <NavbarButton
           key="choose-columns"
-          ref={columnButtonRef}
+          ref={setColumnButtonEl}
           label="Columns"
           icon={ApplicationIcons.columns}
           dropdown
@@ -462,7 +463,7 @@ export const SamplesPanel: FC = () => {
         columns={allColumns}
         visibility={visibilityForGrid}
         onVisibilityChange={setColumnVisibility}
-        positionEl={columnButtonRef.current}
+        positionEl={columnButtonEl}
         filteredFields={filteredFields}
         scoresHeading="Scores"
       />

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -319,7 +319,7 @@ export const SamplesPanel: FC = () => {
           input: inputString(sample.input).join("\n"),
           target: Array.isArray(sample.target)
             ? sample.target.join(", ")
-            : (sample.target as string | undefined),
+            : (sample.target),
           error: sample.error,
           limit: sample.limit,
           retries: sample.retries,

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -776,6 +776,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 >
                   <div className={styles.retriedErrors}>
                     <SampleRetriedErrors
+                      key={sample.uuid || String(sample.id)}
                       id={sample.uuid || String(sample.id)}
                       retries={sample.error_retries}
                       scrollRef={scrollRef}

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -232,7 +232,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const sampleUrlBuilder = useSampleUrlBuilder();
   const onSelectedTab = useCallback(
     (e: MouseEvent<HTMLElement>) => {
-      const el = e.currentTarget as HTMLElement;
+      const el = e.currentTarget;
       const id = el.id;
       setSelectedTab(id);
 
@@ -968,7 +968,7 @@ const metadataViewsForSample = (
         <CardBody padded={false}>
           <RecordTree
             id={`task-sample-metadata-${id}`}
-            record={sample?.metadata as Record<string, unknown>}
+            record={sample?.metadata}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
             copyButton={true}
@@ -985,7 +985,7 @@ const metadataViewsForSample = (
         <CardBody padded={false}>
           <RecordTree
             id={`task-sample-store-${id}`}
-            record={sample?.store as Record<string, unknown>}
+            record={sample?.store}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
             processStore={true}

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -184,6 +184,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   // processes the new tail. Diverging events trigger a rebuild.
   const messagesRef = useRef<MessagesFromEventsState | null>(null);
   const sampleMessages = useMemo(() => {
+    /* eslint-disable react-hooks/refs */
     if (sample?.messages) {
       messagesRef.current = null;
       return sample.messages;
@@ -193,6 +194,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
       messagesRef.current = null;
       return [];
     }
+    /* eslint-enable react-hooks/refs */
   }, [sample?.messages, runningSampleData]);
 
   const hasSampleData =
@@ -282,6 +284,9 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const sampleUsages = usageViewsForSample(`${baseId}-${id}`, sample, evalSpec);
   const sampleMetadatas = metadataViewsForSample(
     `${baseId}-${id}`,
+    // The helper only forwards scrollRef into JSX props (RecordTree
+    // scrollRef={...}); it never reads .current during render.
+    // eslint-disable-next-line react-hooks/refs
     scrollRef,
     sample
   );
@@ -296,7 +301,8 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const displayMode = useStore((state) => state.app.displayMode);
   const setDisplayMode = useStore((state) => state.appActions.setDisplayMode);
 
-  const filterRef = useRef<HTMLButtonElement | null>(null);
+  const [filterButtonEl, setFilterButtonEl] =
+    useState<HTMLButtonElement | null>(null);
   const optionsRef = useRef<HTMLButtonElement | null>(null);
 
   // Fall back to store state for single-file mode where URL doesn't contain sample ID/epoch
@@ -460,7 +466,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
         label={`Events: ${label}`}
         icon={ApplicationIcons.filter}
         onClick={toggleFilter}
-        ref={filterRef}
+        ref={setFilterButtonEl}
         subtle
       />
     );
@@ -619,7 +625,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 <TranscriptFilterPopover
                   showing={isShowing}
                   setShowing={setShowing}
-                  positionEl={filterRef.current}
+                  positionEl={filterButtonEl}
                 />
 
                 {!sampleEvents || sampleEvents.length === 0 ? (

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, RefObject, useEffect, useState } from "react";
+import { FC, RefObject, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
 
@@ -21,15 +21,11 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   scrollRef,
 }) => {
   // Accordion: default to the most recent failure (closest to the success).
+  // Callers must pass key={id} so the state resets when the sample changes
+  // (the same component instance can be reused on the inline display path).
   const [expandedIndex, setExpandedIndex] = useState<number | null>(
     retries.length - 1
   );
-
-  // Reset accordion state when switching to a different sample (the same
-  // component instance can be reused across samples on the inline display path).
-  useEffect(() => {
-    setExpandedIndex(retries.length - 1);
-  }, [id, retries.length]);
 
   const onToggleOpen = (index: number) => {
     setExpandedIndex((cur) => (cur === index ? null : index));

--- a/apps/inspect/src/app/samples/SamplesTools.tsx
+++ b/apps/inspect/src/app/samples/SamplesTools.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useRef, useState } from "react";
+import { FC, Fragment, useState } from "react";
 
 import { useScores, useSelectedScores } from "../../state/hooks";
 import { useStore } from "../../state/store";
@@ -16,12 +16,14 @@ interface SampleToolsProps {}
 // selection is handled by the column-chooser popover in `SamplesTab`.
 export const SampleTools: FC<SampleToolsProps> = () => {
   const [showViewOptions, setShowViewOptions] = useState(false);
-  const viewButtonRef = useRef<HTMLButtonElement>(null);
+  const [viewButtonEl, setViewButtonEl] = useState<HTMLButtonElement | null>(
+    null
+  );
   return (
     <Fragment>
       <SampleFilter />
       <NavbarButton
-        ref={viewButtonRef}
+        ref={setViewButtonEl}
         label="View"
         icon={ApplicationIcons.options}
         dropdown
@@ -34,7 +36,7 @@ export const SampleTools: FC<SampleToolsProps> = () => {
       <SamplesViewOptionsPopover
         showing={showViewOptions}
         setShowing={setShowViewOptions}
-        positionEl={viewButtonRef.current}
+        positionEl={viewButtonEl}
       />
     </Fragment>
   );

--- a/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -220,7 +220,7 @@ export const createEvalDescriptor = (
           return score.name;
         });
         const sampleScorer = sample.scores[scoreLabel.scorer];
-        const scoreVal = sampleScorer.value as ScoreValue;
+        const scoreVal = sampleScorer.value;
 
         if (typeof scoreVal === "object") {
           const names = Object.keys(scoreVal);

--- a/apps/inspect/src/app/samples/descriptor/types.ts
+++ b/apps/inspect/src/app/samples/descriptor/types.ts
@@ -30,7 +30,7 @@ export interface ScorerDescriptor {
 
 export interface ScoreDescriptor {
   scoreType: string;
-  categories?: Array<Object>;
+  categories?: unknown[];
   min?: number;
   max?: number;
   filterable?: boolean;

--- a/apps/inspect/src/app/samples/error/SampleErrorView.tsx
+++ b/apps/inspect/src/app/samples/error/SampleErrorView.tsx
@@ -9,19 +9,13 @@ import styles from "./SampleErrorView.module.css";
 
 interface SampleErrorViewProps {
   message?: string;
-  align?: string;
   style?: CSSProperties;
 }
 
 /**
  * Component to display a styled error message.
  */
-export const SampleErrorView: FC<SampleErrorViewProps> = ({
-  message,
-  align,
-}) => {
-  align = align || "center";
-
+export const SampleErrorView: FC<SampleErrorViewProps> = ({ message }) => {
   const type = errorType(message);
 
   return (

--- a/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
@@ -226,7 +226,7 @@ describe("resolveSamplesView precedence", () => {
         compactScores: false,
         colorScalesEnabled: true,
       }),
-    } as SamplesViewState;
+    };
     delete (legacy as Partial<SamplesViewState>).userOverrides;
     const evalDefault: TaskSamplesView = {
       name: "Eval",

--- a/apps/inspect/src/app/samples/list/useSamplesView.ts
+++ b/apps/inspect/src/app/samples/list/useSamplesView.ts
@@ -75,10 +75,7 @@ export function useSamplesViewScoreColorScales(): Record<
   WireScoreColorScale
 > {
   const evalDefault = useEvalDefaultSamplesView();
-  return (evalDefault?.score_color_scales ?? kNoScoreColorScales) as Record<
-    string,
-    WireScoreColorScale
-  >;
+  return evalDefault?.score_color_scales ?? kNoScoreColorScales;
 }
 
 /** Resolved `colorScalesEnabled` — same access pattern as the

--- a/apps/inspect/src/app/samples/messagesFromEvents.test.ts
+++ b/apps/inspect/src/app/samples/messagesFromEvents.test.ts
@@ -60,8 +60,8 @@ describe("messagesFromEvents", () => {
       makeModelEvent({ inputId: "msg-1", outputId: "msg-2" }),
     ]);
     expect(messages).toHaveLength(2);
-    expect(messages[0]!.id).toBe("msg-1");
-    expect(messages[1]!.id).toBe("msg-2");
+    expect(messages[0].id).toBe("msg-1");
+    expect(messages[1].id).toBe("msg-2");
   });
 
   it("skips model events with error set", () => {
@@ -74,8 +74,8 @@ describe("messagesFromEvents", () => {
       makeModelEvent({ inputId: "msg-1", outputId: "msg-2" }),
     ]);
     expect(messages).toHaveLength(2);
-    expect(messages[0]!.id).toBe("msg-1");
-    expect(messages[1]!.id).toBe("msg-2");
+    expect(messages[0].id).toBe("msg-1");
+    expect(messages[1].id).toBe("msg-2");
   });
 
   it("includes the latest event's output when not yet folded into a later input", () => {

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -273,7 +273,7 @@ const PrintMetadata: FC<{ sample: EvalSample }> = ({ sample }) => {
       <Card key="print-metadata">
         <CardHeader label="Metadata" />
         <CardBody>
-          <MetaDataGrid entries={sample?.metadata as Record<string, unknown>} />
+          <MetaDataGrid entries={sample?.metadata} />
         </CardBody>
       </Card>
     );
@@ -284,7 +284,7 @@ const PrintMetadata: FC<{ sample: EvalSample }> = ({ sample }) => {
       <Card key="print-store">
         <CardHeader label="Store" />
         <CardBody>
-          <MetaDataGrid entries={sample?.store as Record<string, unknown>} />
+          <MetaDataGrid entries={sample?.store} />
         </CardBody>
       </Card>
     );

--- a/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
+++ b/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, useCallback, useMemo, useRef, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 
 import { PopOver, ToolButton } from "@tsmono/react/components";
 
@@ -20,7 +20,7 @@ export const SelectScorer: FC<SelectScorerProps> = ({
   setSelectedScores,
 }) => {
   const [showing, setShowing] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [buttonEl, setButtonEl] = useState<HTMLButtonElement | null>(null);
 
   const selectedKeys = useMemo(() => {
     return new Set(selectedScores?.map((s) => `${s.scorer}.${s.name}`));
@@ -54,12 +54,12 @@ export const SelectScorer: FC<SelectScorerProps> = ({
         label={label}
         icon={ApplicationIcons.metrics}
         onClick={() => setShowing(!showing)}
-        ref={buttonRef}
+        ref={setButtonEl}
         className={clsx(styles.bodyColorButton)}
       />
       <PopOver
         id="score-selector-popover"
-        positionEl={buttonRef.current}
+        positionEl={buttonEl}
         isOpen={showing}
         setIsOpen={setShowing}
         placement="bottom-start"

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.ts
@@ -80,10 +80,7 @@ class Parser {
 
   private error(message: string): ParseFailure {
     const at = this.peek();
-    return new ParseFailure(
-      message,
-      at?.from ?? this.tokens.at(-1)?.to ?? 0
-    );
+    return new ParseFailure(message, at?.from ?? this.tokens.at(-1)?.to ?? 0);
   }
 
   parse(): FilterAst {

--- a/apps/inspect/src/app/samples/sample-tools/filterAst.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterAst.ts
@@ -32,6 +32,15 @@ export interface ParseError {
   position: number;
 }
 
+class ParseFailure extends Error {
+  constructor(
+    message: string,
+    readonly position: number
+  ) {
+    super(message);
+  }
+}
+
 export interface ParseResult {
   ast: FilterAst | null;
   error: ParseError | null;
@@ -69,9 +78,12 @@ class Parser {
     return this.eat()!;
   }
 
-  private error(message: string): ParseError {
+  private error(message: string): ParseFailure {
     const at = this.peek();
-    return { message, position: at?.from ?? this.tokens.at(-1)?.to ?? 0 };
+    return new ParseFailure(
+      message,
+      at?.from ?? this.tokens.at(-1)?.to ?? 0
+    );
   }
 
   parse(): FilterAst {
@@ -274,8 +286,8 @@ export function parseFilter(text: string): ParseResult {
     const ast = parser.parse();
     return { ast, error: null };
   } catch (e) {
-    if (typeof e === "object" && e !== null && "message" in e) {
-      return { ast: null, error: e as ParseError };
+    if (e instanceof ParseFailure) {
+      return { ast: null, error: { message: e.message, position: e.position } };
     }
     return {
       ast: null,

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -127,7 +127,7 @@ const totalTokens = (sample: SampleSummary): number | null => {
 };
 
 const targetString = (target: SampleSummary["target"]): string =>
-  Array.isArray(target) ? target.join(", ") : ((target as string) ?? "");
+  Array.isArray(target) ? target.join(", ") : ((target) ?? "");
 
 const sampleVariables = (
   sample: SampleSummary,
@@ -198,8 +198,8 @@ export const sampleFilterItems = (
       });
       return;
     }
-    var tooltip = `${canonicalName}: ${descriptor.scoreType}`;
-    var categories: string[] = [];
+    let tooltip = `${canonicalName}: ${descriptor.scoreType}`;
+    let categories: string[] = [];
     if (descriptor.min !== undefined || descriptor.max !== undefined) {
       const rounded = (num: number) => {
         // Additional round-trip to remove trailing zeros.
@@ -248,7 +248,7 @@ export const filterExpression = (
       );
     };
     const targetContains = (regex: string): boolean => {
-      let targets = Array.isArray(sample.target)
+      const targets = Array.isArray(sample.target)
         ? sample.target
         : [sample.target];
       return targets.some((target) => target.match(new RegExp(regex, "i")));

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -127,7 +127,7 @@ const totalTokens = (sample: SampleSummary): number | null => {
 };
 
 const targetString = (target: SampleSummary["target"]): string =>
-  Array.isArray(target) ? target.join(", ") : ((target) ?? "");
+  Array.isArray(target) ? target.join(", ") : (target ?? "");
 
 const sampleVariables = (
   sample: SampleSummary,

--- a/apps/inspect/src/app/samples/scores/SampleScoresGrid.tsx
+++ b/apps/inspect/src/app/samples/scores/SampleScoresGrid.tsx
@@ -78,7 +78,7 @@ export const SampleScoresGrid: FC<SampleScoresGridProps> = ({
         const scoreData = evalSample.scores[scorer];
         const explanation = scoreData.explanation || "(No Explanation)";
         const answer = scoreData.answer;
-        let metadata = scoreData.metadata || {};
+        const metadata = scoreData.metadata || {};
 
         return (
           <Fragment key={`${scorer}-row`}>

--- a/apps/inspect/src/app/samples/transcript/hooks.ts
+++ b/apps/inspect/src/app/samples/transcript/hooks.ts
@@ -60,7 +60,7 @@ export const useTranscriptFilter = () => {
   }, [setFilteredEventTypes]);
 
   const setNoneFilter = useCallback(() => {
-    setFilteredEventTypes(Object.keys(eventTypes) as AllEventTypes[]);
+    setFilteredEventTypes(Object.keys(eventTypes));
   }, [setFilteredEventTypes]);
 
   const isDefaultFilter = useMemo(() => {

--- a/apps/inspect/src/app/shared/samples-grid/RotatedHeader.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/RotatedHeader.tsx
@@ -28,8 +28,7 @@ export const RotatedHeader: FC<IHeaderParams> = (props) => {
   const [filterActive, setFilterActive] = useState(false);
 
   useEffect(() => {
-    const updateSort = () =>
-      setSort((props.column.getSort() ?? null));
+    const updateSort = () => setSort(props.column.getSort() ?? null);
     const updateFilter = () => setFilterActive(props.column.isFilterActive());
     props.column.addEventListener("sortChanged", updateSort);
     props.column.addEventListener("filterChanged", updateFilter);

--- a/apps/inspect/src/app/shared/samples-grid/RotatedHeader.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/RotatedHeader.tsx
@@ -29,7 +29,7 @@ export const RotatedHeader: FC<IHeaderParams> = (props) => {
 
   useEffect(() => {
     const updateSort = () =>
-      setSort((props.column.getSort() ?? null) as SortDir);
+      setSort((props.column.getSort() ?? null));
     const updateFilter = () => setFilterActive(props.column.isFilterActive());
     props.column.addEventListener("sortChanged", updateSort);
     props.column.addEventListener("filterChanged", updateFilter);

--- a/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
@@ -143,8 +143,18 @@ export const SamplesGrid = <TRow,>(
     className,
   } = props;
 
-  const internalGridRef = useRef<AgGridReact<TRow>>(null);
-  const gridRef = externalGridRef ?? internalGridRef;
+  const gridRef = useRef<AgGridReact<TRow>>(null);
+  // Bridge the grid instance to the optional external ref while keeping a
+  // true local ref. The previous `externalGridRef ?? internalGridRef`
+  // conditional isn't recognized as a ref by the React Compiler, which
+  // forced `gridRef.current` into every callback's inferred dependencies.
+  const attachGridRef = useCallback(
+    (instance: AgGridReact<TRow> | null) => {
+      gridRef.current = instance;
+      if (externalGridRef) externalGridRef.current = instance;
+    },
+    [externalGridRef]
+  );
   const gridContainerRef = useRef<HTMLDivElement>(null);
 
   // Focus the grid container on mount so keyboard nav works without a click.
@@ -152,17 +162,15 @@ export const SamplesGrid = <TRow,>(
     gridContainerRef.current?.focus();
   }, []);
 
-  // Keyboard nav.
-  const handleKeyDown = useMemo(
-    () => makeKeyboardHandler(gridRef, onRowOpen),
-    [gridRef, onRowOpen]
-  );
+  // Keyboard nav. The handler is created inside the effect because it
+  // closes over the grid ref, which render-phase code must not touch.
   useEffect(() => {
     const el = gridContainerRef.current;
     if (!el) return;
+    const handleKeyDown = makeKeyboardHandler(gridRef, onRowOpen);
     el.addEventListener("keydown", handleKeyDown);
     return () => el.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
+  }, [onRowOpen]);
 
   // Row click → select + open. Modifier keys / middle button open in new window.
   const handleRowClick = useCallback(
@@ -179,7 +187,7 @@ export const SamplesGrid = <TRow,>(
       );
       onRowOpen(e.data, { newWindow, via: "click" });
     },
-    [gridRef, onRowOpen]
+    [onRowOpen]
   );
 
   const handleCellMouseDown = useCallback(
@@ -202,7 +210,7 @@ export const SamplesGrid = <TRow,>(
       node.setSelected(true);
       gridRef.current.api.ensureNodeVisible(node, "middle");
     }
-  }, [gridRef, selectedRowId]);
+  }, [selectedRowId]);
   useEffect(() => {
     selectExternalRow();
   }, [selectExternalRow]);
@@ -224,7 +232,7 @@ export const SamplesGrid = <TRow,>(
       gridRef.current.api.ensureIndexVisible(rowData.length - 1, "bottom");
     }
     prevCountRef.current = rowData.length;
-  }, [rowData.length, followOutput, gridRef]);
+  }, [rowData.length, followOutput]);
 
   // When followOutput transitions from true → false (eval finished), scroll
   // to top so the user starts at the beginning of the now-static list.
@@ -237,7 +245,7 @@ export const SamplesGrid = <TRow,>(
       }, 100);
     }
     prevFollowRef.current = followOutput;
-  }, [followOutput, gridRef]);
+  }, [followOutput]);
 
   const effectiveRowHeight =
     rowHeight ??
@@ -254,7 +262,7 @@ export const SamplesGrid = <TRow,>(
     const totalH = api.getDisplayedRowCount() * effectiveRowHeight;
     const viewportH = v.bottom - v.top;
     followingRef.current = v.bottom >= totalH - viewportH * 0.1;
-  }, [followOutput, gridRef, effectiveRowHeight]);
+  }, [followOutput, effectiveRowHeight]);
 
   const applyVisibility = useApplyColumnVisibility(
     gridRef,
@@ -310,12 +318,19 @@ export const SamplesGrid = <TRow,>(
 
   const handleFilterChanged = useCallback(() => {
     if (gridRef.current?.api) onFilterChanged?.(gridRef.current.api);
-  }, [gridRef, onFilterChanged]);
+  }, [onFilterChanged]);
 
   // Re-fit columns when the grid is resized or new columns appear
   // (e.g. score columns discovered on first data load). Only active when
   // `refitOnSizeChange` is set.
-  const refitColumns = useRef(createGridColumnResizer(gridRef)).current;
+  // Lazily created on first use: creating it during render would pass the
+  // grid ref into non-React code, and the single instance must survive
+  // re-renders so the debounce timer isn't reset.
+  const resizerRef = useRef<(() => void) | null>(null);
+  const refitColumns = useCallback(() => {
+    resizerRef.current ??= createGridColumnResizer(gridRef);
+    resizerRef.current();
+  }, []);
   const maxColCount = useRef(0);
   const handleGridColumnsChanged = useCallback(
     (e: GridColumnsChangedEvent<TRow>) => {
@@ -354,13 +369,7 @@ export const SamplesGrid = <TRow,>(
     }
     selectExternalRow();
     if (gridRef.current?.api) onFirstDataRendered?.(gridRef.current.api);
-  }, [
-    followOutput,
-    rowData.length,
-    selectExternalRow,
-    gridRef,
-    onFirstDataRendered,
-  ]);
+  }, [followOutput, rowData.length, selectExternalRow, onFirstDataRendered]);
 
   return (
     <div className={clsx(styles.gridWrapper, className)}>
@@ -380,7 +389,7 @@ export const SamplesGrid = <TRow,>(
         tabIndex={0}
       >
         <AgGridReact<TRow>
-          ref={gridRef}
+          ref={attachGridRef}
           rowData={rowData}
           columnDefs={columnDefs}
           defaultColDef={defaultColDef}

--- a/apps/inspect/src/app/shared/useKeyedMemo.ts
+++ b/apps/inspect/src/app/shared/useKeyedMemo.ts
@@ -1,3 +1,5 @@
+/* eslint-disable react-hooks/refs -- deliberate render-time ref cache;
+   see the "use no memo" rationale inside useKeyedMemo */
 import { useRef } from "react";
 
 const shallowEqual = (
@@ -32,6 +34,13 @@ export function useKeyedMemo<S, T>(
   itemDeps: (item: S) => readonly unknown[],
   build: (item: S) => T
 ): T[] {
+  // Deliberate render-time ref cache — the per-key identity reuse this
+  // hook exists for can't be expressed with useMemo or compiler
+  // memoization (both are all-or-nothing over the whole array). Safe
+  // under concurrent rendering because the cache is pure: a discarded
+  // render can only drop or repopulate entries, never change what a
+  // given deps tuple builds.
+  "use no memo";
   const cacheRef = useRef(
     new Map<string, { deps: readonly unknown[]; value: T }>()
   );

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -340,7 +340,7 @@ export const clientApi = (
   const get_log_root = async (): Promise<LogRoot> => {
     const logFiles = await api.get_log_root();
     if (logFiles) {
-      return logFiles!;
+      return logFiles;
     } else if (log_file) {
       // Is there an explicitly passed log file?
       const summary = await get_log_details(log_file);

--- a/apps/inspect/src/client/api/static-http/fetch.ts
+++ b/apps/inspect/src/client/api/static-http/fetch.ts
@@ -60,7 +60,7 @@ export const fetchLogFile = async (
   file: string
 ): Promise<LogContents | undefined> => {
   return fetchFile<LogContents>(file, async (text): Promise<LogContents> => {
-    const log = (await asyncJsonParse(text)) as EvalLog;
+    const log = await asyncJsonParse<EvalLog>(text);
     if (log.version === 1) {
       if (log.results) {
         const untypedLog = log as any;
@@ -113,7 +113,7 @@ export const fetchJsonFile = async <T>(
   return fetchFile<T>(
     file,
     async (text) => {
-      return (await asyncJsonParse(text)) as T;
+      return await asyncJsonParse<T>(text);
     },
     handleError
   );

--- a/apps/inspect/src/client/api/view-server/api-view-server.test.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.test.ts
@@ -25,7 +25,7 @@ describe("viewServerApi.eval_log_sample_data_direct", () => {
             has_more: false,
           }),
       } as unknown as Response;
-    }) as typeof fetch;
+    });
 
     const api = viewServerApi({ apiBaseUrl: "https://viewer.test" });
 

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -508,7 +508,7 @@ export function viewServerApi(
     }
 
     const text = await response.text();
-    const log = (await asyncJsonParse<EvalLog>(text)) as EvalLog;
+    const log = (await asyncJsonParse<EvalLog>(text));
     const etag = response.headers.get("ETag") ?? undefined;
     return { log, etag };
   };

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -508,7 +508,7 @@ export function viewServerApi(
     }
 
     const text = await response.text();
-    const log = (await asyncJsonParse<EvalLog>(text));
+    const log = await asyncJsonParse<EvalLog>(text);
     const etag = response.headers.get("ETag") ?? undefined;
     return { log, etag };
   };

--- a/apps/inspect/src/client/api/view-server/request.ts
+++ b/apps/inspect/src/client/api/view-server/request.ts
@@ -88,7 +88,7 @@ export function serverRequestApi(
       return Boolean(
         apiUrl && new URL(apiUrl).origin !== window.location.origin
       );
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/apps/inspect/src/client/api/view-server/request.ts
+++ b/apps/inspect/src/client/api/view-server/request.ts
@@ -31,7 +31,7 @@ export function unwrapFastapiDetail(body: string): string {
       parsed &&
       typeof parsed === "object" &&
       "detail" in parsed &&
-      typeof (parsed as { detail: unknown }).detail === "string"
+      typeof (parsed).detail === "string"
     ) {
       return (parsed as { detail: string }).detail;
     }

--- a/apps/inspect/src/client/api/view-server/request.ts
+++ b/apps/inspect/src/client/api/view-server/request.ts
@@ -31,7 +31,7 @@ export function unwrapFastapiDetail(body: string): string {
       parsed &&
       typeof parsed === "object" &&
       "detail" in parsed &&
-      typeof (parsed).detail === "string"
+      typeof parsed.detail === "string"
     ) {
       return (parsed as { detail: string }).detail;
     }

--- a/apps/inspect/src/client/api/vscode/api-vscode.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.ts
@@ -276,7 +276,7 @@ async function get_user_info(): Promise<UserInfo> {
     // See the matching note on `edit_log` above.
     const info =
       typeof response === "string"
-        ? (JSON5.parse(response))
+        ? JSON5.parse(response)
         : (response as UserInfo);
     return info ?? {};
   } catch (e: any) {
@@ -297,7 +297,7 @@ async function get_app_config(): Promise<AppConfig> {
     const response = await vscodeClient(kMethodAppConfig, []);
     if (!response) return { inspect_version: "unknown", scout_version: null };
     return typeof response === "string"
-      ? (JSON5.parse(response))
+      ? JSON5.parse(response)
       : (response as AppConfig);
   } catch (e: any) {
     if (e?.code === kJsonRpcMethodNotFound) {

--- a/apps/inspect/src/client/api/vscode/api-vscode.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.ts
@@ -276,7 +276,7 @@ async function get_user_info(): Promise<UserInfo> {
     // See the matching note on `edit_log` above.
     const info =
       typeof response === "string"
-        ? (JSON5.parse(response) as UserInfo)
+        ? (JSON5.parse(response))
         : (response as UserInfo);
     return info ?? {};
   } catch (e: any) {
@@ -297,7 +297,7 @@ async function get_app_config(): Promise<AppConfig> {
     const response = await vscodeClient(kMethodAppConfig, []);
     if (!response) return { inspect_version: "unknown", scout_version: null };
     return typeof response === "string"
-      ? (JSON5.parse(response) as AppConfig)
+      ? (JSON5.parse(response))
       : (response as AppConfig);
   } catch (e: any) {
     if (e?.code === kJsonRpcMethodNotFound) {

--- a/apps/inspect/src/client/api/vscode/jsonrpc.ts
+++ b/apps/inspect/src/client/api/vscode/jsonrpc.ts
@@ -202,7 +202,7 @@ function asJsonRpcRequest(data: any): JsonRpcRequest | null {
 function asJsonRpcResponse(data: any): JsonRpcResponse | null {
   const message = asJsonRpcMessage(data);
   if (message) {
-    return message as JsonRpcResponse;
+    return message;
   }
   return null;
 }

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -31,7 +31,7 @@ function createTestLogSummary(overrides: Partial<LogPreview> = {}): LogPreview {
     started_at: "2024-01-01T00:00:00Z",
     completed_at: "2024-01-01T01:00:00Z",
     ...overrides,
-  } as LogPreview;
+  };
 }
 
 // Helper function to create test LogInfo
@@ -97,7 +97,7 @@ function createTestSampleSummary(
     },
     completed: true,
     ...overrides,
-  } as SampleSummary;
+  };
 }
 
 describe("Database Service", () => {

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -79,7 +79,7 @@ export class AppDatabase extends Dexie {
         return true;
       }
       return false;
-    } catch (error) {
+    } catch {
       // Database doesn't exist or has issues - let normal flow handle it
       return false;
     }

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -104,7 +104,7 @@ export class DatabaseService {
 
       const db = this.getDb();
       // Sort by mtime if available, otherwise by id (insertion order)
-      let files = await db.logs.toArray();
+      const files = await db.logs.toArray();
 
       // Sort by mtime (descending) if present, otherwise maintain insertion order.
       // Note: != null (not !==) catches both null and undefined.

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -339,9 +339,7 @@ export const openRemoteLogFile = async (
         readHeader(),
         listSamples().then((sampleIds) =>
           Promise.all(
-            sampleIds.map(({ sampleId, epoch }) =>
-              readSample(sampleId, epoch).then((sample) => sample)
-            )
+            sampleIds.map(({ sampleId, epoch }) => readSample(sampleId, epoch))
           )
         ),
       ]);

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -158,7 +158,7 @@ export const openRemoteLogFile = async (
     maxBytes?: number,
     preprocessor?: JSONPreprocessor,
     onProgress?: ProgressCallback
-  ): Promise<Object> => {
+  ): Promise<object> => {
     try {
       let data = await remoteZipFile.readFile(file, maxBytes, onProgress);
 
@@ -340,7 +340,7 @@ export const openRemoteLogFile = async (
         listSamples().then((sampleIds) =>
           Promise.all(
             sampleIds.map(({ sampleId, epoch }) =>
-              readSample(sampleId, epoch).then((sample) => sample as EvalSample)
+              readSample(sampleId, epoch).then((sample) => sample)
             )
           )
         ),

--- a/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
@@ -52,7 +52,7 @@ describe("fetchPendingSampleDataDirect", () => {
           statusText: "OK",
           arrayBuffer: async () => body.buffer,
         } as unknown as Response;
-      }) as typeof fetch;
+      });
     });
 
     afterEach(() => {

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -113,7 +113,7 @@ const readSegment = async (seg: SegmentRef): Promise<SampleData> => {
   const bytes = new Uint8Array(await resp.arrayBuffer());
   const zip = await openZipFileFromBuffer(bytes);
   const memberBytes = await zip.readFile(seg.member_name);
-  return (await asyncJsonParseBytes(memberBytes));
+  return await asyncJsonParseBytes(memberBytes);
 };
 
 // Over-inclusive segment filter -> per-item filter here. Mirrors

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -113,7 +113,7 @@ const readSegment = async (seg: SegmentRef): Promise<SampleData> => {
   const bytes = new Uint8Array(await resp.arrayBuffer());
   const zip = await openZipFileFromBuffer(bytes);
   const memberBytes = await zip.readFile(seg.member_name);
-  return (await asyncJsonParseBytes(memberBytes)) as SampleData;
+  return (await asyncJsonParseBytes(memberBytes));
 };
 
 // Over-inclusive segment filter -> per-item filter here. Mirrors

--- a/apps/inspect/src/client/storage/index.ts
+++ b/apps/inspect/src/client/storage/index.ts
@@ -11,10 +11,7 @@ const resolveStorage = (): ClientStorage | undefined => {
     return {
       getItem: (_name: string) => {
         const state = vscodeApi.getState() as string;
-        const deserialized = JSON5.parse(state) as {
-          state: PersistedState;
-          version: number;
-        };
+        const deserialized = JSON5.parse(state);
         return deserialized;
       },
       setItem: (_name: string, value: unknown) => {

--- a/apps/inspect/src/client/storage/index.ts
+++ b/apps/inspect/src/client/storage/index.ts
@@ -9,7 +9,12 @@ const resolveStorage = (): ClientStorage | undefined => {
   const vscodeApi = getVscodeApi();
   if (vscodeApi) {
     return {
-      getItem: (_name: string) => {
+      getItem: (
+        _name: string
+      ): {
+        state: PersistedState;
+        version: number;
+      } => {
         const state = vscodeApi.getState() as string;
         const deserialized = JSON5.parse(state);
         return deserialized;

--- a/apps/inspect/src/components/FindBand.tsx
+++ b/apps/inspect/src/components/FindBand.tsx
@@ -3,7 +3,6 @@ import {
   KeyboardEvent,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -229,20 +228,23 @@ export const FindBand: FC<FindBandProps> = () => {
     }
   }, []);
 
-  const debouncedSearch = useMemo(
-    () =>
-      debounce(async () => {
-        if (!searchBoxRef.current) return;
-        await handleSearch(false);
-        // Mark for cursor restore on next keypress (keeps find highlight visible)
-        needsCursorRestoreRef.current = true;
-      }, 300),
-    [handleSearch]
-  );
+  const runDebouncedSearch = useCallback(async () => {
+    if (!searchBoxRef.current) return;
+    await handleSearch(false);
+    // Mark for cursor restore on next keypress (keeps find highlight visible)
+    needsCursorRestoreRef.current = true;
+  }, [handleSearch]);
+
+  // Created in an effect (not useMemo) because runDebouncedSearch reads refs,
+  // and the compiler can't prove debounce() won't invoke it during render.
+  const debouncedSearchRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    debouncedSearchRef.current = debounce(runDebouncedSearch, 300);
+  }, [runDebouncedSearch]);
 
   const handleInputChange = useCallback(() => {
-    debouncedSearch();
-  }, [debouncedSearch]);
+    debouncedSearchRef.current?.();
+  }, []);
 
   const handleBeforeInput = useCallback(() => {
     const input = searchBoxRef.current;

--- a/apps/inspect/src/main.tsx
+++ b/apps/inspect/src/main.tsx
@@ -14,7 +14,7 @@ const applicationStorage = storage;
 
 // Application capabilities
 const vscode = getVscodeApi();
-let capabilities: Capabilities = {
+const capabilities: Capabilities = {
   downloadFiles: true,
   downloadLogs: !!applicationApi.download_log,
   webWorkers: true,
@@ -55,7 +55,7 @@ if (!container) {
 }
 
 // Render into the root
-const root = createRoot(container as HTMLElement);
+const root = createRoot(container);
 root.render(<App api={applicationApi} />);
 
 function restoreHash() {

--- a/apps/inspect/src/scoring/metrics.ts
+++ b/apps/inspect/src/scoring/metrics.ts
@@ -96,11 +96,11 @@ export const toDisplayScorers = (scores?: EvalScores): ScoreSummary[] => {
       }),
       unscoredSamples:
         score.unscored_samples !== null
-          ? (score.unscored_samples as number)
+          ? (score.unscored_samples)
           : undefined,
       scoredSamples:
         score.scored_samples !== null
-          ? (score.scored_samples as number)
+          ? (score.scored_samples)
           : undefined,
     };
   });

--- a/apps/inspect/src/scoring/metrics.ts
+++ b/apps/inspect/src/scoring/metrics.ts
@@ -95,13 +95,9 @@ export const toDisplayScorers = (scores?: EvalScores): ScoreSummary[] => {
         };
       }),
       unscoredSamples:
-        score.unscored_samples !== null
-          ? (score.unscored_samples)
-          : undefined,
+        score.unscored_samples !== null ? score.unscored_samples : undefined,
       scoredSamples:
-        score.scored_samples !== null
-          ? (score.scored_samples)
-          : undefined,
+        score.scored_samples !== null ? score.scored_samples : undefined,
     };
   });
 };

--- a/apps/inspect/src/setupTests.ts
+++ b/apps/inspect/src/setupTests.ts
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom/vitest";
 // Setup fake IndexedDB for database tests
 import "fake-indexeddb/auto";
 
-global.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+global.TextDecoder = TextDecoder;
 global.TextEncoder = TextEncoder;
 
 // Mock build-time constants used by logger

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -497,16 +497,6 @@ export const useMessageVisibility = (
   }, [visible, setVisible, id]);
 };
 
-export const usePrevious = <T>(value: T) => {
-  const ref = useRef<T | undefined>(undefined);
-
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-
-  return ref.current;
-};
-
 export const useSetSelectedLogIndex = () => {
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile

--- a/apps/inspect/src/state/logSlice.ts
+++ b/apps/inspect/src/state/logSlice.ts
@@ -227,7 +227,7 @@ export const createLogSlice = (
               logPolling.startPolling(logFileName);
               return;
             }
-          } catch (e) {
+          } catch {
             // Cache read failed, continue with normal flow
           }
         }

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -477,7 +477,7 @@ export const createLogsSlice = (
           const samples = await dbService.readAllSampleSummaries();
           log.debug(`Retrieved ${samples.length} cached samples`);
           return samples;
-        } catch (e) {
+        } catch {
           log.debug("No cached samples available");
           return [];
         }
@@ -497,7 +497,7 @@ export const createLogsSlice = (
           const samples = await dbService.querySampleSummaries(filter);
           log.debug(`Query returned ${samples.length} samples`);
           return samples;
-        } catch (e) {
+        } catch {
           log.debug("Sample query failed, returning empty results");
           return [];
         }

--- a/apps/inspect/src/state/sampleSlice.ts
+++ b/apps/inspect/src/state/sampleSlice.ts
@@ -11,7 +11,7 @@ import { StoreState } from "./store";
 import { isLargeSample } from "./store_filter";
 
 // Create a module-level ref to store large sample objects
-let selectedSampleRef: { current: EvalSample | undefined } = {
+const selectedSampleRef: { current: EvalSample | undefined } = {
   current: undefined,
 };
 

--- a/apps/inspect/src/state/scoring.ts
+++ b/apps/inspect/src/state/scoring.ts
@@ -17,7 +17,7 @@ const getScorersFromSamples = (samples: SampleSummary[]): ScoreLabel[] => {
       ) {
         dictScorers.add(scorerKey);
         for (const innerKey of Object.keys(
-          scoreValue.value as Record<string, unknown>
+          scoreValue.value
         )) {
           const label = `${scorerKey}:${innerKey}`;
           if (!scoreLabelsMap.has(label)) {

--- a/apps/inspect/src/state/scoring.ts
+++ b/apps/inspect/src/state/scoring.ts
@@ -16,9 +16,7 @@ const getScorersFromSamples = (samples: SampleSummary[]): ScoreLabel[] => {
         !Array.isArray(scoreValue.value)
       ) {
         dictScorers.add(scorerKey);
-        for (const innerKey of Object.keys(
-          scoreValue.value
-        )) {
+        for (const innerKey of Object.keys(scoreValue.value)) {
           const label = `${scorerKey}:${innerKey}`;
           if (!scoreLabelsMap.has(label)) {
             scoreLabelsMap.set(label, { name: innerKey, scorer: scorerKey });

--- a/apps/inspect/src/state/store.ts
+++ b/apps/inspect/src/state/store.ts
@@ -160,7 +160,7 @@ export const initializeStore = (
               await databaseService.closeDatabase();
 
               appCleanup();
-              await logsCleanup();
+              logsCleanup();
               logCleanup();
               sampleCleanup();
             },

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -1,11 +1,11 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
 import { SampleSummary } from "../client/api/types";
 
-import { useLogSelection, usePrevious, useSampleData } from "./hooks";
+import { useLogSelection, useSampleData } from "./hooks";
 import { getSamplePolling } from "./samplePollingInstance";
 import {
   resolveSample,
@@ -44,15 +44,15 @@ export function useLoadSample() {
   const sampleEpoch = logSelection.sample?.epoch;
   const sampleCompleted = logSelection.sample?.completed;
 
-  // Track changes over time
+  // Track changes over time (updated inside the load effect below)
   const currentSampleCompleted =
     sampleCompleted !== undefined ? sampleCompleted : true;
-  const prevCompleted = usePrevious(currentSampleCompleted);
-  const prevLogFile = usePrevious<string | undefined>(logSelection.logFile);
-  const prevSampleId = usePrevious(sampleId);
-  const prevSampleNeedsReload = usePrevious<number>(
-    sampleData.sampleNeedsReload
-  );
+  const prevRef = useRef<{
+    completed?: boolean;
+    logFile?: string;
+    sampleId?: string | number;
+    sampleNeedsReload?: number;
+  }>({});
 
   const loadSample = useCallback(
     async (
@@ -156,6 +156,13 @@ export function useLoadSample() {
   );
 
   useEffect(() => {
+    const prev = prevRef.current;
+    prevRef.current = {
+      completed: currentSampleCompleted,
+      logFile: logSelection.logFile,
+      sampleId,
+      sampleNeedsReload: sampleData.sampleNeedsReload,
+    };
     if (
       logSelection.logFile &&
       sampleId !== undefined &&
@@ -181,14 +188,15 @@ export function useLoadSample() {
 
       // Check if this is a meaningful change (not just initial render)
       const logFileChanged =
-        prevLogFile !== undefined && prevLogFile !== logSelection.logFile;
+        prev.logFile !== undefined && prev.logFile !== logSelection.logFile;
       const sampleIdChanged =
-        prevSampleId !== undefined && prevSampleId !== sampleId;
+        prev.sampleId !== undefined && prev.sampleId !== sampleId;
       const completedChanged =
-        prevCompleted !== undefined && currentSampleCompleted !== prevCompleted;
+        prev.completed !== undefined &&
+        currentSampleCompleted !== prev.completed;
       const needsReloadChanged =
-        prevSampleNeedsReload !== undefined &&
-        prevSampleNeedsReload !== sampleData.sampleNeedsReload;
+        prev.sampleNeedsReload !== undefined &&
+        prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
 
       // Only load if:
       // 1. The current sample is not already loaded AND not currently loading, OR
@@ -221,10 +229,6 @@ export function useLoadSample() {
     sampleData.status,
     sampleData.sampleNeedsReload,
     sampleData.getSelectedSample,
-    prevLogFile,
-    prevSampleId,
-    prevCompleted,
-    prevSampleNeedsReload,
     loadSample,
     getSelectedSample,
   ]);

--- a/apps/inspect/src/utils/clear-events-preprocessor.test.ts
+++ b/apps/inspect/src/utils/clear-events-preprocessor.test.ts
@@ -5,9 +5,7 @@ import { describe, expect, it } from "vitest";
 import { clearLargeEventsArray } from "./clear-events-preprocessor";
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder() as InstanceType<
-  typeof globalThis.TextDecoder
->;
+const decoder = new TextDecoder();
 
 function encode(str: string): Uint8Array {
   return encoder.encode(str);

--- a/apps/inspect/src/utils/debugging.ts
+++ b/apps/inspect/src/utils/debugging.ts
@@ -92,10 +92,7 @@ export function findDifferences(
   }
 
   // --- Plain objects -------------------------------------------------------
-  const allKeys = new Set([
-    ...Object.keys(obj1),
-    ...Object.keys(obj2),
-  ]);
+  const allKeys = new Set([...Object.keys(obj1), ...Object.keys(obj2)]);
 
   const diff: string[] = [];
 

--- a/apps/inspect/src/utils/debugging.ts
+++ b/apps/inspect/src/utils/debugging.ts
@@ -5,15 +5,15 @@ export function printCircularReferences(obj: Record<string, unknown>): void {
     // Only proceed if value is an object (not null)
     if (value !== null && typeof value === "object") {
       // Check if we've seen this object before
-      if (seenObjects.has(value as object)) {
+      if (seenObjects.has(value)) {
         console.log(
-          `Circular reference detected at path: ${seenObjects.get(value as object)}`
+          `Circular reference detected at path: ${seenObjects.get(value)}`
         );
         return;
       }
 
       // Store the current path for this object
-      seenObjects.set(value as object, path);
+      seenObjects.set(value, path);
 
       // Recursively check all properties
       for (const key in value) {
@@ -93,8 +93,8 @@ export function findDifferences(
 
   // --- Plain objects -------------------------------------------------------
   const allKeys = new Set([
-    ...Object.keys(obj1 as Record<string, unknown>),
-    ...Object.keys(obj2 as Record<string, unknown>),
+    ...Object.keys(obj1),
+    ...Object.keys(obj2),
   ]);
 
   const diff: string[] = [];

--- a/apps/inspect/src/utils/workQueue.ts
+++ b/apps/inspect/src/utils/workQueue.ts
@@ -42,7 +42,6 @@ export class WorkQueue<TInput, TOutput> {
   enqueue(items: TInput[], priority: WorkPriority = WorkPriority.Medium) {
     const now = Date.now();
 
-    let newItemsCount = 0;
     for (const item of items) {
       const id = this.options.getId(item);
       const existing = this.itemsById.get(id);
@@ -61,7 +60,6 @@ export class WorkQueue<TInput, TOutput> {
           addedAt: now,
           retries: 0,
         });
-        newItemsCount++;
       }
     }
     void this.startProcessing();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.1
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tsmono/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config
       '@tsmono/prettier-config':
         specifier: workspace:*
         version: link:../../tooling/prettier-config


### PR DESCRIPTION
This started with me looking into React Compiler and seeing how easy it would be to integrate. Claude pointed out that Inspect's viewer doesn't use the shared eslint config, and that `eslint-plugin-react-hooks` v7 includes React rules that will help keep you inline with what the compiler can optimize.

We now make use of `@tsmono/eslint-config/react` for Inspect. Changes have been made to following React rules e.g. not accessing refs during render and not mutating props. Several TypeScript rules are still ignored and will benefit from more clean up in the future.