### PR TITLE
perf(viewer): lazy-load markdown-it-mathjax3 + batch markdown render commits

### DIFF
--- a/packages/react/src/components/MarkdownDiv.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MarkdownDiv } from "./MarkdownDiv";
+
+describe("MarkdownDiv render coordination", () => {
+  it("keeps callbacks independent for duplicate markdown with different post-processing", async () => {
+    render(
+      <>
+        <MarkdownDiv
+          markdown="same **markdown**"
+          postProcess={(html) =>
+            `<section data-testid="first">${html}</section>`
+          }
+        />
+        <MarkdownDiv
+          markdown="same **markdown**"
+          postProcess={(html) => `<aside data-testid="second">${html}</aside>`}
+        />
+      </>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("first").innerHTML).toContain(
+        "<strong>markdown</strong>"
+      );
+      expect(screen.getByTestId("second").innerHTML).toContain(
+        "<strong>markdown</strong>"
+      );
+    });
+  });
+});

--- a/packages/react/src/components/MarkdownDiv.tsx
+++ b/packages/react/src/components/MarkdownDiv.tsx
@@ -73,48 +73,29 @@ const MarkdownDivComponent = forwardRef<HTMLDivElement, MarkdownDivProps>(
       // Reset to sanitized markdown text when markdown changes (keep this synchronous for immediate feedback)
       setRenderedHtml(sanitizeMarkdown(markdown));
 
-      // Process markdown asynchronously using the queue
-      const { promise, cancel } = renderQueue.enqueue(() =>
-        renderMarkdown(markdown, rendererName)
-      );
-
-      // Update state when rendering completes
-      promise
-        .then((result) => {
-          // Update cache with pre-post-processed content (with simple size limit)
+      const { cancel } = renderCoordinator.enqueue(
+        () => renderMarkdown(markdown, rendererName),
+        (result) => {
           if (renderCache.size >= MAX_CACHE_SIZE) {
-            // Remove oldest entry (first key)
             const firstKey = renderCache.keys().next().value;
             if (firstKey) {
               renderCache.delete(firstKey);
             }
           }
           renderCache.set(cacheKey, result);
-
-          // Apply post-processing after caching
-          const finalHtml = applyPostProcess(result);
-
-          // Use startTransition to mark this as a non-urgent update
-          startTransition(() => {
-            setRenderedHtml(finalHtml);
-          });
-        })
-        .catch((error: unknown) => {
-          console.error("Markdown rendering error:", error);
-        });
+          setRenderedHtml(applyPostProcess(result));
+        }
+      );
 
       return () => {
         // Cancel rendering if component unmounts
         cancel();
       };
-    }, [
-      markdown,
-      rendererName,
-      cachedHtml,
-      renderedHtml,
-      cacheKey,
-      applyPostProcess,
-    ]);
+      // The effect must re-run only when source inputs change, not when its own
+      // async output updates; reading current renderedHtml in the cached branch
+      // without subscribing here is intentional.
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally excludes renderedHtml; see comment above
+    }, [markdown, rendererName, cachedHtml, cacheKey, applyPostProcess]);
 
     return (
       <div
@@ -228,5 +209,72 @@ class MarkdownRenderQueue {
   }
 }
 
