### PR TITLE
perf(viewer): O(n) hasToolEvents precompute for transcript virtualization

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -18,6 +18,7 @@ import { GeneratingIndicator } from "../indicators/GeneratingIndicator";
 
 import { EventLabelContext } from "./EventLabelContext";
 import { eventSearchText } from "./eventText";
+import { computeHasToolEventsAtDepth } from "./hasToolEventsAtDepth";
 import { RenderedEventNode } from "./TranscriptVirtualList";
 import styles from "./TranscriptVirtualListComponent.module.css";
 import { EventNode, EventNodeContext, EventPanelCallbacks } from "./types";
@@ -88,25 +89,13 @@ export const TranscriptVirtualListComponent: FC<
     return idx === -1 ? undefined : idx;
   });
 
-  const hasToolEventsAtCurrentDepth = useCallback(
-    (startIndex: number) => {
-      const startNode = eventNodes[startIndex];
-      if (!startNode) return false;
-      // Walk backwards from this index to see if we see any tool events
-      // at this depth, prior to this event
-      for (let i = startIndex; i >= 0; i--) {
-        const node = eventNodes[i];
-        if (!node) return false;
-
-        if (node.event.event === "tool") {
-          return true;
-        }
-        if (node.depth < startNode.depth) {
-          return false;
-        }
-      }
-      return false;
-    },
+  // Pre-compute, in O(n), whether each event has a tool event at its depth.
+  // This was previously an O(n^2) per-index backward scan run once per node
+  // while building contextMap, which dominated time-to-first-paint on large or
+  // deeply nested transcripts. computeHasToolEventsAtDepth returns the
+  // identical boolean for every index (locked by hasToolEventsAtDepth.test.ts).
+  const hasToolEventsLookup = useMemo(
+    () => computeHasToolEventsAtDepth(eventNodes),
     [eventNodes]
   );
 
@@ -125,12 +114,12 @@ export const TranscriptVirtualListComponent: FC<
   const contextMap = useMemo(() => {
     const map = new Map<string, EventNodeContext>();
     for (const [i, node] of eventNodes.entries()) {
-      const hasToolEvents = hasToolEventsAtCurrentDepth(i);
+      const hasToolEvents = hasToolEventsLookup[i] ?? false;
       const turnInfo = turnMap?.get(node.id);
       map.set(node.id, { hasToolEvents, turnInfo, ...eventNodeContext });
     }
     return map;
-  }, [eventNodes, hasToolEventsAtCurrentDepth, turnMap, eventNodeContext]);
+  }, [eventNodes, hasToolEventsLookup, turnMap, eventNodeContext]);
 
   const eventLabels = eventNodeContext?.eventLabels;
 

--- a/packages/inspect-components/src/transcript/hasToolEventsAtDepth.test.ts
+++ b/packages/inspect-components/src/transcript/hasToolEventsAtDepth.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { computeHasToolEventsAtDepth } from "./hasToolEventsAtDepth";
+import { EventNode } from "./types";
+
+// Only `event.event` (the discriminant) and `depth` affect the lookup, so the
+// rest of the Event payload is stubbed. Mirrors transform/flatten.test.ts.
+const node = (
+  eventType: string,
+  depth: number,
+  id = `${eventType}-${depth}-${Math.random()}`
+): EventNode => {
+  const event = { event: eventType } as unknown as Event;
+  return new EventNode(id, event, depth);
+};
+
+// Faithful O(n^2) reference: a LITERAL transcription of the backward scan the
+// component uses today (TranscriptVirtualListComponent.tsx:91-111). The tool
+// check precedes the depth check, exactly as in the live code. The fast path
+// must equal this for every index, on every input. Do NOT "fix" or simplify
+// this oracle — it encodes the real (current) behavior, bugs and all.
+const referenceHasToolEvents = (nodes: EventNode[]): boolean[] =>
+  nodes.map((_unused, startIndex) => {
+    const startNode = nodes[startIndex];
+    if (!startNode) return false;
+    for (let i = startIndex; i >= 0; i--) {
+      const n = nodes[i];
+      if (!n) return false;
+      if (n.event.event === "tool") return true; // tool check FIRST
+      if (n.depth < startNode.depth) return false; // depth check SECOND
+    }
+    return false;
+  });
+
+describe("computeHasToolEventsAtDepth", () => {
+  it("returns an empty array for no events", () => {
+    expect(computeHasToolEventsAtDepth([])).toEqual([]);
+  });
+
+  it("marks a tool event and equal-depth followers in the same run", () => {
+    const nodes = [node("model", 0), node("tool", 0), node("info", 0)];
+    expect(computeHasToolEventsAtDepth(nodes)).toEqual([false, true, true]);
+  });
+
+  it("keeps true for a deeper sibling after a tool at the start (tool@0, info@1)", () => {
+    // Oracle-mandated case. Backward scan from info@1 (depth 1) continues past
+    // itself (1 is not < 1) and hits tool@0 -> true.
+    const nodes = [node("tool", 0), node("info", 1)];
+    expect(computeHasToolEventsAtDepth(nodes)).toEqual([true, true]);
+  });
+
+  it("counts a deeper tool event for a later shallower sibling", () => {
+    // Backward scan from the trailing depth-0 node reaches the depth-1 tool
+    // before any strictly-shallower node, so it counts. This is the case the
+    // old forward-scan port got WRONG.
+    const nodes = [node("model", 0), node("tool", 1), node("info", 0)];
+    expect(computeHasToolEventsAtDepth(nodes)).toEqual([false, true, true]);
+  });
+
+  it("resets when a strictly shallower non-tool node interrupts the run", () => {
+    const nodes = [node("tool", 1), node("info", 0), node("info", 1)];
+    expect(computeHasToolEventsAtDepth(nodes)).toEqual([true, true, false]);
+  });
+
+  it("propagates a tool nested two levels deep up to a returning ancestor", () => {
+    const nodes = [
+      node("model", 0),
+      node("model", 1),
+      node("tool", 2),
+      node("info", 0),
+    ];
+    expect(computeHasToolEventsAtDepth(nodes)).toEqual([
+      false,
+      false,
+      true,
+      true,
+    ]);
+  });
+
+  it("matches the reference backward scan on randomized fixtures", () => {
+    // Deterministic LCG so any failure reproduces exactly.
+    let seed = 0x12345;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let trial = 0; trial < 1000; trial++) {
+      const len = Math.floor(rand() * 40);
+      const nodes: EventNode[] = [];
+      for (let i = 0; i < len; i++) {
+        const depth = Math.floor(rand() * 4);
+        const eventType = rand() < 0.3 ? "tool" : "model";
+        nodes.push(node(eventType, depth, `n${i}`));
+      }
+      expect(computeHasToolEventsAtDepth(nodes)).toEqual(
+        referenceHasToolEvents(nodes)
+      );
+    }
+  });
+});

