### PR TITLE
Tool block grammar for server-side and client tool calls

### DIFF
--- a/packages/inspect-components/src/chat/ChatMessage.module.css
+++ b/packages/inspect-components/src/chat/ChatMessage.module.css
@@ -10,6 +10,21 @@
   opacity: 0.7;
 }
 
+/* Segmented assistant turn: prose bands and flush tool rows stack with
+   hairline separators inside the turn container. */
+.turnSegments > * + * {
+  border-top: 1px solid var(--bs-light-border-subtle);
+}
+
+/* The prose row keeps the assistant band; the left accent is supplied here so
+   the turn reads the same outside the readable variant (which re-applies the
+   identical color via the [data-message-role] rules). Extra vertical padding
+   gives the prose rows more weight between the tool rows. */
+.proseSegment {
+  padding: 0.9rem 0.7rem;
+  border-left: 3px solid var(--inspect-readable-assistant-border);
+}
+
 .timestamp {
   opacity: 0.5;
   font-size: var(--inspect-font-size-smaller);

--- a/packages/inspect-components/src/chat/ChatMessage.tsx
+++ b/packages/inspect-components/src/chat/ChatMessage.tsx
@@ -1,7 +1,11 @@
 import clsx from "clsx";
 import { FC, memo, ReactNode, useState } from "react";
 
-import type { ContentImage, ContentText } from "@tsmono/inspect-common/types";
+import type {
+  ContentImage,
+  ContentText,
+  ContentToolUse,
+} from "@tsmono/inspect-common/types";
 import {
   CopyButton,
   ExpandablePanel,
@@ -13,8 +17,10 @@ import {
 import { RecordTree } from "../content/RecordTree";
 
 import styles from "./ChatMessage.module.css";
-import { MessageContents } from "./MessageContents";
-import { Message } from "./messages";
+import { MessageContent } from "./MessageContent";
+import { defaultContext, MessageContents } from "./MessageContents";
+import { hasServerToolUse, Message } from "./messages";
+import { ServerToolCall } from "./server-tools/ServerToolCall";
 import {
   codexToolMarkdown,
   formatSubagentNotifications,
@@ -89,13 +95,13 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
       : undefined;
 
   // When the role header is hidden, skip rendering if there's no visible
-  // text content (e.g. assistant messages with only tool_calls).
+  // content (e.g. assistant messages with only tool_calls).
   if (hideRole) {
     const content = message.content;
     const hasVisibleContent =
       typeof content === "string"
         ? content.trim().length > 0
-        : Array.isArray(content) && content.some((c) => c.type !== "tool_use");
+        : Array.isArray(content) && content.length > 0;
     const hasToolCalls =
       "tool_calls" in message &&
       Array.isArray(message.tool_calls) &&
@@ -103,6 +109,125 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
     if (!hasVisibleContent && !hasToolCalls) {
       return null;
     }
+  }
+
+  const roleHeader = !hideRole ? (
+    <div
+      className={clsx(
+        styles.messageGrid,
+        message.role === "tool" ? styles.toolMessageGrid : undefined,
+        "text-style-label"
+      )}
+    >
+      <div>
+        {message.role}
+        {message.role === "tool"
+          ? message.function
+            ? `: ${message.function}`
+            : ""
+          : ""}
+        {linkingEnabled && messageUrl ? (
+          <CopyButton
+            icon={linkIcon}
+            value={messageUrl}
+            className={clsx(styles.copyLink)}
+          />
+        ) : (
+          ""
+        )}
+      </div>
+      {(message.timestamp && formatDateTime) || label ? (
+        <div className={styles.headerEnd}>
+          {message.timestamp && formatDateTime && (
+            <span className={styles.timestamp} title={message.timestamp}>
+              {formatDateTime(new Date(message.timestamp))}
+            </span>
+          )}
+          {label}
+        </div>
+      ) : null}
+    </div>
+  ) : null;
+
+  const metadataBlock =
+    message.metadata && Object.keys(message.metadata).length > 0 ? (
+      <LabeledValue
+        label="Metadata"
+        className={clsx(styles.metadataLabel, "text-size-smaller")}
+      >
+        <RecordTree
+          record={message.metadata}
+          id={`${id}-metadata`}
+          defaultExpandLevel={0}
+          copyButton={true}
+        />
+      </LabeledValue>
+    ) : null;
+
+  // An assistant turn with server-side tool calls renders as one seamless
+  // container: prose rows keep the assistant band, each tool_use stacks as a
+  // flush tool block row, separated by hairlines.
+  const segments = segmentTurnContent(message);
+  if (segments) {
+    const context = defaultContext();
+    return (
+      <div
+        data-message-id={message.id || undefined}
+        className={clsx(
+          message.role,
+          "text-size-base",
+          styles.message,
+          styles.turnSegments,
+          mouseOver ? styles.hover : undefined
+        )}
+        onMouseEnter={() => setMouseOver(true)}
+        onMouseLeave={() => setMouseOver(false)}
+      >
+        {segments.map((segment, index) => {
+          if (segment.kind === "tool") {
+            return (
+              <ServerToolCall
+                key={`${id}-segment-${index}`}
+                id={`${id}-server-tool-${index}`}
+                content={segment.content}
+              />
+            );
+          }
+          // An empty leading prose segment still renders when it hosts the
+          // role header (the turn starts directly with a tool call).
+          if (segment.contents.length === 0 && (index > 0 || hideRole)) {
+            return null;
+          }
+          return (
+            <div
+              key={`${id}-segment-${index}`}
+              data-message-role={message.role}
+              className={styles.proseSegment}
+            >
+              {index === 0 ? roleHeader : null}
+              {segment.contents.length > 0 ? (
+                <ExpandablePanel
+                  id={`${id}-message-${index}`}
+                  collapse={collapse}
+                  lines={25}
+                >
+                  <MessageContent
+                    contents={segment.contents}
+                    context={context}
+                    references={references}
+                  />
+                </ExpandablePanel>
+              ) : null}
+            </div>
+          );
+        })}
+        {metadataBlock ? (
+          <div data-message-role={message.role} className={styles.proseSegment}>
+            {metadataBlock}
+          </div>
+        ) : null}
+      </div>
+    );
   }
 
   return (
@@ -119,43 +244,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
       onMouseEnter={() => setMouseOver(true)}
       onMouseLeave={() => setMouseOver(false)}
     >
-      {!hideRole && (
-        <div
-          className={clsx(
-            styles.messageGrid,
-            message.role === "tool" ? styles.toolMessageGrid : undefined,
-            "text-style-label"
-          )}
-        >
-          <div>
-            {message.role}
-            {message.role === "tool"
-              ? message.function
-                ? `: ${message.function}`
-                : ""
-              : ""}
-            {linkingEnabled && messageUrl ? (
-              <CopyButton
-                icon={linkIcon}
-                value={messageUrl}
-                className={clsx(styles.copyLink)}
-              />
-            ) : (
-              ""
-            )}
-          </div>
-          {(message.timestamp && formatDateTime) || label ? (
-            <div className={styles.headerEnd}>
-              {message.timestamp && formatDateTime && (
-                <span className={styles.timestamp} title={message.timestamp}>
-                  {formatDateTime(new Date(message.timestamp))}
-                </span>
-              )}
-              {label}
-            </div>
-          ) : null}
-        </div>
-      )}
+      {roleHeader}
       <div
         className={clsx(
           styles.messageContents,
@@ -203,22 +292,35 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
           )}
         </ExpandablePanel>
 
-        {message.metadata && Object.keys(message.metadata).length > 0 ? (
-          <LabeledValue
-            label="Metadata"
-            className={clsx(styles.metadataLabel, "text-size-smaller")}
-          >
-            <RecordTree
-              record={message.metadata}
-              id={`${id}-metadata`}
-              defaultExpandLevel={0}
-              copyButton={true}
-            />
-          </LabeledValue>
-        ) : (
-          ""
-        )}
+        {metadataBlock}
       </div>
     </div>
   );
 });
+
+type TurnSegment =
+  | { kind: "prose"; contents: Exclude<Message["content"], string> }
+  | { kind: "tool"; content: ContentToolUse };
+
+/** Splits an assistant message that carries server-side tool calls into
+ * alternating prose / tool-call segments (in content order). Returns
+ * undefined for messages that render the regular way. */
+const segmentTurnContent = (message: Message): TurnSegment[] | undefined => {
+  if (!hasServerToolUse(message) || !Array.isArray(message.content)) {
+    return undefined;
+  }
+  const segments: TurnSegment[] = [{ kind: "prose", contents: [] }];
+  for (const item of message.content) {
+    if (item.type === "tool_use") {
+      segments.push({ kind: "tool", content: item });
+    } else {
+      const last = segments[segments.length - 1];
+      if (last?.kind === "prose") {
+        last.contents.push(item);
+      } else {
+        segments.push({ kind: "prose", contents: [item] });
+      }
+    }
+  }
+  return segments;
+};

--- a/packages/inspect-components/src/chat/ChatMessageRow.module.css
+++ b/packages/inspect-components/src/chat/ChatMessageRow.module.css
@@ -50,9 +50,19 @@
   background-color: rgba(var(--bs-info-rgb), 0.12);
 }
 
-/* Prototype: self-contained box (used when tool calls are un-embedded) so the
-   assistant message and each tool call read as separate cards rather than one
-   connected band. */
+/* Assistant turn with server-side tool calls: one seamless container — the
+   prose band and flush tool rows inside supply their own left edges, so the
+   frame itself has no left border. */
+.turnContainer {
+  border: 1px solid var(--bs-light-border-subtle);
+  border-left: none;
+  border-radius: var(--bs-border-radius);
+  overflow: hidden;
+}
+
+/* Self-contained box (used when tool calls are un-embedded) so the assistant
+   message and each tool call read as separate cards rather than one connected
+   band. */
 .box {
   position: relative;
   border: solid 1px var(--bs-light-border-subtle);
@@ -60,33 +70,16 @@
   padding: 0.7rem;
 }
 
-/* An assistant turn rendered as one connected stack: the message, its tool
-   call(s), and output(s) sit flush so they read as a single card with a
-   continuous left gutter. */
-.attachedGroup {
-  display: flex;
-  flex-direction: column;
-}
-
-.attachedBottom {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  /* Drop the divider so the call/output pair reads as one seamless card —
-     only the background color shifts (blue call → gray output). */
-  border-bottom: 0;
-}
-
-.attachedTop {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-top: 0;
+/* Tool blocks carry their own frame; the wrapper only anchors the chip. */
+.toolPart {
+  position: relative;
 }
 
 /* Tool-call number chip, pinned to the top-right of its box to mirror the
    position chip on a message's role line. */
 .toolLabel {
   position: absolute;
-  top: 0.7rem;
+  top: 0.45rem;
   right: 0.7rem;
   z-index: 1;
 }

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -125,7 +125,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
     let idx = 0;
     for (const tool_call of resolvedMessage.message.tool_calls) {
       // Extract tool input
-      const { name, input, description, functionCall, contentType } =
+      const { name, input, description, functionCall, contentType, title } =
         resolveToolInput(tool_call.function, tool_call.arguments);
 
       let toolMessage: ChatMessageTool | undefined;
@@ -159,6 +159,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
             id={`${index}-tool-call-${idx}`}
             key={`tool-call-${idx}`}
             tool={name}
+            title={resolvedToolView?.title || title}
             functionCall={functionCall}
             input={input}
             description={description}

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -7,10 +7,9 @@ import type { MarkdownReference } from "@tsmono/react/components";
 import { ChatMessage } from "./ChatMessage";
 import styles from "./ChatMessageRow.module.css";
 import { MessageLabel } from "./MessageLabel";
-import { Message, ResolvedMessage } from "./messages";
+import { hasServerToolUse, Message, ResolvedMessage } from "./messages";
+import { ClientToolCall } from "./tools/ClientToolCall";
 import { resolveToolInput, substituteToolCallContent } from "./tools/tool";
-import { ToolCallErrorView } from "./tools/ToolCallErrorView";
-import { ToolCallView } from "./tools/ToolCallView";
 import {
   ChatViewDisplayOptions,
   ChatViewLabelOptions,
@@ -57,7 +56,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
   const getCustomToolView = tools?.renderToolCall;
 
   const views: ReactNode[] = [];
-  const viewKinds: Array<"message" | "tool" | "tool-result"> = [];
+  const viewKinds: Array<"message" | "tool"> = [];
   const viewChips: Array<ReactNode | undefined> = [];
   const useLabels = showLabels || Object.keys(labelValues || {}).length > 0;
 
@@ -145,8 +144,9 @@ export const ChatMessageRow = memo(function ChatMessageRow({
         ? substituteToolCallContent(tool_call.view, tool_call.arguments)
         : undefined;
 
-      // The call (title + input) is one peer block; its output (or error) is a
-      // separate peer block beneath it. Compact mode keeps the single line.
+      // Each tool call is one self-contained block: collapsible header with
+      // the input zone and output well beneath. Compact mode keeps the
+      // single line.
       if (toolCallStyle === "compact") {
         views.push(
           <ToolCallViewCompact idx={idx} functionCall={functionCall} />
@@ -155,7 +155,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
         viewChips.push(undefined);
       } else {
         views.push(
-          <ToolCallView
+          <ClientToolCall
             id={`${index}-tool-call-${idx}`}
             key={`tool-call-${idx}`}
             tool={name}
@@ -164,49 +164,20 @@ export const ChatMessageRow = memo(function ChatMessageRow({
             description={description}
             contentType={contentType}
             output={resolvedToolOutput}
+            error={toolMessage?.error ?? undefined}
             view={resolvedToolView}
-            section="call"
             getCustomToolView={getCustomToolView}
           />
         );
         viewKinds.push("tool");
-        // The position chip sits on the call (the blue tool box). Tools inherit
-        // the parent message's citation when a label map is supplied.
+        // The position chip sits on the tool block. Tools inherit the parent
+        // message's citation when a label map is supplied.
         const toolLabel = useLabels
           ? labelForBlock(resolvedMessage.message.id, toolNumber)
           : undefined;
         viewChips.push(
           toolLabel?.trim() ? <MessageLabel label={toolLabel} /> : undefined
         );
-
-        if (toolMessage?.error) {
-          views.push(
-            <ToolCallErrorView
-              key={`tool-call-${idx}-error`}
-              error={toolMessage.error}
-            />
-          );
-          viewKinds.push("tool-result");
-          viewChips.push(undefined);
-        } else if (hasOutputContent(resolvedToolOutput)) {
-          views.push(
-            <ToolCallView
-              id={`${index}-tool-call-${idx}`}
-              key={`tool-call-${idx}-output`}
-              tool={name}
-              functionCall={functionCall}
-              input={input}
-              description={description}
-              contentType={contentType}
-              output={resolvedToolOutput}
-              view={resolvedToolView}
-              section="output"
-              getCustomToolView={getCustomToolView}
-            />
-          );
-          viewKinds.push("tool-result");
-          viewChips.push(undefined);
-        }
       }
       toolNumber++;
 
@@ -224,34 +195,41 @@ export const ChatMessageRow = memo(function ChatMessageRow({
   if (useLabels || hasTools) {
     // Each row part is a peer block: the message in its role band, the tool
     // call in the blue tool box, and the tool output in a plain bordered box.
-    const renderPart = (
-      idx: number,
-      attached?: { top?: boolean; bottom?: boolean }
-    ) => {
+    const renderPart = (idx: number) => {
       const kind = viewKinds[idx];
       const isMessage = kind === "message";
+      // A message with server-side tool calls is a seamless turn container:
+      // ChatMessage renders the band/tool rows internally, so the wrapper
+      // carries the container frame instead of the role band.
+      const isTurn = isMessage && hasServerToolUse(resolvedMessage.message);
       const chip = viewChips[idx];
       return (
         <div
           key={`chat-message-row-${index}-part-${idx}`}
           data-message-role={
-            isMessage ? resolvedMessage.message.role : undefined
+            isMessage && !isTurn ? resolvedMessage.message.role : undefined
           }
-          data-message-kind={kind}
+          data-message-kind={isMessage ? kind : undefined}
           className={clsx(
-            isMessage && styles.container,
-            hasTools ? styles.box : undefined,
+            isMessage && !isTurn && styles.container,
+            isTurn
+              ? styles.turnContainer
+              : isMessage && hasTools
+                ? styles.box
+                : undefined,
+            !isMessage ? styles.toolPart : undefined,
             isMessage &&
+              !isTurn &&
               highlightUserMessage &&
               resolvedMessage.message.role === "user"
               ? styles.user
               : undefined,
-            isMessage && !hasTools && idx === 0 ? styles.first : undefined,
-            isMessage && !hasTools && idx === views.length - 1
+            isMessage && !isTurn && !hasTools && idx === 0
+              ? styles.first
+              : undefined,
+            isMessage && !isTurn && !hasTools && idx === views.length - 1
               ? styles.last
               : undefined,
-            attached?.bottom ? styles.attachedBottom : undefined,
-            attached?.top ? styles.attachedTop : undefined,
             highlightLabeled && isMessage && messageChip
               ? styles.highlight
               : undefined
@@ -263,41 +241,28 @@ export const ChatMessageRow = memo(function ChatMessageRow({
       );
     };
 
-    // Attach a tool output to the bottom of its call so the call/output read as
-    // one connected card; the assistant message stays a separate peer above.
-    const items: ReactNode[] = [];
-    for (let idx = 0; idx < views.length; idx++) {
-      if (viewKinds[idx] === "tool" && viewKinds[idx + 1] === "tool-result") {
-        items.push(
-          <div
-            key={`chat-message-row-${index}-toolgroup-${idx}`}
-            className={styles.attachedGroup}
-          >
-            {renderPart(idx, { bottom: true })}
-            {renderPart(idx + 1, { top: true })}
-          </div>
-        );
-        idx++;
-      } else {
-        items.push(renderPart(idx));
-      }
-    }
-
-    return <div className={clsx(styles.grid, className)}>{items}</div>;
+    return (
+      <div className={clsx(styles.grid, className)}>
+        {views.map((_, idx) => renderPart(idx))}
+      </div>
+    );
   } else {
+    const isTurn = hasServerToolUse(resolvedMessage.message);
     return views.map((view, idx) => {
       return (
         <div
           key={`chat-message-row-unlabeled-${index}-part-${idx}`}
-          data-message-role={resolvedMessage.message.role}
+          data-message-role={isTurn ? undefined : resolvedMessage.message.role}
           className={clsx(
-            styles.container,
-            idx === 0 ? styles.first : undefined,
-            idx === views.length - 1 ? styles.last : undefined,
+            isTurn ? styles.turnContainer : styles.container,
+            !isTurn && idx === 0 ? styles.first : undefined,
+            !isTurn && idx === views.length - 1 ? styles.last : undefined,
             idx === views.length - 1 ? styles.bottomMargin : undefined,
             className,
-            styles.simple,
-            highlightUserMessage && resolvedMessage.message.role === "user"
+            !isTurn && styles.simple,
+            !isTurn &&
+              highlightUserMessage &&
+              resolvedMessage.message.role === "user"
               ? styles.user
               : undefined
           )}
@@ -389,15 +354,6 @@ const resolveToolMessage = (toolMessage?: ChatMessageTool): ContentTool[] => {
   }
 };
 
-// Whether a resolved tool output has anything worth rendering in its own
-// result box (skip an empty box when the call produced no output).
-const hasOutputContent = (output: ContentTool[]): boolean =>
-  output.some((tool) =>
-    tool.content.some(
-      (item) => item.type !== "text" || item.text.trim().length > 0
-    )
-  );
-
 const hasVisibleContent = (message: Message): boolean => {
   const content = message.content;
   if (typeof content === "string") {
@@ -408,7 +364,9 @@ const hasVisibleContent = (message: Message): boolean => {
   }
   return content.some((c) => {
     if (c.type === "tool_use") {
-      return false;
+      // Server-side tool calls render as their own rows of the turn
+      // container, so they make the message worth rendering.
+      return true;
     }
     if (c.type === "text") {
       const hasText = c.text.trim().length > 0;

--- a/packages/inspect-components/src/chat/MessageContent.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.tsx
@@ -266,12 +266,13 @@ const messageRenderers: Record<string, MessageRenderer> = {
       return <ToolOutput output={c.content} key={key} />;
     },
   },
-  // server-side tool use
+  // server-side tool use. Assistant turns render these as flush rows of the
+  // turn container (see ChatMessage); this fallback covers any other context,
+  // so the block carries its own frame.
   tool_use: {
     render: (key, content) => {
       const c = content as ContentToolUse;
-      // If the tool use has a tool, render it
-      return <ServerToolCall id={key} content={c} />;
+      return <ServerToolCall id={key} content={c} flush={false} />;
     },
   },
   data: {

--- a/packages/inspect-components/src/chat/index.ts
+++ b/packages/inspect-components/src/chat/index.ts
@@ -29,11 +29,7 @@ export type { ToolCallViewProps } from "./tools/ToolCallView";
 export { ToolCallView } from "./tools/ToolCallView";
 export type { ClientToolCallProps } from "./tools/ClientToolCall";
 export { ClientToolCall } from "./tools/ClientToolCall";
-export {
-  ToolBlock,
-  ToolBlockInput,
-  ToolBlockOutput,
-} from "./tools/ToolBlock";
+export { ToolBlock, ToolBlockInput, ToolBlockOutput } from "./tools/ToolBlock";
 export { ToolCallErrorView } from "./tools/ToolCallErrorView";
 export { ToolOutput } from "./tools/ToolOutput";
 export { MessageContent, isMessageContent } from "./MessageContent";

--- a/packages/inspect-components/src/chat/index.ts
+++ b/packages/inspect-components/src/chat/index.ts
@@ -27,6 +27,13 @@ export {
 // Components
 export type { ToolCallViewProps } from "./tools/ToolCallView";
 export { ToolCallView } from "./tools/ToolCallView";
+export type { ClientToolCallProps } from "./tools/ClientToolCall";
+export { ClientToolCall } from "./tools/ClientToolCall";
+export {
+  ToolBlock,
+  ToolBlockInput,
+  ToolBlockOutput,
+} from "./tools/ToolBlock";
 export { ToolCallErrorView } from "./tools/ToolCallErrorView";
 export { ToolOutput } from "./tools/ToolOutput";
 export { MessageContent, isMessageContent } from "./MessageContent";

--- a/packages/inspect-components/src/chat/messages.ts
+++ b/packages/inspect-components/src/chat/messages.ts
@@ -32,6 +32,17 @@ export interface ResolvedMessage {
   toolMessages: ChatMessageTool[];
 }
 
+/** Whether an assistant message carries server-side tool calls (provider
+ * executed `tool_use` content blocks) — these render as flush rows of the
+ * assistant turn container rather than as message body. */
+export const hasServerToolUse = (message: Message): boolean => {
+  return (
+    message.role === "assistant" &&
+    Array.isArray(message.content) &&
+    message.content.some((c) => c.type === "tool_use")
+  );
+};
+
 export const resolveMessages = (messages: ChatMessage[]): ResolvedMessage[] => {
   // Filter tool messages into a sidelist that the chat stream
   // can use to lookup the tool responses

--- a/packages/inspect-components/src/chat/server-tools/ServerToolCall.module.css
+++ b/packages/inspect-components/src/chat/server-tools/ServerToolCall.module.css
@@ -1,42 +1,18 @@
-.mcpToolUse {
-  margin-left: 0.5em;
-  margin-top: 2em;
-  margin-bottom: 2em;
-  padding: 0.25em 0.75em;
-  border-left: solid 5px var(--bs-border-color);
+.tool {
+  margin-bottom: 0.5em;
 }
 
-.title {
-  margin-bottom: 0.25em;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  column-gap: 0.3em;
-  align-items: baseline;
-  border-bottom: solid 1px var(--bs-border-color);
-}
-
-.titleText {
-  margin-bottom: 0;
-}
-
-.args {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: 0.5em;
-  row-gap: 0.1em;
-  margin-bottom: 1em;
-  align-items: baseline;
-}
-
-.argLabel pre {
+.execOutput {
   margin: 0;
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  font-size: var(--inspect-font-size-smaller);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
-.error {
-  color: red;
-  font-weight: bold;
-}
-
-.toolPanel {
-  display: contents;
+.execError {
+  color: var(--inspect-tool-error-color);
 }

--- a/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
+++ b/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
@@ -1,145 +1,260 @@
 import clsx from "clsx";
-import { FC, ReactNode } from "react";
+import { FC } from "react";
 
 import type { ContentToolUse } from "@tsmono/inspect-common/types";
 import { ExpandablePanel } from "@tsmono/react/components";
 import { asJsonObjArray, isJson } from "@tsmono/util";
 
-import { useContentIcons } from "../../content/IconsContext";
 import { RecordTree } from "../../content/RecordTree";
 import { RenderedContent } from "../../content/RenderedContent";
+import { iconForTool } from "../tools/tool";
+import { ToolBlock, ToolBlockInput, ToolBlockOutput } from "../tools/ToolBlock";
+import { ToolCallErrorView } from "../tools/ToolCallErrorView";
+import { ToolInput } from "../tools/ToolInput";
 
 import styles from "./ServerToolCall.module.css";
 
 interface ServerToolCallProps {
   id?: string;
   content: ContentToolUse;
+  /** Flush rows stack inside the assistant turn container; standalone
+   * renders carry their own frame (border + radius). */
+  flush?: boolean;
   className?: string | string[];
 }
 
 /**
- * Renders the ToolOutput component.
+ * Renders a server-side tool call (web_search, web_fetch, provider-executed
+ * MCP tools) as a flush row of the assistant turn: the shared tool block
+ * grammar with a globe icon and a neutral "server" pill as the only server
+ * signals.
  */
 export const ServerToolCall: FC<ServerToolCallProps> = ({
   id,
   content,
+  flush = true,
   className,
 }) => {
-  return <McpToolUse id={id} content={content} className={className} />;
-};
-
-const McpToolUse: FC<ServerToolCallProps> = ({ id, content, className }) => {
-  const icons = useContentIcons();
-
-  // Resolve the arguments from the content
   const args = resolveArgs(content);
+  const title = content.context
+    ? `${content.context} — ${content.name}`
+    : content.name;
 
-  const titleStr = content.context
-    ? `${content.context} — ${content.name}()`
-    : `${content.name}()`;
+  // Multi-line string args (code bodies) get a real input zone; only short
+  // args (the query for web_search, the URL for web_fetch) summarize on the
+  // header line.
+  const summaryArgs: Record<string, unknown> = {};
+  const inputArgs: Array<[string, string]> = [];
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === "string" && value.includes("\n")) {
+      inputArgs.push([key, value]);
+    } else {
+      summaryArgs[key] = value;
+    }
+  }
 
   const listToolsResult = maybeListTools(content);
   const webSearchResult = maybeWebSearchResult(content);
+  const codeExecutionResult = maybeCodeExecution(content);
+  const execHasOutput =
+    !!codeExecutionResult &&
+    (!!codeExecutionResult.stdout ||
+      !!codeExecutionResult.stderr ||
+      codeExecutionResult.encrypted ||
+      (codeExecutionResult.returnCode ?? 0) !== 0);
+  const hasResult =
+    !!content.error ||
+    !!listToolsResult ||
+    !!webSearchResult ||
+    (codeExecutionResult
+      ? execHasOutput
+      : hasResultContent(content.result));
 
   return (
-    <div id={id} className={clsx(styles.mcpToolUse, className)}>
-      <div
-        className={clsx(
-          styles.title,
-          "text-size-small",
-          "text-style-secondary"
-        )}
-      >
-        <i className={icons.role.tool} />
-        <pre className={styles.titleText}>{titleStr}</pre>
-        <div className={styles.type}>{content.type}</div>
-      </div>
-
-      <div className={styles.args}>
-        {Object.keys(args).map((key, index) => {
-          const value = args[key];
-
-          let valueRecord: Record<string, unknown> | undefined = undefined;
-          if (Array.isArray(value)) {
-            valueRecord = {};
-            for (let i = 0; i < value.length; i++) {
-              valueRecord[`[${i}]`] = value[i];
-            }
-          } else if (value && typeof value === "object") {
-            valueRecord = value as Record<string, unknown>;
-          }
-
-          return (
-            <>
-              <LabelDiv label={key} />
-              {valueRecord ? (
-                <RecordTree id={`${id}-val-${index}`} record={valueRecord} />
-              ) : (
-                <ValueDiv>{value as ReactNode}</ValueDiv>
-              )}
-            </>
-          );
-        })}
-
-        {webSearchResult ? (
-          <>
-            <LabelDiv label={"results"} />
-            <ValueDiv>
-              {webSearchResult.result.map((result, index) => (
-                <div key={index} className={styles.result}>
-                  <a
-                    href={result.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {result.title}
-                  </a>
-                </div>
-              ))}
-            </ValueDiv>
-          </>
-        ) : undefined}
-
-        {listToolsResult
-          ? listToolsResult.result.map((tool, index) => (
-              <>
-                <ExpandablePanel
-                  id={`${id}-output`}
-                  collapse={true}
-                  className={clsx(styles.toolPanel)}
-                >
-                  <LabelDiv label={tool.name} />
-                  <ValueDiv>
-                    <div>{tool.description}</div>
-                    <RecordTree
-                      id={`${id}-tool-${index}`}
-                      record={{ schema: tool.input_schema }}
-                      defaultExpandLevel={0}
-                    />
-                  </ValueDiv>
-                </ExpandablePanel>
-              </>
-            ))
-          : undefined}
-      </div>
-
-      {content.error ? (
-        <div className={styles.error}>
-          <span>Error: {content.error}</span>
-        </div>
-      ) : !listToolsResult && !webSearchResult ? (
-        <div className={clsx("text-size-small")}>
-          <ExpandablePanel id={`${id}-output`} collapse={true}>
-            <RenderedContent
-              id={`${id}-output`}
-              entry={{ name: "Output", value: content.result }}
-              renderOptions={{ renderString: "markdown" }}
-            />
+    <ToolBlock
+      id={id}
+      flush={flush}
+      icon={iconForTool(content.name, { server: true })}
+      title={title}
+      summary={argsSummary(summaryArgs)}
+      pill="server"
+      className={className}
+    >
+      {inputArgs.length > 0 ? (
+        <ToolBlockInput>
+          <ExpandablePanel
+            id={`${id}-input`}
+            collapse={true}
+            border={false}
+            lines={20}
+            className={"text-size-small"}
+          >
+            {inputArgs.map(([key, value]) => (
+              <ToolInput
+                key={key}
+                contentType={
+                  content.tool_type === "code_execution" ? "python" : undefined
+                }
+                contents={value}
+              />
+            ))}
           </ExpandablePanel>
-        </div>
-      ) : undefined}
-    </div>
+        </ToolBlockInput>
+      ) : null}
+      {hasResult ? (
+        <ToolBlockOutput>
+          {content.error ? (
+            <ToolCallErrorView
+              error={{ type: "unknown", message: content.error }}
+            />
+          ) : webSearchResult ? (
+            <WebSearchResults id={id} results={webSearchResult.result} />
+          ) : listToolsResult ? (
+            <ListToolsResult id={id} tools={listToolsResult.result} />
+          ) : codeExecutionResult ? (
+            <CodeExecutionResult id={id} result={codeExecutionResult} />
+          ) : (
+            <ExpandablePanel
+              id={`${id}-output`}
+              collapse={true}
+              border={false}
+              lines={15}
+            >
+              <RenderedContent
+                id={`${id}-output`}
+                entry={{ name: "Output", value: content.result }}
+                renderOptions={{ renderString: "markdown" }}
+              />
+            </ExpandablePanel>
+          )}
+        </ToolBlockOutput>
+      ) : null}
+    </ToolBlock>
   );
+};
+
+const WebSearchResults: FC<{ id?: string; results: WebResult[] }> = ({
+  id,
+  results,
+}) => {
+  return (
+    <ExpandablePanel
+      id={`${id}-output`}
+      collapse={true}
+      border={false}
+      lines={15}
+    >
+      {results.map((result, index) => (
+        <div key={index}>
+          <a href={result.url} target="_blank" rel="noopener noreferrer">
+            {result.title}
+          </a>
+        </div>
+      ))}
+    </ExpandablePanel>
+  );
+};
+
+const ListToolsResult: FC<{ id?: string; tools: ToolInfo[] }> = ({
+  id,
+  tools,
+}) => {
+  return (
+    <ExpandablePanel
+      id={`${id}-output`}
+      collapse={true}
+      border={false}
+      lines={15}
+    >
+      {tools.map((tool, index) => (
+        <div key={tool.name} className={styles.tool}>
+          <code className="text-size-smaller">{tool.name}</code>
+          <div className="text-size-smaller">{tool.description}</div>
+          <RecordTree
+            id={`${id}-tool-${index}`}
+            record={{ schema: tool.input_schema }}
+            defaultExpandLevel={0}
+          />
+        </div>
+      ))}
+    </ExpandablePanel>
+  );
+};
+
+const CodeExecutionResult: FC<{
+  id?: string;
+  result: CodeExecutionOutput;
+}> = ({ id, result }) => {
+  return (
+    <ExpandablePanel
+      id={`${id}-output`}
+      collapse={true}
+      border={false}
+      lines={15}
+    >
+      {result.stdout ? <pre className={styles.execOutput}>{result.stdout}</pre> : null}
+      {result.stderr ? (
+        <pre className={clsx(styles.execOutput, styles.execError)}>
+          {result.stderr}
+        </pre>
+      ) : null}
+      {!result.stdout && !result.stderr && result.encrypted ? (
+        <div className={clsx("text-style-secondary", "text-size-smaller")}>
+          Output encrypted by the model provider.
+        </div>
+      ) : null}
+      {typeof result.returnCode === "number" && result.returnCode !== 0 ? (
+        <div className={clsx("text-style-secondary", "text-size-smaller")}>
+          exit code {result.returnCode}
+        </div>
+      ) : null}
+    </ExpandablePanel>
+  );
+};
+
+interface CodeExecutionOutput {
+  stdout?: string;
+  stderr?: string;
+  returnCode?: number;
+  encrypted: boolean;
+}
+
+/** Parses a code_execution result payload into stdout/stderr/exit code.
+ * Returns undefined when the result isn't the expected JSON shape (the
+ * generic markdown rendering applies instead). */
+const maybeCodeExecution = (
+  content: ContentToolUse
+): CodeExecutionOutput | undefined => {
+  if (content.tool_type !== "code_execution" || !isJson(content.result)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(content.result) as Record<string, unknown>;
+    if (typeof parsed !== "object" || parsed === null) {
+      return undefined;
+    }
+    // The execution payload nests under `content` (Anthropic's
+    // code_execution_tool_result shape); fall back to the top level.
+    const payload =
+      typeof parsed.content === "object" &&
+      parsed.content !== null &&
+      !Array.isArray(parsed.content)
+        ? (parsed.content as Record<string, unknown>)
+        : parsed;
+    const str = (value: unknown): string | undefined =>
+      typeof value === "string" && value.length > 0 ? value : undefined;
+    return {
+      stdout: str(payload.stdout),
+      stderr: str(payload.stderr),
+      returnCode:
+        typeof payload.return_code === "number"
+          ? payload.return_code
+          : undefined,
+      encrypted: typeof payload.encrypted_stdout === "string",
+    };
+  } catch {
+    return undefined;
+  }
 };
 
 const resolveArgs = (content: ContentToolUse): Record<string, unknown> => {
@@ -165,6 +280,28 @@ const resolveArgs = (content: ContentToolUse): Record<string, unknown> => {
   }
 };
 
+/** Single-line header summary: the lone arg's value (the query for
+ * web_search, the URL for web_fetch), or `key: value` pairs otherwise. */
+const argsSummary = (args: Record<string, unknown>): string => {
+  const entries = Object.entries(args);
+  const single = entries.length === 1 ? entries[0] : undefined;
+  if (single && typeof single[1] === "string") {
+    return single[1];
+  }
+  return entries
+    .map(
+      ([key, value]) =>
+        `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`
+    )
+    .join(", ");
+};
+
+const hasResultContent = (result: ContentToolUse["result"]): boolean => {
+  if (result === null || result === undefined) return false;
+  if (typeof result === "string") return result.trim().length > 0;
+  return true;
+};
+
 const maybeWebSearchResult = (
   content: ContentToolUse
 ): { result: WebResult[] } | undefined => {
@@ -187,24 +324,6 @@ const maybeListTools = (
   if (objArray !== undefined) {
     return { result: objArray as ToolInfo[] };
   }
-};
-
-const LabelDiv: FC<{ label: string }> = ({ label }) => {
-  return (
-    <div
-      className={clsx(
-        styles.argLabel,
-        "text-style-secondary",
-        "text-size-smaller"
-      )}
-    >
-      <pre>{label}</pre>
-    </div>
-  );
-};
-
-const ValueDiv: FC<{ children: ReactNode }> = ({ children }) => {
-  return <div className={clsx("text-size-smaller")}>{children}</div>;
 };
 
 interface WebResult {

--- a/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
+++ b/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
@@ -66,9 +66,7 @@ export const ServerToolCall: FC<ServerToolCallProps> = ({
     !!content.error ||
     !!listToolsResult ||
     !!webSearchResult ||
-    (codeExecutionResult
-      ? execHasOutput
-      : hasResultContent(content.result));
+    (codeExecutionResult ? execHasOutput : hasResultContent(content.result));
 
   return (
     <ToolBlock
@@ -192,7 +190,9 @@ const CodeExecutionResult: FC<{
       border={false}
       lines={15}
     >
-      {result.stdout ? <pre className={styles.execOutput}>{result.stdout}</pre> : null}
+      {result.stdout ? (
+        <pre className={styles.execOutput}>{result.stdout}</pre>
+      ) : null}
       {result.stderr ? (
         <pre className={clsx(styles.execOutput, styles.execError)}>
           {result.stderr}

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
@@ -1,0 +1,10 @@
+/* Custom tool views (answer, submit, todo lists) own their full rendering —
+   they get the block frame (accent edge + container border) without the
+   header row. */
+.custom {
+  border: 1px solid var(--bs-light-border-subtle);
+  border-left: 3px solid var(--inspect-readable-tool-call-border);
+  border-radius: var(--bs-border-radius);
+  overflow: hidden;
+  padding: 0.7rem;
+}

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
@@ -1,0 +1,144 @@
+import clsx from "clsx";
+import { FC, ReactNode } from "react";
+
+import type {
+  ToolCallContent,
+  ToolCallError,
+} from "@tsmono/inspect-common/types";
+import { ExpandablePanel } from "@tsmono/react/components";
+
+import styles from "./ClientToolCall.module.css";
+import { getDefaultCustomToolView } from "./customToolRendering";
+import { iconForTool } from "./tool";
+import { ToolBlock, ToolBlockInput, ToolBlockOutput } from "./ToolBlock";
+import { ToolCallErrorView } from "./ToolCallErrorView";
+import { ToolCallView, ToolCallViewProps } from "./ToolCallView";
+import { ToolInput } from "./ToolInput";
+
+export interface ClientToolCallProps {
+  id: string;
+  tool: string;
+  /** Header display title; defaults to the tool name. */
+  title?: string;
+  functionCall: string;
+  input?: unknown;
+  description?: string;
+  contentType?: string;
+  view?: ToolCallContent;
+  output: ToolCallViewProps["output"];
+  error?: ToolCallError;
+  className?: string | string[];
+  getCustomToolView?: (props: ToolCallViewProps) => ReactNode | undefined;
+}
+
+/**
+ * A client tool call rendered with the shared tool block grammar: collapsible
+ * header (terminal icon · mono tool name · args summary), the input zone
+ * (e.g. code) and the output well stacked beneath.
+ */
+export const ClientToolCall: FC<ClientToolCallProps> = ({
+  id,
+  tool,
+  title,
+  functionCall,
+  input,
+  description,
+  contentType,
+  view,
+  output,
+  error,
+  className,
+  getCustomToolView,
+}) => {
+  // Custom views render the call and its result as one self-contained UI —
+  // give them the block frame without the header.
+  const viewProps: ToolCallViewProps = {
+    id,
+    tool,
+    functionCall,
+    input,
+    description,
+    contentType,
+    view,
+    output,
+  };
+  const customView =
+    getCustomToolView?.(viewProps) ?? getDefaultCustomToolView(viewProps);
+  if (customView) {
+    return <div className={clsx(styles.custom, className)}>{customView}</div>;
+  }
+
+  const hasInput =
+    (input !== undefined && input !== null && input !== "") || !!view?.content;
+  const showError = !!error;
+  const showOutput = !showError && hasOutputContent(output);
+
+  return (
+    <ToolBlock
+      id={id}
+      icon={iconForTool(tool)}
+      title={title || tool}
+      summary={description ?? inlineArgs(functionCall, title || tool)}
+      className={className}
+    >
+      {hasInput ? (
+        <ToolBlockInput>
+          <ExpandablePanel
+            id={`${id}-tool-input`}
+            collapse={true}
+            border={false}
+            lines={20}
+            className={clsx("text-size-small")}
+          >
+            <ToolInput
+              contentType={contentType}
+              contents={input}
+              toolCallView={view}
+            />
+          </ExpandablePanel>
+        </ToolBlockInput>
+      ) : null}
+      {showError ? (
+        <ToolBlockOutput>
+          <ToolCallErrorView error={error} />
+        </ToolBlockOutput>
+      ) : showOutput ? (
+        <ToolBlockOutput>
+          <ToolCallView {...viewProps} section="output" />
+        </ToolBlockOutput>
+      ) : null}
+    </ToolBlock>
+  );
+};
+
+/** The args portion of the rendered function call (the text inside the
+ * parens), as a single-line header summary. */
+const inlineArgs = (functionCall: string, tool: string): string | undefined => {
+  if (functionCall.startsWith(`${tool}(`) && functionCall.endsWith(")")) {
+    const inner = functionCall
+      .slice(tool.length + 1, -1)
+      .replace(/\s+/g, " ")
+      .trim();
+    return inner.length > 0 ? inner : undefined;
+  }
+  return functionCall !== tool ? functionCall : undefined;
+};
+
+/** Whether the tool output has anything worth an output well. */
+const hasOutputContent = (output: ToolCallViewProps["output"]): boolean => {
+  if (output === undefined || output === null) return false;
+  if (typeof output === "string") return output.trim().length > 0;
+  if (typeof output === "number" || typeof output === "boolean") return true;
+  const items = Array.isArray(output) ? output : [output];
+  return items.some((item) => {
+    if (item.type === "tool") {
+      return item.content.some(
+        (c) => c.type !== "text" || c.text.trim().length > 0
+      );
+    }
+    if (item.type === "text") {
+      return item.text.trim().length > 0;
+    }
+    return true;
+  });
+};

--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -1,0 +1,104 @@
+/* Shared tool-call block grammar. Colors map to existing theme tokens: the
+   tool accent + header tint are the readable tool-call tokens (defined for
+   every theme), the output well is the tool-output fill, hairlines/border are
+   the subtle border token. */
+.block {
+  border-left: 3px solid var(--inspect-readable-tool-call-border);
+}
+
+.standalone {
+  border-top: 1px solid var(--bs-light-border-subtle);
+  border-right: 1px solid var(--bs-light-border-subtle);
+  border-bottom: 1px solid var(--bs-light-border-subtle);
+  border-radius: var(--bs-border-radius);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 13px;
+  background-color: var(--inspect-readable-tool-call-bg);
+}
+
+.icon {
+  flex: none;
+  font-size: 13px;
+  color: var(--inspect-readable-tool-call-border);
+}
+
+.title {
+  flex: none;
+  font-family: var(--bs-font-monospace);
+  font-size: var(--inspect-font-size-smaller);
+  font-weight: 600;
+  color: var(--inspect-readable-tool-call-border);
+}
+
+.summary {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--bs-font-monospace);
+  font-size: var(--inspect-font-size-smaller);
+  color: var(--bs-secondary-color);
+}
+
+.pill {
+  flex: none;
+  /* Right-aligned even when there is no args summary to push it over. */
+  margin-left: auto;
+  font-size: var(--inspect-font-size-smallestest);
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--bs-secondary-color);
+  background-color: var(--bs-body-bg);
+  border: 1px solid var(--bs-light-border-subtle);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.inputZone {
+  border-top: 1px solid var(--bs-light-border-subtle);
+  background-color: var(--inspect-readable-tool-call-bg);
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+
+.outputWell {
+  border-top: 1px solid var(--bs-light-border-subtle);
+  background-color: var(--inspect-tool-output-bg);
+  padding: 12px 15px;
+  font-size: var(--inspect-font-size-smaller);
+  line-height: 1.6;
+}
+
+/* The zones own their padding/fill; flatten the boxed surfaces that nested
+   renderers (prism code blocks, tool-call-input call-outs, tool output wells)
+   would otherwise stack inside them. !important outranks the readable
+   variant's higher-specificity :root[data-theme-variant] surface rules. */
+.inputZone :global(pre.tool-call-input),
+.inputZone :global(div.tool-call-input) {
+  background-color: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.inputZone :global(.tool-call-input) :global(pre[class*="language-"]) {
+  margin: 0 !important;
+  padding: 0 !important;
+  background-color: transparent !important;
+}
+
+.outputWell :global(.tool-output) {
+  background-color: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}

--- a/packages/inspect-components/src/chat/tools/ToolBlock.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.tsx
@@ -1,0 +1,73 @@
+import clsx from "clsx";
+import { FC, ReactNode } from "react";
+
+import styles from "./ToolBlock.module.css";
+
+interface ToolBlockProps {
+  id?: string;
+  /** Bootstrap icon class for the tool kind (terminal = client, globe = server). */
+  icon: string;
+  /** Tool name, rendered in monospace with the tool accent color. */
+  title: string;
+  /** Single-line args summary; ellipsized, never wraps. */
+  summary?: string;
+  /** Optional neutral pill after the title (e.g. "server"). */
+  pill?: string;
+  /** Flush rows (server calls inside the assistant turn) carry no container
+   * border of their own — the turn container frames them. */
+  flush?: boolean;
+  className?: string | string[];
+  children?: ReactNode;
+}
+
+/**
+ * The shared tool-call block grammar: a tinted header row (tool icon · mono
+ * tool name · optional pill · args summary) with the tool's input/output
+ * zones stacked beneath it.
+ */
+export const ToolBlock: FC<ToolBlockProps> = ({
+  id,
+  icon,
+  title,
+  summary,
+  pill,
+  flush,
+  className,
+  children,
+}) => {
+  return (
+    <div
+      id={id}
+      className={clsx(
+        styles.block,
+        flush ? undefined : styles.standalone,
+        className
+      )}
+    >
+      <div className={styles.header}>
+        <i className={clsx("bi", icon, styles.icon)} />
+        <span className={styles.title}>{title}</span>
+        {summary ? <span className={styles.summary}>{summary}</span> : null}
+        {pill ? <span className={styles.pill}>{pill}</span> : null}
+      </div>
+      {children}
+    </div>
+  );
+};
+
+/** Input zone (e.g. code) — code fill, hairline top. */
+export const ToolBlockInput: FC<{
+  className?: string | string[];
+  children?: ReactNode;
+}> = ({ className, children }) => {
+  return <div className={clsx(styles.inputZone, className)}>{children}</div>;
+};
+
+/** Output well — faint fill, hairline top; content is whatever the tool
+ * returned, rendered by the caller. */
+export const ToolBlockOutput: FC<{
+  className?: string | string[];
+  children?: ReactNode;
+}> = ({ className, children }) => {
+  return <div className={clsx(styles.outputWell, className)}>{children}</div>;
+};

--- a/packages/inspect-components/src/chat/tools/tool.ts
+++ b/packages/inspect-components/src/chat/tools/tool.ts
@@ -2,6 +2,79 @@ import type { ToolCallContent } from "@tsmono/inspect-common/types";
 
 export const kToolTodoContentType = "agent/todo-list";
 
+/* Per-tool header icons (Bootstrap Icons classes) for the tool block
+   grammar. Keyed by the tool names Inspect and the common CLI agents emit. */
+const kToolIcons: Record<string, string> = {
+  // shells
+  bash: "bi-terminal",
+  Bash: "bi-terminal",
+  bash_session: "bi-terminal",
+  shell: "bi-terminal",
+  shell_command: "bi-terminal",
+  exec_command: "bi-terminal",
+  // code
+  python: "bi-code-square",
+  code_execution: "bi-code-square",
+  // web
+  web_search: "bi-search",
+  WebSearch: "bi-search",
+  web_fetch: "bi-globe2",
+  WebFetch: "bi-globe2",
+  web_browser: "bi-window",
+  // editing / files
+  text_editor: "bi-pencil-square",
+  str_replace_editor: "bi-pencil-square",
+  str_replace_based_edit_tool: "bi-pencil-square",
+  Edit: "bi-pencil-square",
+  Write: "bi-pencil-square",
+  NotebookEdit: "bi-pencil-square",
+  Read: "bi-file-earmark-text",
+  Glob: "bi-search",
+  Grep: "bi-search",
+  // sub-agents
+  task: "bi-people",
+  Task: "bi-people",
+  agent: "bi-people",
+  Agent: "bi-people",
+  spawn_agent: "bi-people",
+  send_input: "bi-people",
+  wait_agent: "bi-people",
+  resume_agent: "bi-people",
+  close_agent: "bi-people",
+  agent_status: "bi-people",
+  agent_wait: "bi-people",
+  agent_cancel: "bi-people",
+  agent_list: "bi-people",
+  // planning
+  TodoWrite: "bi-list-check",
+  todo_write: "bi-list-check",
+  update_plan: "bi-list-check",
+  think: "bi-lightbulb",
+  // misc
+  computer: "bi-display",
+  tool_search: "bi-search",
+  mcp_list_tools: "bi-plug",
+  mcp_call: "bi-plug",
+};
+
+/**
+ * Header icon for a tool call. Unknown client tools get the general tool
+ * icon; unknown server tools keep the globe (the server tell).
+ */
+export const iconForTool = (
+  tool: string,
+  options?: { server?: boolean }
+): string => {
+  const icon = kToolIcons[tool];
+  if (icon) {
+    return icon;
+  }
+  if (tool.startsWith("browser_")) {
+    return "bi-window";
+  }
+  return options?.server ? "bi-globe2" : "bi-tools";
+};
+
 export interface ToolCallResult {
   name: string;
   functionCall: string;

--- a/packages/inspect-components/src/transcript/ToolEventView.module.css
+++ b/packages/inspect-components/src/transcript/ToolEventView.module.css
@@ -20,32 +20,6 @@
   min-width: 0;
 }
 
-/* The call/output attached pair (colors + inner flatten come from the shared
-   [data-message-kind] theme rules; here we supply the box structure). */
-.attachedGroup {
-  display: flex;
-  flex-direction: column;
-}
-
-.toolBox {
-  position: relative;
-  border: 1px solid var(--bs-light-border-subtle);
-  border-radius: var(--bs-border-radius);
-  padding: 0.7rem;
-}
-
-.attachedBottom {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  border-bottom: 0;
-}
-
-.attachedTop {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-top: 0;
-}
-
 .approvalWrap {
   margin-top: 0.5rem;
 }

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -174,4 +174,3 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
     </EventPanel>
   );
 };
-

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -4,10 +4,9 @@ import { FC, useMemo } from "react";
 import type { ModelEvent, ToolEvent } from "@tsmono/inspect-common/types";
 import {
   ChatView,
+  ClientToolCall,
   resolveToolInput,
   substituteToolCallContent,
-  ToolCallErrorView,
-  ToolCallView,
   type ChatViewLabelOptions,
 } from "@tsmono/inspect-components/chat";
 
@@ -97,60 +96,22 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
   );
 
   const showError = !!event.error && event.error.type !== "approval";
-  const showResult = !showError && hasResultContent(event.result);
 
-  // Render the call and its output as one attached pair (blue call box with the
-  // gray output box seamlessly beneath it), mirroring the messages view. The
-  // colors/flatten come from the shared [data-message-kind] rules in the theme.
+  // The shared tool block grammar: collapsible header with the input zone and
+  // output well stacked beneath.
   const toolCallView = (
-    <div className={styles.attachedGroup}>
-      <div
-        data-message-kind="tool"
-        className={clsx(
-          styles.toolBox,
-          showError || showResult ? styles.attachedBottom : undefined
-        )}
-      >
-        <ToolCallView
-          id={`${eventNode.id}-tool-call`}
-          tool={name}
-          functionCall={functionCall}
-          input={input}
-          description={description}
-          contentType={contentType}
-          output=""
-          mode="compact"
-          view={resolvedView}
-          section="call"
-        />
-      </div>
-      {showError ? (
-        <div
-          data-message-kind="tool-result"
-          className={clsx(styles.toolBox, styles.attachedTop)}
-        >
-          <ToolCallErrorView error={event.error!} />
-        </div>
-      ) : showResult ? (
-        <div
-          data-message-kind="tool-result"
-          className={clsx(styles.toolBox, styles.attachedTop)}
-        >
-          <ToolCallView
-            id={`${eventNode.id}-tool-call`}
-            tool={name}
-            functionCall={functionCall}
-            input={input}
-            description={description}
-            contentType={contentType}
-            output={event.result || ""}
-            mode="compact"
-            view={resolvedView}
-            section="output"
-          />
-        </div>
-      ) : null}
-    </div>
+    <ClientToolCall
+      id={`${eventNode.id}-tool-call`}
+      tool={name}
+      title={displayName}
+      functionCall={functionCall}
+      input={input}
+      description={description}
+      contentType={contentType}
+      output={event.result ?? ""}
+      error={showError ? event.error! : undefined}
+      view={resolvedView}
+    />
   );
 
   const toolLabel = toolLabels.messageLabels?.[event.id];
@@ -214,10 +175,3 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
   );
 };
 
-// Whether a tool event has output worth rendering in its own result box.
-function hasResultContent(result: ToolEvent["result"]): boolean {
-  if (result === null || result === undefined) return false;
-  if (typeof result === "string") return result.trim().length > 0;
-  if (Array.isArray(result)) return result.length > 0;
-  return true;
-}

--- a/packages/theme/src/base.css
+++ b/packages/theme/src/base.css
@@ -79,6 +79,8 @@
 }
 
 :root[data-bs-theme="dark"] {
+  --inspect-tool-output-bg: #14171c;
+
   --inspect-msg-label-bg: #2a2a2e;
   --inspect-msg-label-bg-hover: #33333a;
   --inspect-msg-label-border: #3a3a40;
@@ -150,55 +152,6 @@
 :root[data-theme-variant="readable"] [data-message-role] div.tool-call-input {
   background-color: var(--inspect-tool-output-bg);
   border-left: 1px solid var(--bs-light-border-subtle);
-}
-
-/* The tool call is its own peer block: under readable the whole box is the blue
-   call surface (header + input). */
-:root[data-theme-variant="readable"] [data-message-kind="tool"] {
-  background-color: var(--inspect-readable-tool-call-bg);
-  border-left: 3px solid var(--inspect-readable-tool-call-border);
-}
-
-/* Flush the call input AND the output to the box padding edge in EVERY theme so
-   they line up. The input otherwise carries ToolInput's .toolView padding (and,
-   under readable, the .tool-call-input padding) plus the prism code block's own
-   padding/margin, over-indenting it relative to the output. The `:root` prefix
-   lifts specificity above the readable .tool-call-input rule. */
-:root [data-message-kind="tool"] pre.tool-call-input,
-:root [data-message-kind="tool"] div.tool-call-input {
-  border: 0;
-  border-radius: 0;
-  padding: 0 !important;
-}
-:root [data-message-kind="tool"] .tool-call-input pre[class*="language-"] {
-  margin: 0 !important;
-  padding: 0 !important;
-}
-:root [data-message-kind="tool-result"] .tool-output {
-  margin: 0 !important;
-  padding: 0 !important;
-}
-:root[data-theme-variant="readable"]
-  [data-message-kind="tool"]
-  pre.tool-call-input,
-:root[data-theme-variant="readable"]
-  [data-message-kind="tool"]
-  div.tool-call-input {
-  background-color: transparent;
-}
-
-/* The tool output attaches beneath its call — a light-gray box that shares the
-   call's blue left gutter so the pair reads as one connected card. */
-:root[data-theme-variant="readable"] [data-message-kind="tool-result"] {
-  background-color: var(--inspect-tool-output-bg);
-  border-left: 3px solid var(--inspect-readable-tool-call-border);
-}
-:root[data-theme-variant="readable"]
-  [data-message-kind="tool-result"]
-  .tool-output {
-  background-color: transparent;
-  border: 0;
-  border-radius: 0;
 }
 
 /* Light subtle box around tool output (standalone transcript tool events). */


### PR DESCRIPTION
## Summary

Fixes #324 

A shared tool-call block grammar for the Inspect transcript viewer, per the server-side tool call design handoff:

- **Server-side tool calls** (`web_search`, `web_fetch`, `code_execution`, provider-executed MCP) render as flush rows of the assistant turn container — prose rows keep the assistant band, each `tool_use` stacks beneath with hairline separators. No more card-in-card nesting.
- **Client tool calls** adopt the identical block: a tinted header row (per-tool icon, mono tool name, ellipsized args summary) with the input zone and output well stacked beneath. The only server tells are the header icon and a neutral grey `server` pill (right-aligned).
- Multi-line code args render in a real input zone (python-highlighted for `code_execution`) instead of the one-line header summary, and `code_execution` results parse into stdout / stderr / exit code instead of raw JSON.
- Per-tool header icons via `iconForTool` (shells → terminal, python/code_execution → code square, web_search → magnifier, editors → pencil, sub-agents → people, MCP → plug, …) with a general-tool fallback for unknown client tools and the globe for unknown server tools.

## Implementation

- `ToolBlock` — the shared block shell (header + input/output zones); colors map to existing theme tokens only (tool-call accent/tint, tool-output fill, subtle borders). Added the missing dark value for `--inspect-tool-output-bg`.
- `ServerToolCall` — rewritten on ToolBlock; keeps the web_search link list and mcp_list_tools renderings.
- `ClientToolCall` — block shell around the existing `ToolInput` / `ToolCallView` output rendering; custom tool views (submit, answer, tool_search, app-provided) keep their own UI inside the framed block.
- `ChatMessage` / `ChatMessageRow` — assistant turns with server tools render segmented (prose bands + flush tool rows) in one seamless rounded container; replaces the attached call/output pair blocks.
- Removed the now-dead `data-message-kind` peer-block rules from the theme.

## Testing

- `pnpm typecheck`, `pnpm lint`, component tests (448 passed)
- Visually verified against the design spec in the Inspect viewer (transcript + messages tabs, light/dark) with logs containing web_search/code_execution server tools and python client tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)