### PR TITLE
Tool block: respect Event Colors toggle + zone fill refinements

### DIFF
--- a/packages/inspect-components/src/chat/ChatMessage.module.css
+++ b/packages/inspect-components/src/chat/ChatMessage.module.css
@@ -22,7 +22,7 @@
    padding gives the prose rows more weight between the tool rows. */
 .proseSegment {
   padding: 0.9rem 0.7rem;
-  border-left: 3px solid var(--inspect-turn-prose-accent);
+  border-left: var(--inspect-turn-prose-edge);
 }
 
 .timestamp {

--- a/packages/inspect-components/src/chat/ChatMessage.module.css
+++ b/packages/inspect-components/src/chat/ChatMessage.module.css
@@ -16,13 +16,13 @@
   border-top: 1px solid var(--bs-light-border-subtle);
 }
 
-/* The prose row keeps the assistant band; the left accent is supplied here so
-   the turn reads the same outside the readable variant (which re-applies the
-   identical color via the [data-message-role] rules). Extra vertical padding
-   gives the prose rows more weight between the tool rows. */
+/* The prose row keeps the assistant band; the left accent token is neutral
+   by default and colorized under the readable variant (where the
+   [data-message-role] rules re-apply the identical color). Extra vertical
+   padding gives the prose rows more weight between the tool rows. */
 .proseSegment {
   padding: 0.9rem 0.7rem;
-  border-left: 3px solid var(--inspect-readable-assistant-border);
+  border-left: 3px solid var(--inspect-turn-prose-accent);
 }
 
 .timestamp {

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
@@ -3,7 +3,7 @@
    header row. */
 .custom {
   border: 1px solid var(--bs-light-border-subtle);
-  border-left: 3px solid var(--inspect-tool-block-accent);
+  border-left: var(--inspect-tool-block-edge);
   border-radius: var(--bs-border-radius);
   overflow: hidden;
   padding: 0.7rem;

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.module.css
@@ -3,7 +3,7 @@
    header row. */
 .custom {
   border: 1px solid var(--bs-light-border-subtle);
-  border-left: 3px solid var(--inspect-readable-tool-call-border);
+  border-left: 3px solid var(--inspect-tool-block-accent);
   border-radius: var(--bs-border-radius);
   overflow: hidden;
   padding: 0.7rem;

--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -63,7 +63,7 @@
 
 .inputZone {
   border-top: 1px solid var(--bs-light-border-subtle);
-  background-color: var(--inspect-tool-block-header-bg);
+  background-color: var(--inspect-tool-block-input-bg);
   padding: 0.5rem;
   overflow-x: auto;
 }

--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -3,7 +3,7 @@
    variant (the Event Colors toggle); the output well is the tool-output
    fill, hairlines/border are the subtle border token. */
 .block {
-  border-left: 3px solid var(--inspect-tool-block-accent);
+  border-left: var(--inspect-tool-block-edge);
 }
 
 .standalone {

--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -70,7 +70,7 @@
 
 .outputWell {
   border-top: 1px solid var(--bs-light-border-subtle);
-  background-color: var(--inspect-tool-output-bg);
+  background-color: var(--inspect-tool-block-output-bg);
   padding: 12px 15px;
   font-size: var(--inspect-font-size-smaller);
   line-height: 1.6;

--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -1,9 +1,9 @@
-/* Shared tool-call block grammar. Colors map to existing theme tokens: the
-   tool accent + header tint are the readable tool-call tokens (defined for
-   every theme), the output well is the tool-output fill, hairlines/border are
-   the subtle border token. */
+/* Shared tool-call block grammar. Colors come from the tool-block tokens,
+   which are neutral by default and only colorized under the readable
+   variant (the Event Colors toggle); the output well is the tool-output
+   fill, hairlines/border are the subtle border token. */
 .block {
-  border-left: 3px solid var(--inspect-readable-tool-call-border);
+  border-left: 3px solid var(--inspect-tool-block-accent);
 }
 
 .standalone {
@@ -19,13 +19,13 @@
   align-items: center;
   gap: 9px;
   padding: 9px 13px;
-  background-color: var(--inspect-readable-tool-call-bg);
+  background-color: var(--inspect-tool-block-header-bg);
 }
 
 .icon {
   flex: none;
   font-size: 13px;
-  color: var(--inspect-readable-tool-call-border);
+  color: var(--inspect-tool-block-ink);
 }
 
 .title {
@@ -33,7 +33,7 @@
   font-family: var(--bs-font-monospace);
   font-size: var(--inspect-font-size-smaller);
   font-weight: 600;
-  color: var(--inspect-readable-tool-call-border);
+  color: var(--inspect-tool-block-ink);
 }
 
 .summary {
@@ -63,7 +63,7 @@
 
 .inputZone {
   border-top: 1px solid var(--bs-light-border-subtle);
-  background-color: var(--inspect-readable-tool-call-bg);
+  background-color: var(--inspect-tool-block-header-bg);
   padding: 0.5rem;
   overflow-x: auto;
 }

--- a/packages/theme/src/base.css
+++ b/packages/theme/src/base.css
@@ -83,9 +83,10 @@
      are plain 1px card borders uncolored, 3px accent bands colorized. */
   --inspect-tool-block-edge: 1px solid var(--bs-light-border-subtle);
   --inspect-tool-block-header-bg: var(--bs-tertiary-bg);
-  /* Visibly darker than the output well so input/output read as distinct
-     zones without the readable tints. */
-  --inspect-tool-block-input-bg: var(--bs-secondary-bg);
+  /* The input continues the header surface; the output is lighter (plain
+     page background) so the call and its result read as distinct zones. */
+  --inspect-tool-block-input-bg: var(--inspect-tool-block-header-bg);
+  --inspect-tool-block-output-bg: var(--bs-body-bg);
   --inspect-tool-block-ink: var(--bs-secondary-color);
   --inspect-turn-prose-edge: 1px solid var(--bs-light-border-subtle);
 }
@@ -121,6 +122,7 @@
   --inspect-tool-block-edge: 3px solid var(--inspect-readable-tool-call-border);
   --inspect-tool-block-header-bg: var(--inspect-readable-tool-call-bg);
   --inspect-tool-block-input-bg: var(--inspect-readable-tool-call-bg);
+  --inspect-tool-block-output-bg: var(--inspect-tool-output-bg);
   --inspect-tool-block-ink: var(--inspect-readable-tool-call-border);
   --inspect-turn-prose-edge: 3px solid var(--inspect-readable-assistant-border);
 }

--- a/packages/theme/src/base.css
+++ b/packages/theme/src/base.css
@@ -82,6 +82,9 @@
      variant points them at the colored tool tokens below. */
   --inspect-tool-block-accent: var(--bs-light-border-subtle);
   --inspect-tool-block-header-bg: var(--bs-tertiary-bg);
+  /* Visibly darker than the output well so input/output read as distinct
+     zones without the readable tints. */
+  --inspect-tool-block-input-bg: var(--bs-secondary-bg);
   --inspect-tool-block-ink: var(--bs-secondary-color);
   --inspect-turn-prose-accent: var(--bs-light-border-subtle);
 }
@@ -116,6 +119,7 @@
   --bs-body-color: var(--inspect-readable-body-color);
   --inspect-tool-block-accent: var(--inspect-readable-tool-call-border);
   --inspect-tool-block-header-bg: var(--inspect-readable-tool-call-bg);
+  --inspect-tool-block-input-bg: var(--inspect-readable-tool-call-bg);
   --inspect-tool-block-ink: var(--inspect-readable-tool-call-border);
   --inspect-turn-prose-accent: var(--inspect-readable-assistant-border);
 }

--- a/packages/theme/src/base.css
+++ b/packages/theme/src/base.css
@@ -79,14 +79,15 @@
 
   /* Tool block (header/edge/zones) tokens: neutral by default so the
      design-consistent look holds when Event Colors is off; the readable
-     variant points them at the colored tool tokens below. */
-  --inspect-tool-block-accent: var(--bs-light-border-subtle);
+     variant points them at the colored tool tokens below. The left edges
+     are plain 1px card borders uncolored, 3px accent bands colorized. */
+  --inspect-tool-block-edge: 1px solid var(--bs-light-border-subtle);
   --inspect-tool-block-header-bg: var(--bs-tertiary-bg);
   /* Visibly darker than the output well so input/output read as distinct
      zones without the readable tints. */
   --inspect-tool-block-input-bg: var(--bs-secondary-bg);
   --inspect-tool-block-ink: var(--bs-secondary-color);
-  --inspect-turn-prose-accent: var(--bs-light-border-subtle);
+  --inspect-turn-prose-edge: 1px solid var(--bs-light-border-subtle);
 }
 
 :root[data-bs-theme="dark"] {
@@ -117,11 +118,11 @@
    already emit (no per-role classes, no duplicated styles). */
 :root[data-theme-variant="readable"] {
   --bs-body-color: var(--inspect-readable-body-color);
-  --inspect-tool-block-accent: var(--inspect-readable-tool-call-border);
+  --inspect-tool-block-edge: 3px solid var(--inspect-readable-tool-call-border);
   --inspect-tool-block-header-bg: var(--inspect-readable-tool-call-bg);
   --inspect-tool-block-input-bg: var(--inspect-readable-tool-call-bg);
   --inspect-tool-block-ink: var(--inspect-readable-tool-call-border);
-  --inspect-turn-prose-accent: var(--inspect-readable-assistant-border);
+  --inspect-turn-prose-edge: 3px solid var(--inspect-readable-assistant-border);
 }
 
 :root[data-theme-variant="readable"] [data-message-role] {

--- a/packages/theme/src/base.css
+++ b/packages/theme/src/base.css
@@ -76,6 +76,14 @@
   --inspect-msg-label-bg-hover: #ebebef;
   --inspect-msg-label-border: #e4e4e9;
   --inspect-msg-label-text: #5f5f68;
+
+  /* Tool block (header/edge/zones) tokens: neutral by default so the
+     design-consistent look holds when Event Colors is off; the readable
+     variant points them at the colored tool tokens below. */
+  --inspect-tool-block-accent: var(--bs-light-border-subtle);
+  --inspect-tool-block-header-bg: var(--bs-tertiary-bg);
+  --inspect-tool-block-ink: var(--bs-secondary-color);
+  --inspect-turn-prose-accent: var(--bs-light-border-subtle);
 }
 
 :root[data-bs-theme="dark"] {
@@ -106,6 +114,10 @@
    already emit (no per-role classes, no duplicated styles). */
 :root[data-theme-variant="readable"] {
   --bs-body-color: var(--inspect-readable-body-color);
+  --inspect-tool-block-accent: var(--inspect-readable-tool-call-border);
+  --inspect-tool-block-header-bg: var(--inspect-readable-tool-call-bg);
+  --inspect-tool-block-ink: var(--inspect-readable-tool-call-border);
+  --inspect-turn-prose-accent: var(--inspect-readable-assistant-border);
 }
 
 :root[data-theme-variant="readable"] [data-message-role] {


### PR DESCRIPTION
## Summary

Follow-ups to #326 (these landed on that branch after it was squash-merged, so they never reached main):

- **Tool blocks respect the Event Colors toggle** — the header tint, accent edge, and title ink hardcoded the readable tool tokens, so tool calls stayed colorized when Event Colors was off. They now route through neutral-by-default `--inspect-tool-block-*` tokens that the readable variant repoints (same for the assistant turn's prose-row edge).
- **No accent band when uncolored** — the left edges are border shorthands: a plain 1px card border (matching other message types) when colors are off, the 3px accent band only when colorized.
- **Zone fills** — the input zone continues the header surface (one continuous tinted "call" surface) and the output well sits on the lighter page background when uncolored; the colorized scheme (blue header/input, faint output fill) is unchanged.

## Testing

- typecheck / lint / prettier / component tests (448 passed)
- Visually verified both toggle states (light + dark) in the Inspect viewer against logs with server-side (web_search, code_execution) and client (python) tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)