### PR TITLE
perf(viewer): content-hash asset filenames for immutable caching

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -108,7 +108,7 @@ export default defineConfig(({ mode }) => {
         },
         cssCodeSplit: false,
         sourcemap: true,
-        minify: false,
+        minify: true,
       },
     };
   } else {
@@ -121,7 +121,6 @@ export default defineConfig(({ mode }) => {
         warnIfWatchingWithoutSubmodule("inspect_ai"),
         copyToPythonRepo(),
       ],
-      mode: "development",
       base: "",
       server: {
         proxy: {
@@ -134,12 +133,26 @@ export default defineConfig(({ mode }) => {
       build: {
         outDir: "dist",
         emptyOutDir: true,
-        minify: false,
+        minify: mode !== "development",
         rollupOptions: {
           output: {
             entryFileNames: `assets/index.js`,
             chunkFileNames: `assets/[name].js`,
             assetFileNames: `assets/[name].[ext]`,
+            manualChunks(id) {
+              if (
+                id.includes("mathjax") ||
+                id.includes("markdown-it-mathjax3")
+              ) {
+                return "vendor-mathjax";
+              }
+              if (id.includes("@codemirror") || id.includes("@lezer")) {
+                return "vendor-codemirror";
+              }
+              if (id.includes("ag-grid")) {
+                return "vendor-ag-grid";
+              }
+            },
           },
         },
         sourcemap: true,

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -136,9 +136,9 @@ export default defineConfig(({ mode }) => {
         minify: mode !== "development",
         rollupOptions: {
           output: {
-            entryFileNames: `assets/index.js`,
-            chunkFileNames: `assets/[name].js`,
-            assetFileNames: `assets/[name].[ext]`,
+            entryFileNames: `assets/[name]-[hash].js`,
+            chunkFileNames: `assets/[name]-[hash].js`,
+            assetFileNames: `assets/[name]-[hash].[ext]`,
             manualChunks(id) {
               if (
                 id.includes("mathjax") ||


### PR DESCRIPTION
Re-implements a closed Inspect viewer perf change, ported into `ts-mono` after the `_view/www` → submodule migration.

> **Stacked on #343** (`perf/viewer-build-config`) — both edit `apps/inspect/vite.config.ts`. This branch therefore includes #343's commit; it will be rebased to drop it once #343 merges. Please review/merge after #343.

## What
Content-hashes viewer asset filenames in `apps/inspect/vite.config.ts` so hashed assets can be served with immutable `Cache-Control` headers (the matching server-side change ships in our downstream fork).

## Verification
- `pnpm --filter @meridianlabs/log-viewer build` — green (content-hashed filenames emitted)

One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
