### PR TITLE
Cap oversized tool/text output to prevent resize layerization stalls

### DIFF
--- a/packages/inspect-components/src/chat/tools/ToolOutput.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolOutput.tsx
@@ -5,6 +5,7 @@ import type { Content } from "@tsmono/inspect-common/types";
 import { ANSIDisplay } from "@tsmono/react/components";
 import { isAnsiOutput, isJson } from "@tsmono/util";
 
+import { cappedText } from "../../content/cappedText";
 import { ContentDocumentView } from "../documents/ContentDocumentView";
 import { JsonMessageContent } from "../JsonMessageContent";
 
@@ -95,9 +96,20 @@ const ToolTextOutput: FC<ToolTextOutputProps> = ({ text }) => {
     );
   }
 
+  // A multi-megabyte tool result becomes a single ~1,000,000px-tall <pre>,
+  // which the browser re-layerizes on every resize (~1.4s each — laggy in
+  // Blink, spinlocks WebKit). Cap it so the giant node never enters the DOM;
+  // a fixed-height scroller does not help because the off-screen content is
+  // still layerized.
+  const { text: capped, notice } = cappedText(text);
   return (
-    <pre className={clsx(styles.textOutput, "tool-output")}>
-      <code className={clsx("sourceCode", styles.textCode)}>{text.trim()}</code>
-    </pre>
+    <>
+      <pre className={clsx(styles.textOutput, "tool-output")}>
+        <code className={clsx("sourceCode", styles.textCode)}>
+          {capped.trim()}
+        </code>
+      </pre>
+      {notice}
+    </>
   );
 };

--- a/packages/inspect-components/src/content/RenderedText.tsx
+++ b/packages/inspect-components/src/content/RenderedText.tsx
@@ -7,6 +7,7 @@ import {
   type MarkdownRenderer,
 } from "@tsmono/react/components";
 
