### PR TITLE
perf(viewer): production build config — minification, vendor splitting, content-hashed immutable assets

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -108,7 +108,7 @@ export default defineConfig(({ mode }) => {
         },
         cssCodeSplit: false,
         sourcemap: true,
-        minify: false,
+        minify: true,
       },
     };
   } else {
@@ -121,7 +121,6 @@ export default defineConfig(({ mode }) => {
         warnIfWatchingWithoutSubmodule("inspect_ai"),
         copyToPythonRepo(),
       ],
-      mode: "development",
       base: "",
       server: {
         proxy: {
@@ -134,12 +133,26 @@ export default defineConfig(({ mode }) => {
       build: {
         outDir: "dist",
         emptyOutDir: true,
-        minify: false,
+        minify: mode !== "development",
         rollupOptions: {
           output: {
-            entryFileNames: `assets/index.js`,
-            chunkFileNames: `assets/[name].js`,
-            assetFileNames: `assets/[name].[ext]`,
+            entryFileNames: `assets/[name]-[hash].js`,
+            chunkFileNames: `assets/[name]-[hash].js`,
+            assetFileNames: `assets/[name]-[hash].[ext]`,
+            manualChunks(id) {
+              if (
+                id.includes("mathjax") ||
+                id.includes("markdown-it-mathjax3")
+              ) {
+                return "vendor-mathjax";
+              }
+              if (id.includes("@codemirror") || id.includes("@lezer")) {
+                return "vendor-codemirror";
+              }
+              if (id.includes("ag-grid")) {
+                return "vendor-ag-grid";
+              }
+            },
           },
         },
         sourcemap: true,


### PR DESCRIPTION
Re-implements two closed Inspect viewer perf changes — production minification and content-hashed immutable assets — ported into `ts-mono` after the `_view/www` → submodule migration. Combined into one PR since both are `apps/inspect/vite.config.ts` build-config changes and the content-hashing builds directly on the minification/chunking setup.

## What
- Production minification + vendor chunk splitting.
- Content-hashed asset filenames, so hashed assets can be served with immutable `Cache-Control` (the matching server-side change ships in our downstream fork).

## Verification
- `pnpm --filter @meridianlabs/log-viewer build` — green (minified, content-hashed filenames emitted)

Supersedes #348 (folded in here). One of a series re-porting the closed Inspect viewer PRs into ts-mono.
