### PR TITLE
Viewer: regenerate types for AppConfig.log_dirs (multi-log-dir PR 2a)

### DIFF
--- a/apps/inspect/e2e/fixtures/handlers.ts
+++ b/apps/inspect/e2e/fixtures/handlers.ts
@@ -15,6 +15,7 @@ export const defaultHandlers = [
     return HttpResponse.json<AppConfig>({
       inspect_version: "0.0.0-e2e",
       scout_version: null,
+      log_dirs: [],
     });
   }),
 

--- a/apps/inspect/src/client/api/index.ts
+++ b/apps/inspect/src/client/api/index.ts
@@ -33,6 +33,7 @@ const resolveApi = (): ClientAPI => {
               ? {
                   inspect_version: data.inspect_version,
                   scout_version: null,
+                  log_dirs: [],
                 }
               : undefined;
           const api = staticHttpApi(

--- a/apps/inspect/src/client/api/static-http/api-static-http.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.ts
@@ -17,6 +17,7 @@ import {
 const kFallbackAppConfig: AppConfig = {
   inspect_version: "unknown",
   scout_version: null,
+  log_dirs: [],
 };
 
 /**

--- a/apps/inspect/src/client/api/vscode/api-vscode.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.ts
@@ -295,13 +295,14 @@ async function get_user_info(): Promise<UserInfo> {
 async function get_app_config(): Promise<AppConfig> {
   try {
     const response = await vscodeClient(kMethodAppConfig, []);
-    if (!response) return { inspect_version: "unknown", scout_version: null };
+    if (!response)
+      return { inspect_version: "unknown", scout_version: null, log_dirs: [] };
     return typeof response === "string"
       ? (JSON5.parse(response) as AppConfig)
       : (response as AppConfig);
   } catch (e: any) {
     if (e?.code === kJsonRpcMethodNotFound) {
-      return { inspect_version: "unknown", scout_version: null };
+      return { inspect_version: "unknown", scout_version: null, log_dirs: [] };
     }
     throw e;
   }

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -580,6 +580,11 @@ export interface components {
         AppConfig: {
             /** Inspect Version */
             inspect_version: string;
+            /**
+             * Log Dirs
+             * @default []
+             */
+            log_dirs: components["schemas"]["LogDirInfo"][];
             /** Scout Version */
             scout_version?: string | null;
         };
@@ -959,12 +964,10 @@ export interface components {
          *     also accepted at the task and eval layers (where they participate in
          *     the per-field merge — precedence: eval > sample > task).
          *
-         *     The fields excluded from this base class — ``checkpoints_dir`` and
-         *     ``retention`` — are eval-wide concerns that the sample layer must
+         *     The fields excluded from this base class — ``checkpoints_location``
+         *     and ``retention`` — are eval-wide concerns that the sample layer must
          *     not influence. They live only on the derived :class:`CheckpointConfig`,
          *     which is the type used at the task and eval layers.
-         *
-         *     See ``design/plans/checkpointing-working.md`` §2.
          */
         CheckpointSampleConfig: {
             /** Max Consecutive Failures */
@@ -2361,6 +2364,20 @@ export interface components {
              * @enum {string}
              */
             type: "llm";
+        };
+        /**
+         * LogDirInfo
+         * @description A configured log directory.
+         *
+         *     Attributes:
+         *         log_dir: Resolved path/URI the client sends back as `?log_dir=`.
+         *         aliased: Display string with the home directory replaced by `~`.
+         */
+        LogDirInfo: {
+            /** Aliased */
+            aliased: string;
+            /** Log Dir */
+            log_dir: string;
         };
         /** LogDirResponse */
         LogDirResponse: {

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -138,6 +138,7 @@ export type ApproverPolicyConfig = S["ApproverPolicyConfig"];
 
 // Server response types
 export type AppConfig = S["AppConfig"];
+export type LogDirInfo = S["LogDirInfo"];
 export type AttachmentData = S["AttachmentData"];
 export type CallPoolData = S["CallPoolData"];
 export type EventData = S["EventData"];


### PR DESCRIPTION
## Summary

Type side of the multi-log-directory **PR 2a** handshake. Regenerates `generated.ts` from the updated `inspect-openapi.json` so `AppConfig` now carries `log_dirs: LogDirInfo[]`, and adapts the few `AppConfig` fallback/mock literals accordingly.

**Companion PR (required):** the server/CLI side lands in `UKGovernmentBEIS/inspect_ai` (adds `AppConfig.log_dirs`, multi-dir `view_server`, repeatable `--log-dir`, and the regenerated `inspect-openapi.json`). These must land coordinated — this PR's `generated.ts` reflects that repo's schema change.

### Changes
- Regenerated `packages/inspect-common/src/types/generated.ts` (adds `AppConfig.log_dirs` + `LogDirInfo` schema). `log_dirs` is **required** (this repo's "required = non-nullable" convention; the Python field is `list[LogDirInfo] = []`).
- Exported `LogDirInfo` from the `@tsmono/inspect-common/types` barrel (needed by PR 2b's frontend merge).
- Defaulted `log_dirs: []` in the 5 `AppConfig` fallback/mock literals that now must provide it (`static-http`, `vscode` ×2, `client/api/index.ts` embedded path, e2e handler) — all are version/fallback paths with no configured dirs.

### Not in scope
Frontend consumption of `log_dirs` (merged listing, Directory column) is **PR 2b**.

## Test Plan
- [x] `pnpm check` (typecheck + lint + prettier, 24/24) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)