+import { cappedText } from "./cappedText";
 import { useDisplayMode } from "./DisplayModeContext";
 
 interface RenderedTextProps {
@@ -30,28 +31,38 @@ export const RenderedText = forwardRef<
     ref
   ) => {
     const displayMode = useDisplayMode();
-    if (forceRender || displayMode === "rendered") {
-      return (
+    const { text, notice } = cappedText(markdown);
+
+    const body =
+      forceRender || displayMode === "rendered" ? (
         <MarkdownDivWithReferences
           ref={ref as ForwardedRef<HTMLDivElement>}
-          markdown={markdown}
+          markdown={text}
           references={references}
           options={options}
           style={style}
           className={className}
           renderer={renderer}
         />
-      );
-    } else {
-      return (
+      ) : (
         <Preformatted
           ref={ref as ForwardedRef<HTMLPreElement>}
-          text={markdown}
+          text={text}
           style={style}
           className={className}
         />
       );
+
+    if (notice === null) {
+      return body;
     }
+
+    return (
+      <>
+        {body}
+        {notice}
+      </>
+    );
   }
 );
 

--- a/packages/inspect-components/src/content/cappedText.module.css
+++ b/packages/inspect-components/src/content/cappedText.module.css
@@ -1,0 +1,6 @@
+.notice {
+  margin-top: 0.25rem;
+  font-size: var(--inspect-font-size-smaller);
+  color: var(--bs-secondary-color);
+  font-style: italic;
+}

--- a/packages/inspect-components/src/content/cappedText.tsx
+++ b/packages/inspect-components/src/content/cappedText.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from "react";
+
+import styles from "./cappedText.module.css";
+
+// Beyond this size, rendering text as a single DOM node produces an element
+// tens-of-thousands to millions of pixels tall. The browser then lays out,
+// paints, and (most expensively) *layerizes* that whole node on every resize —
+// a single resize of a ~1,000,000px node was measured at ~14s of `Layerize`,
+// wedging the main thread (laggy in Blink, spinlocks WebKit). A fixed-height
+// scroller does not help: the off-screen content is still layerized. The only
+// reliable fix is to keep the giant node out of the DOM entirely, so we render
+// a head slice and a static notice for the remainder.
+const MAX_INLINE_CHARS = 250_000;
+
+interface CappedText {
+  /** The text to render: a head slice when capped, the full text otherwise. */
+  text: string;
+  /** Whether the text was truncated. */
+  truncated: boolean;
+  /** A static notice to render after the body, or null when not truncated. */
+  notice: ReactNode;
+}
+
+/**
+ * Caps very large text so a single huge DOM node never enters the layout/paint
+ * path. Returns a (possibly truncated) string and a static notice describing
+ * how much was hidden. Intentionally offers no expand affordance — revealing
+ * the full content would reintroduce the performance cliff.
+ */
+export const cappedText = (full: string): CappedText => {
+  if (full.length <= MAX_INLINE_CHARS) {
+    return { text: full, truncated: false, notice: null };
+  }
+  const text = full.slice(0, MAX_INLINE_CHARS);
+  const hidden = full.length - text.length;
+  return {
+    text,
+    truncated: true,
+    notice: (
+      <div className={styles.notice}>
+        {`Output truncated — ${formatSize(hidden)} hidden`}
+      </div>
+    ),
+  };
+};
+
+const formatSize = (n: number): string => {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)} MB`;
+  }
+  if (n >= 1_000) {
+    return `${Math.round(n / 1_000)} KB`;
+  }
+  return `${n} chars`;
+};

--- a/packages/react/src/components/ExpandablePanel.tsx
+++ b/packages/react/src/components/ExpandablePanel.tsx
@@ -103,8 +103,20 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
     //      visible (clipped) area, so a `mask-image` gradient on the wrapper
     //      fades the bottom of the *visible* region — not the bottom of the
     //      natural-height content (which would sit off-screen).
+    // `contain: layout paint` isolates the collapsed subtree so the browser
+    // does not lay out, paint, or *layerize* the clipped overflow. Without it,
+    // a pathologically tall child (e.g. a multi-megabyte tool result that
+    // renders ~1,000,000px tall) forces the compositor to build a layer for
+    // the entire natural height on every resize — observed as ~1.4s per
+    // `Layerize` call, wedging the main thread (laggy in Blink, spinlocks
+    // WebKit). `size` containment is intentionally omitted so the box still
+    // sizes to `maxHeight`.
     const contentStyles: CSSProperties = effectiveCollapsed
-      ? { overflow: "hidden", maxHeight: `${lines}rem` }
+      ? {
+          overflow: "hidden",
+          maxHeight: `${lines}rem`,
+          contain: "layout paint",
+        }
       : {};
 
     const handleToggle = useCallback(() => {


### PR DESCRIPTION
## Problem

Viewing a transcript with a very large tool result (a single ~15 MB command output) made the scout viewer laggy on resize in Chrome and **spinlock in Safari**.

A Chrome performance trace of a single resize showed the cost was **~14s in `Layerize`** (49 calls, up to 1.4s each) plus ~2.7s Layout / ~1.6s Paint. The output renders as one **~1,000,000px-tall DOM node**; the compositor re-layerizes that entire node on every resize. It's a compositor cost (invisible to JS profiling), and a fixed-height scroller does **not** help — the off-screen content is still layerized.

## Fix

- New `cappedText` helper caps rendered text at **250k chars**, used by both `ToolTextOutput` (the path for this content) and `RenderedText` (message/reasoning text). Beyond the cap it renders a static "Output truncated — N hidden" notice. No expand affordance — revealing the full content would reintroduce the cliff.
- `contain: layout paint` on the collapsed `ExpandablePanel` content wrapper as defense-in-depth, so large-but-capped panels still composite cheaply.

## Verification

On the reproducing transcript, the largest rendered node dropped from **~1,045,498px → ~55,478px** tall (15.2M chars → 250k). `pnpm check` and `pnpm test` pass.

> Note: `Layerize` cannot be measured headlessly, so the final smoothness check is a manual resize in Chrome/Safari on the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)