-// Shared rendering queue
-const renderQueue = new MarkdownRenderQueue(10);
+class MarkdownRenderCoordinator {
+  private nextId = 0;
+  private completedResults = new Map<number, string>();
+  private pendingCallbacks = new Map<number, (html: string) => void>();
+  private flushScheduled = false;
+  private queue: MarkdownRenderQueue;
+
+  constructor(maxConcurrent: number = 10) {
+    this.queue = new MarkdownRenderQueue(maxConcurrent);
+  }
+
+  enqueue(
+    task: () => Promise<string>,
+    onComplete: (html: string) => void
+  ): { cancel: () => void } {
+    const id = this.nextId++;
+    this.pendingCallbacks.set(id, onComplete);
+
+    const { promise, cancel } = this.queue.enqueue(task);
+
+    promise
+      .then((result) => {
+        this.completedResults.set(id, result);
+        this.scheduleFlush();
+      })
+      .catch((error: unknown) => {
+        this.pendingCallbacks.delete(id);
+        this.completedResults.delete(id);
+        console.error("Markdown rendering error:", error);
+      });
+
+    return {
+      cancel: () => {
+        cancel();
+        this.pendingCallbacks.delete(id);
+        this.completedResults.delete(id);
+      },
+    };
+  }
+
+  private scheduleFlush(): void {
+    if (!this.flushScheduled) {
+      this.flushScheduled = true;
+      queueMicrotask(() => this.flush());
+    }
+  }
+
+  private flush(): void {
+    this.flushScheduled = false;
+    const batch = new Map(this.completedResults);
+    this.completedResults.clear();
+
+    if (batch.size === 0) {
+      return;
+    }
+
+    startTransition(() => {
+      for (const [id, html] of batch) {
+        const callback = this.pendingCallbacks.get(id);
+        if (callback) {
+          callback(html);
+          this.pendingCallbacks.delete(id);
+        }
+      }
+    });
+  }
+}
+
+const renderCoordinator = new MarkdownRenderCoordinator(10);

--- a/packages/react/src/components/markdownRendering.ts
+++ b/packages/react/src/components/markdownRendering.ts
@@ -4,7 +4,21 @@
  */
 
 import MarkdownIt from "markdown-it";
-import markdownitMathjax3 from "markdown-it-mathjax3";
+
+type MarkdownItPlugin = (md: MarkdownIt) => void;
+
+let mathjaxPluginPromise: Promise<MarkdownItPlugin> | null = null;
+const getMathjaxPlugin = (): Promise<MarkdownItPlugin> => {
+  if (!mathjaxPluginPromise) {
+    mathjaxPluginPromise = import("markdown-it-mathjax3").then(
+      (m) => m.default as MarkdownItPlugin
+    );
+  }
+  return mathjaxPluginPromise;
+};
+
+export const hasMathContent = (text: string): boolean =>
+  text.includes("$") || text.includes("\\(") || text.includes("\\[");
 
 // Module-level cache for lazy-initialized markdown-it instances
 const mdInstanceCache: Record<string, MarkdownIt> = {};
@@ -24,8 +38,15 @@ export const unescapeHtmlForMath = (content: string): string => {
     .replace(/&quot;/g, '"');
 };
 
-export const getMarkdownInstance = (renderer: MarkdownRenderer): MarkdownIt => {
-  const cached = mdInstanceCache[renderer];
+export const getMarkdownInstance = async (
+  renderer: MarkdownRenderer,
+  contentHasMath?: boolean
+): Promise<MarkdownIt> => {
+  const useMath =
+    (renderer === "full" || renderer === "fragment") && !!contentHasMath;
+  const cacheKey = `${renderer}:${useMath ? "1" : "0"}`;
+
+  const cached = mdInstanceCache[cacheKey];
   if (cached) {
     return cached;
   }
@@ -35,14 +56,14 @@ export const getMarkdownInstance = (renderer: MarkdownRenderer): MarkdownIt => {
       "emphasis",
       "newline",
     ]);
-    mdInstanceCache[renderer] = md;
+    mdInstanceCache[cacheKey] = md;
     return md;
   }
 
   const md = new MarkdownIt({ breaks: true, html: true });
