### PR TITLE
perf(viewer): align transcript find ordering with structured tool output

### DIFF
--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -9,7 +9,7 @@ import type {
   ToolEvent,
 } from "@tsmono/inspect-common/types";
 
-import { eventSearchText, eventsToStr } from "./eventText";
+import { eventSearchText, eventsToStr, extractEventFields } from "./eventText";
 import { EventNode } from "./types";
 
 const reasoning = (r: Partial<ContentReasoning>): ContentReasoning => ({
@@ -280,15 +280,15 @@ const toolEvent = (result: unknown): ToolEvent =>
   }) as unknown as ToolEvent;
 
 describe("eventsToStr — extractEventFields sanitization", () => {
-  it("sanitizes tool result containing image content", () => {
+  it("walks a tool result array: text renders, data: image drops (no placeholder, no leak)", () => {
     const out = eventsToStr([
       toolEvent([
         { type: "image", image: "data:image/png;base64,_HUGE_PNG_" },
         { type: "text", text: "see image" },
       ]),
     ]);
-    expect(out).toContain("<image />");
     expect(out).toContain("see image");
+    expect(out).not.toContain("<image />");
     expect(out).not.toContain("_HUGE_PNG_");
   });
 });
@@ -660,6 +660,102 @@ describe("eventSearchText", () => {
     );
     expect(texts).toContain("Web Search");
     expect(texts).toContain("search");
+  });
+
+  test("tool: array result yields one ordered search segment per rendered block", () => {
+    const node = makeNode({
+      event: "tool",
+      function: "browser",
+      view: { title: "Browser" },
+      arguments: { action: "get_page_text" },
+      result: [
+        { type: "text", text: "Revenue Recognition in policy docs" },
+        {
+          type: "tool",
+          content: [
+            { type: "text", text: "Revenue Recognition in extracted page" },
+          ],
+        },
+        { type: "image", image: "data:image/png;base64,abc123" },
+      ],
+      error: null,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const resultSegments = extractEventFields(node.event)
+      .filter(([key]) => key === "result")
+      .map(([, value]) => value);
+    expect(resultSegments).toEqual([
+      "Revenue Recognition in policy docs",
+      "Revenue Recognition in extracted page",
+    ]);
+
+    const texts = eventSearchText(node);
+    expect(texts).toContain('{"action":"get_page_text"}');
+    expect(texts.join("\n")).not.toContain("data:image/png;base64");
+  });
+
+  test("tool: array document renders its filename; audio/video render no text", () => {
+    const node = makeNode({
+      event: "tool",
+      function: "fetch",
+      arguments: null,
+      result: [
+        {
+          type: "document",
+          filename: "report.pdf",
+          document: "data:application/pdf;base64,_DOC_BLOB_",
+          mime_type: "application/pdf",
+        },
+        { type: "audio", audio: "data:audio/mp3;base64,_AUDIO_BLOB_" },
+        { type: "video", video: "data:video/mp4;base64,_VIDEO_BLOB_" },
+      ],
+      error: null,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const resultSegments = extractEventFields(node.event)
+      .filter(([key]) => key === "result")
+      .map(([, value]) => value);
+    expect(resultSegments).toEqual(["report.pdf"]);
+    const joined = resultSegments.join("\n");
+    expect(joined).not.toContain("_AUDIO_BLOB_");
+    expect(joined).not.toContain("_VIDEO_BLOB_");
+    expect(joined).not.toContain("_DOC_BLOB_");
+  });
+
+  test("tool: excluded hard cases stay safe (no payload leak), not renderer-exact", () => {
+    const imageNode = makeNode({
+      event: "tool",
+      function: "view_image",
+      arguments: null,
+      result: { type: "image", image: "data:image/png;base64,_HUGE_BLOB_" },
+      error: null,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    expect(eventSearchText(imageNode).join("\n")).not.toContain("_HUGE_BLOB_");
+
+    const dataNode = makeNode({
+      event: "tool",
+      function: "fetch",
+      arguments: null,
+      result: [{ type: "data", data: { secret: "_DATA_VALUE_" } }],
+      error: null,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    expect(eventSearchText(dataNode).join("\n")).not.toContain("_DATA_VALUE_");
+
+    const objectNode = makeNode({
+      event: "tool",
+      function: "calc",
+      arguments: null,
+      result: { answer: 42, label: "ok" },
+      error: null,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const objectSegments = extractEventFields(objectNode.event)
+      .filter(([key]) => key === "result")
+      .map(([, value]) => value);
+    expect(objectSegments).toEqual(['{"answer":42,"label":"ok"}']);
   });
 
   test("error: includes error message", () => {

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -113,7 +113,9 @@ export const extractEventFields = (event: EventType): [string, string][] => {
         if (typeof toolEvent.result === "string") {
           fields.push(["result", toolEvent.result]);
         } else {
-          fields.push(["result", sanitizeStringify(toolEvent.result)]);
+          for (const text of extractToolResultText(toolEvent.result)) {
+            fields.push(["result", text]);
+          }
         }
       }
       // Tool error
@@ -473,4 +475,60 @@ const extractContentText = (content: string | Array<Content>): string[] => {
     }
   }
   return texts;
+};
+
+const extractToolResultText = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => extractToolResultItemText(item));
+  }
+  return [sanitizeStringify(value)];
+};
+
+const extractToolResultItemText = (item: unknown): string[] => {
+  if (typeof item === "string") {
+    return [item];
+  }
+  if (item == null) {
+    return [];
+  }
+  if (
+    typeof item === "number" ||
+    typeof item === "boolean" ||
+    typeof item === "bigint"
+  ) {
+    return [item.toString()];
+  }
+  if (typeof item === "symbol") {
+    return [String(item)];
+  }
+  if (typeof item !== "object") {
+    return [];
+  }
+  if (!("type" in item)) {
+    return [sanitizeStringify(item)];
+  }
+
+  switch (item.type) {
+    case "text":
+      return "text" in item && typeof item.text === "string" ? [item.text] : [];
+    case "image":
+      return "image" in item &&
+        typeof item.image === "string" &&
+        !item.image.startsWith("data:")
+        ? [item.image]
+        : [];
+    case "document":
+      return "filename" in item && typeof item.filename === "string"
+        ? [item.filename]
+        : [];
+    case "audio":
+    case "video":
+      return [];
+    case "tool":
+      return "content" in item && Array.isArray(item.content)
+        ? item.content.flatMap((inner) => extractToolResultItemText(inner))
+        : [sanitizeStringify(item)];
+    default:
+      return [sanitizeStringify(item)];
+  }
 };


### PR DESCRIPTION
Re-implements a closed Inspect viewer change, ported into `ts-mono` after the `_view/www` → submodule migration.

## What
Aligns in-transcript find ordering and match counts with how structured tool output is rendered (`transcript/eventText.ts`): an array tool result is walked into one searchable segment per rendered block in render order (dropping non-text payloads) instead of a single JSON blob. The PR documents exactly which cases are renderer-exact vs. approximate.

## Verification
- `pnpm --filter @tsmono/inspect-components test -- eventText` (incl. new tests) — green

One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
