### PR TITLE
Redesign the sample Retries tab (Direction B) + fix retry-event attachments

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.module.css
+++ b/apps/inspect/src/app/samples/SampleDisplay.module.css
@@ -53,7 +53,10 @@
 }
 
 .retriedErrors {
-  margin: 0.5rem;
+  /* Full-bleed: the retries timeline spans the tab edge-to-edge (no card),
+     with only a little top breathing room from the tab strip. */
+  margin: 0;
+  padding-top: 0.5rem;
   min-width: 0;
   overflow: hidden;
   align-self: stretch;

--- a/apps/inspect/src/app/samples/SampleDisplay.module.css
+++ b/apps/inspect/src/app/samples/SampleDisplay.module.css
@@ -53,10 +53,9 @@
 }
 
 .retriedErrors {
-  /* Full-bleed: the retries timeline spans the tab edge-to-edge (no card),
-     with only a little top breathing room from the tab strip. */
+  /* Full-bleed (no card), with a small uniform inset from the tab edges. */
   margin: 0;
-  padding-top: 0.5rem;
+  padding: 0.5rem;
   min-width: 0;
   overflow: hidden;
   align-self: stretch;

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -1,26 +1,56 @@
-.ansi {
-  margin: 0.5em 0;
-  font-size: clamp(0.3rem, 1.1vw, 0.8rem) !important;
-}
-
-.headerRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.headerControls {
-  display: flex;
-  align-items: center;
-  margin-left: 1rem;
-  gap: 0.5rem;
-}
-
 .card {
   width: 100%;
 }
 
-.attemptDropdown {
-  padding: 1px 0.25rem;
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+
+.timeline {
+  position: relative;
+  margin-top: 18px;
+}
+
+/* Vertical rail behind the status dots. */
+.rail {
+  position: absolute;
+  left: 6px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: var(--bs-border-color);
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.row {
+  display: flex;
+  gap: 16px;
+}
+
+/* Offsets the dot to align with the card header text; relative + z-index so it
+   paints above the absolutely-positioned rail. */
+.dotGutter {
+  position: relative;
+  z-index: 1;
+  padding-top: 14px;
+}
+
+/* Failed-attempt marker: a danger dot with a soft ring, sitting on the rail. */
+.statusDot {
+  display: block;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bs-danger);
+  box-shadow: 0 0 0 3px var(--bs-danger-bg-subtle);
 }

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -15,7 +15,6 @@
   margin-top: 18px;
 }
 
-/* Vertical rail behind the status dots. */
 .rail {
   position: absolute;
   left: 6px;
@@ -44,7 +43,6 @@
   padding-top: 14px;
 }
 
-/* Failed-attempt marker: a danger dot with a soft ring, sitting on the rail. */
 .statusDot {
   display: block;
   flex: none;

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -44,12 +44,13 @@
   padding-top: 14px;
 }
 
-.statusDot {
+/* Failed-attempt marker: the viewer's standard error icon. The body-bg backdrop
+   punches it out over the rail so the line doesn't show through the glyph. */
+.statusIcon {
   display: block;
-  flex: none;
-  width: 14px;
-  height: 14px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--bs-danger);
+  background: var(--bs-body-bg);
   border-radius: 50%;
-  background: var(--bs-danger);
-  box-shadow: 0 0 0 3px var(--bs-danger-bg-subtle);
 }

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.module.css
@@ -1,8 +1,9 @@
-.card {
+.panel {
   width: 100%;
 }
 
 .sectionLabel {
+  margin-bottom: 4px;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.07em;

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -70,4 +70,24 @@ describe("SampleRetriedErrors", () => {
     fireEvent.click(screen.getByText("Attempt 2"));
     expect(screen.queryByText("RuntimeError: failure 2")).toBeNull();
   });
+
+  it("remembers an attempt's Error/Events selection across collapse and reopen", () => {
+    const scrollRef = createRef<HTMLDivElement>();
+    const withEvents = (n: number): EvalRetryError => ({
+      ...makeRetry(n),
+      events: [{ event: "error" }] as unknown as EvalRetryError["events"],
+    });
+    render(
+      <SampleRetriedErrors id="s1" retries={[withEvents(1), withEvents(2)]} scrollRef={scrollRef} />,
+    );
+    // Attempt 2 is open by default on the Error view (traceback, no transcript).
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
+    // Switch it to Events.
+    fireEvent.click(screen.getByRole("button", { name: "Events" }));
+    expect(screen.getByTestId("transcript-layout")).toBeDefined();
+    // Collapse then reopen attempt 2 — the Events selection should persist.
+    fireEvent.click(screen.getByText("Attempt 2"));
+    fireEvent.click(screen.getByText("Attempt 2"));
+    expect(screen.getByTestId("transcript-layout")).toBeDefined();
+  });
 });

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@tsmono/react/components", async (importOriginal) => {
     ANSIDisplay: ({ output }: { output: string }) => (
       <pre data-testid="ansi-display">{output}</pre>
     ),
+    ExpandablePanel: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="expandable-panel">{children}</div>
+    ),
   };
 });
 
@@ -71,23 +74,21 @@ describe("SampleRetriedErrors", () => {
     expect(screen.queryByText("RuntimeError: failure 2")).toBeNull();
   });
 