--- a/packages/inspect-components/src/transcript/hasToolEventsAtDepth.ts
+++ b/packages/inspect-components/src/transcript/hasToolEventsAtDepth.ts
@@ -1,0 +1,68 @@
+import { EventNode } from "./types";
+
+/**
+ * For each event node, compute whether a backward scan from that node reaches a
+ * tool event before it reaches any node strictly shallower than itself. This
+ * reproduces, in O(n), the exact result of the former per-index O(n^2) backward
+ * scan (`hasToolEventsAtCurrentDepth`) so callers see no behavior change.
+ *
+ * Semantics (matching the old scan exactly): scanning backward from index i,
+ * return true on the first tool event encountered; otherwise return false on
+ * the first non-tool node shallower than i's depth. The tool check precedes the
+ * depth check, so a node that is both a tool and shallower still returns true.
+ *
+ * O(n) reformulation. The backward scan from i stops at the first index that is
+ * either a tool OR strictly shallower than depth[i]; the result is true iff
+ * that first stop is a tool. Equivalently: let `lastToolIndex` be the most
+ * recent tool at or before i, and `prevShallower` be the nearest preceding
+ * index strictly shallower than depth[i]. The scan hits the tool before any
+ * strictly-shallower node iff `lastToolIndex >= prevShallower` (and a tool
+ * exists at all). We compute `prevShallower` for every i in amortized O(1)
+ * using a monotonic stack whose depths strictly increase from the bottom (a
+ * classic "previous strictly-smaller element" stack); each node is pushed and
+ * popped at most once, so the whole pass is O(n).
+ */
+export function computeHasToolEventsAtDepth(
+  eventNodes: EventNode[]
+): boolean[] {
+  const result = new Array<boolean>(eventNodes.length);
+  // Monotonic stack of {index, depth} with strictly-increasing depth from the
+  // bottom; after popping, the top is the nearest preceding node strictly
+  // shallower than the current node.
+  const shallowerStack: { index: number; depth: number }[] = [];
+  let lastToolIndex = -1;
+
+  for (let i = 0; i < eventNodes.length; i++) {
+    const node = eventNodes[i];
+    if (!node) {
+      result[i] = false;
+      continue;
+    }
+    const depth = node.depth;
+
+    // Pop every entry at this depth or deeper; whatever remains is the nearest
+    // preceding node strictly shallower than `depth`.
+    while (
+      shallowerStack.length > 0 &&
+      shallowerStack[shallowerStack.length - 1]!.depth >= depth
+    ) {
+      shallowerStack.pop();
+    }
+    const prevShallower =
+      shallowerStack.length > 0
+        ? shallowerStack[shallowerStack.length - 1]!.index
+        : -1;
+    shallowerStack.push({ index: i, depth });
+
+    if (node.event.event === "tool") {
+      lastToolIndex = i;
+    }
+
+    // True iff a tool exists at/before i and the most recent tool is no earlier
+    // than the most recent strictly-shallower node (so the backward scan reaches
+    // the tool before being stopped by a shallower node).
+    result[i] = lastToolIndex >= 0 && lastToolIndex >= prevShallower;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Re-implements a closed Inspect viewer perf change, ported into `ts-mono` after the `_view/www` → submodule migration.

## What
Replaces an O(n²) `hasToolEvents` scan with an O(n) precompute for transcript virtualization (`packages/inspect-components`), verified equivalent with a characterization test.

## Verification
- `pnpm --filter @tsmono/inspect-components test` + `pnpm --filter scout typecheck` — green

One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
