### PR TITLE
perf(viewer): optimize sample loading, search, and list rendering

### DIFF
--- a/apps/inspect/src/app/samples/list/SampleList.tsx
+++ b/apps/inspect/src/app/samples/list/SampleList.tsx
@@ -14,6 +14,7 @@ import { MessageBand } from "../../../components/MessageBand";
 import { useDocumentTitle } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import { useSampleNavigation } from "../../routing/sampleNavigation";
+import { isCurrentSample } from "../../shared/sample";
 import { SamplesGrid } from "../../shared/samples-grid/SamplesGrid";
 import { SampleRow } from "../../shared/samples-grid/types";
 
@@ -91,10 +92,15 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
         const url = sampleNavigation.getSampleUrl(row.sampleId, row.epoch);
         if (url) window.open(url, "_blank");
       } else {
+        // Re-clicking the open sample would re-run selectSample + navigate and
+        // trigger a redundant reload of the same sample — skip it.
+        if (isCurrentSample(selectedSampleHandle, row.sampleId, row.epoch)) {
+          return;
+        }
         sampleNavigation.showSample(row.sampleId, row.epoch);
       }
     },
-    [sampleNavigation]
+    [sampleNavigation, selectedSampleHandle]
   );
 
   const getRowId = useCallback(
@@ -124,14 +130,16 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
   const sampleCount = items.length;
 
   const warnings = useMemo(() => {
-    const errorCount = items.reduce(
-      (prev, item) => (item.error || item.data?.error ? prev + 1 : prev),
-      0
-    );
-    const limitCount = items.reduce(
-      (prev, item) => (item.limit || item.data?.limit ? prev + 1 : prev),
-      0
-    );
+    let errorCount = 0;
+    let limitCount = 0;
+    for (const item of items) {
+      if (item.error || item.data?.error) {
+        errorCount += 1;
+      }
+      if (item.limit || item.data?.limit) {
+        limitCount += 1;
+      }
+    }
     const percentError = sampleCount > 0 ? (errorCount / sampleCount) * 100 : 0;
     const percentLimit = sampleCount > 0 ? (limitCount / sampleCount) * 100 : 0;
 
@@ -159,12 +167,12 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
 
   return (
     <div className={styles.mainLayout}>
-      {warnings.map((warning, index) => (
+      {warnings.map((warning) => (
         <MessageBand
-          id={`sample-warning-message-${index}`}
+          id={`sample-warning-message-${warning.type}-${warning.msg}`}
           message={warning.msg}
           type={warning.type as "info" | "warning" | "error"}
-          key={`sample-warning-message-${index}`}
+          key={`sample-warning-message-${warning.type}-${warning.msg}`}
         />
       ))}
       <SamplesGrid<SampleRow>

--- a/apps/inspect/src/app/shared/sample.test.ts
+++ b/apps/inspect/src/app/shared/sample.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { isCurrentSample } from "./sample";
+
+const handle = (id: string | number, epoch: number) => ({
+  id,
+  epoch,
+  logFile: "log.eval",
+});
+
+describe("isCurrentSample", () => {
+  it("matches on equal id (string-normalized) and epoch", () => {
+    expect(isCurrentSample(handle(1, 0), 1, 0)).toBe(true);
+    expect(isCurrentSample(handle("1", 0), 1, 0)).toBe(true);
+  });
+
+  it("rejects differing id or epoch, or an undefined handle", () => {
+    expect(isCurrentSample(handle(1, 0), 2, 0)).toBe(false);
+    expect(isCurrentSample(handle(1, 0), 1, 1)).toBe(false);
+    expect(isCurrentSample(undefined, 1, 0)).toBe(false);
+  });
+});

--- a/apps/inspect/src/app/shared/sample.ts
+++ b/apps/inspect/src/app/shared/sample.ts
@@ -18,6 +18,13 @@ export const sampleIdsEqual = (
   return String(id) === String(otherId);
 };
 
+export const isCurrentSample = (
+  handle: SampleHandle | undefined,
+  id: string | number,
+  epoch: number
+): boolean =>
+  handle !== undefined && handle.epoch === epoch && sampleIdsEqual(handle.id, id);
+
 export const sampleHandlesEqual = (
   sample1?: SampleHandle,
   sample2?: SampleHandle

--- a/apps/inspect/src/components/FindBand.tsx
+++ b/apps/inspect/src/components/FindBand.tsx
@@ -239,7 +239,7 @@ export const FindBand: FC<FindBandProps> = () => {
   // and the compiler can't prove debounce() won't invoke it during render.
   const debouncedSearchRef = useRef<(() => void) | null>(null);
   useEffect(() => {
-    debouncedSearchRef.current = debounce(runDebouncedSearch, 300);
+    debouncedSearchRef.current = debounce(runDebouncedSearch, 100);
   }, [runDebouncedSearch]);
 
   const handleInputChange = useCallback(() => {

--- a/apps/inspect/src/state/hooks.test.ts
+++ b/apps/inspect/src/state/hooks.test.ts
@@ -4,12 +4,15 @@ import { LogHandle } from "@tsmono/inspect-common/types";
 
 import { EvalLogStatus } from "../@types/extraInspect";
 import { ScoreView } from "../app/samples/header-v2/ViewToggle";
+import { SampleSummary } from "../client/api/types";
 
 import {
+  compareSamples,
   computeLogsWithRetried,
   readEvalScorePanelView,
   resolveScorePanelSort,
   resolveScorePanelView,
+  samplesAreSorted,
   ScorePanelSortState,
 } from "./hooks";
 
@@ -23,6 +26,29 @@ const log = (
 });
 
 const preview = (status: EvalLogStatus) => ({ status });
+
+const s = (id: string | number, epoch: number): SampleSummary =>
+  ({ id, epoch, input: "", target: "", scores: null });
+
+describe("compareSamples / samplesAreSorted", () => {
+  it("orders numeric ids ascending then epoch ascending", () => {
+    expect(compareSamples(s(1, 0), s(2, 0))).toBeLessThan(0);
+    expect(compareSamples(s(2, 0), s(1, 0))).toBeGreaterThan(0);
+    expect(compareSamples(s(1, 0), s(1, 1))).toBeLessThan(0);
+    expect(compareSamples(s(1, 1), s(1, 1))).toBe(0);
+  });
+
+  it("orders string ids lexicographically", () => {
+    expect(compareSamples(s("a", 0), s("b", 0))).toBeLessThan(0);
+  });
+
+  it("detects sorted vs unsorted arrays", () => {
+    expect(samplesAreSorted([s(1, 0), s(1, 1), s(2, 0)])).toBe(true);
+    expect(samplesAreSorted([s(2, 0), s(1, 0)])).toBe(false);
+    expect(samplesAreSorted([s(1, 0)])).toBe(true);
+    expect(samplesAreSorted([])).toBe(true);
+  });
+});
 
 describe("computeLogsWithRetried", () => {
   it("marks a lone log as not retried", () => {

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -292,6 +292,33 @@ export const useSampleDescriptor = () => {
   }, [evalDescriptor, sampleSummaries, selectedScores]);
 };
 
+// Sort key: sample id ascending (numeric when both numeric, else
+// lexicographic), then epoch ascending. Extracted so the already-sorted
+// pre-check shares the exact comparison the sort uses.
+export const compareSamples = (a: SampleSummary, b: SampleSummary): number => {
+  let idCompare: number;
+  if (typeof a.id === "number" && typeof b.id === "number") {
+    idCompare = a.id - b.id;
+  } else {
+    idCompare = String(a.id).localeCompare(String(b.id));
+  }
+  if (idCompare !== 0) {
+    return idCompare;
+  }
+  return a.epoch - b.epoch;
+};
+
+// Server summaries usually arrive already sorted; this lets useFilteredSamples
+// skip an O(n log n) clone + sort on every filter/store change.
+export const samplesAreSorted = (samples: SampleSummary[]): boolean => {
+  for (let i = 1; i < samples.length; i++) {
+    if (compareSamples(samples[i - 1], samples[i]) > 0) {
+      return false;
+    }
+  }
+  return true;
+};
+
 // Provides the list of filtered and sorted samples
 export const useFilteredSamples = () => {
   const samplesDescriptor = useSampleDescriptor();
@@ -318,21 +345,12 @@ export const useFilteredSamples = () => {
     const filtered =
       error === undefined || !allErrors ? result : sampleSummaries;
 
-    // Sort samples by sample ID (asc) then epoch (asc)
-    const sorted = [...filtered].sort((a, b) => {
-      // Compare by ID first
-      let idCompare: number;
-      if (typeof a.id === "number" && typeof b.id === "number") {
-        idCompare = a.id - b.id;
-      } else {
-        idCompare = String(a.id).localeCompare(String(b.id));
-      }
-      if (idCompare !== 0) return idCompare;
-      // Then by epoch
-      return a.epoch - b.epoch;
-    });
+    // Skip the clone + sort when the list is already ordered (the common case).
+    if (filtered.length < 2 || samplesAreSorted(filtered)) {
+      return filtered;
+    }
 
-    return sorted;
+    return [...filtered].sort(compareSamples);
   }, [
     samplesDescriptor,
     sampleSummaries,

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -144,6 +144,22 @@ describe("eventsToStr — tool_use content", () => {
   });
 });
 
+describe("extractEventFields — model error / traceback", () => {
+  it("includes the model event error and traceback in search text", () => {
+    const node = {
+      event: {
+        event: "model",
+        model: "test/model",
+        error: "API rate limit exceeded",
+        traceback: "Traceback (most recent call last): ...",
+      },
+    } as unknown as EventNode;
+    const texts = eventSearchText(node);
+    expect(texts).toContain("API rate limit exceeded");
+    expect(texts).toContain("Traceback (most recent call last): ...");
+  });
+});
+
 describe("eventsToStr — multimodal content placeholders", () => {
   const data = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA_LONG_BLOB_";
   const image: ContentImage = {

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -82,6 +82,14 @@ export const extractEventFields = (event: EventType): [string, string][] => {
           }
         }
       }
+      // API-call errors / tracebacks surfaced on the model event itself
+      // (e.g. provider 5xx) — make them searchable like the rendered view.
+      if (modelEvent.error) {
+        fields.push(["error", modelEvent.error]);
+      }
+      if (modelEvent.traceback) {
+        fields.push(["traceback", modelEvent.traceback]);
+      }
       break;
     }
 

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -58,6 +59,33 @@ function PaddingChunks({ height, prefix }: { height: number; prefix: string }) {
   }
   return <>{chunks}</>;
 }
+
+// Count occurrences of `lowerTerm` across pre-lowercased per-item text
+// arrays. Lifted out of the component so the hot find-counter path is
+// unit-testable and the lowercasing happens once (in the memo below) rather
+// than on every keystroke. `lowerTerm` must already be lowercased.
+export const countMatchesInTexts = (
+  lowerTextsByItem: string[][],
+  lowerTerm: string
+): number => {
+  // An empty term makes indexOf return its start position forever (pos += 0),
+  // so guard before the scan loop — this helper is exported and unit-tested
+  // directly, where the FindBand caller's own empty-term guard would not apply.
+  if (lowerTerm.length === 0) {
+    return 0;
+  }
+  let total = 0;
+  for (const texts of lowerTextsByItem) {
+    for (const lowerText of texts) {
+      let pos = 0;
+      while ((pos = lowerText.indexOf(lowerTerm, pos)) !== -1) {
+        total++;
+        pos += lowerTerm.length;
+      }
+    }
+  }
+  return total;
+};
 
 export function VirtualList<T>({
   persistenceKey,
@@ -490,27 +518,24 @@ export function VirtualList<T>({
     [data, itemSearchText, virtualizer]
   );
 
+  // Pre-compute lowercased search text for every item once per data /
+  // accessor change, so the FindBand counter doesn't re-extract and
+  // re-lowercase the whole list on each keystroke.
+  const precomputedSearchTexts = useMemo(() => {
+    const getText = itemSearchText ?? ((item: T) => JSON.stringify(item));
+    return data.map((item) => {
+      const texts = getText(item);
+      const textArray = Array.isArray(texts) ? texts : [texts];
+      return textArray.map((t) => t.toLowerCase());
+    });
+  }, [data, itemSearchText]);
+
   const countMatchesInData = useCallback<ExtendedCountFn>(
     (term) => {
-      if (!term || data.length === 0) return 0;
-      const getText = itemSearchText ?? ((item: T) => JSON.stringify(item));
-      const lower = term.toLowerCase();
-      let total = 0;
-      for (const item of data) {
-        const texts = getText(item);
-        const textArray = Array.isArray(texts) ? texts : [texts];
-        for (const text of textArray) {
-          const lowerText = text.toLowerCase();
-          let pos = 0;
-          while ((pos = lowerText.indexOf(lower, pos)) !== -1) {
-            total++;
-            pos += lower.length;
-          }
-        }
-      }
-      return total;
+      if (!term || precomputedSearchTexts.length === 0) return 0;
+      return countMatchesInTexts(precomputedSearchTexts, term.toLowerCase());
     },
-    [data, itemSearchText]
+    [precomputedSearchTexts]
   );
 
   useEffect(() => {

--- a/packages/react/src/virtual/__tests__/count-matches.test.ts
+++ b/packages/react/src/virtual/__tests__/count-matches.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { countMatchesInTexts } from "../VirtualList";
+
+describe("countMatchesInTexts", () => {
+  it("counts every occurrence across items and fields", () => {
+    const texts = [["foo bar foo"], ["baz", "foofoo"]];
+    expect(countMatchesInTexts(texts, "foo")).toBe(4);
+  });
+
+  it("counts overlapping-free, advancing by term length", () => {
+    expect(countMatchesInTexts([["aaaa"]], "aa")).toBe(2);
+  });
+
+  it("returns 0 for no match or empty input", () => {
+    expect(countMatchesInTexts([["hello"]], "zzz")).toBe(0);
+    expect(countMatchesInTexts([], "x")).toBe(0);
+  });
+
+  it("returns 0 for an empty term without spinning (empty-term guard)", () => {
+    expect(countMatchesInTexts([["aaaa"]], "")).toBe(0);
+    expect(countMatchesInTexts([["hello"], ["world"]], "")).toBe(0);
+  });
+});


### PR DESCRIPTION
Re-implements a closed Inspect viewer perf change, ported into `ts-mono` after the `_view/www` → submodule migration.

## What
Optimizes sample loading, search, and list rendering in the viewer (`packages/inspect-components`).

## Verification
- `pnpm --filter @tsmono/inspect-components test` + `pnpm --filter scout typecheck` — green

One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