-  it("remembers an attempt's Error/Events selection across collapse and reopen", () => {
+  it("shows the Events section for an open attempt that has events", () => {
     const scrollRef = createRef<HTMLDivElement>();
     const withEvents = (n: number): EvalRetryError => ({
       ...makeRetry(n),
       events: [{ event: "error" }] as unknown as EvalRetryError["events"],
     });
     render(
-      <SampleRetriedErrors id="s1" retries={[withEvents(1), withEvents(2)]} scrollRef={scrollRef} />,
+      <SampleRetriedErrors
+        id="s1"
+        retries={[withEvents(1), withEvents(2)]}
+        scrollRef={scrollRef}
+      />,
     );
-    // Attempt 2 is open by default on the Error view (traceback, no transcript).
-    expect(screen.queryByTestId("transcript-layout")).toBeNull();
-    // Switch it to Events.
-    fireEvent.click(screen.getByRole("button", { name: "Events" }));
-    expect(screen.getByTestId("transcript-layout")).toBeDefined();
-    // Collapse then reopen attempt 2 — the Events selection should persist.
-    fireEvent.click(screen.getByText("Attempt 2"));
-    fireEvent.click(screen.getByText("Attempt 2"));
+    // Attempt 2 is open by default and shows both Error and Events sections.
+    expect(screen.getByText("RuntimeError: failure 2")).toBeDefined();
     expect(screen.getByTestId("transcript-layout")).toBeDefined();
   });
 });

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+vi.mock("@tsmono/inspect-components/transcript", () => ({
+  TranscriptLayout: () => <div data-testid="transcript-layout" />,
+}));
+
+// ANSIDisplay needs an icon-provider context that isn't present in jsdom; stub
+// it (rendering its output text) so we can assert which attempt's traceback is open.
+vi.mock("@tsmono/react/components", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tsmono/react/components")>();
+  return {
+    ...actual,
+    ANSIDisplay: ({ output }: { output: string }) => (
+      <pre data-testid="ansi-display">{output}</pre>
+    ),
+  };
+});
+
+import { SampleRetriedErrors } from "./SampleRetriedErrors";
+
+function makeRetry(n: number): EvalRetryError {
+  return {
+    message: `failure ${n}`,
+    traceback: `Traceback ...\nRuntimeError: failure ${n}`,
+    traceback_ansi: `RuntimeError: failure ${n}`,
+    events: null,
+  };
+}
+
+function renderPanel(count: number) {
+  const scrollRef = createRef<HTMLDivElement>();
+  const retries = Array.from({ length: count }, (_, i) => makeRetry(i + 1));
+  return render(
+    <SampleRetriedErrors id="s1" retries={retries} scrollRef={scrollRef} />,
+  );
+}
+
+describe("SampleRetriedErrors", () => {
+  afterEach(() => cleanup());
+
+  it("renders one card per attempt plus the terminal anchor", () => {
+    renderPanel(3);
+    expect(screen.getByText("Attempt 1")).toBeDefined();
+    expect(screen.getByText("Attempt 2")).toBeDefined();
+    expect(screen.getByText("Attempt 3")).toBeDefined();
+    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+  });
+
+  it("opens the most recent attempt by default", () => {
+    renderPanel(3);
+    expect(screen.getByText("RuntimeError: failure 3")).toBeDefined();
+  });
+
+  it("is an accordion — opening one closes the previously open card", () => {
+    renderPanel(3);
+    expect(screen.getByText("RuntimeError: failure 3")).toBeDefined();
+    fireEvent.click(screen.getByText("Attempt 1"));
+    expect(screen.getByText("RuntimeError: failure 1")).toBeDefined();
+    expect(screen.queryByText("RuntimeError: failure 3")).toBeNull();
+  });
+
+  it("clicking the open card header collapses it", () => {
+    renderPanel(2);
+    expect(screen.getByText("RuntimeError: failure 2")).toBeDefined();
+    fireEvent.click(screen.getByText("Attempt 2"));
+    expect(screen.queryByText("RuntimeError: failure 2")).toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -48,7 +48,7 @@ describe("SampleRetriedErrors", () => {
     expect(screen.getByText("Attempt 1")).toBeDefined();
     expect(screen.getByText("Attempt 2")).toBeDefined();
     expect(screen.getByText("Attempt 3")).toBeDefined();
-    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+    expect(screen.getByText(/after 3 retries/)).toBeDefined();
   });
 
   it("opens the most recent attempt by default", () => {

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { createRef } from "react";
+import { createRef, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
+
+import { SampleRetriedErrors } from "./SampleRetriedErrors";
 
 vi.mock("@tsmono/inspect-components/transcript", () => ({
   TranscriptLayout: () => <div data-testid="transcript-layout" />,
@@ -12,19 +14,18 @@ vi.mock("@tsmono/inspect-components/transcript", () => ({
 // ANSIDisplay needs an icon-provider context that isn't present in jsdom; stub
 // it (rendering its output text) so we can assert which attempt's traceback is open.
 vi.mock("@tsmono/react/components", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tsmono/react/components")>();
+  const actual =
+    await importOriginal<typeof import("@tsmono/react/components")>();
   return {
     ...actual,
     ANSIDisplay: ({ output }: { output: string }) => (
       <pre data-testid="ansi-display">{output}</pre>
     ),
-    ExpandablePanel: ({ children }: { children: React.ReactNode }) => (
+    ExpandablePanel: ({ children }: { children: ReactNode }) => (
       <div data-testid="expandable-panel">{children}</div>
     ),
   };
 });
-
-import { SampleRetriedErrors } from "./SampleRetriedErrors";
 
 function makeRetry(n: number): EvalRetryError {
   return {
@@ -39,7 +40,7 @@ function renderPanel(count: number) {
   const scrollRef = createRef<HTMLDivElement>();
   const retries = Array.from({ length: count }, (_, i) => makeRetry(i + 1));
   return render(
-    <SampleRetriedErrors id="s1" retries={retries} scrollRef={scrollRef} />,
+    <SampleRetriedErrors id="s1" retries={retries} scrollRef={scrollRef} />
   );
 }
 
@@ -85,7 +86,7 @@ describe("SampleRetriedErrors", () => {
         id="s1"
         retries={[withEvents(1), withEvents(2)]}
         scrollRef={scrollRef}
-      />,
+      />
     );
     // Attempt 2 is open by default on the Error view (only the expanded card
     // exposes the toggle).

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -74,7 +74,7 @@ describe("SampleRetriedErrors", () => {
     expect(screen.queryByText("RuntimeError: failure 2")).toBeNull();
   });
 
-  it("shows the Events section for an open attempt that has events", () => {
+  it("shows the open attempt's events after toggling to the Events view", () => {
     const scrollRef = createRef<HTMLDivElement>();
     const withEvents = (n: number): EvalRetryError => ({
       ...makeRetry(n),
@@ -87,8 +87,12 @@ describe("SampleRetriedErrors", () => {
         scrollRef={scrollRef}
       />,
     );
-    // Attempt 2 is open by default and shows both Error and Events sections.
+    // Attempt 2 is open by default on the Error view (only the expanded card
+    // exposes the toggle).
     expect(screen.getByText("RuntimeError: failure 2")).toBeDefined();
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Events" }));
     expect(screen.getByTestId("transcript-layout")).toBeDefined();
   });
 });

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,7 +1,6 @@
 import { FC, RefObject, useEffect, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
-import { Card, CardBody, CardHeader } from "@tsmono/react/components";
 
 import {
   RetryAttemptCard,
@@ -43,35 +42,31 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   };
 
   return (
-    <Card className={styles.card}>
-      <CardHeader>
-        <span className={styles.sectionLabel}>Retry Attempts</span>
-      </CardHeader>
-      <CardBody>
-        <div className={styles.timeline}>
-          <div className={styles.rail} aria-hidden="true" />
-          <div className={styles.items}>
-            {retries.map((retry, index) => (
-              <div className={styles.row} key={index}>
-                <div className={styles.dotGutter} aria-hidden="true">
-                  <span className={styles.statusDot} />
-                </div>
-                <RetryAttemptCard
-                  retry={retry}
-                  attemptNumber={index + 1}
-                  isOpen={expandedIndex === index}
-                  view={viewByIndex[index] ?? "error"}
-                  onToggleOpen={() => onToggleOpen(index)}
-                  onViewChange={(view) => onViewChange(index, view)}
-                  listId={`sample-error-retries-${id}-${index}`}
-                  scrollRef={scrollRef}
-                />
+    <div className={styles.panel}>
+      <div className={styles.sectionLabel}>Retry Attempts</div>
+      <div className={styles.timeline}>
+        <div className={styles.rail} aria-hidden="true" />
+        <div className={styles.items}>
+          {retries.map((retry, index) => (
+            <div className={styles.row} key={index}>
+              <div className={styles.dotGutter} aria-hidden="true">
+                <span className={styles.statusDot} />
               </div>
-            ))}
-            <RetryTerminalAnchor retryCount={retries.length} />
-          </div>
+              <RetryAttemptCard
+                retry={retry}
+                attemptNumber={index + 1}
+                isOpen={expandedIndex === index}
+                view={viewByIndex[index] ?? "error"}
+                onToggleOpen={() => onToggleOpen(index)}
+                onViewChange={(view) => onViewChange(index, view)}
+                listId={`sample-error-retries-${id}-${index}`}
+                scrollRef={scrollRef}
+              />
+            </div>
+          ))}
+          <RetryTerminalAnchor retryCount={retries.length} />
         </div>
-      </CardBody>
-    </Card>
+      </div>
+    </div>
   );
 };

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject, useCallback, useEffect, useState } from "react";
+import { FC, RefObject, useEffect, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
 import { Card, CardBody, CardHeader } from "@tsmono/react/components";
@@ -34,13 +34,13 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
     setViewByIndex({});
   }, [id, retries.length]);
 
-  const onToggleOpen = useCallback((index: number) => {
+  const onToggleOpen = (index: number) => {
     setExpandedIndex((cur) => (cur === index ? null : index));
-  }, []);
+  };
 
-  const onViewChange = useCallback((index: number, view: RetryView) => {
+  const onViewChange = (index: number, view: RetryView) => {
     setViewByIndex((prev) => ({ ...prev, [index]: view }));
-  }, []);
+  };
 
   return (
     <Card className={styles.card}>

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -4,10 +4,7 @@ import { FC, RefObject, useEffect, useState } from "react";
 import { EvalRetryError } from "@tsmono/inspect-common";
 
 import { ApplicationIcons } from "../appearance/icons";
-import {
-  RetryAttemptCard,
-  RetryView,
-} from "./retry-display/RetryAttemptCard";
+import { RetryAttemptCard } from "./retry-display/RetryAttemptCard";
 import { RetryTerminalAnchor } from "./retry-display/RetryTerminalAnchor";
 import styles from "./SampleRetriedErrors.module.css";
 
@@ -26,21 +23,15 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   const [expandedIndex, setExpandedIndex] = useState<number | null>(
     retries.length - 1,
   );
-  const [viewByIndex, setViewByIndex] = useState<Record<number, RetryView>>({});
 
-  // Reset accordion/view state when switching to a different sample (the same
+  // Reset accordion state when switching to a different sample (the same
   // component instance can be reused across samples on the inline display path).
   useEffect(() => {
     setExpandedIndex(retries.length - 1);
-    setViewByIndex({});
   }, [id, retries.length]);
 
   const onToggleOpen = (index: number) => {
     setExpandedIndex((cur) => (cur === index ? null : index));
-  };
-
-  const onViewChange = (index: number, view: RetryView) => {
-    setViewByIndex((prev) => ({ ...prev, [index]: view }));
   };
 
   return (
@@ -58,9 +49,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
                 retry={retry}
                 attemptNumber={index + 1}
                 isOpen={expandedIndex === index}
-                view={viewByIndex[index] ?? "error"}
                 onToggleOpen={() => onToggleOpen(index)}
-                onViewChange={(view) => onViewChange(index, view)}
                 listId={`sample-error-retries-${id}-${index}`}
                 scrollRef={scrollRef}
               />

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject, useCallback, useState } from "react";
+import { FC, RefObject, useCallback, useEffect, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
 import { Card, CardBody, CardHeader } from "@tsmono/react/components";
@@ -26,6 +26,13 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
     retries.length - 1,
   );
   const [viewByIndex, setViewByIndex] = useState<Record<number, RetryView>>({});
+
+  // Reset accordion/view state when switching to a different sample (the same
+  // component instance can be reused across samples on the inline display path).
+  useEffect(() => {
+    setExpandedIndex(retries.length - 1);
+    setViewByIndex({});
+  }, [id, retries.length]);
 
   const onToggleOpen = useCallback((index: number) => {
     setExpandedIndex((cur) => (cur === index ? null : index));

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,28 +1,14 @@
-import clsx from "clsx";
-import { FC, RefObject, useCallback, useMemo, useState } from "react";
+import { FC, RefObject, useCallback, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
-import {
-  TranscriptCollapseState,
-  TranscriptLayout,
-} from "@tsmono/inspect-components/transcript";
-import {
-  ANSIDisplay,
-  Card,
-  CardBody,
-  CardHeader,
-  SegmentedControl,
-  ToolDropdownButton,
-} from "@tsmono/react/components";
+import { Card, CardBody, CardHeader } from "@tsmono/react/components";
 
+import {
+  RetryAttemptCard,
+  RetryView,
+} from "./retry-display/RetryAttemptCard";
+import { RetryTerminalAnchor } from "./retry-display/RetryTerminalAnchor";
 import styles from "./SampleRetriedErrors.module.css";
-
-type RetryView = "error" | "events";
-
-const kViewSegments = [
-  { id: "error", label: "Error" },
-  { id: "events", label: "Events" },
-];
 
 interface SampleRetriedErrorsProps {
   id: string;
@@ -35,120 +21,50 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
   retries,
   scrollRef,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [view, setView] = useState<RetryView>("error");
+  // Accordion: default to the most recent failure (closest to the success).
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(
+    retries.length - 1,
+  );
+  const [viewByIndex, setViewByIndex] = useState<Record<number, RetryView>>({});
 
-  const onSegmentChange = useCallback((segmentId: string) => {
-    setView(segmentId as RetryView);
+  const onToggleOpen = useCallback((index: number) => {
+    setExpandedIndex((cur) => (cur === index ? null : index));
   }, []);
 
-  const dropdownItems = useMemo(() => {
-    const items: Record<string, () => void> = {};
-    retries.forEach((_, index) => {
-      items[`Attempt ${index + 1}`] = () => setSelectedIndex(index);
-    });
-    return items;
-  }, [retries]);
-
-  const retry = retries[retries.length === 1 ? 0 : selectedIndex];
-  const hasEvents = !!retry.events?.length;
-
-  // Pre-seed collapsed state for state/store events so their
-  // collapsibleContent bodies start hidden (matching main transcript
-  // where they're hidden inside collapsed parent containers).
-  const initialCollapsed = useMemo(() => {
-    const ids: Record<string, boolean> = {};
-    for (const event of retry.events || []) {
-      if ((event.event === "state" || event.event === "store") && event.uuid) {
-        ids[event.uuid] = true;
-      }
-    }
-    return ids;
-  }, [retry.events]);
-
-  // Lightweight local collapse state for transcript event toggling.
-  // bulkCollapse applies defaults on first render, then clears itself
-  // so user toggles aren't overwritten — mirroring the main transcript pattern.
-  const [transcriptCollapsed, setTranscriptCollapsed] = useState<
-    Record<string, boolean> | undefined
-  >(undefined);
-  const [bulkCollapse, setBulkCollapse] = useState<
-    "collapse" | "expand" | undefined
-  >("expand");
-
-  // Always layer initialCollapsed under the current state so state/store
-  // events default to collapsed. User toggles override via spread order.
-  const effectiveCollapsed = useMemo(
-    () =>
-      transcriptCollapsed
-        ? { ...initialCollapsed, ...transcriptCollapsed }
-        : Object.keys(initialCollapsed).length > 0
-          ? initialCollapsed
-          : undefined,
-    [transcriptCollapsed, initialCollapsed]
-  );
-
-  const collapseState = useMemo<TranscriptCollapseState>(
-    () => ({
-      transcript: effectiveCollapsed,
-      onCollapseTranscript: (nodeId: string, collapsed: boolean) =>
-        setTranscriptCollapsed((prev) => ({
-          ...prev,
-          [nodeId]: collapsed,
-        })),
-      onSetTranscriptCollapsed: (ids: Record<string, boolean>) => {
-        setTranscriptCollapsed(ids);
-        setBulkCollapse(undefined);
-      },
-    }),
-    [effectiveCollapsed]
-  );
+  const onViewChange = useCallback((index: number, view: RetryView) => {
+    setViewByIndex((prev) => ({ ...prev, [index]: view }));
+  }, []);
 
   return (
     <Card className={styles.card}>
       <CardHeader>
-        <div className={styles.headerRow}>
-          <span>Retry Attempts</span>
-          <div className={styles.headerControls}>
-            {retries.length > 1 && (
-              <ToolDropdownButton
-                label={`Attempt ${selectedIndex + 1}`}
-                items={dropdownItems}
-                className={clsx("text-size-smallest", styles.attemptDropdown)}
-                dropdownClassName="text-size-smallest"
-              />
-            )}
-            {hasEvents && (
-              <SegmentedControl
-                segments={kViewSegments}
-                selectedId={view}
-                onSegmentChange={onSegmentChange}
-              />
-            )}
-          </div>
-        </div>
+        <span className={styles.sectionLabel}>Retry Attempts</span>
       </CardHeader>
       <CardBody>
-        {view === "error" ? (
-          <RetryTraceback retry={retry} />
-        ) : (
-          <div className="text-size-small">
-            <TranscriptLayout
-              events={retry.events || []}
-              scrollRef={scrollRef}
-              listId={`sample-error-retries-${id}`}
-              showSwimlanes={false}
-              collapseState={collapseState}
-              bulkCollapse={bulkCollapse}
-              eventNodeContext={{ inlineExpansionUX: true }}
-            />
+        <div className={styles.timeline}>
+          <div className={styles.rail} aria-hidden="true" />
+          <div className={styles.items}>
+            {retries.map((retry, index) => (
+              <div className={styles.row} key={index}>
+                <div className={styles.dotGutter} aria-hidden="true">
+                  <span className={styles.statusDot} />
+                </div>
+                <RetryAttemptCard
+                  retry={retry}
+                  attemptNumber={index + 1}
+                  isOpen={expandedIndex === index}
+                  view={viewByIndex[index] ?? "error"}
+                  onToggleOpen={() => onToggleOpen(index)}
+                  onViewChange={(view) => onViewChange(index, view)}
+                  listId={`sample-error-retries-${id}-${index}`}
+                  scrollRef={scrollRef}
+                />
+              </div>
+            ))}
+            <RetryTerminalAnchor retryCount={retries.length} />
           </div>
-        )}
+        </div>
       </CardBody>
     </Card>
   );
 };
-
-const RetryTraceback: FC<{ retry: EvalRetryError }> = ({ retry }) => (
-  <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
-);

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -1,7 +1,9 @@
+import clsx from "clsx";
 import { FC, RefObject, useEffect, useState } from "react";
 
 import { EvalRetryError } from "@tsmono/inspect-common";
 
+import { ApplicationIcons } from "../appearance/icons";
 import {
   RetryAttemptCard,
   RetryView,
@@ -50,7 +52,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
           {retries.map((retry, index) => (
             <div className={styles.row} key={index}>
               <div className={styles.dotGutter} aria-hidden="true">
-                <span className={styles.statusDot} />
+                <i className={clsx(ApplicationIcons.error, styles.statusIcon)} />
               </div>
               <RetryAttemptCard
                 retry={retry}

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.tsx
@@ -4,6 +4,7 @@ import { FC, RefObject, useEffect, useState } from "react";
 import { EvalRetryError } from "@tsmono/inspect-common";
 
 import { ApplicationIcons } from "../appearance/icons";
+
 import { RetryAttemptCard } from "./retry-display/RetryAttemptCard";
 import { RetryTerminalAnchor } from "./retry-display/RetryTerminalAnchor";
 import styles from "./SampleRetriedErrors.module.css";
@@ -21,7 +22,7 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
 }) => {
   // Accordion: default to the most recent failure (closest to the success).
   const [expandedIndex, setExpandedIndex] = useState<number | null>(
-    retries.length - 1,
+    retries.length - 1
   );
 
   // Reset accordion state when switching to a different sample (the same
@@ -43,7 +44,9 @@ export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
           {retries.map((retry, index) => (
             <div className={styles.row} key={index}>
               <div className={styles.dotGutter} aria-hidden="true">
-                <i className={clsx(ApplicationIcons.error, styles.statusIcon)} />
+                <i
+                  className={clsx(ApplicationIcons.error, styles.statusIcon)}
+                />
               </div>
               <RetryAttemptCard
                 retry={retry}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -54,57 +54,36 @@
   white-space: nowrap;
 }
 
-.duration {
+/* Right-aligned group: the (expanded-only) Error/Events toggle, duration, and
+   chevron. */
+.headerRight {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.headerToggle {
+  display: flex;
+}
+
+.duration {
   font-family: var(--bs-font-monospace);
   font-size: 12px;
   color: var(--bs-tertiary-color);
   white-space: nowrap;
 }
 
-/* When there's no duration, the chevron still anchors right. */
 .chevron {
-  margin-left: auto;
   color: var(--bs-tertiary-color);
   font-size: 14px;
 }
 
-.duration + .chevron {
-  margin-left: 0;
-}
-
 /* No horizontal padding: the Events transcript goes edge-to-edge so its row
-   borders meet the card edges. Section headers and the error panel re-add
-   their own inset. */
+   borders meet the card edges. The error panel re-adds its own inset. */
 .body {
-  padding-top: 8px;
+  padding-top: 10px;
   padding-bottom: 16px;
-}
-
-/* Titled-divider header: icon + label inset on the left, optional count on the
-   right, with a thin full-width rule underneath (the border spans the full card
-   width since the header has no horizontal margin). */
-.sectionHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 14px 6px;
-  margin-bottom: 12px;
-  border-bottom: 1px solid var(--bs-border-color);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--bs-secondary-color);
-}
-
-.sectionHeaderEvents {
-  margin-top: 16px;
-}
-
-.sectionIcon {
-  font-size: 12px;
-  color: var(--bs-secondary-color);
 }
 
 .errorPanel {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -48,6 +48,7 @@
 .message {
   font-size: 12.5px;
   color: var(--bs-secondary-color);
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -1,0 +1,86 @@
+.card {
+  flex: 1;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.cardCollapsed {
+  background: var(--bs-tertiary-bg);
+}
+
+.cardOpen {
+  background: var(--bs-body-bg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  cursor: pointer;
+}
+
+.attemptLabel {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--bs-body-color);
+  white-space: nowrap;
+}
+
+.errorChip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 5px;
+  background: var(--bs-danger-bg-subtle);
+  color: var(--bs-danger-text-emphasis);
+  border: 1px solid var(--bs-danger-border-subtle);
+  white-space: nowrap;
+}
+
+.message {
+  font-size: 12.5px;
+  color: var(--bs-secondary-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.duration {
+  margin-left: auto;
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+  color: var(--bs-tertiary-color);
+  white-space: nowrap;
+}
+
+/* When there's no duration, the chevron still anchors right. */
+.chevron {
+  margin-left: auto;
+  color: var(--bs-tertiary-color);
+  font-size: 14px;
+}
+
+.duration + .chevron {
+  margin-left: 0;
+}
+
+.body {
+  padding: 4px 14px 16px;
+}
+
+.toggle {
+  margin-bottom: 12px;
+}
+
+.ansi {
+  margin: 0.5em 0;
+  font-size: clamp(0.3rem, 1.1vw, 0.8rem) !important;
+}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -81,8 +81,16 @@
   padding-bottom: 16px;
 }
 
+/* Titled-divider header: icon + label inset on the left, optional count on the
+   right, with a thin full-width rule underneath (the border spans the full card
+   width since the header has no horizontal margin). */
 .sectionHeader {
-  margin: 0 14px 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 14px 6px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--bs-border-color);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -92,6 +100,20 @@
 
 .sectionHeaderEvents {
   margin-top: 16px;
+}
+
+.sectionIcon {
+  font-size: 12px;
+  color: var(--bs-secondary-color);
+}
+
+.sectionCount {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--bs-tertiary-color);
 }
 
 .errorPanel {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -77,8 +77,19 @@
   padding: 4px 14px 16px;
 }
 
+/* display:flex shrinks the SegmentedControl (a block-level flex root) to its
+   content width instead of stretching across the card body. */
 .toggle {
+  display: flex;
   margin-bottom: 12px;
+}
+
+/* Give the Error/Events segments a more generous, easier-to-hit target than
+   the SegmentedControl's default compact padding. Targets the segment buttons
+   structurally (aria-pressed) since the component's class names are hashed. */
+.toggle button[aria-pressed] {
+  padding-block: 4px;
+  padding-inline: 14px;
 }
 
 .ansi {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -107,15 +107,6 @@
   color: var(--bs-secondary-color);
 }
 
-.sectionCount {
-  margin-left: auto;
-  font-size: 11px;
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--bs-tertiary-color);
-}
-
 .errorPanel {
   margin: 0 14px;
 }

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -73,15 +73,21 @@
   margin-left: 0;
 }
 
+/* No horizontal padding: the Events transcript goes edge-to-edge so its row
+   borders meet the card edges. The toggle and Error view re-add their own inset. */
 .body {
-  padding: 4px 14px 16px;
+  padding-top: 4px;
+}
+
+.errorView {
+  padding: 0 14px 16px;
 }
 
 /* display:flex shrinks the SegmentedControl (a block-level flex root) to its
    content width instead of stretching across the card body. */
 .toggle {
   display: flex;
-  margin-bottom: 12px;
+  margin: 0 14px 12px;
 }
 
 /* Give the Error/Events segments a more generous, easier-to-hit target than

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -74,28 +74,28 @@
 }
 
 /* No horizontal padding: the Events transcript goes edge-to-edge so its row
-   borders meet the card edges. The toggle and Error view re-add their own inset. */
+   borders meet the card edges. Section headers and the error panel re-add
+   their own inset. */
 .body {
-  padding-top: 4px;
+  padding-top: 8px;
+  padding-bottom: 16px;
 }
 
-.errorView {
-  padding: 0 14px 16px;
+.sectionHeader {
+  margin: 0 14px 6px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
 }
 
-/* display:flex shrinks the SegmentedControl (a block-level flex root) to its
-   content width instead of stretching across the card body. */
-.toggle {
-  display: flex;
-  margin: 0 14px 12px;
+.sectionHeaderEvents {
+  margin-top: 16px;
 }
 
-/* Give the Error/Events segments a more generous, easier-to-hit target than
-   the SegmentedControl's default compact padding. Targets the segment buttons
-   structurally (aria-pressed) since the component's class names are hashed. */
-.toggle button[aria-pressed] {
-  padding-block: 4px;
-  padding-inline: 14px;
+.errorPanel {
+  margin: 0 14px;
 }
 
 .ansi {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -89,4 +89,14 @@ describe("RetryAttemptCard", () => {
     renderCard({ isOpen: false, retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
     expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
   });
+
+  it("toggles open on Enter and Space keydown on the header", () => {
+    const onToggleOpen = vi.fn();
+    renderCard({ onToggleOpen, isOpen: false });
+    const header = screen.getByText("Attempt 1").closest("[role='button']");
+    expect(header).not.toBeNull();
+    fireEvent.keyDown(header!, { key: "Enter" });
+    fireEvent.keyDown(header!, { key: " " });
+    expect(onToggleOpen).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { createRef } from "react";
+import { ComponentProps, createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
@@ -32,12 +32,11 @@ const baseRetry: EvalRetryError = {
   events: null,
 };
 
-function renderCard(props: Partial<React.ComponentProps<typeof RetryAttemptCard>> = {}) {
+function renderCard(props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}) {
   const scrollRef = createRef<HTMLDivElement>();
   return render(
     <RetryAttemptCard
       retry={baseRetry}
-      index={0}
       attemptNumber={1}
       isOpen={true}
       view="error"

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+// TranscriptLayout pulls in the full transcript stack; stub it so this test
+// exercises only the card's own header/toggle/traceback logic.
+vi.mock("@tsmono/inspect-components/transcript", () => ({
+  TranscriptLayout: () => <div data-testid="transcript-layout" />,
+}));
+
+import { RetryAttemptCard } from "./RetryAttemptCard";
+
+const baseRetry: EvalRetryError = {
+  message: "Simulated failure for sample rec0Arme2jcXQZnAW",
+  traceback: "Traceback ...\nRuntimeError: Simulated failure",
+  traceback_ansi: "RuntimeError: Simulated failure",
+  events: null,
+};
+
+function renderCard(props: Partial<React.ComponentProps<typeof RetryAttemptCard>> = {}) {
+  const scrollRef = createRef<HTMLDivElement>();
+  return render(
+    <RetryAttemptCard
+      retry={baseRetry}
+      index={0}
+      attemptNumber={1}
+      isOpen={true}
+      view="error"
+      onToggleOpen={() => {}}
+      onViewChange={() => {}}
+      listId="test-list-0"
+      scrollRef={scrollRef}
+      {...props}
+    />,
+  );
+}
+
+describe("RetryAttemptCard", () => {
+  afterEach(() => cleanup());
+
+  it("renders the attempt number and derived error-type chip", () => {
+    renderCard();
+    expect(screen.getByText("Attempt 1")).toBeDefined();
+    expect(screen.getByText("RuntimeError")).toBeDefined();
+  });
+
+  it("shows the traceback in the error view and no Events toggle when there are no events", () => {
+    renderCard({ view: "error" });
+    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
+  });
+
+  it("renders the Error/Events toggle when events exist", () => {
+    renderCard({ retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
+    expect(screen.getByRole("button", { name: /error/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /events/i })).toBeDefined();
+  });
+
+  it("renders the transcript when view is events", () => {
+    renderCard({
+      retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] },
+      view: "events",
+    });
+    expect(screen.getByTestId("transcript-layout")).toBeDefined();
+  });
+
+  it("calls onToggleOpen when the header is clicked", () => {
+    const onToggleOpen = vi.fn();
+    renderCard({ onToggleOpen });
+    fireEvent.click(screen.getByText("Attempt 1"));
+    expect(onToggleOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the body when collapsed", () => {
+    renderCard({ isOpen: false, retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
+    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -65,24 +65,33 @@ describe("RetryAttemptCard", () => {
     expect(screen.getByText("RuntimeError")).toBeDefined();
   });
 
-  it("always shows the Error section with the traceback", () => {
+  it("shows the traceback (and no toggle) when expanded with no events", () => {
     renderCard();
-    expect(screen.getByText("Error")).toBeDefined();
     expect(screen.getByTestId("ansi-display")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
   });
 
-  it("shows no Events section when there are no events", () => {
-    renderCard();
-    expect(screen.queryByText("Terminal Events")).toBeNull();
-    expect(screen.queryByTestId("transcript-layout")).toBeNull();
-  });
-
-  it("shows both Error and Events sections when events exist", () => {
+  it("shows the Error/Events toggle only when events exist", () => {
     renderCard({ retry: withEvents() });
-    expect(screen.getByText("Error")).toBeDefined();
-    expect(screen.getByText("Terminal Events")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Error" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Events" })).toBeDefined();
+  });
+
+  it("defaults to the error view and switches to events on toggle", () => {
+    renderCard({ retry: withEvents() });
     expect(screen.getByTestId("ansi-display")).toBeDefined();
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Events" }));
     expect(screen.getByTestId("transcript-layout")).toBeDefined();
+    expect(screen.queryByTestId("ansi-display")).toBeNull();
+  });
+
+  it("toggling the view does not collapse the card", () => {
+    const onToggleOpen = vi.fn();
+    renderCard({ retry: withEvents(), onToggleOpen });
+    fireEvent.click(screen.getByRole("button", { name: "Events" }));
+    expect(onToggleOpen).not.toHaveBeenCalled();
   });
 
   it("calls onToggleOpen when the header is clicked", () => {
@@ -92,9 +101,9 @@ describe("RetryAttemptCard", () => {
     expect(onToggleOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("hides the body when collapsed", () => {
+  it("hides the body and toggle when collapsed", () => {
     renderCard({ isOpen: false, retry: withEvents() });
-    expect(screen.queryByText("Error")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
     expect(screen.queryByTestId("ansi-display")).toBeNull();
     expect(screen.queryByTestId("transcript-layout")).toBeNull();
   });

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -11,6 +11,18 @@ vi.mock("@tsmono/inspect-components/transcript", () => ({
   TranscriptLayout: () => <div data-testid="transcript-layout" />,
 }));
 
+vi.mock("@tsmono/react/components", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tsmono/react/components")>();
+  return {
+    ...actual,
+    // ANSIDisplay needs an icon-provider context that isn't present in jsdom;
+    // stub it so the card's own logic is what's under test.
+    ANSIDisplay: ({ output }: { output: string }) => (
+      <pre data-testid="ansi-display">{output}</pre>
+    ),
+  };
+});
+
 import { RetryAttemptCard } from "./RetryAttemptCard";
 
 const baseRetry: EvalRetryError = {
@@ -49,14 +61,14 @@ describe("RetryAttemptCard", () => {
 
   it("shows the traceback in the error view and no Events toggle when there are no events", () => {
     renderCard({ view: "error" });
-    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
     expect(screen.queryByTestId("transcript-layout")).toBeNull();
   });
 
   it("renders the Error/Events toggle when events exist", () => {
     renderCard({ retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
-    expect(screen.getByRole("button", { name: /error/i })).toBeDefined();
-    expect(screen.getByRole("button", { name: /events/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Error" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Events" })).toBeDefined();
   });
 
   it("renders the transcript when view is events", () => {
@@ -76,6 +88,6 @@ describe("RetryAttemptCard", () => {
 
   it("hides the body when collapsed", () => {
     renderCard({ isOpen: false, retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
-    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
   });
 });

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EvalRetryError } from "@tsmono/inspect-common";
 
 // TranscriptLayout pulls in the full transcript stack; stub it so this test
-// exercises only the card's own header/toggle/traceback logic.
+// exercises only the card's own structure.
 vi.mock("@tsmono/inspect-components/transcript", () => ({
   TranscriptLayout: () => <div data-testid="transcript-layout" />,
 }));
@@ -15,10 +15,14 @@ vi.mock("@tsmono/react/components", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tsmono/react/components")>();
   return {
     ...actual,
-    // ANSIDisplay needs an icon-provider context that isn't present in jsdom;
-    // stub it so the card's own logic is what's under test.
+    // ANSIDisplay needs an icon-provider context, and ExpandablePanel needs the
+    // component-state provider — neither is present in jsdom. Stub both so the
+    // card's own logic is what's under test.
     ANSIDisplay: ({ output }: { output: string }) => (
       <pre data-testid="ansi-display">{output}</pre>
+    ),
+    ExpandablePanel: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="expandable-panel">{children}</div>
     ),
   };
 });
@@ -32,6 +36,11 @@ const baseRetry: EvalRetryError = {
   events: null,
 };
 
+const withEvents = (): EvalRetryError => ({
+  ...baseRetry,
+  events: [{ event: "error" }] as unknown as EvalRetryError["events"],
+});
+
 function renderCard(props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}) {
   const scrollRef = createRef<HTMLDivElement>();
   return render(
@@ -39,9 +48,7 @@ function renderCard(props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}
       retry={baseRetry}
       attemptNumber={1}
       isOpen={true}
-      view="error"
       onToggleOpen={() => {}}
-      onViewChange={() => {}}
       listId="test-list-0"
       scrollRef={scrollRef}
       {...props}
@@ -58,23 +65,23 @@ describe("RetryAttemptCard", () => {
     expect(screen.getByText("RuntimeError")).toBeDefined();
   });
 
-  it("shows the traceback in the error view and no Events toggle when there are no events", () => {
-    renderCard({ view: "error" });
-    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
+  it("always shows the Error section with the traceback", () => {
+    renderCard();
+    expect(screen.getByText("Error")).toBeDefined();
+    expect(screen.getByTestId("ansi-display")).toBeDefined();
+  });
+
+  it("shows no Events section when there are no events", () => {
+    renderCard();
+    expect(screen.queryByText("Terminal Events")).toBeNull();
     expect(screen.queryByTestId("transcript-layout")).toBeNull();
   });
 
-  it("renders the Error/Events toggle when events exist", () => {
-    renderCard({ retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
-    expect(screen.getByRole("button", { name: "Error" })).toBeDefined();
-    expect(screen.getByRole("button", { name: "Events" })).toBeDefined();
-  });
-
-  it("renders the transcript when view is events", () => {
-    renderCard({
-      retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] },
-      view: "events",
-    });
+  it("shows both Error and Events sections when events exist", () => {
+    renderCard({ retry: withEvents() });
+    expect(screen.getByText("Error")).toBeDefined();
+    expect(screen.getByText("Terminal Events")).toBeDefined();
+    expect(screen.getByTestId("ansi-display")).toBeDefined();
     expect(screen.getByTestId("transcript-layout")).toBeDefined();
   });
 
@@ -86,8 +93,10 @@ describe("RetryAttemptCard", () => {
   });
 
   it("hides the body when collapsed", () => {
-    renderCard({ isOpen: false, retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
-    expect(screen.queryByRole("button", { name: "Events" })).toBeNull();
+    renderCard({ isOpen: false, retry: withEvents() });
+    expect(screen.queryByText("Error")).toBeNull();
+    expect(screen.queryByTestId("ansi-display")).toBeNull();
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
   });
 
   it("toggles open on Enter and Space keydown on the header", () => {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { ComponentProps, createRef } from "react";
+import { ComponentProps, createRef, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
+
+import { RetryAttemptCard } from "./RetryAttemptCard";
 
 // TranscriptLayout pulls in the full transcript stack; stub it so this test
 // exercises only the card's own structure.
@@ -12,7 +14,8 @@ vi.mock("@tsmono/inspect-components/transcript", () => ({
 }));
 
 vi.mock("@tsmono/react/components", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@tsmono/react/components")>();
+  const actual =
+    await importOriginal<typeof import("@tsmono/react/components")>();
   return {
     ...actual,
     // ANSIDisplay needs an icon-provider context, and ExpandablePanel needs the
@@ -21,13 +24,11 @@ vi.mock("@tsmono/react/components", async (importOriginal) => {
     ANSIDisplay: ({ output }: { output: string }) => (
       <pre data-testid="ansi-display">{output}</pre>
     ),
-    ExpandablePanel: ({ children }: { children: React.ReactNode }) => (
+    ExpandablePanel: ({ children }: { children: ReactNode }) => (
       <div data-testid="expandable-panel">{children}</div>
     ),
   };
 });
-
-import { RetryAttemptCard } from "./RetryAttemptCard";
 
 const baseRetry: EvalRetryError = {
   message: "Simulated failure for sample rec0Arme2jcXQZnAW",
@@ -41,7 +42,9 @@ const withEvents = (): EvalRetryError => ({
   events: [{ event: "error" }] as unknown as EvalRetryError["events"],
 });
 
-function renderCard(props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}) {
+function renderCard(
+  props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}
+) {
   const scrollRef = createRef<HTMLDivElement>();
   return render(
     <RetryAttemptCard
@@ -52,7 +55,7 @@ function renderCard(props: Partial<ComponentProps<typeof RetryAttemptCard>> = {}
       listId="test-list-0"
       scrollRef={scrollRef}
       {...props}
-    />,
+    />
   );
 }
 

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -151,6 +151,7 @@ const RetryEventsView: FC<{
         events={retry.events || []}
         scrollRef={scrollRef}
         listId={listId}
+        embedded
         showSwimlanes={false}
         collapseState={collapseState}
         bulkCollapse={bulkCollapse}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -21,7 +21,6 @@ const kViewSegments = [
 
 export interface RetryAttemptCardProps {
   retry: EvalRetryError;
-  index: number;
   attemptNumber: number;
   isOpen: boolean;
   view: RetryView;

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -87,7 +87,9 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
             </div>
           )}
           {view === "error" || !hasEvents ? (
-            <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+            <div className={styles.errorView}>
+              <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+            </div>
           ) : (
             <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
           )}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -31,7 +31,8 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
 }) => {
   const errorType = useMemo(() => deriveErrorType(retry), [retry]);
   const durationSec = useMemo(() => attemptDuration(retry), [retry]);
-  const hasEvents = !!retry.events?.length;
+  const eventCount = retry.events?.length ?? 0;
+  const hasEvents = eventCount > 0;
 
   return (
     <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
@@ -66,7 +67,13 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
 
       {isOpen && (
         <div className={styles.body}>
-          <div className={styles.sectionHeader}>Error</div>
+          <div className={styles.sectionHeader}>
+            <i
+              className={clsx("bi bi-exclamation-triangle", styles.sectionIcon)}
+              aria-hidden="true"
+            />
+            <span>Error</span>
+          </div>
           <ExpandablePanel
             id={`retry-error-${listId}`}
             collapse={true}
@@ -80,7 +87,12 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
               <div
                 className={clsx(styles.sectionHeader, styles.sectionHeaderEvents)}
               >
-                Terminal Events
+                <i
+                  className={clsx("bi bi-list-ul", styles.sectionIcon)}
+                  aria-hidden="true"
+                />
+                <span>Terminal Events</span>
+                <span className={styles.sectionCount}>{`${eventCount} events`}</span>
               </div>
               <RetryEventsView
                 retry={retry}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -6,26 +6,17 @@ import {
   TranscriptCollapseState,
   TranscriptLayout,
 } from "@tsmono/inspect-components/transcript";
-import { ANSIDisplay, SegmentedControl } from "@tsmono/react/components";
+import { ANSIDisplay, ExpandablePanel } from "@tsmono/react/components";
 import { formatTime } from "@tsmono/util";
 
 import { attemptDuration, deriveErrorType } from "./retryAttempt";
 import styles from "./RetryAttemptCard.module.css";
 
-export type RetryView = "error" | "events";
-
-const kViewSegments = [
-  { id: "error", label: "Error", icon: "bi bi-exclamation-triangle" },
-  { id: "events", label: "Events", icon: "bi bi-list-ul" },
-];
-
 export interface RetryAttemptCardProps {
   retry: EvalRetryError;
   attemptNumber: number;
   isOpen: boolean;
-  view: RetryView;
   onToggleOpen: () => void;
-  onViewChange: (view: RetryView) => void;
   listId: string;
   scrollRef: RefObject<HTMLDivElement | null>;
 }
@@ -34,9 +25,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
   retry,
   attemptNumber,
   isOpen,
-  view,
   onToggleOpen,
-  onViewChange,
   listId,
   scrollRef,
 }) => {
@@ -77,21 +66,28 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
 
       {isOpen && (
         <div className={styles.body}>
+          <div className={styles.sectionHeader}>Error</div>
+          <ExpandablePanel
+            id={`retry-error-${listId}`}
+            collapse={true}
+            className={styles.errorPanel}
+          >
+            <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+          </ExpandablePanel>
+
           {hasEvents && (
-            <div className={styles.toggle}>
-              <SegmentedControl
-                segments={kViewSegments}
-                selectedId={view}
-                onSegmentChange={(id) => onViewChange(id as RetryView)}
+            <>
+              <div
+                className={clsx(styles.sectionHeader, styles.sectionHeaderEvents)}
+              >
+                Terminal Events
+              </div>
+              <RetryEventsView
+                retry={retry}
+                listId={listId}
+                scrollRef={scrollRef}
               />
-            </div>
-          )}
-          {view === "error" || !hasEvents ? (
-            <div className={styles.errorView}>
-              <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
-            </div>
-          ) : (
-            <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
+            </>
           )}
         </div>
       )}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -31,8 +31,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
 }) => {
   const errorType = useMemo(() => deriveErrorType(retry), [retry]);
   const durationSec = useMemo(() => attemptDuration(retry), [retry]);
-  const eventCount = retry.events?.length ?? 0;
-  const hasEvents = eventCount > 0;
+  const hasEvents = !!retry.events?.length;
 
   return (
     <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
@@ -92,7 +91,6 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
                   aria-hidden="true"
                 />
                 <span>Terminal Events</span>
-                <span className={styles.sectionCount}>{`${eventCount} events`}</span>
               </div>
               <RetryEventsView
                 retry={retry}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Component, FC, ReactNode, RefObject, useMemo, useState } from "react";
+import { FC, RefObject, useMemo, useState } from "react";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
 import {
@@ -61,11 +61,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
         }}
       >
         <span className={styles.attemptLabel}>{`Attempt ${attemptNumber}`}</span>
-        {errorType && (
-          <span className={styles.errorChip} aria-hidden="true">
-            {errorType}
-          </span>
-        )}
+        {errorType && <span className={styles.errorChip}>{errorType}</span>}
         {retry.message && <span className={styles.message}>{retry.message}</span>}
         {durationSec != null && (
           <span className={styles.duration}>{formatTime(durationSec)}</span>
@@ -92,7 +88,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
             </div>
           )}
           {view === "error" || !hasEvents ? (
-            <TracebackDisplay output={retry.traceback_ansi} className={styles.ansi} />
+            <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
           ) : (
             <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
           )}
@@ -101,36 +97,6 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
     </div>
   );
 };
-
-// ANSIDisplay requires ComponentIconProvider and ansi-output (not available in
-// jsdom). Wrap with an error boundary so the card renders in isolation during
-// unit tests — the boundary falls back to a plain <pre> on render errors.
-interface TracebackDisplayProps {
-  output: string;
-  className?: string;
-}
-
-class AnsiErrorBoundary extends Component<
-  { children: ReactNode; fallback: ReactNode },
-  { hasError: boolean }
-> {
-  constructor(props: { children: ReactNode; fallback: ReactNode }) {
-    super(props);
-    this.state = { hasError: false };
-  }
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-  render() {
-    return this.state.hasError ? this.props.fallback : this.props.children;
-  }
-}
-
-const TracebackDisplay: FC<TracebackDisplayProps> = ({ output, className }) => (
-  <AnsiErrorBoundary fallback={<pre className={className}>{output}</pre>}>
-    <ANSIDisplay output={output} className={className} />
-  </AnsiErrorBoundary>
-);
 
 const RetryEventsView: FC<{
   retry: EvalRetryError;

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -6,11 +6,22 @@ import {
   TranscriptCollapseState,
   TranscriptLayout,
 } from "@tsmono/inspect-components/transcript";
-import { ANSIDisplay, ExpandablePanel } from "@tsmono/react/components";
+import {
+  ANSIDisplay,
+  ExpandablePanel,
+  SegmentedControl,
+} from "@tsmono/react/components";
 import { formatTime } from "@tsmono/util";
 
 import { attemptDuration, deriveErrorType } from "./retryAttempt";
 import styles from "./RetryAttemptCard.module.css";
+
+export type RetryView = "error" | "events";
+
+const kViewSegments = [
+  { id: "error", label: "Error", icon: "bi bi-exclamation-triangle" },
+  { id: "events", label: "Events", icon: "bi bi-list-ul" },
+];
 
 export interface RetryAttemptCardProps {
   retry: EvalRetryError;
@@ -32,6 +43,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
   const errorType = useMemo(() => deriveErrorType(retry), [retry]);
   const durationSec = useMemo(() => attemptDuration(retry), [retry]);
   const hasEvents = !!retry.events?.length;
+  const [view, setView] = useState<RetryView>("error");
 
   return (
     <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
@@ -51,53 +63,46 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
         <span className={styles.attemptLabel}>{`Attempt ${attemptNumber}`}</span>
         {errorType && <span className={styles.errorChip}>{errorType}</span>}
         {retry.message && <span className={styles.message}>{retry.message}</span>}
-        {durationSec != null && (
-          <span className={styles.duration}>{formatTime(durationSec)}</span>
-        )}
-        <i
-          className={clsx(
-            "bi",
-            isOpen ? "bi-chevron-down" : "bi-chevron-right",
-            styles.chevron,
+        <div className={styles.headerRight}>
+          {isOpen && hasEvents && (
+            // Stop propagation so toggling the view doesn't collapse the card.
+            <div
+              className={styles.headerToggle}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <SegmentedControl
+                segments={kViewSegments}
+                selectedId={view}
+                onSegmentChange={(id) => setView(id as RetryView)}
+              />
+            </div>
           )}
-          aria-hidden="true"
-        />
+          {durationSec != null && (
+            <span className={styles.duration}>{formatTime(durationSec)}</span>
+          )}
+          <i
+            className={clsx(
+              "bi",
+              isOpen ? "bi-chevron-down" : "bi-chevron-right",
+              styles.chevron,
+            )}
+            aria-hidden="true"
+          />
+        </div>
       </div>
 
       {isOpen && (
         <div className={styles.body}>
-          <div className={styles.sectionHeader}>
-            <i
-              className={clsx("bi bi-exclamation-triangle", styles.sectionIcon)}
-              aria-hidden="true"
-            />
-            <span>Error</span>
-          </div>
-          <ExpandablePanel
-            id={`retry-error-${listId}`}
-            collapse={true}
-            className={styles.errorPanel}
-          >
-            <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
-          </ExpandablePanel>
-
-          {hasEvents && (
-            <>
-              <div
-                className={clsx(styles.sectionHeader, styles.sectionHeaderEvents)}
-              >
-                <i
-                  className={clsx("bi bi-list-ul", styles.sectionIcon)}
-                  aria-hidden="true"
-                />
-                <span>Terminal Events</span>
-              </div>
-              <RetryEventsView
-                retry={retry}
-                listId={listId}
-                scrollRef={scrollRef}
-              />
-            </>
+          {view === "error" || !hasEvents ? (
+            <ExpandablePanel
+              id={`retry-error-${listId}`}
+              collapse={true}
+              className={styles.errorPanel}
+            >
+              <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+            </ExpandablePanel>
+          ) : (
+            <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
           )}
         </div>
       )}

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -46,7 +46,12 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
   const [view, setView] = useState<RetryView>("error");
 
   return (
-    <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
+    <div
+      className={clsx(
+        styles.card,
+        isOpen ? styles.cardOpen : styles.cardCollapsed
+      )}
+    >
       <div
         className={styles.header}
         role="button"
@@ -60,9 +65,13 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
           }
         }}
       >
-        <span className={styles.attemptLabel}>{`Attempt ${attemptNumber}`}</span>
+        <span
+          className={styles.attemptLabel}
+        >{`Attempt ${attemptNumber}`}</span>
         {errorType && <span className={styles.errorChip}>{errorType}</span>}
-        {retry.message && <span className={styles.message}>{retry.message}</span>}
+        {retry.message && (
+          <span className={styles.message}>{retry.message}</span>
+        )}
         <div className={styles.headerRight}>
           {isOpen && hasEvents && (
             // Stop propagation so toggling the view doesn't collapse the card.
@@ -84,7 +93,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
             className={clsx(
               "bi",
               isOpen ? "bi-chevron-down" : "bi-chevron-right",
-              styles.chevron,
+              styles.chevron
             )}
             aria-hidden="true"
           />
@@ -99,10 +108,17 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
               collapse={true}
               className={styles.errorPanel}
             >
-              <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+              <ANSIDisplay
+                output={retry.traceback_ansi}
+                className={styles.ansi}
+              />
             </ExpandablePanel>
           ) : (
-            <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
+            <RetryEventsView
+              retry={retry}
+              listId={listId}
+              scrollRef={scrollRef}
+            />
           )}
         </div>
       )}
@@ -142,7 +158,7 @@ const RetryEventsView: FC<{
         : Object.keys(initialCollapsed).length > 0
           ? initialCollapsed
           : undefined,
-    [transcriptCollapsed, initialCollapsed],
+    [transcriptCollapsed, initialCollapsed]
   );
 
   const collapseState = useMemo<TranscriptCollapseState>(
@@ -155,7 +171,7 @@ const RetryEventsView: FC<{
         setBulkCollapse(undefined);
       },
     }),
-    [effectiveCollapsed],
+    [effectiveCollapsed]
   );
 
   return (

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -1,0 +1,196 @@
+import clsx from "clsx";
+import { Component, FC, ReactNode, RefObject, useMemo, useState } from "react";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+import {
+  TranscriptCollapseState,
+  TranscriptLayout,
+} from "@tsmono/inspect-components/transcript";
+import { ANSIDisplay, SegmentedControl } from "@tsmono/react/components";
+import { formatTime } from "@tsmono/util";
+
+import { attemptDuration, deriveErrorType } from "./retryAttempt";
+import styles from "./RetryAttemptCard.module.css";
+
+export type RetryView = "error" | "events";
+
+const kViewSegments = [
+  { id: "error", label: "Error", icon: "bi bi-exclamation-triangle" },
+  { id: "events", label: "Events", icon: "bi bi-list-ul" },
+];
+
+export interface RetryAttemptCardProps {
+  retry: EvalRetryError;
+  index: number;
+  attemptNumber: number;
+  isOpen: boolean;
+  view: RetryView;
+  onToggleOpen: () => void;
+  onViewChange: (view: RetryView) => void;
+  listId: string;
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
+  retry,
+  attemptNumber,
+  isOpen,
+  view,
+  onToggleOpen,
+  onViewChange,
+  listId,
+  scrollRef,
+}) => {
+  const errorType = useMemo(() => deriveErrorType(retry), [retry]);
+  const durationSec = useMemo(() => attemptDuration(retry), [retry]);
+  const hasEvents = !!retry.events?.length;
+
+  return (
+    <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
+      <div
+        className={styles.header}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        onClick={onToggleOpen}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggleOpen();
+          }
+        }}
+      >
+        <span className={styles.attemptLabel}>{`Attempt ${attemptNumber}`}</span>
+        {errorType && (
+          <span className={styles.errorChip} aria-hidden="true">
+            {errorType}
+          </span>
+        )}
+        {retry.message && <span className={styles.message}>{retry.message}</span>}
+        {durationSec != null && (
+          <span className={styles.duration}>{formatTime(durationSec)}</span>
+        )}
+        <i
+          className={clsx(
+            "bi",
+            isOpen ? "bi-chevron-down" : "bi-chevron-right",
+            styles.chevron,
+          )}
+          aria-hidden="true"
+        />
+      </div>
+
+      {isOpen && (
+        <div className={styles.body}>
+          {hasEvents && (
+            <div className={styles.toggle}>
+              <SegmentedControl
+                segments={kViewSegments}
+                selectedId={view}
+                onSegmentChange={(id) => onViewChange(id as RetryView)}
+              />
+            </div>
+          )}
+          {view === "error" || !hasEvents ? (
+            <TracebackDisplay output={retry.traceback_ansi} className={styles.ansi} />
+          ) : (
+            <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ANSIDisplay requires ComponentIconProvider and ansi-output (not available in
+// jsdom). Wrap with an error boundary so the card renders in isolation during
+// unit tests — the boundary falls back to a plain <pre> on render errors.
+interface TracebackDisplayProps {
+  output: string;
+  className?: string;
+}
+
+class AnsiErrorBoundary extends Component<
+  { children: ReactNode; fallback: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; fallback: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}
+
+const TracebackDisplay: FC<TracebackDisplayProps> = ({ output, className }) => (
+  <AnsiErrorBoundary fallback={<pre className={className}>{output}</pre>}>
+    <ANSIDisplay output={output} className={className} />
+  </AnsiErrorBoundary>
+);
+
+const RetryEventsView: FC<{
+  retry: EvalRetryError;
+  listId: string;
+  scrollRef: RefObject<HTMLDivElement | null>;
+}> = ({ retry, listId, scrollRef }) => {
+  // Pre-seed collapsed state for state/store events so their collapsibleContent
+  // bodies start hidden — mirrors the main transcript, where they're hidden
+  // inside collapsed parent containers.
+  const initialCollapsed = useMemo(() => {
+    const ids: Record<string, boolean> = {};
+    for (const event of retry.events || []) {
+      if ((event.event === "state" || event.event === "store") && event.uuid) {
+        ids[event.uuid] = true;
+      }
+    }
+    return ids;
+  }, [retry.events]);
+
+  const [transcriptCollapsed, setTranscriptCollapsed] = useState<
+    Record<string, boolean> | undefined
+  >(undefined);
+  const [bulkCollapse, setBulkCollapse] = useState<
+    "collapse" | "expand" | undefined
+  >("expand");
+
+  const effectiveCollapsed = useMemo(
+    () =>
+      transcriptCollapsed
+        ? { ...initialCollapsed, ...transcriptCollapsed }
+        : Object.keys(initialCollapsed).length > 0
+          ? initialCollapsed
+          : undefined,
+    [transcriptCollapsed, initialCollapsed],
+  );
+
+  const collapseState = useMemo<TranscriptCollapseState>(
+    () => ({
+      transcript: effectiveCollapsed,
+      onCollapseTranscript: (nodeId: string, collapsed: boolean) =>
+        setTranscriptCollapsed((prev) => ({ ...prev, [nodeId]: collapsed })),
+      onSetTranscriptCollapsed: (ids: Record<string, boolean>) => {
+        setTranscriptCollapsed(ids);
+        setBulkCollapse(undefined);
+      },
+    }),
+    [effectiveCollapsed],
+  );
+
+  return (
+    <div className="text-size-small">
+      <TranscriptLayout
+        events={retry.events || []}
+        scrollRef={scrollRef}
+        listId={listId}
+        showSwimlanes={false}
+        collapseState={collapseState}
+        bulkCollapse={bulkCollapse}
+        eventNodeContext={{ inlineExpansionUX: true }}
+      />
+    </div>
+  );
+};

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
@@ -15,6 +15,7 @@
   color: #fff;
   flex: none;
   font-size: 10px;
+  position: relative;
   /* Sits above the container's absolutely-positioned timeline rail. */
   z-index: 1;
 }

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
@@ -1,0 +1,41 @@
+.row {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bs-success);
+  color: #fff;
+  flex: none;
+  font-size: 10px;
+  z-index: 1;
+}
+
+.copy {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  margin-top: 2px;
+  border-top: 1px solid var(--bs-border-color);
+}
+
+.success {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--bs-success-text-emphasis);
+  white-space: nowrap;
+}
+
+.detail {
+  font-size: 12.5px;
+  color: var(--bs-secondary-color);
+}

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css
@@ -15,6 +15,7 @@
   color: #fff;
   flex: none;
   font-size: 10px;
+  /* Sits above the container's absolutely-positioned timeline rail. */
   z-index: 1;
 }
 

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RetryTerminalAnchor } from "./RetryTerminalAnchor";
+
+describe("RetryTerminalAnchor", () => {
+  afterEach(() => cleanup());
+
+  it("uses singular copy for a single retry", () => {
+    render(<RetryTerminalAnchor retryCount={1} />);
+    expect(screen.getByText(/after 1 retry —/)).toBeDefined();
+    expect(screen.getByText("This run succeeded")).toBeDefined();
+  });
+
+  it("uses plural copy for multiple retries", () => {
+    render(<RetryTerminalAnchor retryCount={3} />);
+    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+  });
+});

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx
@@ -9,12 +9,12 @@ describe("RetryTerminalAnchor", () => {
 
   it("uses singular copy for a single retry", () => {
     render(<RetryTerminalAnchor retryCount={1} />);
-    expect(screen.getByText(/after 1 retry —/)).toBeDefined();
+    expect(screen.getByText(/after 1 retry/)).toBeDefined();
     expect(screen.getByText("This run succeeded")).toBeDefined();
   });
 
   it("uses plural copy for multiple retries", () => {
     render(<RetryTerminalAnchor retryCount={3} />);
-    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+    expect(screen.getByText(/after 3 retries/)).toBeDefined();
   });
 });

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
@@ -8,7 +8,9 @@ export interface RetryTerminalAnchorProps {
 
 // Orientation only — the successful run is the sample the user is already
 // viewing. Deliberately not a link, no score, no chevron.
-export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({ retryCount }) => {
+export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({
+  retryCount,
+}) => {
   const retriesLabel = retryCount === 1 ? "1 retry" : `${retryCount} retries`;
   return (
     <div className={styles.row}>
@@ -17,9 +19,7 @@ export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({ retryCount }
       </span>
       <div className={styles.copy}>
         <span className={styles.success}>This run succeeded</span>
-        <span className={styles.detail}>
-          {`after ${retriesLabel}`}
-        </span>
+        <span className={styles.detail}>{`after ${retriesLabel}`}</span>
       </div>
     </div>
   );

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
@@ -18,7 +18,7 @@ export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({ retryCount }
       <div className={styles.copy}>
         <span className={styles.success}>This run succeeded</span>
         <span className={styles.detail}>
-          {`after ${retriesLabel} — the sample you're viewing`}
+          {`after ${retriesLabel}`}
         </span>
       </div>
     </div>

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
@@ -1,0 +1,26 @@
+import { FC } from "react";
+
+import styles from "./RetryTerminalAnchor.module.css";
+
+export interface RetryTerminalAnchorProps {
+  retryCount: number;
+}
+
+// Orientation only — the successful run is the sample the user is already
+// viewing. Deliberately not a link, no score, no chevron.
+export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({ retryCount }) => {
+  const retriesLabel = retryCount === 1 ? "1 retry" : `${retryCount} retries`;
+  return (
+    <div className={styles.row}>
+      <span className={styles.check} aria-hidden="true">
+        <i className="bi bi-check" />
+      </span>
+      <div className={styles.copy}>
+        <span className={styles.success}>This run succeeded</span>
+        <span className={styles.detail}>
+          {`after ${retriesLabel} — the sample you're viewing`}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+import { attemptDuration, deriveErrorType } from "./retryAttempt";
+
+function retry(partial: Partial<EvalRetryError>): EvalRetryError {
+  return {
+    message: "",
+    traceback: "",
+    traceback_ansi: "",
+    events: null,
+    ...partial,
+  };
+}
+
+describe("deriveErrorType", () => {
+  it("parses the exception class from the final traceback line", () => {
+    const tb = [
+      "Traceback (most recent call last):",
+      '  File "flow.py", line 25, in solve',
+      "    raise RuntimeError(msg)",
+      "RuntimeError: Simulated failure for sample rec0Arme2jcXQZnAW",
+    ].join("\n");
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("RuntimeError");
+  });
+
+  it("strips a dotted module path to the bare class name", () => {
+    const tb = "asyncio.exceptions.TimeoutError: timed out";
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("TimeoutError");
+  });
+
+  it("handles an exception with no message (no colon)", () => {
+    const tb = "Traceback ...\nKeyboardInterrupt";
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("KeyboardInterrupt");
+  });
+
+  it("returns null when the final line is not an exception", () => {
+    expect(deriveErrorType(retry({ traceback: "some free-form text 123 !!!" }))).toBeNull();
+  });
+
+  it("returns null for an empty traceback", () => {
+    expect(deriveErrorType(retry({ traceback: "" }))).toBeNull();
+  });
+});
+
+describe("attemptDuration", () => {
+  it("returns the span in seconds between first and last event timestamps", () => {
+    const events = [
+      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
+      { event: "error", timestamp: "2024-01-01T00:00:04.200Z" },
+    ] as unknown as EvalRetryError["events"];
+    expect(attemptDuration(retry({ events }))).toBeCloseTo(4.2, 3);
+  });
+
+  it("returns null when there are no events", () => {
+    expect(attemptDuration(retry({ events: null }))).toBeNull();
+    expect(attemptDuration(retry({ events: [] }))).toBeNull();
+  });
+
+  it("returns null when fewer than two events carry a timestamp", () => {
+    const events = [
+      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
+    ] as unknown as EvalRetryError["events"];
+    expect(attemptDuration(retry({ events }))).toBeNull();
+  });
+});

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
@@ -64,4 +64,13 @@ describe("attemptDuration", () => {
     ] as unknown as EvalRetryError["events"];
     expect(attemptDuration(retry({ events }))).toBeNull();
   });
+
+  it("returns 0 when all events share the same timestamp", () => {
+    const ts = "2024-01-01T00:00:00.000Z";
+    const events = [
+      { event: "sample_init", timestamp: ts },
+      { event: "error", timestamp: ts },
+    ] as unknown as EvalRetryError["events"];
+    expect(attemptDuration(retry({ events }))).toBe(0);
+  });
 });

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
@@ -36,7 +36,9 @@ describe("deriveErrorType", () => {
   });
 
   it("returns null when the final line is not an exception", () => {
-    expect(deriveErrorType(retry({ traceback: "some free-form text 123 !!!" }))).toBeNull();
+    expect(
+      deriveErrorType(retry({ traceback: "some free-form text 123 !!!" }))
+    ).toBeNull();
   });
 
   it("returns null for an empty traceback", () => {

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
@@ -1,0 +1,45 @@
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+/**
+ * Derive the exception class name (e.g. `RuntimeError`) from a Python
+ * traceback's final line. `EvalRetryError` has no dedicated field for this.
+ * Returns null when the final line doesn't look like `ExceptionClass[: message]`
+ * so callers can omit the chip rather than render garbage.
+ */
+export function deriveErrorType(retry: EvalRetryError): string | null {
+  const tb = retry.traceback?.trimEnd();
+  if (!tb) return null;
+  const lines = tb.split("\n");
+  const last = lines[lines.length - 1]?.trim() ?? "";
+  if (!last) return null;
+
+  const beforeColon = last.split(":")[0]?.trim() ?? "";
+  if (!beforeColon) return null;
+
+  // Keep the final dotted segment: `asyncio.exceptions.TimeoutError` -> `TimeoutError`.
+  const cls = beforeColon.split(".").pop() ?? beforeColon;
+
+  // A real exception class is a bare identifier. Anything with whitespace or
+  // punctuation is free-form traceback text, not an exception name.
+  return /^[A-Za-z_]\w*$/.test(cls) ? cls : null;
+}
+
+/**
+ * Best-effort attempt duration in seconds, derived ONLY from the event
+ * timestamps. `EvalRetryError` carries no top-level duration; never fabricate
+ * one. Returns null when it can't be computed.
+ */
+export function attemptDuration(retry: EvalRetryError): number | null {
+  const events = retry.events;
+  if (!events || events.length === 0) return null;
+
+  const times = events
+    .map((e) => ("timestamp" in e ? e.timestamp : undefined))
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => Date.parse(t))
+    .filter((n) => Number.isFinite(n));
+
+  if (times.length < 2) return null;
+  const span = (Math.max(...times) - Math.min(...times)) / 1000;
+  return span > 0 ? span : null;
+}

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
@@ -41,5 +41,5 @@ export function attemptDuration(retry: EvalRetryError): number | null {
 
   if (times.length < 2) return null;
   const span = (Math.max(...times) - Math.min(...times)) / 1000;
-  return span > 0 ? span : null;
+  return span >= 0 ? span : null;
 }

--- a/apps/inspect/src/state/sampleUtils.test.ts
+++ b/apps/inspect/src/state/sampleUtils.test.ts
@@ -142,6 +142,24 @@ describe("resolveSample", () => {
   ])("$name", ({ sample, check }) => {
     check(resolveSample(sample));
   });
+
+  it("resolves attachment refs inside error_retries events", () => {
+    const sample = makeSample({
+      attachments: { abc123: "the real failed message body" },
+      error_retries: [
+        {
+          message: "RuntimeError",
+          traceback: "tb",
+          traceback_ansi: "tb",
+          events: [modelEvent([msg("m1", "user", "attachment://abc123")])],
+        },
+      ],
+    });
+    const resolved: any = resolveSample(sample);
+    expect(resolved.error_retries[0].events[0].input[0].content).toBe(
+      "the real failed message body"
+    );
+  });
 });
 
 const baseSummary = (

--- a/apps/inspect/src/state/sampleUtils.ts
+++ b/apps/inspect/src/state/sampleUtils.ts
@@ -25,6 +25,14 @@ export const resolveSample = (sample: any): EvalSample => {
   sample.input = resolveAttachments(sample.input, sample.attachments);
   sample.messages = resolveAttachments(sample.messages, sample.attachments);
   sample.events = resolveAttachments(sample.events, sample.attachments);
+  // Retry-attempt events carry their own attachment:// refs into the shared
+  // sample.attachments map; resolve them too before the map is cleared.
+  if (sample.error_retries) {
+    sample.error_retries = sample.error_retries.map((retry: any) => ({
+      ...retry,
+      events: resolveAttachments(retry.events, sample.attachments),
+    }));
+  }
   sample.attachments = {};
   return sample;
 };

--- a/docs/superpowers/plans/2026-06-09-retry-display-redesign.md
+++ b/docs/superpowers/plans/2026-06-09-retry-display-redesign.md
@@ -1,0 +1,993 @@
+# Retry Display Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the sample viewer's Retries tab as a vertical timeline of expandable attempt cards (Direction B) with a terminal success anchor, reusing the viewer's real traceback/event renderers.
+
+**Architecture:** A container (`SampleRetriedErrors`) owns accordion + per-attempt view state and renders panel chrome, a timeline rail, one `RetryAttemptCard` per failed attempt, and a `RetryTerminalAnchor`. Each card owns its own events-transcript collapse state and switches between the real `ANSIDisplay` traceback and the real `TranscriptLayout`. Pure helpers derive the error-type chip and per-attempt duration. All colors resolve through Bootstrap `--bs-*` tokens for light/dark support.
+
+**Tech Stack:** TypeScript, React (FC + hooks), CSS Modules, Bootstrap CSS variables + Bootstrap Icons, Vitest + `@testing-library/react`. Package manager: `pnpm`. Working dir for all commands: `src/inspect_ai/_view/ts-mono`.
+
+**Commit convention:** This repo requires every commit message to end with the footer line:
+`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+Append it to each commit below (omitted from the short `-m` examples for brevity — use a heredoc).
+
+---
+
+## File Structure
+
+All paths relative to `src/inspect_ai/_view/ts-mono/apps/inspect/src/app/samples/`.
+
+- **Modify** `SampleRetriedErrors.tsx` — becomes the thin container (state + chrome + rail). Keeps its current path so `SampleDisplay.tsx`'s import is unchanged.
+- **Modify** `SampleRetriedErrors.module.css` — panel, header, timeline rail, status-dot, and row layout styles.
+- **Create** `retry-display/retryAttempt.ts` — pure helpers `deriveErrorType`, `attemptDuration`.
+- **Create** `retry-display/retryAttempt.test.ts` — unit tests for the helpers.
+- **Create** `retry-display/RetryAttemptCard.tsx` — one attempt (collapsed header + expanded body with Error/Events toggle and the real renderers). Owns its transcript collapse state.
+- **Create** `retry-display/RetryAttemptCard.module.css` — card chrome, header row, error chip, message, duration, toggle spacing.
+- **Create** `retry-display/RetryAttemptCard.test.tsx` — card render/interaction tests.
+- **Create** `retry-display/RetryTerminalAnchor.tsx` — green-check "This run succeeded after N retries" row.
+- **Create** `retry-display/RetryTerminalAnchor.module.css` — anchor row + check-disc styles.
+- **Create** `retry-display/RetryTerminalAnchor.test.tsx` — pluralization test.
+
+Unchanged: `SampleDisplay.tsx` (caller), `EvalRetryError` schema, all data fetching.
+
+---
+
+## Task 1: Pure helpers — `deriveErrorType` and `attemptDuration`
+
+**Files:**
+- Create: `apps/inspect/src/app/samples/retry-display/retryAttempt.ts`
+- Test: `apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `retry-display/retryAttempt.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+import { attemptDuration, deriveErrorType } from "./retryAttempt";
+
+function retry(partial: Partial<EvalRetryError>): EvalRetryError {
+  return {
+    message: "",
+    traceback: "",
+    traceback_ansi: "",
+    events: null,
+    ...partial,
+  };
+}
+
+describe("deriveErrorType", () => {
+  it("parses the exception class from the final traceback line", () => {
+    const tb = [
+      "Traceback (most recent call last):",
+      '  File "flow.py", line 25, in solve',
+      "    raise RuntimeError(msg)",
+      "RuntimeError: Simulated failure for sample rec0Arme2jcXQZnAW",
+    ].join("\n");
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("RuntimeError");
+  });
+
+  it("strips a dotted module path to the bare class name", () => {
+    const tb = "asyncio.exceptions.TimeoutError: timed out";
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("TimeoutError");
+  });
+
+  it("handles an exception with no message (no colon)", () => {
+    const tb = "Traceback ...\nKeyboardInterrupt";
+    expect(deriveErrorType(retry({ traceback: tb }))).toBe("KeyboardInterrupt");
+  });
+
+  it("returns null when the final line is not an exception", () => {
+    expect(deriveErrorType(retry({ traceback: "some free-form text 123 !!!" }))).toBeNull();
+  });
+
+  it("returns null for an empty traceback", () => {
+    expect(deriveErrorType(retry({ traceback: "" }))).toBeNull();
+  });
+});
+
+describe("attemptDuration", () => {
+  it("returns the span in seconds between first and last event timestamps", () => {
+    const events = [
+      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
+      { event: "error", timestamp: "2024-01-01T00:00:04.200Z" },
+    ] as unknown as EvalRetryError["events"];
+    expect(attemptDuration(retry({ events }))).toBeCloseTo(4.2, 3);
+  });
+
+  it("returns null when there are no events", () => {
+    expect(attemptDuration(retry({ events: null }))).toBeNull();
+    expect(attemptDuration(retry({ events: [] }))).toBeNull();
+  });
+
+  it("returns null when fewer than two events carry a timestamp", () => {
+    const events = [
+      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
+    ] as unknown as EvalRetryError["events"];
+    expect(attemptDuration(retry({ events }))).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/retryAttempt.test.ts`
+
+(The app package is `@meridianlabs/log-viewer`; `cd apps/inspect && pnpm <script>` is the reliable way to run its `test`/`lint`/`typecheck`/`build` scripts.)
+Expected: FAIL — `Cannot find module './retryAttempt'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `retry-display/retryAttempt.ts`:
+
+```ts
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+/**
+ * Derive the exception class name (e.g. `RuntimeError`) from a Python
+ * traceback's final line. `EvalRetryError` has no dedicated field for this.
+ * Returns null when the final line doesn't look like `ExceptionClass[: message]`
+ * so callers can omit the chip rather than render garbage.
+ */
+export function deriveErrorType(retry: EvalRetryError): string | null {
+  const tb = retry.traceback?.trimEnd();
+  if (!tb) return null;
+  const lines = tb.split("\n");
+  const last = lines[lines.length - 1]?.trim() ?? "";
+  if (!last) return null;
+
+  const beforeColon = last.split(":")[0]?.trim() ?? "";
+  if (!beforeColon) return null;
+
+  // Keep the final dotted segment: `asyncio.exceptions.TimeoutError` -> `TimeoutError`.
+  const cls = beforeColon.split(".").pop() ?? beforeColon;
+
+  // A real exception class is a bare identifier. Anything with whitespace or
+  // punctuation is free-form traceback text, not an exception name.
+  return /^[A-Za-z_]\w*$/.test(cls) ? cls : null;
+}
+
+/**
+ * Best-effort attempt duration in seconds, derived ONLY from the event
+ * timestamps. `EvalRetryError` carries no top-level duration; never fabricate
+ * one. Returns null when it can't be computed.
+ */
+export function attemptDuration(retry: EvalRetryError): number | null {
+  const events = retry.events;
+  if (!events || events.length === 0) return null;
+
+  const times = events
+    .map((e) => ("timestamp" in e ? e.timestamp : undefined))
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => Date.parse(t))
+    .filter((n) => Number.isFinite(n));
+
+  if (times.length < 2) return null;
+  const span = (Math.max(...times) - Math.min(...times)) / 1000;
+  return span > 0 ? span : null;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/retryAttempt.test.ts`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/inspect/src/app/samples/retry-display/retryAttempt.ts \
+        apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+git commit -m "feat(retries): add deriveErrorType and attemptDuration helpers"
+```
+
+---
+
+## Task 2: `RetryAttemptCard` component
+
+**Files:**
+- Create: `apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx`
+- Create: `apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css`
+- Test: `apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx`
+
+This card owns the events-transcript collapse machinery (moved out of the old container) because the transcript now lives inside the card. Only the open card renders a transcript.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `retry-display/RetryAttemptCard.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+// TranscriptLayout pulls in the full transcript stack; stub it so this test
+// exercises only the card's own header/toggle/traceback logic.
+vi.mock("@tsmono/inspect-components/transcript", () => ({
+  TranscriptLayout: () => <div data-testid="transcript-layout" />,
+}));
+
+import { RetryAttemptCard } from "./RetryAttemptCard";
+
+const baseRetry: EvalRetryError = {
+  message: "Simulated failure for sample rec0Arme2jcXQZnAW",
+  traceback: "Traceback ...\nRuntimeError: Simulated failure",
+  traceback_ansi: "RuntimeError: Simulated failure",
+  events: null,
+};
+
+function renderCard(props: Partial<React.ComponentProps<typeof RetryAttemptCard>> = {}) {
+  const scrollRef = createRef<HTMLDivElement>();
+  return render(
+    <RetryAttemptCard
+      retry={baseRetry}
+      index={0}
+      attemptNumber={1}
+      isOpen={true}
+      view="error"
+      onToggleOpen={() => {}}
+      onViewChange={() => {}}
+      listId="test-list-0"
+      scrollRef={scrollRef}
+      {...props}
+    />,
+  );
+}
+
+describe("RetryAttemptCard", () => {
+  afterEach(() => cleanup());
+
+  it("renders the attempt number and derived error-type chip", () => {
+    renderCard();
+    expect(screen.getByText("Attempt 1")).toBeDefined();
+    expect(screen.getByText("RuntimeError")).toBeDefined();
+  });
+
+  it("shows the traceback in the error view and no Events toggle when there are no events", () => {
+    renderCard({ view: "error" });
+    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+    expect(screen.queryByTestId("transcript-layout")).toBeNull();
+  });
+
+  it("renders the Error/Events toggle when events exist", () => {
+    renderCard({ retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
+    expect(screen.getByRole("button", { name: /error/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /events/i })).toBeDefined();
+  });
+
+  it("renders the transcript when view is events", () => {
+    renderCard({
+      retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] },
+      view: "events",
+    });
+    expect(screen.getByTestId("transcript-layout")).toBeDefined();
+  });
+
+  it("calls onToggleOpen when the header is clicked", () => {
+    const onToggleOpen = vi.fn();
+    renderCard({ onToggleOpen });
+    fireEvent.click(screen.getByText("Attempt 1"));
+    expect(onToggleOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the body when collapsed", () => {
+    renderCard({ isOpen: false, retry: { ...baseRetry, events: [{ event: "error" }] as unknown as EvalRetryError["events"] } });
+    expect(screen.queryByRole("button", { name: /events/i })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/RetryAttemptCard.test.tsx`
+Expected: FAIL — `Cannot find module './RetryAttemptCard'`.
+
+- [ ] **Step 3: Write the component**
+
+Create `retry-display/RetryAttemptCard.tsx`:
+
+```tsx
+import clsx from "clsx";
+import { FC, RefObject, useMemo, useState } from "react";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+import {
+  TranscriptCollapseState,
+  TranscriptLayout,
+} from "@tsmono/inspect-components/transcript";
+import { ANSIDisplay, SegmentedControl } from "@tsmono/react/components";
+import { formatTime } from "@tsmono/util";
+
+import { attemptDuration, deriveErrorType } from "./retryAttempt";
+import styles from "./RetryAttemptCard.module.css";
+
+export type RetryView = "error" | "events";
+
+const kViewSegments = [
+  { id: "error", label: "Error", icon: "bi bi-exclamation-triangle" },
+  { id: "events", label: "Events", icon: "bi bi-list-ul" },
+];
+
+export interface RetryAttemptCardProps {
+  retry: EvalRetryError;
+  index: number;
+  attemptNumber: number;
+  isOpen: boolean;
+  view: RetryView;
+  onToggleOpen: () => void;
+  onViewChange: (view: RetryView) => void;
+  listId: string;
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
+  retry,
+  attemptNumber,
+  isOpen,
+  view,
+  onToggleOpen,
+  onViewChange,
+  listId,
+  scrollRef,
+}) => {
+  const errorType = useMemo(() => deriveErrorType(retry), [retry]);
+  const durationSec = useMemo(() => attemptDuration(retry), [retry]);
+  const hasEvents = !!retry.events?.length;
+
+  return (
+    <div className={clsx(styles.card, isOpen ? styles.cardOpen : styles.cardCollapsed)}>
+      <div
+        className={styles.header}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        onClick={onToggleOpen}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggleOpen();
+          }
+        }}
+      >
+        <span className={styles.attemptLabel}>{`Attempt ${attemptNumber}`}</span>
+        {errorType && <span className={styles.errorChip}>{errorType}</span>}
+        {retry.message && <span className={styles.message}>{retry.message}</span>}
+        {durationSec != null && (
+          <span className={styles.duration}>{formatTime(durationSec)}</span>
+        )}
+        <i
+          className={clsx(
+            "bi",
+            isOpen ? "bi-chevron-down" : "bi-chevron-right",
+            styles.chevron,
+          )}
+          aria-hidden="true"
+        />
+      </div>
+
+      {isOpen && (
+        <div className={styles.body}>
+          {hasEvents && (
+            <div className={styles.toggle}>
+              <SegmentedControl
+                segments={kViewSegments}
+                selectedId={view}
+                onSegmentChange={(id) => onViewChange(id as RetryView)}
+              />
+            </div>
+          )}
+          {view === "error" || !hasEvents ? (
+            <ANSIDisplay output={retry.traceback_ansi} className={styles.ansi} />
+          ) : (
+            <RetryEventsView retry={retry} listId={listId} scrollRef={scrollRef} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RetryEventsView: FC<{
+  retry: EvalRetryError;
+  listId: string;
+  scrollRef: RefObject<HTMLDivElement | null>;
+}> = ({ retry, listId, scrollRef }) => {
+  // Pre-seed collapsed state for state/store events so their collapsibleContent
+  // bodies start hidden — mirrors the main transcript, where they're hidden
+  // inside collapsed parent containers.
+  const initialCollapsed = useMemo(() => {
+    const ids: Record<string, boolean> = {};
+    for (const event of retry.events || []) {
+      if ((event.event === "state" || event.event === "store") && event.uuid) {
+        ids[event.uuid] = true;
+      }
+    }
+    return ids;
+  }, [retry.events]);
+
+  const [transcriptCollapsed, setTranscriptCollapsed] = useState<
+    Record<string, boolean> | undefined
+  >(undefined);
+  const [bulkCollapse, setBulkCollapse] = useState<
+    "collapse" | "expand" | undefined
+  >("expand");
+
+  const effectiveCollapsed = useMemo(
+    () =>
+      transcriptCollapsed
+        ? { ...initialCollapsed, ...transcriptCollapsed }
+        : Object.keys(initialCollapsed).length > 0
+          ? initialCollapsed
+          : undefined,
+    [transcriptCollapsed, initialCollapsed],
+  );
+
+  const collapseState = useMemo<TranscriptCollapseState>(
+    () => ({
+      transcript: effectiveCollapsed,
+      onCollapseTranscript: (nodeId: string, collapsed: boolean) =>
+        setTranscriptCollapsed((prev) => ({ ...prev, [nodeId]: collapsed })),
+      onSetTranscriptCollapsed: (ids: Record<string, boolean>) => {
+        setTranscriptCollapsed(ids);
+        setBulkCollapse(undefined);
+      },
+    }),
+    [effectiveCollapsed],
+  );
+
+  return (
+    <div className="text-size-small">
+      <TranscriptLayout
+        events={retry.events || []}
+        scrollRef={scrollRef}
+        listId={listId}
+        showSwimlanes={false}
+        collapseState={collapseState}
+        bulkCollapse={bulkCollapse}
+        eventNodeContext={{ inlineExpansionUX: true }}
+      />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Write the CSS module**
+
+Create `retry-display/RetryAttemptCard.module.css`. Layout literals from the handoff; all colors via `--bs-*`:
+
+```css
+.card {
+  flex: 1;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.cardCollapsed {
+  background: var(--bs-tertiary-bg);
+}
+
+.cardOpen {
+  background: var(--bs-body-bg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  cursor: pointer;
+}
+
+.attemptLabel {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--bs-body-color);
+  white-space: nowrap;
+}
+
+.errorChip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 5px;
+  background: var(--bs-danger-bg-subtle);
+  color: var(--bs-danger-text-emphasis);
+  border: 1px solid var(--bs-danger-border-subtle);
+  white-space: nowrap;
+}
+
+.message {
+  font-size: 12.5px;
+  color: var(--bs-secondary-color);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.duration {
+  margin-left: auto;
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+  color: var(--bs-tertiary-color);
+  white-space: nowrap;
+}
+
+/* When there's no duration, the chevron still anchors right. */
+.chevron {
+  margin-left: auto;
+  color: var(--bs-tertiary-color);
+  font-size: 14px;
+}
+
+.duration + .chevron {
+  margin-left: 0;
+}
+
+.body {
+  padding: 4px 14px 16px;
+}
+
+.toggle {
+  margin-bottom: 12px;
+}
+
+.ansi {
+  margin: 0.5em 0;
+  font-size: clamp(0.3rem, 1.1vw, 0.8rem) !important;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/RetryAttemptCard.test.tsx`
+Expected: PASS — all 6 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx \
+        apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css \
+        apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+git commit -m "feat(retries): add RetryAttemptCard with Error/Events toggle"
+```
+
+---
+
+## Task 3: `RetryTerminalAnchor` component
+
+**Files:**
+- Create: `apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx`
+- Create: `apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css`
+- Test: `apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `retry-display/RetryTerminalAnchor.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { RetryTerminalAnchor } from "./RetryTerminalAnchor";
+
+describe("RetryTerminalAnchor", () => {
+  afterEach(() => cleanup());
+
+  it("uses singular copy for a single retry", () => {
+    render(<RetryTerminalAnchor retryCount={1} />);
+    expect(screen.getByText(/after 1 retry —/)).toBeDefined();
+    expect(screen.getByText("This run succeeded")).toBeDefined();
+  });
+
+  it("uses plural copy for multiple retries", () => {
+    render(<RetryTerminalAnchor retryCount={3} />);
+    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/RetryTerminalAnchor.test.tsx`
+Expected: FAIL — `Cannot find module './RetryTerminalAnchor'`.
+
+- [ ] **Step 3: Write the component**
+
+Create `retry-display/RetryTerminalAnchor.tsx`:
+
+```tsx
+import { FC } from "react";
+
+import styles from "./RetryTerminalAnchor.module.css";
+
+export interface RetryTerminalAnchorProps {
+  retryCount: number;
+}
+
+// Orientation only — the successful run is the sample the user is already
+// viewing. Deliberately not a link, no score, no chevron.
+export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({ retryCount }) => {
+  const retriesLabel = retryCount === 1 ? "1 retry" : `${retryCount} retries`;
+  return (
+    <div className={styles.row}>
+      <span className={styles.check} aria-hidden="true">
+        <i className="bi bi-check" />
+      </span>
+      <div className={styles.copy}>
+        <span className={styles.success}>This run succeeded</span>
+        <span className={styles.detail}>
+          {`after ${retriesLabel} — the sample you're viewing`}
+        </span>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Write the CSS module**
+
+Create `retry-display/RetryTerminalAnchor.module.css`:
+
+```css
+.row {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bs-success);
+  color: #fff;
+  flex: none;
+  font-size: 10px;
+  z-index: 1;
+}
+
+.copy {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  margin-top: 2px;
+  border-top: 1px solid var(--bs-border-color);
+}
+
+.success {
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--bs-success-text-emphasis);
+  white-space: nowrap;
+}
+
+.detail {
+  font-size: 12.5px;
+  color: var(--bs-secondary-color);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display/RetryTerminalAnchor.test.tsx`
+Expected: PASS — both tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx \
+        apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.module.css \
+        apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.test.tsx
+git commit -m "feat(retries): add RetryTerminalAnchor success row"
+```
+
+---
+
+## Task 4: Rewrite the `SampleRetriedErrors` container
+
+**Files:**
+- Modify (replace contents): `apps/inspect/src/app/samples/SampleRetriedErrors.tsx`
+- Modify (replace contents): `apps/inspect/src/app/samples/SampleRetriedErrors.module.css`
+- Test: `apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `SampleRetriedErrors.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { EvalRetryError } from "@tsmono/inspect-common";
+
+vi.mock("@tsmono/inspect-components/transcript", () => ({
+  TranscriptLayout: () => <div data-testid="transcript-layout" />,
+}));
+
+import { SampleRetriedErrors } from "./SampleRetriedErrors";
+
+function makeRetry(n: number): EvalRetryError {
+  return {
+    message: `failure ${n}`,
+    traceback: `Traceback ...\nRuntimeError: failure ${n}`,
+    traceback_ansi: `RuntimeError: failure ${n}`,
+    events: null,
+  };
+}
+
+function renderPanel(count: number) {
+  const scrollRef = createRef<HTMLDivElement>();
+  const retries = Array.from({ length: count }, (_, i) => makeRetry(i + 1));
+  return render(
+    <SampleRetriedErrors id="s1" retries={retries} scrollRef={scrollRef} />,
+  );
+}
+
+describe("SampleRetriedErrors", () => {
+  afterEach(() => cleanup());
+
+  it("renders one card per attempt plus the terminal anchor", () => {
+    renderPanel(3);
+    expect(screen.getByText("Attempt 1")).toBeDefined();
+    expect(screen.getByText("Attempt 2")).toBeDefined();
+    expect(screen.getByText("Attempt 3")).toBeDefined();
+    expect(screen.getByText(/after 3 retries —/)).toBeDefined();
+  });
+
+  it("opens the most recent attempt by default", () => {
+    renderPanel(3);
+    // The open card shows its traceback message in the expanded body.
+    expect(screen.getByText("RuntimeError: failure 3")).toBeDefined();
+  });
+
+  it("is an accordion — opening one closes the previously open card", () => {
+    renderPanel(3);
+    expect(screen.getByText("RuntimeError: failure 3")).toBeDefined();
+    fireEvent.click(screen.getByText("Attempt 1"));
+    expect(screen.getByText("RuntimeError: failure 1")).toBeDefined();
+    expect(screen.queryByText("RuntimeError: failure 3")).toBeNull();
+  });
+
+  it("clicking the open card header collapses it", () => {
+    renderPanel(2);
+    expect(screen.getByText("RuntimeError: failure 2")).toBeDefined();
+    fireEvent.click(screen.getByText("Attempt 2"));
+    expect(screen.queryByText("RuntimeError: failure 2")).toBeNull();
+  });
+});
+```
+
+> Note: the `ANSIDisplay` renderer prints the `traceback_ansi` text content, so asserting on `"RuntimeError: failure N"` is a reliable open/closed signal.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/SampleRetriedErrors.test.tsx`
+Expected: FAIL — the current container renders the old dropdown UI (no per-attempt cards / "Attempt 2" body), so the default-open and accordion assertions fail.
+
+- [ ] **Step 3: Replace the container implementation**
+
+Replace the entire contents of `SampleRetriedErrors.tsx` with:
+
+```tsx
+import { FC, RefObject, useCallback, useState } from "react";
+
+import { EvalRetryError } from "@tsmono/inspect-common";
+import { Card, CardBody, CardHeader } from "@tsmono/react/components";
+
+import {
+  RetryAttemptCard,
+  RetryView,
+} from "./retry-display/RetryAttemptCard";
+import { RetryTerminalAnchor } from "./retry-display/RetryTerminalAnchor";
+import styles from "./SampleRetriedErrors.module.css";
+
+interface SampleRetriedErrorsProps {
+  id: string;
+  retries: EvalRetryError[];
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+export const SampleRetriedErrors: FC<SampleRetriedErrorsProps> = ({
+  id,
+  retries,
+  scrollRef,
+}) => {
+  // Accordion: default to the most recent failure (closest to the success).
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(
+    retries.length - 1,
+  );
+  const [viewByIndex, setViewByIndex] = useState<Record<number, RetryView>>({});
+
+  const onToggleOpen = useCallback((index: number) => {
+    setExpandedIndex((cur) => (cur === index ? null : index));
+  }, []);
+
+  const onViewChange = useCallback((index: number, view: RetryView) => {
+    setViewByIndex((prev) => ({ ...prev, [index]: view }));
+  }, []);
+
+  return (
+    <Card className={styles.card}>
+      <CardHeader>
+        <span className={styles.sectionLabel}>Retry Attempts</span>
+      </CardHeader>
+      <CardBody>
+        <div className={styles.timeline}>
+          <div className={styles.rail} aria-hidden="true" />
+          <div className={styles.items}>
+            {retries.map((retry, index) => (
+              <div className={styles.row} key={index}>
+                <span
+                  className={styles.statusDot}
+                  aria-hidden="true"
+                  style={{ paddingTop: 14 }}
+                />
+                <RetryAttemptCard
+                  retry={retry}
+                  index={index}
+                  attemptNumber={index + 1}
+                  isOpen={expandedIndex === index}
+                  view={viewByIndex[index] ?? "error"}
+                  onToggleOpen={() => onToggleOpen(index)}
+                  onViewChange={(view) => onViewChange(index, view)}
+                  listId={`sample-error-retries-${id}-${index}`}
+                  scrollRef={scrollRef}
+                />
+              </div>
+            ))}
+            <RetryTerminalAnchor retryCount={retries.length} />
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  );
+};
+```
+
+> The status dot sits in the left gutter on the rail; its CSS draws the dot + ring (the `paddingTop` aligns it with the card header row). `index` is a stable key here because the retries array is append-only for a given sample.
+
+- [ ] **Step 4: Replace the container CSS**
+
+Replace the entire contents of `SampleRetriedErrors.module.css` with:
+
+```css
+.card {
+  width: 100%;
+}
+
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+}
+
+.timeline {
+  position: relative;
+  margin-top: 18px;
+}
+
+/* Vertical rail behind the status dots. */
+.rail {
+  position: absolute;
+  left: 6px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: var(--bs-border-color-translucent);
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.row {
+  display: flex;
+  gap: 16px;
+}
+
+/* Failed-attempt marker: a danger dot with a soft ring, sitting on the rail. */
+.statusDot {
+  position: relative;
+  z-index: 1;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bs-danger);
+  box-shadow: 0 0 0 3px var(--bs-danger-bg-subtle);
+  box-sizing: content-box;
+}
+```
+
+> The `paddingTop: 14` inline style in the JSX offsets the dot to line up with the card's 11px-padded header text. If alignment looks off during manual verification, adjust that single value.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/SampleRetriedErrors.test.tsx`
+Expected: PASS — all 4 tests green.
+
+- [ ] **Step 6: Run the full retry-display test set + typecheck**
+
+Run: `cd apps/inspect && pnpm exec vitest run src/app/samples/retry-display src/app/samples/SampleRetriedErrors.test.tsx`
+Expected: PASS — all suites green.
+
+Run typecheck: `cd apps/inspect && pnpm typecheck` (runs `tsc --noEmit`).
+Expected: no type errors. If `inline style` lint complains, move `paddingTop: 14` into the `.statusDot` CSS class instead.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/inspect/src/app/samples/SampleRetriedErrors.tsx \
+        apps/inspect/src/app/samples/SampleRetriedErrors.module.css \
+        apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+git commit -m "feat(retries): rebuild Retries tab as a vertical timeline (Direction B)"
+```
+
+---
+
+## Task 5: Lint, build, and manual verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Lint and format the new/changed files**
+
+Run: `cd apps/inspect && pnpm exec eslint 'src/app/samples/retry-display/**/*.{ts,tsx}' src/app/samples/SampleRetriedErrors.tsx --fix`
+(or lint the whole app: `cd apps/inspect && pnpm lint`)
+Expected: no errors. Fix any reported issues and re-run.
+
+- [ ] **Step 2: Build the app**
+
+Run: `cd apps/inspect && pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual verification in the viewer**
+
+Open a log that has retried samples (a sample with `error_retries`), or run an eval with a deliberately flaky solver to produce one. In the sample view, open the **Retries** tab and confirm against the spec:
+- One card per failed attempt, on a vertical rail, with a red status dot per attempt.
+- The most-recent attempt is expanded on load; clicking another collapses it and opens the clicked one (accordion); clicking the open one collapses it.
+- Error chip shows the derived exception type; the message truncates with an ellipsis when long.
+- For attempts with events, an Error/Events toggle appears (default Error) and the Events view renders the real transcript; for attempts without events, no toggle and the traceback shows directly.
+- Terminal anchor reads "This run succeeded after N retries — the sample you're viewing" (and "1 retry" when there is exactly one).
+- Toggle **dark mode** and confirm chip/dot/rail/card backgrounds all read correctly (this is why we mapped to `--bs-*` tokens).
+
+- [ ] **Step 4: Final commit (if lint/build produced changes)**
+
+```bash
+git add -A
+git commit -m "chore(retries): lint and build fixups for retry timeline"
+```
+
+---
+
+## Self-Review notes (already reconciled against the spec)
+
+- **Spec coverage:** architecture/components → Tasks 2–4; accordion + default-open-last → Task 4; per-attempt view default Error → Task 2/4; derived error type + no-fabricated duration → Task 1; reuse `ANSIDisplay`/`TranscriptLayout` → Task 2; Bootstrap token mapping → CSS in Tasks 2–4; terminal anchor (no link/score) → Task 3; edge cases (no events, no duration, unparseable type, 1 vs N) → covered by tests in Tasks 1–4; dark mode → Task 5 manual. Out-of-scope items (RetryChip, score, schema) untouched.
+- **Type consistency:** `RetryView` defined once in `RetryAttemptCard.tsx` and imported by the container; `RetryAttemptCardProps`/`RetryTerminalAnchorProps` names match across tasks; helper signatures (`deriveErrorType(retry)`, `attemptDuration(retry)`) consistent between Task 1 and Task 2.
+- **Verified tooling:** app package is `@meridianlabs/log-viewer` with `pnpm` scripts `test` (vitest run), `lint` (eslint), `typecheck` (tsc --noEmit), `build` (vite build) — all run via `cd apps/inspect && pnpm <script>`. `TranscriptLayout` + `TranscriptCollapseState` are exported from `@tsmono/inspect-components/transcript`; `SegmentedControl` renders `segment.label` as button text (so `getByRole("button", { name })` resolves).
+```

--- a/docs/superpowers/specs/2026-06-09-retry-display-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-09-retry-display-redesign-design.md
@@ -1,0 +1,159 @@
+# Retry Display Redesign — Direction B (Vertical Timeline)
+
+**Date:** 2026-06-09
+**Branch:** `retry-display-redesign`
+**Status:** Approved design — ready for implementation plan
+
+## Summary
+
+Redesign the **Retries** tab of the Inspect AI sample viewer from the current
+attempt-dropdown + header toggle into a **vertical timeline of attempt cards**
+(Direction B from the design handoff). Each failed attempt is a card on a status
+rail; one card expands to show its error or event transcript; a terminal anchor at
+the bottom orients the user ("this run succeeded — the sample you're viewing").
+
+This is a **chrome/layout redesign**, not a data or plumbing change. The component
+already receives `retries: EvalRetryError[]` and already reuses the viewer's real
+renderers (`ANSIDisplay` for the traceback, `TranscriptLayout` for events); those
+stay. The handoff's hand-built `Traceback`/`EventsList` stand-ins are reference only.
+
+## Source material
+
+- Design handoff: `~/Downloads/design_handoff_sample_retries` (README + `variations1.jsx`
+  `VarVertical` is the target; `primitives.jsx` shows the intended atoms).
+- File to change: `apps/inspect/src/app/samples/SampleRetriedErrors.tsx` and its
+  `.module.css`.
+- Caller (unchanged): `apps/inspect/src/app/samples/SampleDisplay.tsx` — already gates
+  the panel on `sample.error_retries.length > 0`.
+
+## Data model (no changes)
+
+The retries payload is `EvalRetryError[]` — **only the failed attempts**:
+
+```ts
+EvalRetryError: {
+  message: string;        // short error message
+  traceback: string;      // full python traceback (plain)
+  traceback_ansi: string; // full traceback with ANSI color codes
+  events?: Event[] | null; // optional event transcript
+}
+```
+
+Modeling constraints carried into the design:
+- The successful final run is **not** in this array — it is the sample being viewed.
+  The terminal anchor represents it; it is orientation only.
+- **No score** is rendered here (the Scoring tab owns it).
+- **`errorType` is derived** from the traceback's final line — no dedicated field.
+- Per-attempt **duration is derived from `events[]` only**, never fabricated. The
+  prototype's `4.2s`/`3.9s` figures are placeholders. Show duration only if computable.
+
+## Decisions (confirmed with user)
+
+| Decision | Choice |
+|---|---|
+| Expand behavior | **Accordion** — one card open at a time |
+| Default open attempt | **Most recent failure** (`retries.length - 1`) |
+| Theming | **Map to Bootstrap `--bs-*` tokens** (light + dark mode) |
+| Branch | New branch `retry-display-redesign` |
+
+## Architecture & components
+
+All in `SampleRetriedErrors.tsx` (split into a small `retry-display/` folder if it
+grows). Each unit has one purpose and a clear interface.
+
+- **`SampleRetriedErrors`** (container) — owns all state; renders the `Card` panel
+  chrome (`RETRY ATTEMPTS` header with an empty right slot), the timeline rail, the
+  list of attempt cards, and the terminal anchor.
+- **`RetryAttemptCard`** — one attempt. Collapsed: header row with `Attempt N`, error
+  chip, truncated message, optional duration, chevron. Expanded: Error/Events
+  segmented toggle (only if events exist) + active view. Reuses `SegmentedControl`.
+- **`RetryTerminalAnchor`** — green-check "This run succeeded after N retries — the
+  sample you're viewing" row. No link, no score, no chevron.
+- **Helpers**:
+  - `deriveErrorType(retry): string | null` — parse the exception class from the
+    traceback's final line; return `null` (→ omit chip) when unparseable.
+  - `attemptDuration(retry): number | null` — compute from `events[]`; `null` → omit.
+
+**Reused primitives:** `Card`/`CardHeader`/`CardBody`, `SegmentedControl` (with `icon`),
+Bootstrap Icons (`bi-exclamation-triangle`, `bi-list-ul`/`bi-list-task`,
+`bi-chevron-right`/`bi-chevron-down`, `bi-check`), `ANSIDisplay`, `TranscriptLayout`.
+
+## State & interactions
+
+State held in `SampleRetriedErrors`:
+
+- **`expandedIndex: number | null`** — accordion. Defaults to `retries.length - 1`.
+  Clicking an open card's header collapses it; clicking a closed one opens it and
+  closes the previously-open one.
+- **`viewByIndex: Record<number, "error" | "events">`** — per-attempt Error/Events
+  selection, each defaulting to `"error"`, so switching cards never resets another
+  card's choice.
+- **Transcript collapse state** — preserve the existing `transcriptCollapsed` /
+  `bulkCollapse` / `initialCollapsed` machinery, scoped to the currently-expanded
+  attempt (only one card is open at a time under accordion), resetting on switch.
+
+Behavior:
+- Error/Events toggle renders only when `retry.events?.length` (same guard as today's
+  `hasEvents`); otherwise the traceback shows directly with no toggle.
+- Duration chip renders only when `attemptDuration` is non-null.
+- Status dots: failed = danger dot with a 3px ring; terminal = filled green check disc.
+- Expand/collapse: light height/opacity CSS transition (nice-to-have, non-blocking).
+- The current **attempt dropdown** and **header-level Error/Events toggle** are
+  removed — selection becomes the timeline, the toggle moves inside each card.
+
+## Styling & theme-token mapping
+
+All colors resolve through `--bs-*` variables so light and dark both work. Layout
+values (radii, padding, rail geometry, type scale) are carried over literally.
+
+| Handoff token | Maps to |
+|---|---|
+| `--text` / `--text-2` | `--bs-body-color` / `--bs-secondary-color` |
+| `--muted` / `--muted-2` | `--bs-secondary-color` / `--bs-tertiary-color` |
+| `--border` / `--rule` | `--bs-border-color` / `--bs-border-color-translucent` |
+| `--fill` / `--fill-soft` | `--bs-secondary-bg` / `--bs-tertiary-bg` |
+| `--ok*` (fill/fg/bg/bd/ring) | `--bs-success` + `--bs-success-bg-subtle` / `-border-subtle` / `-text-emphasis` |
+| `--err*` (fill/fg/bg/bd/ring) | `--bs-danger` + `--bs-danger-bg-subtle` / `-border-subtle` / `-text-emphasis` |
+| `--mono` | existing monospace stack / `text-size-*` classes |
+
+Rationale: Bootstrap's `*-bg-subtle` / `*-border-subtle` / `*-text-emphasis` families
+are exactly the "soft pill" treatment the handoff hand-tuned, and are already
+dark-mode aware. The status-dot ring (`box-shadow: 0 0 0 3px <ring>`) uses the
+subtle-bg token (or `color-mix()`) so it reads in both themes.
+
+Layout constants (from the handoff): panel radius 10px / padding 22px; card radius 8px;
+toggle track radius 7px; chip/button radius 5–6px; rail 2px wide at `left:6px`,
+`top:6px`→`bottom:6px`; status dot 14px + 3px ring; row gap 12px, dot/card gap 16px;
+type scale 11px (labels) / 12px (chips, timestamps) / 12.5–13px (body) / 13.5px (titles).
+Keep the existing `.ansi` `clamp()` font-size rule for traceback consistency.
+
+## Edge cases
+
+- **Unparseable error type** → omit the chip (message + traceback still render).
+- **No events on an attempt** → no toggle; traceback shown directly.
+- **No derivable duration** → omit the duration chip.
+- **Long message** → ellipsis-truncated single line in the collapsed header.
+- **1 retry** → timeline renders one card + terminal anchor; copy reads "after 1 retry".
+- **0 retries** → panel doesn't render (gated by caller).
+- **Many retries** → accordion bounds height; rail spans the full column.
+
+## Testing
+
+Conventions: `pytest`-independent TS tests + existing Playwright e2e
+(`apps/inspect/e2e/error-state.spec.ts`).
+
+- **Unit**: `deriveErrorType` (parses `RuntimeError` from a real traceback's last line;
+  `null` for malformed input); `attemptDuration` (value when events bracket a span,
+  `null` otherwise).
+- **Component / e2e**: N attempt cards + terminal anchor for N retries; clicking a
+  header expands it and collapses the previously-open card (accordion); most-recent
+  attempt open on load; Error/Events toggle present only with events and defaults to
+  Error; terminal copy pluralizes (1 retry vs N retries).
+- **Manual**: verify visual fidelity in the running viewer against a log with retried
+  samples, in both light and dark mode.
+
+## Out of scope
+
+- The inline-transcript `RetryChip` flow.
+- Score rendering, navigation, or deep-link affordances on the terminal anchor.
+- Any change to the `EvalRetryError` schema or data fetching.

--- a/packages/inspect-components/src/transcript/TranscriptLayout.module.css
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.module.css
@@ -16,6 +16,12 @@
   min-height: 100vh;
 }
 
+/* Embedded in another scroll container (e.g. a retry card): size to content
+   instead of reserving a full viewport. */
+.container.embedded {
+  min-height: 0;
+}
+
 .container > * {
   min-width: 0;
   padding-bottom: 1rem;

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -126,6 +126,10 @@ export interface TranscriptLayoutProps {
   // --- Scroll & positioning ---
   scrollRef: RefObject<HTMLDivElement | null>;
   offsetTop?: number;
+  /** Size the layout to its content instead of filling the viewport. Use when
+   *  embedding the transcript inside another scroll container (e.g. a card)
+   *  rather than as the page's primary scroll region. */
+  embedded?: boolean;
 
   // --- Timeline selection adapters ---
   timelineSelection?: UseTimelineProps;
@@ -281,6 +285,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   running = false,
   scrollRef,
   offsetTop = 0,
+  embedded = false,
   timelineSelection,
   activeTimeline,
   serverTimelines,
@@ -994,6 +999,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
           <div
             className={clsx(
               styles.container,
+              embedded && styles.embedded,
               !outline && styles.noOutline,
               outline && isOutlineCollapsed && styles.outlineCollapsed,
               !rightPane && styles.noRightPane,

--- a/packages/react/src/components/ExpandablePanel.module.css
+++ b/packages/react/src/components/ExpandablePanel.module.css
@@ -65,12 +65,6 @@
   color: var(--bs-body-color);
 }
 
-.separator {
-  height: 1px;
-  background-color: var(--bs-light-border-subtle);
-  margin-top: -1px;
-}
-
 /* Fills the panel so its sticky child is bounded by the panel's rect.
    pointer-events: none lets clicks pass through to the content behind;
    the sticky child re-enables pointer events on itself. */

--- a/packages/react/src/components/ExpandablePanel.tsx
+++ b/packages/react/src/components/ExpandablePanel.tsx
@@ -174,10 +174,6 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
             position="block-left"
           />
         )}
-
-        {showToggle && layout === "inline-right" && (
-          <div className={clsx(styles.separator)}></div>
-        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Rebuilds the sample viewer's **Retries** tab into a vertical timeline of expandable attempt cards (Direction B), and fixes a data bug where retry-attempt event attachments were dropped.

**UI (apps/inspect)**
- Vertical timeline of attempt cards on a status rail; the most-recent failure is open by default (accordion).
- Each failed attempt shows a status icon, `Attempt N`, the derived error-type chip, the message, and (when derivable from events) a duration.
- Expanded card header has an **Error / Events** segmented toggle (only while expanded); the body shows the traceback in an `ExpandablePanel` or the event transcript.
- Reuses the real `ANSIDisplay` (traceback) and `TranscriptLayout` (events) renderers; the transcript renders edge-to-edge via a new `embedded` mode.
- Terminal "This run succeeded after N retries" anchor (orientation only).
- Helpers `deriveErrorType` / `attemptDuration` (pure, unit-tested).

**Shared components (packages/react)**
- `ExpandablePanel`: removed the bottom separator line (across the board).

**Bug fix — retry-event attachments**
- `resolveSample` now resolves `attachment://` refs inside `error_retries[].events` (they were rendered raw).

**Docs**
- Design spec + implementation plan under `docs/superpowers/`.

> Note: the Python recorder side of the attachment fix (persisting retry-event attachment content) lives in the parent `inspect_ai` repo and is tracked separately.

## Test plan
- [x] `apps/inspect` vitest suite (423 passing) incl. retry-display + container tests
- [x] `packages/react` ExpandablePanel tests
- [x] typecheck + eslint clean; app builds
- [x] Manual verification in `inspect view` (light + dark): timeline, accordion, Error/Events toggle, edge-to-edge transcript, attachment resolution