### PR TITLE
Regenerate types for anthropic fallback models

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1136,12 +1136,10 @@ export interface components {
          *     also accepted at the task and eval layers (where they participate in
          *     the per-field merge — precedence: eval > sample > task).
          *
-         *     The fields excluded from this base class — ``checkpoints_dir`` and
-         *     ``retention`` — are eval-wide concerns that the sample layer must
+         *     The fields excluded from this base class — ``checkpoints_location``
+         *     and ``retention`` — are eval-wide concerns that the sample layer must
          *     not influence. They live only on the derived :class:`CheckpointConfig`,
          *     which is the type used at the task and eval layers.
-         *
-         *     See ``design/plans/checkpointing-working.md`` §2.
          */
         CheckpointSampleConfig: {
             /** Max Consecutive Failures */
@@ -1571,6 +1569,8 @@ export interface components {
             extra_headers?: {
                 [key: string]: string;
             } | null;
+            /** Fallback Models */
+            fallback_models?: string[] | null;
             /** Frequency Penalty */
             frequency_penalty?: number | null;
             /** Internal Tools */
@@ -1654,6 +1654,8 @@ export interface components {
             extra_headers?: {
                 [key: string]: string;
             } | null;
+            /** Fallback Models */
+            fallback_models?: string[] | null;
             /** Frequency Penalty */
             frequency_penalty?: number | null;
             /** Internal Tools */
@@ -2329,6 +2331,25 @@ export interface components {
             working_time?: number | null;
         };
         /**
+         * ModelFallback
+         * @description A model fallback (request served by a different model than requested).
+         */
+        ModelFallback: {
+            /**
+             * Count
+             * @default 1
+             */
+            count: number;
+            /** Fallback Model */
+            fallback_model: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Model */
+            model: string;
+        };
+        /**
          * ModelOutput
          * @description Output from model generation.
          */
@@ -2345,6 +2366,7 @@ export interface components {
             completion: string;
             /** Error */
             error?: string | null;
+            fallback?: components["schemas"]["ModelFallback"] | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;


### PR DESCRIPTION
Regenerated `apps/scout/src/types/generated.ts` from updated openapi schema:

- New `ModelFallback` schema + `fallback` field on `ModelOutput`
- New `fallback_models` field on generate config schemas
- `checkpoints_dir` → `checkpoints_location` doc comment update