### PR TITLE
Fix log-list column widths snapping back while data loads

### DIFF
--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -36,10 +36,10 @@ import "../../shared/agGrid";
 
 import styles from "../../shared/gridCells.module.css";
 import { createGridKeyboardHandler } from "../../shared/gridKeyboardNavigation";
-import { createGridColumnResizer } from "../../shared/gridUtils";
 import { openInNewTab } from "../../shared/openInNewTab";
 import gridChromeStyles from "../../shared/samples-grid/SamplesGrid.module.css";
 import { useApplyColumnVisibility } from "../../shared/useApplyColumnVisibility";
+import { useGridColumnRefit } from "../../shared/useGridColumnRefit";
 import { FileLogItem, FolderLogItem, PendingTaskItem } from "../LogItem";
 
 import {
@@ -415,29 +415,27 @@ export const LogListGrid: FC<LogListGridProps> = ({
 
   const maxColCount = useRef(0);
 
-  // Lazily created on first use: creating it during render would pass the
-  // grid ref into non-React code, and the single instance must survive
-  // re-renders so the debounce timer isn't reset.
-  const resizerRef = useRef<(() => void) | null>(null);
-  const resizeGridColumns = useCallback(() => {
-    resizerRef.current ??= createGridColumnResizer(gridRef);
-    resizerRef.current();
-  }, []);
+  // Auto-fit defers to the user: once they manually resize a column, all
+  // subsequent auto-fits below are suppressed so their widths stick.
+  const { refitColumns, handleColumnResized } = useGridColumnRefit(gridRef);
 
-  // Resize grid columns when columns prop changes (e.g., when columns are hidden/unhidden)
+  // Refit when the column set changes (e.g. the scores view-mode toggle
+  // swaps the score column set). `columns` is content-stable across
+  // logDetails flushes (see useLogListColumns), so this no longer fires —
+  // and wipes user-dragged widths — on every detail flush while loading.
   useEffect(() => {
-    resizeGridColumns();
-  }, [columns, resizeGridColumns]);
+    refitColumns();
+  }, [columns, refitColumns]);
 
   const handleGridColumnsChanged = useCallback(
     (e: GridColumnsChangedEvent<LogListRow>) => {
       const cols = e.api.getColumnDefs();
       if (cols && cols.length > maxColCount.current) {
         maxColCount.current = cols.length;
-        resizeGridColumns();
+        refitColumns();
       }
     },
-    [resizeGridColumns]
+    [refitColumns]
   );
 
   // Find functionality - searches across the currently visible columns.
@@ -602,7 +600,8 @@ export const LogListGrid: FC<LogListGridProps> = ({
           rowSelection={{ mode: "singleRow", checkboxes: false }}
           getRowId={(params) => params.data.id}
           onGridColumnsChanged={handleGridColumnsChanged}
-          onGridSizeChanged={resizeGridColumns}
+          onGridSizeChanged={refitColumns}
+          onColumnResized={handleColumnResized}
           theme={themeBalham}
           enableCellTextSelection={true}
           initialState={initialGridState}

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -19,9 +19,11 @@ import {
   createFolderFirstComparator,
 } from "../../../shared/gridComparators";
 import { getFieldKey } from "../../../shared/gridUtils";
+import { useStableValue } from "../../../shared/useStableValue";
 import { PreformattedTooltip } from "../PreformattedTooltip";
 
 import localStyles from "./columns.module.css";
+import { computeScorerMap, scorerMapsEqual } from "./scorerMap";
 import { LogListRow } from "./types";
 
 const styles = { ...sharedStyles, ...localStyles };
@@ -39,16 +41,6 @@ const primaryModelValue = (row: LogListRow | undefined): string | undefined => {
   if (row.model && row.model !== kModelNone) return row.model;
   return displayModelRoles(row)[0]?.[1];
 };
-
-/**
- * Build a stable, unique column key for a (scorer, metric) pair. The reducer
- * is intentionally omitted so the same logical metric is one column regardless
- * of whether the log recorded `reducer=null` (default, silently mean) or
- * `reducer="mean"` (explicit). "/" is used as separator because ag-grid treats
- * "." in `field` as nested-object access.
- */
-const scorerMetricKey = (scorerName: string, metricName: string): string =>
-  `${scorerName}/${metricName}`;
 
 /** Human-readable header: "scorer / metric". */
 const scorerMetricHeader = (scorerName: string, metricName: string): string =>
@@ -101,40 +93,18 @@ export const useLogListColumns = (
   );
   const logDetails = useStore((state) => state.logs.logDetails);
 
-  // Detect all unique (scorer, reducer, metric) combinations across all logs
-  // from their results. Previously this collapsed on metric name alone, which
-  // merged distinct scorers emitting the same metric (e.g. two "accuracy"s)
-  // into a single column.
-  const scorerMap = useMemo(() => {
-    const info: Record<
-      string,
-      { scorerName: string; metricName: string; valueType: string }
-    > = {};
-
-    for (const [logName, details] of Object.entries(logDetails)) {
-      if (scopePrefix && !logName.startsWith(scopePrefix)) {
-        continue;
-      }
-      if (details.results?.scores) {
-        for (const evalScore of details.results.scores) {
-          if (evalScore.metrics) {
-            for (const [metricName, metric] of Object.entries(
-              evalScore.metrics
-            )) {
-              const key = scorerMetricKey(evalScore.name, metricName);
-              info[key] = {
-                scorerName: evalScore.name,
-                metricName,
-                valueType: typeof metric.value,
-              };
-            }
-          }
-        }
-      }
-    }
-
-    return info;
-  }, [logDetails, scopePrefix]);
+  // `logDetails` gets a new identity on every detail flush while a
+  // directory loads, so the memo alone would return a fresh map (and
+  // cascade fresh column defs into the grid) on every flush. Content
+  // equality keeps the map — and everything keyed on it — stable unless
+  // the scorer columns actually changed.
+  const scorerMap = useStableValue(
+    useMemo(
+      () => computeScorerMap(logDetails, scopePrefix),
+      [logDetails, scopePrefix]
+    ),
+    scorerMapsEqual
+  );
 
   // Auto-hide scorer columns by default if not explicitly set. Seed defaults
   // for BOTH the per-scorer fields (`score_<scorer>/<metric>`) and the

--- a/apps/inspect/src/app/log-list/grid/columns/scorerMap.test.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/scorerMap.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { LogDetails } from "../../../../client/api/types";
+
+import { computeScorerMap, scorerMapsEqual } from "./scorerMap";
+
+const details = (
+  scores: Array<{ name: string; metrics: Record<string, number | string> }>
+): LogDetails =>
+  ({
+    results: {
+      scores: scores.map((s) => ({
+        name: s.name,
+        metrics: Object.fromEntries(
+          Object.entries(s.metrics).map(([m, value]) => [m, { value }])
+        ),
+      })),
+    },
+  }) as unknown as LogDetails;
+
+describe("computeScorerMap", () => {
+  it("collects one entry per (scorer, metric) pair across logs", () => {
+    const map = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { accuracy: 0.5 } }]),
+      "/dir/b.eval": details([
+        { name: "model_graded", metrics: { accuracy: 0.7, stderr: 0.1 } },
+      ]),
+    });
+    expect(map).toEqual({
+      "match/accuracy": {
+        scorerName: "match",
+        metricName: "accuracy",
+        valueType: "number",
+      },
+      "model_graded/accuracy": {
+        scorerName: "model_graded",
+        metricName: "accuracy",
+        valueType: "number",
+      },
+      "model_graded/stderr": {
+        scorerName: "model_graded",
+        metricName: "stderr",
+        valueType: "number",
+      },
+    });
+  });
+
+  it("only includes logs under the scope prefix", () => {
+    const map = computeScorerMap(
+      {
+        "/dir/sub/a.eval": details([
+          { name: "match", metrics: { accuracy: 1 } },
+        ]),
+        "/other/b.eval": details([{ name: "other", metrics: { f1: 1 } }]),
+      },
+      "/dir/"
+    );
+    expect(Object.keys(map)).toEqual(["match/accuracy"]);
+  });
+
+  it("skips logs without score results", () => {
+    const map = computeScorerMap({
+      "/dir/a.eval": { sampleSummaries: [] } as unknown as LogDetails,
+    });
+    expect(map).toEqual({});
+  });
+});
+
+describe("scorerMapsEqual", () => {
+  it("treats content-equal maps with distinct identities as equal", () => {
+    const a = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { accuracy: 0.5 } }]),
+    });
+    const b = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { accuracy: 0.9 } }]),
+    });
+    expect(a).not.toBe(b);
+    expect(scorerMapsEqual(a, b)).toBe(true);
+  });
+
+  it("treats two empty maps as equal", () => {
+    expect(scorerMapsEqual({}, {})).toBe(true);
+  });
+
+  it("detects an added (scorer, metric) pair", () => {
+    const a = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { accuracy: 1 } }]),
+    });
+    const b = computeScorerMap({
+      "/dir/a.eval": details([
+        { name: "match", metrics: { accuracy: 1, stderr: 0 } },
+      ]),
+    });
+    expect(scorerMapsEqual(a, b)).toBe(false);
+    expect(scorerMapsEqual(b, a)).toBe(false);
+  });
+
+  it("detects a changed value type for the same pair", () => {
+    const a = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { grade: 1 } }]),
+    });
+    const b = computeScorerMap({
+      "/dir/a.eval": details([{ name: "match", metrics: { grade: "I" } }]),
+    });
+    expect(scorerMapsEqual(a, b)).toBe(false);
+  });
+
+  it("ignores key insertion order", () => {
+    const a = computeScorerMap({
+      "/dir/a.eval": details([{ name: "one", metrics: { accuracy: 1 } }]),
+      "/dir/b.eval": details([{ name: "two", metrics: { accuracy: 1 } }]),
+    });
+    const b = computeScorerMap({
+      "/dir/b.eval": details([{ name: "two", metrics: { accuracy: 1 } }]),
+      "/dir/a.eval": details([{ name: "one", metrics: { accuracy: 1 } }]),
+    });
+    expect(scorerMapsEqual(a, b)).toBe(true);
+  });
+});