-  if (renderer === "full" || renderer === "fragment") {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- plugin has no type declarations
-    md.use(markdownitMathjax3);
+  if (useMath) {
+    const mathjaxPlugin = await getMathjaxPlugin();
+    md.use(mathjaxPlugin);
 
     // Wrap math renderers to unescape HTML entities in TeX content
     // before MathJax processes them. HTML chars in LaTeX blocks are
@@ -74,7 +95,7 @@ export const getMarkdownInstance = (renderer: MarkdownRenderer): MarkdownIt => {
   if (renderer === "fragment") {
     md.disable(["image"]);
   }
-  mdInstanceCache[renderer] = md;
+  mdInstanceCache[cacheKey] = md;
 
   return md;
 };
@@ -248,12 +269,12 @@ export function unescapeCodeHtmlEntities(str: string): string {
   );
 }
 
-type MarkdownRenderFunction = (markdown: string) => string;
+type MarkdownRenderFunction = (markdown: string) => Promise<string>;
 
-const renderFullPipelineMarkdown = (
+const renderFullPipelineMarkdown = async (
   markdown: string,
   renderer: "full" | "fragment"
-): string => {
+): Promise<string> => {
   // Protect backslashes in LaTeX expressions
   const protectedContent = protectBackslashesInLatex(markdown);
 
@@ -270,7 +291,7 @@ const renderFullPipelineMarkdown = (
 
   let html = preparedForMarkdown;
   try {
-    const md = getMarkdownInstance(renderer);
+    const md = await getMarkdownInstance(renderer, hasMathContent(markdown));
     html = md.render(preparedForMarkdown);
   } catch (ex) {
     console.log("Unable to markdown render content");
@@ -288,9 +309,9 @@ const renderFullPipelineMarkdown = (
   return withSup;
 };
 
-const renderTextOnlyMarkdown = (markdown: string): string => {
+const renderTextOnlyMarkdown = async (markdown: string): Promise<string> => {
   try {
-    return getMarkdownInstance("textOnly").render(markdown);
+    return (await getMarkdownInstance("textOnly")).render(markdown);
   } catch (ex) {
     console.log("Unable to markdown render content");
     console.error(ex);
@@ -307,4 +328,4 @@ const markdownRenderers: Record<MarkdownRenderer, MarkdownRenderFunction> = {
 export const renderMarkdown = (
   markdown: string,
   renderer: MarkdownRenderer = defaultMarkdownRenderer
-): string => markdownRenderers[renderer](markdown);
+): Promise<string> => markdownRenderers[renderer](markdown);

--- a/packages/react/src/components/markdownSecurity.test.ts
+++ b/packages/react/src/components/markdownSecurity.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getMarkdownInstance,
+  hasMathContent,
   protectBackslashesInLatex,
   renderMarkdown,
   restoreBackslashesForLatex,
@@ -12,66 +14,87 @@ import {
  * Simulate the async rendering pipeline from MarkdownDiv.
  * This mirrors the steps in the renderQueue.enqueue callback.
  */
-function renderPipeline(
+async function renderPipeline(
   markdown: string,
   renderer: MarkdownRenderer = "full"
-): string {
+): Promise<string> {
   return renderMarkdown(markdown, renderer);
 }
 
 describe("MarkdownDiv XSS security", () => {
   describe("script injection in LaTeX blocks", () => {
-    it("should not produce raw <script> tags from inline math", () => {
-      const result = renderPipeline("$<script>alert(1)</script>$");
+    it("should not produce raw <script> tags from inline math", async () => {
+      const result = await renderPipeline("$<script>alert(1)</script>$");
       expect(result).not.toContain("<script>");
       expect(result).not.toContain("</script>");
     });
 
-    it("should not produce raw <script> tags from block math", () => {
-      const result = renderPipeline("$$<script>alert(1)</script>$$");
+    it("should not produce raw <script> tags from block math", async () => {
+      const result = await renderPipeline("$$<script>alert(1)</script>$$");
       expect(result).not.toContain("<script>");
       expect(result).not.toContain("</script>");
     });
   });
 
   describe("event handler injection in LaTeX blocks", () => {
-    it("should not produce raw <img> with onerror from inline math", () => {
-      const result = renderPipeline('$<img src=x onerror="alert(1)">$');
+    it("should not produce raw <img> with onerror from inline math", async () => {
+      const result = await renderPipeline('$<img src=x onerror="alert(1)">$');
       expect(result).not.toContain("<img");
       expect(result).not.toContain("onerror");
     });
 
-    it("should not produce raw <img> with onerror from block math", () => {
-      const result = renderPipeline('$$<img src=x onerror="alert(1)">$$');
+    it("should not produce raw <img> with onerror from block math", async () => {
+      const result = await renderPipeline('$$<img src=x onerror="alert(1)">$$');
       expect(result).not.toContain("<img");
       expect(result).not.toContain("onerror");
     });
   });
 
   describe("script injection outside LaTeX", () => {
-    it("should escape <script> tags in plain text", () => {
-      const result = renderPipeline("<script>alert(1)</script>");
+    it("should escape <script> tags in plain text", async () => {
+      const result = await renderPipeline("<script>alert(1)</script>");
       expect(result).not.toContain("<script>");
     });
 
-    it("should escape event handlers in plain text", () => {
-      const result = renderPipeline('<img src=x onerror="alert(1)">');
+    it("should escape event handlers in plain text", async () => {
+      const result = await renderPipeline('<img src=x onerror="alert(1)">');
       // The text "onerror" may appear as escaped text, but no raw <img> tag
       expect(result).not.toContain("<img");
     });
   });
 
   describe("legitimate LaTeX still renders", () => {
-    it("should render inline math with backslashes", () => {
-      const result = renderPipeline("$\\frac{1}{2}$");
+    it("should render inline math with backslashes", async () => {
+      const result = await renderPipeline("$\\frac{1}{2}$");
       // MathJax should process this — output should contain mjx-container or similar
       // At minimum, the backslash commands should not be entity-encoded
       expect(result).not.toContain("___LATEX_BACKSLASH___");
     });
 
-    it("should render block math with backslashes", () => {
-      const result = renderPipeline("$$\\sum_{i=0}^{n} x_i$$");
+    it("should render block math with backslashes", async () => {
+      const result = await renderPipeline("$$\\sum_{i=0}^{n} x_i$$");
       expect(result).not.toContain("___LATEX_BACKSLASH___");
+    });
+
+    it("lazily loads mathjax and emits an mjx-container for math content", async () => {
+      const result = await renderPipeline("$\\frac{1}{2}$");
+      expect(result).toContain("mjx-container");
+    });
+
+    it("renders plain content without loading mathjax", async () => {
+      const result = await renderPipeline("hello **world**");
+      expect(result).toContain("<strong>world</strong>");
+      expect(result).not.toContain("mjx-container");
+    });
+
+    it("detects math delimiters before loading mathjax", async () => {
+      expect(hasMathContent("hello **world**")).toBe(false);
+      expect(hasMathContent("$x + y$")).toBe(true);
+      expect(hasMathContent("\\(x + y\\)")).toBe(true);
+      expect(hasMathContent("\\[x + y\\]")).toBe(true);
+
+      const plainFullRenderer = await getMarkdownInstance("full", false);
+      expect(plainFullRenderer.renderer.rules.math_inline).toBeUndefined();
     });
 
     it("should render math with comparison operators via unescapeHtmlForMath", () => {
@@ -128,8 +151,8 @@ describe("MarkdownDiv XSS security", () => {
   });
 
   describe("renderer scenarios", () => {
-    it("fragment renderer omits markdown images", () => {
-      const result = renderPipeline(
+    it("fragment renderer omits markdown images", async () => {
+      const result = await renderPipeline(
         "![alt](https://example.com/image.png)",
         "fragment"
       );
@@ -137,8 +160,8 @@ describe("MarkdownDiv XSS security", () => {
       expect(result).toContain("alt");
     });
 
-    it("textOnly renderer supports emphasis and newlines only", () => {
-      const result = renderPipeline(
+    it("textOnly renderer supports emphasis and newlines only", async () => {
+      const result = await renderPipeline(
         "hello *world*\n![alt](https://example.com/image.png)\n[link](https://example.com)",
         "textOnly"
       );


### PR DESCRIPTION
Re-implements [a closed Inspect viewer perf change](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3356), ported into `ts-mono` after the `_view/www` → submodule migration.

## What
Converts the static `markdown-it-mathjax3` import to a dynamic import so the heavy MathJax engine is fetched only when a transcript contains math, and keys the markdown render coordinator by a unique id so multiple `MarkdownDiv` instances rendering identical content no longer clobber each other's render/cancel bookkeeping.

## Verification
- Falsifiable chunk-split proof: the plugin-entry identifier is absent from the entry chunk and present in a separate dynamic chunk after the change.
- `pnpm --filter @tsmono/react test` + both app typechecks — green

One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
