### PR TITLE
Stable objects for default values

### DIFF
--- a/apps/inspect/src/app/samples/list/SampleList.tsx
+++ b/apps/inspect/src/app/samples/list/SampleList.tsx
@@ -43,6 +43,14 @@ interface SampleListProps {
 const makeSampleRowId = (id: string | number, epoch: number) =>
   `${id}-${epoch}`.replace(/\s+/g, "_");
 
+// Module-level so the grid sees a stable identity across renders.
+const kDefaultColDef: ColDef<SampleRow> = {
+  sortable: true,
+  filter: true,
+  resizable: true,
+  headerTooltipValueGetter: (params) => params.colDef?.headerName,
+};
+
 export const SampleList: FC<SampleListProps> = memo((props) => {
   const {
     items,
@@ -163,12 +171,7 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
         rowData={items}
         columnDefs={columns}
         columnVisibility={columnVisibility}
-        defaultColDef={{
-          sortable: true,
-          filter: true,
-          resizable: true,
-          headerTooltipValueGetter: (params) => params.colDef?.headerName,
-        }}
+        defaultColDef={kDefaultColDef}
         viewMode="list"
         multiline={multiline}
         gridRef={listHandle}

--- a/apps/inspect/src/app/samples/list/useSamplesView.ts
+++ b/apps/inspect/src/app/samples/list/useSamplesView.ts
@@ -49,12 +49,21 @@ export function useSamplesViewMultiline(): boolean {
   return useResolvedSamplesView().multiline;
 }
 
+// Stable fallbacks: a fresh `{}` per render would invalidate every
+// downstream memo (columnDefs, scoreColorScales) and re-fire the
+// `redrawRows` effect in SamplesTab on every render — tearing down and
+// recreating all grid row DOM each time.
+const kNoScoreLabels: Record<string, string> = Object.freeze({});
+const kNoScoreColorScales: Record<string, WireScoreColorScale> = Object.freeze(
+  {}
+);
+
 /** Eval-author-supplied score-label overrides. Read straight from
  *  the wire (no persistence) so a user's stored view from a prior
  *  eval can't shadow the current eval's labels. Returns an empty
  *  object when no overrides are present. */
 export function useSamplesViewScoreLabels(): Record<string, string> {
-  return useEvalDefaultSamplesView()?.score_labels ?? {};
+  return useEvalDefaultSamplesView()?.score_labels ?? kNoScoreLabels;
 }
 
 /** Eval-author-supplied score-cell colour scales. Same wire-only
@@ -66,7 +75,7 @@ export function useSamplesViewScoreColorScales(): Record<
   WireScoreColorScale
 > {
   const evalDefault = useEvalDefaultSamplesView();
-  return (evalDefault?.score_color_scales ?? {}) as Record<
+  return (evalDefault?.score_color_scales ?? kNoScoreColorScales) as Record<
     string,
     WireScoreColorScale
   >;

--- a/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/SamplesGrid.tsx
@@ -50,6 +50,9 @@ const kRotatedHeaderHeight = 115;
 const rowHeightForMode = (mode: SamplesGridViewMode): number =>
   mode === "list" ? kListModeRowHeight : kGridModeRowHeight;
 
+// Module-level so the grid sees a stable identity across renders.
+const kRowSelection = { mode: "singleRow", checkboxes: false } as const;
+
 interface SamplesGridProps<TRow> {
   rowData: TRow[];
   columnDefs: ColDef<TRow>[];
@@ -389,7 +392,7 @@ export const SamplesGrid = <TRow,>(
           headerHeight={headerHeight}
           rowHeight={effectiveRowHeight}
           getRowId={getRowId as (p: GetRowIdParams<TRow>) => string}
-          rowSelection={{ mode: "singleRow", checkboxes: false }}
+          rowSelection={kRowSelection}
           enableCellTextSelection={true}
           suppressCellFocus={true}
           domLayout="normal"


### PR DESCRIPTION
We saw some situations where clicking on rows in the table of samples wouldn't navigate into the sample. When I looked at the DOM, ng-grid was constantly re-rendering and churning the DOM.

The main issue was that the default value returned from `useSamplesViewScoreColorScales` was a new object on every render. That lack of stability would cause this `useEffect` to run repeatedly:

https://github.com/meridianlabs-ai/ts-mono/blob/c0da786415690b11dac02045eed9fca60a343252/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx#L478-L482 

Now that these values are more stable, I no longer see the ng-grid churn.