--- a/apps/inspect/src/app/log-list/grid/columns/scorerMap.ts
+++ b/apps/inspect/src/app/log-list/grid/columns/scorerMap.ts
@@ -1,0 +1,90 @@
+import { LogDetails } from "../../../../client/api/types";
+
+export interface ScorerMetricInfo {
+  scorerName: string;
+  metricName: string;
+  valueType: string;
+}
+
+/** Unique (scorer, metric) pairs discovered across logs, keyed by
+ *  `scorerMetricKey`. Drives which score columns the log list offers. */
+export type ScorerMap = Record<string, ScorerMetricInfo>;
+
+/**
+ * Build a stable, unique column key for a (scorer, metric) pair. The reducer
+ * is intentionally omitted so the same logical metric is one column regardless
+ * of whether the log recorded `reducer=null` (default, silently mean) or
+ * `reducer="mean"` (explicit). "/" is used as separator because ag-grid treats
+ * "." in `field` as nested-object access.
+ */
+export const scorerMetricKey = (
+  scorerName: string,
+  metricName: string
+): string => `${scorerName}/${metricName}`;
+
+/**
+ * Detect all unique (scorer, reducer, metric) combinations across all logs
+ * from their results. Collapsing on metric name alone would merge distinct
+ * scorers emitting the same metric (e.g. two "accuracy"s) into one column.
+ *
+ * @param logDetails - Details map keyed by log file name
+ * @param scopePrefix - When set, only logs whose name starts with this
+ *   prefix contribute (folder view scoping)
+ */
+export function computeScorerMap(
+  logDetails: Record<string, LogDetails>,
+  scopePrefix?: string
+): ScorerMap {
+  const info: ScorerMap = {};
+
+  for (const [logName, details] of Object.entries(logDetails)) {
+    if (scopePrefix && !logName.startsWith(scopePrefix)) {
+      continue;
+    }
+    if (details.results?.scores) {
+      for (const evalScore of details.results.scores) {
+        if (evalScore.metrics) {
+          for (const [metricName, metric] of Object.entries(
+            evalScore.metrics
+          )) {
+            const key = scorerMetricKey(evalScore.name, metricName);
+            info[key] = {
+              scorerName: evalScore.name,
+              metricName,
+              valueType: typeof metric.value,
+            };
+          }
+        }
+      }
+    }
+  }
+
+  return info;
+}
+
+/**
+ * Content equality for two scorer maps, independent of key order.
+ *
+ * `logDetails` gets a new store identity on every detail flush while a
+ * directory is loading, but the set of scorer columns it implies almost
+ * never changes. Comparing content lets callers keep a stable map (and
+ * thus stable ag-grid column defs) across those flushes.
+ */
+export function scorerMapsEqual(a: ScorerMap, b: ScorerMap): boolean {
+  if (a === b) return true;
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const key of aKeys) {
+    const av = a[key];
+    const bv = b[key];
+    if (
+      !bv ||
+      av.scorerName !== bv.scorerName ||
+      av.metricName !== bv.metricName ||
+      av.valueType !== bv.valueType
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/apps/inspect/src/app/shared/useGridColumnRefit.test.ts
+++ b/apps/inspect/src/app/shared/useGridColumnRefit.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import type { ColumnResizedEvent } from "ag-grid-community";
+import type { AgGridReact } from "ag-grid-react";
+import type { RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGridColumnRefit } from "./useGridColumnRefit";
+
+const makeGridRef = () => {
+  const sizeColumnsToFit = vi.fn();
+  const gridRef = {
+    current: { api: { sizeColumnsToFit } },
+  } as unknown as RefObject<AgGridReact<unknown> | null>;
+  return { gridRef, sizeColumnsToFit };
+};
+
+const resizedEvent = (
+  source: string,
+  finished: boolean
+): ColumnResizedEvent<unknown> =>
+  ({ source, finished }) as ColumnResizedEvent<unknown>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useGridColumnRefit", () => {
+  it("fits columns to the grid width when refit is requested", () => {
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.refitColumns();
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).toHaveBeenCalledTimes(1);
+  });
+
+  it("debounces bursts of refit requests into one fit", () => {
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.refitColumns();
+    result.current.refitColumns();
+    result.current.refitColumns();
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops auto-fitting once the user manually resizes a column", () => {
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.handleColumnResized(resizedEvent("uiColumnResized", true));
+    result.current.refitColumns();
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).not.toHaveBeenCalled();
+  });
+
+  it("suppresses a pending refit when a user resize lands mid-debounce", () => {
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.refitColumns();
+    result.current.handleColumnResized(resizedEvent("uiColumnResized", false));
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto-fitting after grid-initiated resize events", () => {
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.handleColumnResized(resizedEvent("sizeColumnsToFit", true));
+    result.current.handleColumnResized(resizedEvent("flex", true));
+    result.current.handleColumnResized(resizedEvent("autosizeColumns", true));
+    result.current.refitColumns();
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/inspect/src/app/shared/useGridColumnRefit.test.ts
+++ b/apps/inspect/src/app/shared/useGridColumnRefit.test.ts
@@ -56,6 +56,17 @@ describe("useGridColumnRefit", () => {
     expect(sizeColumnsToFit).not.toHaveBeenCalled();
   });
 
+  it("stops auto-fitting after a resize-handle double-click autosize", () => {
+    // ag-grid dispatches the public columnResized event with source
+    // "autosizeColumns" (not "uiColumnResized") for double-click autosize.
+    const { gridRef, sizeColumnsToFit } = makeGridRef();
+    const { result } = renderHook(() => useGridColumnRefit(gridRef));
+    result.current.handleColumnResized(resizedEvent("autosizeColumns", true));
+    result.current.refitColumns();
+    vi.advanceTimersByTime(50);
+    expect(sizeColumnsToFit).not.toHaveBeenCalled();
+  });
+
   it("suppresses a pending refit when a user resize lands mid-debounce", () => {
     const { gridRef, sizeColumnsToFit } = makeGridRef();
     const { result } = renderHook(() => useGridColumnRefit(gridRef));
@@ -70,7 +81,7 @@ describe("useGridColumnRefit", () => {
     const { result } = renderHook(() => useGridColumnRefit(gridRef));
     result.current.handleColumnResized(resizedEvent("sizeColumnsToFit", true));
     result.current.handleColumnResized(resizedEvent("flex", true));
-    result.current.handleColumnResized(resizedEvent("autosizeColumns", true));
+    result.current.handleColumnResized(resizedEvent("api", true));
     result.current.refitColumns();
     vi.advanceTimersByTime(50);
     expect(sizeColumnsToFit).toHaveBeenCalledTimes(1);

--- a/apps/inspect/src/app/shared/useGridColumnRefit.ts
+++ b/apps/inspect/src/app/shared/useGridColumnRefit.ts
@@ -1,0 +1,57 @@
+import type { ColumnResizedEvent } from "ag-grid-community";
+import type { AgGridReact } from "ag-grid-react";
+import { RefObject, useCallback, useRef } from "react";
+
+import { debounce } from "@tsmono/util";
+
+const kRefitDebounceMs = 10;
+
+export interface GridColumnRefit<TRow> {
+  /** Debounced `api.sizeColumnsToFit()`. Becomes a no-op for the lifetime
+   *  of the grid instance once the user manually resizes any column. */
+  refitColumns: () => void;
+  /** Wire to `AgGridReact.onColumnResized` so user drags are detected. */
+  handleColumnResized: (e: ColumnResizedEvent<TRow>) => void;
+}
+
+/**
+ * Auto-fit columns to the grid width, deferring to the user.
+ *
+ * `sizeColumnsToFit` is wholesale: it redistributes every column, wiping
+ * any width the user dragged. Callers re-fit when columns appear or the
+ * viewport resizes — but once the user has manually sized a column they
+ * have taken control of the layout, so all subsequent auto-fits are
+ * suppressed (until the grid remounts, e.g. on a scope change). The guard
+ * is checked when the debounce fires, so a fit already pending when the
+ * user starts dragging is suppressed too.
+ *
+ * `"uiColumnResized"` covers both drag-resize and double-click autosize;
+ * grid-initiated sources (`"sizeColumnsToFit"`, `"flex"`, ...) don't trip
+ * the guard.
+ */
+export function useGridColumnRefit<TRow>(
+  gridRef: RefObject<AgGridReact<TRow> | null>
+): GridColumnRefit<TRow> {
+  const userResizedRef = useRef(false);
+  // Lazily created on first use: creating it during render would pass the
+  // grid ref into non-React code, and the single instance must survive
+  // re-renders so the debounce timer isn't reset.
+  const resizerRef = useRef<(() => void) | null>(null);
+
+  const handleColumnResized = useCallback((e: ColumnResizedEvent<TRow>) => {
+    if (e.source === "uiColumnResized") {
+      userResizedRef.current = true;
+    }
+  }, []);
+
+  const refitColumns = useCallback(() => {
+    if (userResizedRef.current) return;
+    resizerRef.current ??= debounce(() => {
+      if (userResizedRef.current) return;
+      gridRef.current?.api?.sizeColumnsToFit();
+    }, kRefitDebounceMs);
+    resizerRef.current();
+  }, [gridRef]);
+
+  return { refitColumns, handleColumnResized };
+}

--- a/apps/inspect/src/app/shared/useGridColumnRefit.ts
+++ b/apps/inspect/src/app/shared/useGridColumnRefit.ts
@@ -14,6 +14,22 @@ export interface GridColumnRefit<TRow> {
   handleColumnResized: (e: ColumnResizedEvent<TRow>) => void;
 }
 
+// ag-grid `columnResized` event sources that mean "the user sized this
+// column themselves". `"uiColumnResized"` is a resize-handle drag;
+// `"autosizeColumns"` is what ag-grid (34.x) dispatches on the public
+// event for a resize-handle double-click autosize (the internal
+// `"uiColumnResized"` source it passes down only surfaces on the
+// column-scoped `widthChanged` event, not here). Both are direct
+// interactions with the resize handle in our config — we never call
+// `api.autoSizeColumns`, and our `fitGridWidth` strategy routes through
+// `sizeColumnsToFitGridBody`, not the autosize path — so neither can be
+// triggered programmatically. Grid-initiated sources (`"sizeColumnsToFit"`,
+// `"flex"`, `"api"`, ...) are intentionally absent.
+const kUserResizeSources: ReadonlySet<string> = new Set([
+  "uiColumnResized",
+  "autosizeColumns",
+]);
+
 /**
  * Auto-fit columns to the grid width, deferring to the user.
  *
@@ -24,10 +40,6 @@ export interface GridColumnRefit<TRow> {
  * suppressed (until the grid remounts, e.g. on a scope change). The guard
  * is checked when the debounce fires, so a fit already pending when the
  * user starts dragging is suppressed too.
- *
- * `"uiColumnResized"` covers both drag-resize and double-click autosize;
- * grid-initiated sources (`"sizeColumnsToFit"`, `"flex"`, ...) don't trip
- * the guard.
  */
 export function useGridColumnRefit<TRow>(
   gridRef: RefObject<AgGridReact<TRow> | null>
@@ -39,7 +51,7 @@ export function useGridColumnRefit<TRow>(
   const resizerRef = useRef<(() => void) | null>(null);
 
   const handleColumnResized = useCallback((e: ColumnResizedEvent<TRow>) => {
-    if (e.source === "uiColumnResized") {
+    if (kUserResizeSources.has(e.source)) {
       userResizedRef.current = true;
     }
   }, []);

--- a/apps/inspect/src/app/shared/useStableValue.test.ts
+++ b/apps/inspect/src/app/shared/useStableValue.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useStableValue } from "./useStableValue";
+
+type Rec = Record<string, number>;
+
+const recordsEqual = (a: Rec, b: Rec): boolean => {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  return aKeys.length === bKeys.length && aKeys.every((k) => a[k] === b[k]);
+};
+
+describe("useStableValue", () => {
+  it("returns the value itself on first render", () => {
+    const first = { a: 1 };
+    const { result } = renderHook(() => useStableValue(first, recordsEqual));
+    expect(result.current).toBe(first);
+  });
+
+  it("keeps the prior reference when a content-equal value arrives", () => {
+    const first = { a: 1 };
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value, recordsEqual),
+      { initialProps: { value: first } }
+    );
+    rerender({ value: { a: 1 } });
+    expect(result.current).toBe(first);
+  });
+
+  it("adopts the new reference when content changes", () => {
+    const first = { a: 1 };
+    const second = { a: 2 };
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value, recordsEqual),
+      { initialProps: { value: first } }
+    );
+    rerender({ value: second });
+    expect(result.current).toBe(second);
+  });
+
+  it("stays stable on content-equal values after a content change", () => {
+    const first = { a: 1 };
+    const second = { a: 2 };
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value, recordsEqual),
+      { initialProps: { value: first } }
+    );
+    rerender({ value: second });
+    rerender({ value: { a: 2 } });
+    expect(result.current).toBe(second);
+  });
+
+  it("skips the equality check when the identity is unchanged", () => {
+    const isEqual = vi.fn(recordsEqual);
+    const value = { a: 1 };
+    const { rerender } = renderHook(
+      ({ value }) => useStableValue(value, isEqual),
+      { initialProps: { value } }
+    );
+    rerender({ value });
+    expect(isEqual).not.toHaveBeenCalled();
+  });
+});

--- a/apps/inspect/src/app/shared/useStableValue.ts
+++ b/apps/inspect/src/app/shared/useStableValue.ts
@@ -1,0 +1,34 @@
+/* eslint-disable react-hooks/refs -- deliberate render-time ref cache;
+   see the "use no memo" rationale inside useStableValue */
+import { useRef } from "react";
+
+/**
+ * Keep the previous reference when a newly computed value is content-equal.
+ *
+ * `useMemo` can only key on dependency identity, so a memo that derives
+ * from a frequently-replaced store object (e.g. `logDetails` during a
+ * directory sync) returns a fresh reference on every flush even when its
+ * content is unchanged — cascading identity churn into everything keyed
+ * on it. This hook cuts that cascade at the source: callers compute the
+ * candidate value as usual and equality decides whether downstream
+ * consumers see a new reference.
+ *
+ * `isEqual` is only consulted when the identity actually changed.
+ */
+export function useStableValue<T>(
+  value: T,
+  isEqual: (a: T, b: T) => boolean
+): T {
+  // Deliberate render-time ref cache — identity stabilization can't be
+  // expressed with useMemo or compiler memoization (both re-derive output
+  // identity from input identity). Safe under concurrent rendering
+  // because reuse is gated on content equality: whichever reference a
+  // discarded or committed render leaves behind, it is content-equal to
+  // the latest value.
+  "use no memo";
+  const ref = useRef(value);
+  if (ref.current !== value && !isEqual(ref.current, value)) {
+    ref.current = value;
+  }
+  return ref.current;
+}


### PR DESCRIPTION
## Problem

While details are still flushing into the task/folder log list (directory sync), dragging a column edge snaps the column back to its auto-fit width within ~10ms.

## Root causes

1. **Column-def identity churn.** The scorer-column memo in `useLogListColumns` keys on the raw `logDetails` store object, which gets a new identity on every detail flush — so `columns` was a fresh array each flush, and the refit effect in `LogListGrid` ran `api.sizeColumnsToFit()` (wiping user-dragged widths) on every flush while a directory loads.
2. **Auto-fit never deferred to the user.** Even with stable identities, genuine column-set growth (new scorer columns discovered mid-load) still refit *all* columns, discarding manual widths.

## Fix

- `computeScorerMap` / `scorerMapsEqual` (new `scorerMap.ts`): scorer discovery extracted to pure functions.
- `useStableValue` (new shared hook): keeps the previous reference when a recomputed value is content-equal, so column defs only change identity when the scorer column set actually changes.
- `useGridColumnRefit` (new shared hook): debounced `sizeColumnsToFit()` that permanently suppresses auto-fits for the grid instance once the user sizes a column (drag *or* resize-handle double-click autosize). The guard is checked when the debounce fires, so a fit already pending when the interaction starts is suppressed too. A scope change remounts the grid and re-enables auto-fit.
- `LogListGrid` wires `onColumnResized` and routes all three refit triggers (columns change, new columns discovered, viewport resize) through the guarded hook.

### Resize event sources (ag-grid 34.3.1)

User-intent sources that lock the layout: `uiColumnResized` (drag) and `autosizeColumns` (resize-handle double-click). Note ag-grid dispatches the *public* `columnResized` event with source `autosizeColumns` for a double-click — the `uiColumnResized` source it passes internally only surfaces on the column-scoped `widthChanged` event, not the grid-level one. Both originate solely from resize-handle interaction in our config (we never call `api.autoSizeColumns`; our `fitGridWidth` strategy routes through `sizeColumnsToFitGridBody`, not the autosize path). Grid-initiated sources (`sizeColumnsToFit`, `flex`, `api`) do not lock the layout.

The samples views were audited too: they already use mount-only `initialWidth`/`initialFlex` and never enable their refit machinery, so no change needed there.

## Testing

- 19 new tests (written first, watched fail): `scorerMap.test.ts`, `useStableValue.test.ts`, `useGridColumnRefit.test.ts` (incl. double-click autosize coverage)
- Full apps/inspect suite passes (453 tests), `tsc --noEmit` clean, eslint clean, production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)