### PR TITLE
Fix event panel nav pills never expanding back from picker mode

### DIFF
--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -103,6 +103,13 @@ export const EventPanel: FC<EventPanelProps> = ({
   );
   const defaultPillId = defaultPill !== -1 ? pillId(defaultPill) : pillId(0);
 
+  // The pill nav and the collapsed-summary text share the same right-aligned
+  // cell — they never appear together (summary text is only supplied for
+  // single-child panels, which have no tabs).
+  const showNavs =
+    !(isCollapsible && collapsibleContent && collapsed) &&
+    filteredArrChildren.length > 1;
+
   const [selectedNav, setSelectedNav] = useProperty(
     eventNodeId,
     "selectedNav",
@@ -127,10 +134,11 @@ export const EventPanel: FC<EventPanelProps> = ({
 
   // title (carries copy-link + headerExtra so they wrap with the title)
   gridColumns.push("minmax(0, max-content)");
+  // navs/summary: 1fr so the cell always spans the row's free space. With an
+  // `auto` track it collapses to the picker's width once collapsed, and the
+  // measured width can then never grow back to the pill row's natural width —
+  // so the picker can never expand to tabs again.
   gridColumns.push("minmax(0, 1fr)");
-  gridColumns.push("minmax(0, max-content)");
-  // navs: auto so it shrinks to picker mode when over-constrained
-  gridColumns.push("auto");
   if (turnLabel) {
     gridColumns.push("max-content");
   }
@@ -208,17 +216,11 @@ export const EventPanel: FC<EventPanelProps> = ({
             </span>
           ) : null}
         </div>
-        <div onClick={toggleCollapse}></div>
         <div
-          className={clsx("text-style-secondary", styles.label)}
-          onClick={toggleCollapse}
+          className={styles.navs}
+          onClick={showNavs ? undefined : toggleCollapse}
         >
-          {collapsed ? text : ""}
-        </div>
-        <div className={styles.navs}>
-          {isCollapsible && collapsibleContent && collapsed ? (
-            ""
-          ) : filteredArrChildren && filteredArrChildren.length > 1 ? (
+          {showNavs ? (
             <EventNavs
               navs={filteredArrChildren.map((child, index) => {
                 const defaultTitle = `Tab ${index}`;
@@ -235,9 +237,11 @@ export const EventPanel: FC<EventPanelProps> = ({
               selectedNav={selectedNav || ""}
               setSelectedNav={setSelectedNav}
             />
-          ) : (
-            ""
-          )}
+          ) : collapsed && text ? (
+            <span className={clsx("text-style-secondary", styles.label)}>
+              {text}
+            </span>
+          ) : null}
         </div>
         {turnLabel && (
           <span className={clsx(styles.turnLabel)}>{turnLabel}</span>


### PR DESCRIPTION
## Problem

In Event Panels, the tab/pill row collapses to a compact picker dropdown when the header is too narrow to show all pills inline. Once collapsed, it **never expands back to tabs**, even when the window is widened with plenty of room.

## Root cause

`EventNavs` uses a `ResizeObserver` on the pill-row wrapper: it switches to the picker when the wrapper's width drops below the pills' natural width, and back to tabs when it grows again.

The wrapper lived in a grid track sized `auto` (content-sized), with a `1fr` spacer column to its left:

- **Tabs → picker** worked: when over-constrained, the navs track shrank below natural width.
- **Picker → tabs never worked**: once in picker mode the cell's content was just the small picker button, so the `auto` track collapsed to ~that width and the `1fr` spacer absorbed all reopened space. The measured "available" width stayed pinned at the picker's size and could never reach the natural width again — a feedback loop.

Confirmed in-browser: 1400px → tabs (wrapper 299px = natural), 650px → picker (wrapper collapses to 102px), back to 1400px → **stuck at 102px, still picker**.

## Fix

Make the navs cell a flexible `minmax(0, 1fr)` track so its measured width reflects the row's free space regardless of its own content. Since the collapsed-summary `text` and the nav pills are mutually exclusive (summary text is only supplied for single-child panels, which have no tabs), the former `1fr` spacer + summary-label + navs columns are folded into that single right-aligned cell. The cell toggles collapse on click only when it isn't hosting nav controls, preserving click-to-expand.

## Verification

Against a real `inspect view` instance + live log:

- **tabs → picker → tabs round-trip now works repeatedly** (wrapper correctly returns to full width / tabs when widened).
- Tabs render correctly at wide width; picker renders un-clipped and its dropdown opens at narrow width.
- `typecheck`, `lint` (0 warnings), and `prettier` all pass.

This is a CSS-grid + `ResizeObserver` layout loop, which jsdom can't reproduce, so the browser round-trip is the regression check rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)