### PR TITLE
Fix stale "running" status in log listing after navigating back

### DIFF
--- a/apps/inspect/src/state/logPolling.ts
+++ b/apps/inspect/src/state/logPolling.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@tsmono/util";
 
 import { ClientAPI } from "../client/api/types";
+import { toLogPreview } from "../client/utils/type-utils";
 import { createPolling } from "../utils/polling";
 
 import { StoreState } from "./store";
@@ -49,6 +50,11 @@ export function createLogPolling(
           `Setting refreshed summary ${logDetails.sampleSummaries.length} samples`,
           logDetails
         );
+
+        // Sync the listing preview so a log that finishes in detail view
+        // isn't stale on the grid. Key by logFileName (the handle name the
+        // grid reads previews by), not the absolute selectedLogFile.
+        state.logs.logPreviews[logFileName] = toLogPreview(logDetails);
 
         // Clear pending summaries if requested
         if (clearPending) {

--- a/apps/inspect/src/state/logSlice.ts
+++ b/apps/inspect/src/state/logSlice.ts
@@ -213,12 +213,19 @@ export const createLogSlice = (
                 dbService.writeLogDetail(logAbsPath, logDetails).catch(() => {
                   // Silently ignore cache errors
                 });
+                // Repaint the listing preview from the fresh status: a log
+                // cached as "started" may have since finished.
+                state.logsActions.updateLogPreviews({
+                  [logFileName]: toLogPreview(logDetails),
+                });
               });
-              // Continue with rest of the function using cached data
-              const header = {
-                [logFileName]: toLogPreview(cachedInfo),
-              };
-              state.logsActions.updateLogPreviews(header);
+              // Don't seed the listing from a cached "started" preview: it can
+              // clobber a fresher status; the fetch above repaints it.
+              if (cachedInfo.status !== "started") {
+                state.logsActions.updateLogPreviews({
+                  [logFileName]: toLogPreview(cachedInfo),
+                });
+              }
               set((state) => {
                 state.log.loadedLog = logFileName;
               });


### PR DESCRIPTION
* when I tested running evals, the listing updated to finish status originally, but navigating to log details and back to the listing showed it as running again, this fix keeps showing it as finished (but let me know if I'm missing some bigger picture)