### PR TITLE
feat(viewer): add client-side action annotations to browser screenshots

### DIFF
--- a/packages/inspect-components/src/chat/tools/AnnotatedToolOutput.test.tsx
+++ b/packages/inspect-components/src/chat/tools/AnnotatedToolOutput.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  AnnotatedToolOutput,
+  renderHtmlAnnotation,
+  renderSvgAnnotation,
+  type ToolAnnotation,
+} from "./AnnotatedToolOutput";
+
+class FakeResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AnnotatedToolOutput", () => {
+  it("renders children unchanged when there is no annotation", () => {
+    render(
+      <AnnotatedToolOutput>
+        <span>child-content</span>
+      </AnnotatedToolOutput>
+    );
+    expect(screen.getByText("child-content")).toBeDefined();
+  });
+
+  it("renders children inside a relative container when annotated", () => {
+    const annotation: ToolAnnotation = {
+      action: "left_click",
+      coordinate: [10, 20],
+    };
+    const { container } = render(
+      <AnnotatedToolOutput annotation={annotation}>
+        <span>child-content</span>
+      </AnnotatedToolOutput>
+    );
+    expect(screen.getByText("child-content")).toBeDefined();
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.position).toBe("relative");
+  });
+});
+
+describe("renderSvgAnnotation", () => {
+  it("draws a ring + cursor for click actions at a coordinate", () => {
+    const { container } = render(
+      <svg>
+        {renderSvgAnnotation(
+          { action: "left_click", coordinate: [10, 20] },
+          1,
+          1
+        )}
+      </svg>
+    );
+    expect(container.querySelector("circle")).not.toBeNull();
+    expect(container.querySelector("path")).not.toBeNull();
+  });
+
+  it("draws a down arrow for scroll actions", () => {
+    const { container } = render(
+      <svg>
+        {renderSvgAnnotation(
+          { action: "scroll", coordinate: [5, 5], scrollDirection: "down" },
+          1,
+          1
+        )}
+      </svg>
+    );
+    expect(container.querySelector("text")?.textContent).toBe("\u2193");
+  });
+
+  it("returns null for click actions without a coordinate", () => {
+    expect(renderSvgAnnotation({ action: "left_click" }, 1, 1)).toBeNull();
+  });
+
+  it("returns null for keyboard actions", () => {
+    expect(renderSvgAnnotation({ action: "type", text: "x" }, 1, 1)).toBeNull();
+  });
+});
+
+describe("renderHtmlAnnotation", () => {
+  it("renders a badge with the typed text for type actions", () => {
+    const { container } = render(
+      <>{renderHtmlAnnotation({ action: "type", text: "hello world" })}</>
+    );
+    expect(container.textContent).toContain("hello world");
+  });
+
+  it("renders a badge for key actions", () => {
+    const { container } = render(
+      <>{renderHtmlAnnotation({ action: "key", text: "Enter" })}</>
+    );
+    expect(container.textContent).toContain("Enter");
+  });
+
+  it("returns null for non-keyboard actions", () => {
+    expect(renderHtmlAnnotation({ action: "left_click" })).toBeNull();
+  });
+});

--- a/packages/inspect-components/src/chat/tools/AnnotatedToolOutput.tsx
+++ b/packages/inspect-components/src/chat/tools/AnnotatedToolOutput.tsx
@@ -1,0 +1,275 @@
+import { FC, ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+export interface ToolAnnotation {
+  action: string;
+  coordinate?: [number, number] | undefined;
+  text?: string | undefined;
+  scrollDirection?: string | undefined;
+}
+
+interface AnnotatedToolOutputProps {
+  children: ReactNode;
+  annotation?: ToolAnnotation;
+}
+
+interface ImageInfo {
+  img: HTMLImageElement;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+export const AnnotatedToolOutput: FC<AnnotatedToolOutputProps> = ({
+  children,
+  annotation,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [imageInfos, setImageInfos] = useState<ImageInfo[]>([]);
+  const observedImagesRef = useRef<Set<HTMLImageElement>>(new Set());
+
+  const updateImageInfos = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const images = Array.from(container.querySelectorAll("img"));
+    if (images.length === 0) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const infos: ImageInfo[] = images
+      .filter((img) => img.naturalWidth > 0 && img.naturalHeight > 0)
+      .map((img) => {
+        const imgRect = img.getBoundingClientRect();
+        return {
+          img,
+          top: imgRect.top - containerRect.top,
+          left: imgRect.left - containerRect.left,
+          width: imgRect.width,
+          height: imgRect.height,
+          naturalWidth: img.naturalWidth,
+          naturalHeight: img.naturalHeight,
+        };
+      });
+
+    setImageInfos(infos);
+  }, []);
+
+  useEffect(() => {
+    if (!annotation) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const resizeObs = new ResizeObserver(updateImageInfos);
+    const observedImages = observedImagesRef.current;
+
+    const trackImage = (img: HTMLImageElement) => {
+      if (observedImages.has(img)) return;
+      observedImages.add(img);
+      resizeObs.observe(img);
+      img.addEventListener("load", updateImageInfos);
+      if (img.complete && img.naturalWidth > 0) {
+        updateImageInfos();
+      }
+    };
+
+    const untrackImage = (img: HTMLImageElement) => {
+      if (!observedImages.has(img)) return;
+      observedImages.delete(img);
+      resizeObs.unobserve(img);
+      img.removeEventListener("load", updateImageInfos);
+    };
+
+    container.querySelectorAll("img").forEach(trackImage);
+
+    const mutationObs = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (node instanceof HTMLImageElement) {
+            trackImage(node);
+          } else if (node instanceof HTMLElement) {
+            node.querySelectorAll("img").forEach(trackImage);
+          }
+        }
+        for (const node of Array.from(mutation.removedNodes)) {
+          if (node instanceof HTMLImageElement) {
+            untrackImage(node);
+          } else if (node instanceof HTMLElement) {
+            node.querySelectorAll("img").forEach(untrackImage);
+          }
+        }
+      }
+      updateImageInfos();
+    });
+    mutationObs.observe(container, { childList: true, subtree: true });
+
+    updateImageInfos();
+
+    return () => {
+      resizeObs.disconnect();
+      mutationObs.disconnect();
+      for (const img of observedImages) {
+        img.removeEventListener("load", updateImageInfos);
+      }
+      observedImages.clear();
+    };
+  }, [annotation, updateImageInfos]);
+
+  if (!annotation) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      {children}
+      {imageInfos.map((info, index) => {
+        const scaleX = info.width / (info.naturalWidth || 1440);
+        const scaleY = info.height / (info.naturalHeight || 900);
+
+        return (
+          <div
+            key={index}
+            style={{
+              position: "absolute",
+              top: info.top,
+              left: info.left,
+              width: info.width,
+              height: info.height,
+              pointerEvents: "none",
+              overflow: "hidden",
+            }}
+          >
+            <svg
+              width="100%"
+              height="100%"
+              style={{ position: "absolute", top: 0, left: 0 }}
+            >
+              {renderSvgAnnotation(annotation, scaleX, scaleY)}
+            </svg>
+            {renderHtmlAnnotation(annotation)}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+const CLICK_ACTIONS = new Set([
+  "left_click",
+  "right_click",
+  "middle_click",
+  "double_click",
+  "triple_click",
+]);
+
+export function renderSvgAnnotation(
+  annotation: ToolAnnotation,
+  scaleX: number,
+  scaleY: number
+): ReactNode {
+  const { action, coordinate } = annotation;
+
+  if (CLICK_ACTIONS.has(action) && coordinate) {
+    const [x, y] = coordinate;
+    const scaledX = x * scaleX;
+    const scaledY = y * scaleY;
+
+    return (
+      <g transform={`translate(${scaledX}, ${scaledY})`}>
+        <circle
+          cx="0"
+          cy="0"
+          r="16"
+          stroke="rgba(239,68,68,0.8)"
+          strokeWidth="3"
+          fill="none"
+          filter="drop-shadow(0 0 6px rgba(239,68,68,0.4))"
+        />
+        <svg viewBox="0 0 32 32" width="30" height="30" x="-10" y="-7">
+          <g fill="none" fillRule="evenodd" transform="translate(10 7)">
+            <path
+              d="m6.148 18.473 1.863-1.003 1.615-.839-2.568-4.816h4.332l-11.379-11.408v16.015l3.316-3.221z"
+              fill="#fff"
+            />
+            <path
+              d="m6.431 17 1.765-.941-2.775-5.202h3.604l-8.025-8.043v11.188l2.53-2.442z"
+              fill="#000"
+            />
+          </g>
+        </svg>
+      </g>
+    );
+  }
+
+  if (action === "scroll" && coordinate) {
+    const [x, y] = coordinate;
+    const scaledX = x * scaleX;
+    const scaledY = y * scaleY;
+
+    let arrow = "\u2195";
+    if (annotation.scrollDirection) {
+      const dir = annotation.scrollDirection.toLowerCase();
+      if (dir.includes("up")) arrow = "\u2191";
+      else if (dir.includes("down")) arrow = "\u2193";
+      else if (dir.includes("left")) arrow = "\u2190";
+      else if (dir.includes("right")) arrow = "\u2192";
+    }
+
+    return (
+      <g transform={`translate(${scaledX}, ${scaledY})`}>
+        <circle cx="0" cy="0" r="18" fill="rgba(59,130,246,0.8)" />
+        <text
+          x="0"
+          y="0"
+          fill="white"
+          fontSize="20"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontWeight="bold"
+        >
+          {arrow}
+        </text>
+      </g>
+    );
+  }
+
+  return null;
+}
+
+export function renderHtmlAnnotation(annotation: ToolAnnotation): ReactNode {
+  const { action, text } = annotation;
+
+  if (action === "type" || action === "key") {
+    const isKey = action === "key";
+    const color = isKey ? "#fbbf24" : "#4ade80";
+
+    return (
+      <div
+        style={{
+          position: "absolute",
+          bottom: "16px",
+          left: isKey ? "auto" : "50%",
+          right: isKey ? "16px" : "auto",
+          transform: isKey ? "none" : "translateX(-50%)",
+          backgroundColor: "rgba(0, 0, 0, 0.8)",
+          color: color,
+          fontFamily: "monospace",
+          padding: "6px 12px",
+          borderRadius: "6px",
+          fontSize: "14px",
+          fontWeight: "bold",
+          whiteSpace: "pre-wrap",
+          maxWidth: "80%",
+          wordBreak: "break-word",
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.3)",
+        }}
+      >
+        {"\u2328 "}
+        {text || ""}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
@@ -26,6 +26,8 @@ export interface ClientToolCallProps {
   contentType?: string;
   view?: ToolCallContent;
   output: ToolCallViewProps["output"];
+  selfAnnotation?: ToolCallViewProps["selfAnnotation"];
+  inputScreenshot?: ToolCallViewProps["inputScreenshot"];
   error?: ToolCallError;
   className?: string | string[];
   getCustomToolView?: (props: ToolCallViewProps) => ReactNode | undefined;
@@ -46,6 +48,8 @@ export const ClientToolCall: FC<ClientToolCallProps> = ({
   contentType,
   view,
   output,
+  selfAnnotation,
+  inputScreenshot,
   error,
   className,
   getCustomToolView,
@@ -61,6 +65,8 @@ export const ClientToolCall: FC<ClientToolCallProps> = ({
     contentType,
     view,
     output,
+    selfAnnotation,
+    inputScreenshot,
   };
   const customView =
     getCustomToolView?.(viewProps) ?? getDefaultCustomToolView(viewProps);
@@ -71,7 +77,8 @@ export const ClientToolCall: FC<ClientToolCallProps> = ({
   const hasInput =
     (input !== undefined && input !== null && input !== "") || !!view?.content;
   const showError = !!error;
-  const showOutput = !showError && hasOutputContent(output);
+  const showAnnotation = !!selfAnnotation && !!inputScreenshot;
+  const showOutput = !showError && (hasOutputContent(output) || showAnnotation);
 
   return (
     <ToolBlock

--- a/packages/inspect-components/src/chat/tools/ToolCallView.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, useMemo } from "react";
+import { FC, ReactNode, useMemo } from "react";
 
 import type {
   ContentAudio,
@@ -11,12 +11,20 @@ import type {
   ContentVideo,
   ToolCallContent,
 } from "@tsmono/inspect-common/types";
-import { ExpandablePanel, MarkdownDiv } from "@tsmono/react/components";
+import {
+  ExpandablePanel,
+  MarkdownDiv,
+  NavPills,
+} from "@tsmono/react/components";
 
 import { MessageContent } from "../MessageContent";
 import { defaultContext, MessagesContext } from "../MessageContents";
 import { ContentTool } from "../types";
 
+import {
+  AnnotatedToolOutput,
+  type ToolAnnotation,
+} from "./AnnotatedToolOutput";
 import { getDefaultCustomToolView } from "./customToolRendering";
 import { codexToolMarkdown } from "./tool";
 import styles from "./ToolCallView.module.css";
@@ -53,11 +61,18 @@ export interface ToolCallViewProps {
         | ContentData
         | ContentDocument
       )[];
+  selfAnnotation?: ToolAnnotation;
+  inputScreenshot?: (
+    | ContentText
+    | ContentImage
+    | ContentAudio
+    | ContentVideo
+  )[];
   mode?: "compact";
   collapsible?: boolean;
   /** Render the whole view, just the call (title + input), or just the output. */
   section?: "all" | "call" | "output";
-  getCustomToolView?: (props: ToolCallViewProps) => React.ReactNode | undefined;
+  getCustomToolView?: (props: ToolCallViewProps) => ReactNode | undefined;
 }
 
 /**
@@ -68,6 +83,8 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
   tool,
   functionCall,
   input,
+  selfAnnotation,
+  inputScreenshot,
   description,
   contentType,
   view,
@@ -144,6 +161,8 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
     description,
     contentType,
     output,
+    selfAnnotation,
+    inputScreenshot,
     mode,
   };
   const customView =
@@ -208,10 +227,31 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
       <MessageContent contents={normalizedContent} context={context} />
     ) : null;
 
+  const showAnnotation = !!selfAnnotation && !!inputScreenshot;
+  const actionElement =
+    selfAnnotation && inputScreenshot ? (
+      <AnnotatedToolOutput annotation={selfAnnotation}>
+        <MessageContent contents={inputScreenshot} context={context} />
+      </AnnotatedToolOutput>
+    ) : null;
+
   return (
     <div className={clsx(styles.toolCallView)}>
       {section !== "output" ? callSection : null}
-      {section !== "call" ? outputSection : null}
+      {section !== "call" ? (
+        showAnnotation ? (
+          hasContent ? (
+            <NavPills id={`${id}-browser-action`}>
+              <div title="Result">{outputSection}</div>
+              <div title="Action">{actionElement}</div>
+            </NavPills>
+          ) : (
+            actionElement
+          )
+        ) : (
+          outputSection
+        )
+      ) : null}
     </div>
   );
 };

--- a/packages/inspect-components/src/chat/tools/browserActionUtils.test.ts
+++ b/packages/inspect-components/src/chat/tools/browserActionUtils.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSelfAnnotation,
+  isBrowserScreenshot,
+  isVisualBrowserAction,
+} from "./browserActionUtils";
+
+describe("isVisualBrowserAction", () => {
+  it("is true for browser/computer visual actions", () => {
+    expect(isVisualBrowserAction("browser", { action: "left_click" })).toBe(
+      true
+    );
+    expect(isVisualBrowserAction("computer", { action: "scroll" })).toBe(true);
+    expect(isVisualBrowserAction("computer", { action: "type" })).toBe(true);
+  });
+
+  it("is false for screenshots, non-browser tools, and missing actions", () => {
+    expect(isVisualBrowserAction("browser", { action: "screenshot" })).toBe(
+      false
+    );
+    expect(isVisualBrowserAction("bash", { action: "left_click" })).toBe(false);
+    expect(isVisualBrowserAction("browser", {})).toBe(false);
+  });
+});
+
+describe("isBrowserScreenshot", () => {
+  it("is true only for a browser/computer screenshot action", () => {
+    expect(isBrowserScreenshot("browser", { action: "screenshot" })).toBe(true);
+    expect(isBrowserScreenshot("computer", { action: "screenshot" })).toBe(
+      true
+    );
+    expect(isBrowserScreenshot("browser", { action: "left_click" })).toBe(
+      false
+    );
+    expect(isBrowserScreenshot("bash", { action: "screenshot" })).toBe(false);
+  });
+});
+
+describe("buildSelfAnnotation", () => {
+  it("maps click coordinates", () => {
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "left_click",
+        coordinate: [10, 20],
+      })
+    ).toEqual({
+      action: "left_click",
+      coordinate: [10, 20],
+      text: undefined,
+      scrollDirection: undefined,
+    });
+  });
+
+  it("maps typed text and scroll direction", () => {
+    expect(
+      buildSelfAnnotation("computer", { action: "type", text: "hi" })
+    ).toEqual({
+      action: "type",
+      coordinate: undefined,
+      text: "hi",
+      scrollDirection: undefined,
+    });
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "scroll",
+        coordinate: [1, 2],
+        scroll_direction: "down",
+      })
+    ).toEqual({
+      action: "scroll",
+      coordinate: [1, 2],
+      text: undefined,
+      scrollDirection: "down",
+    });
+  });
+
+  it("returns undefined for non-visual actions", () => {
+    expect(
+      buildSelfAnnotation("browser", { action: "screenshot" })
+    ).toBeUndefined();
+    expect(
+      buildSelfAnnotation("bash", { action: "left_click" })
+    ).toBeUndefined();
+  });
+});
+
+describe("argument narrowing (malformed args)", () => {
+  it("treats a non-string action as not a visual action", () => {
+    expect(isVisualBrowserAction("browser", { action: 123 })).toBe(false);
+    expect(buildSelfAnnotation("browser", { action: 123 })).toBeUndefined();
+  });
+
+  it("drops a coordinate that is not a finite [number, number] pair", () => {
+    const expected = {
+      action: "left_click",
+      coordinate: undefined,
+      text: undefined,
+      scrollDirection: undefined,
+    };
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "left_click",
+        coordinate: "10,20",
+      })
+    ).toEqual(expected);
+    expect(
+      buildSelfAnnotation("browser", { action: "left_click", coordinate: [10] })
+    ).toEqual(expected);
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "left_click",
+        coordinate: ["10", "20"],
+      })
+    ).toEqual(expected);
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "left_click",
+        coordinate: [Number.NaN, 20],
+      })
+    ).toEqual(expected);
+  });
+
+  it("drops a non-string text or scroll_direction", () => {
+    expect(
+      buildSelfAnnotation("computer", { action: "type", text: 123 })
+    ).toEqual({
+      action: "type",
+      coordinate: undefined,
+      text: undefined,
+      scrollDirection: undefined,
+    });
+    expect(
+      buildSelfAnnotation("browser", {
+        action: "scroll",
+        coordinate: [1, 2],
+        scroll_direction: 5,
+      })
+    ).toEqual({
+      action: "scroll",
+      coordinate: [1, 2],
+      text: undefined,
+      scrollDirection: undefined,
+    });
+  });
+});

--- a/packages/inspect-components/src/chat/tools/browserActionUtils.ts
+++ b/packages/inspect-components/src/chat/tools/browserActionUtils.ts
@@ -1,0 +1,66 @@
+import type { ToolAnnotation } from "./AnnotatedToolOutput";
+
+export const BROWSER_TOOL_FUNCTIONS = new Set(["browser", "computer"]);
+
+export const VISUAL_BROWSER_ACTIONS = new Set([
+  "left_click",
+  "right_click",
+  "middle_click",
+  "double_click",
+  "triple_click",
+  "scroll",
+  "type",
+  "key",
+]);
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asCoordinate(value: unknown): [number, number] | undefined {
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === "number" &&
+    Number.isFinite(value[0]) &&
+    typeof value[1] === "number" &&
+    Number.isFinite(value[1])
+  ) {
+    return [value[0], value[1]];
+  }
+  return undefined;
+}
+
+export function isVisualBrowserAction(
+  functionName: string,
+  args: Record<string, unknown>
+): boolean {
+  if (!BROWSER_TOOL_FUNCTIONS.has(functionName)) return false;
+  const action = asString(args.action);
+  return action !== undefined && VISUAL_BROWSER_ACTIONS.has(action);
+}
+
+export function isBrowserScreenshot(
+  functionName: string,
+  args: Record<string, unknown>
+): boolean {
+  return (
+    BROWSER_TOOL_FUNCTIONS.has(functionName) &&
+    asString(args.action) === "screenshot"
+  );
+}
+
+export function buildSelfAnnotation(
+  functionName: string,
+  args: Record<string, unknown>
+): ToolAnnotation | undefined {
+  if (!isVisualBrowserAction(functionName, args)) return undefined;
+  const action = asString(args.action);
+  if (action === undefined) return undefined;
+  return {
+    action,
+    coordinate: asCoordinate(args.coordinate),
+    text: asString(args.text),
+    scrollDirection: asString(args.scroll_direction),
+  };
+}

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -109,7 +109,9 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
       description={description}
       contentType={contentType}
       output={event.result ?? ""}
-      error={showError ? event.error! : undefined}
+      selfAnnotation={context?.selfAnnotation}
+      inputScreenshot={context?.inputScreenshot}
+      error={showError && event.error ? event.error : undefined}
       view={resolvedView}
     />
   );

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -20,6 +20,7 @@ import { EventLabelContext } from "./EventLabelContext";
 import { eventSearchText } from "./eventText";
 import { RenderedEventNode } from "./TranscriptVirtualList";
 import styles from "./TranscriptVirtualListComponent.module.css";
+import { computeVisualActionContext } from "./transcriptVisualActions";
 import { EventNode, EventNodeContext, EventPanelCallbacks } from "./types";
 
 interface TranscriptVirtualListComponentProps {
@@ -127,7 +128,17 @@ export const TranscriptVirtualListComponent: FC<
     for (const [i, node] of eventNodes.entries()) {
       const hasToolEvents = hasToolEventsAtCurrentDepth(i);
       const turnInfo = turnMap?.get(node.id);
-      map.set(node.id, { hasToolEvents, turnInfo, ...eventNodeContext });
+      const { inputScreenshot, selfAnnotation } = computeVisualActionContext(
+        eventNodes,
+        i
+      );
+      map.set(node.id, {
+        hasToolEvents,
+        turnInfo,
+        ...eventNodeContext,
+        inputScreenshot,
+        selfAnnotation,
+      });
     }
     return map;
   }, [eventNodes, hasToolEventsAtCurrentDepth, turnMap, eventNodeContext]);

--- a/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
+++ b/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import type { InfoEvent, ToolEvent } from "@tsmono/inspect-common/types";
+
+import {
+  computeVisualActionContext,
+  normalizeScreenshotResult,
+} from "./transcriptVisualActions";
+import { EventNode } from "./types";
+
+const IMAGE = {
+  type: "image" as const,
+  image: "data:image/png;base64,abc123",
+  detail: "auto" as const,
+};
+const TEXT = {
+  type: "text" as const,
+  text: "page text",
+  refusal: null,
+  internal: null,
+  citations: null,
+};
+const DOC = {
+  type: "document" as const,
+  document: "data:application/pdf;base64,abc123",
+  filename: "report.pdf",
+  mime_type: "application/pdf",
+};
+
+function toolNode(
+  id: string,
+  fn: string,
+  args: ToolEvent["arguments"],
+  result: ToolEvent["result"]
+): EventNode {
+  const event: ToolEvent = {
+    event: "tool",
+    id,
+    function: fn,
+    arguments: args,
+    result,
+    error: null,
+    events: [],
+    pending: false,
+    timestamp: new Date(0).toISOString(),
+    type: "function",
+    working_start: 0,
+  };
+  return new EventNode(id, event, 0);
+}
+
+function infoNode(id: string): EventNode {
+  const event: InfoEvent = {
+    event: "info",
+    data: null,
+    timestamp: new Date(0).toISOString(),
+    working_start: 0,
+  };
+  return new EventNode(id, event, 0);
+}
+
+function visualActionArgs(
+  action: string,
+  extra: ToolEvent["arguments"] = {}
+): ToolEvent["arguments"] {
+  return { action, ...extra };
+}
+
+describe("normalizeScreenshotResult", () => {
+  it("keeps image/text content and drops documents from arrays", () => {
+    expect(normalizeScreenshotResult([TEXT, IMAGE, DOC])).toEqual([
+      TEXT,
+      IMAGE,
+    ]);
+  });
+
+  it("wraps a single non-document content object", () => {
+    expect(normalizeScreenshotResult(IMAGE)).toEqual([IMAGE]);
+  });
+
+  it("returns undefined for documents, strings, and empty arrays", () => {
+    expect(normalizeScreenshotResult(DOC)).toBeUndefined();
+    expect(normalizeScreenshotResult("done")).toBeUndefined();
+    expect(normalizeScreenshotResult([DOC])).toBeUndefined();
+  });
+});
+
+describe("computeVisualActionContext", () => {
+  it("pairs a click with the preceding screenshot across a non-tool event", () => {
+    const nodes = [
+      toolNode("s1", "browser", visualActionArgs("screenshot"), [TEXT, IMAGE]),
+      infoNode("m1"),
+      toolNode(
+        "c1",
+        "browser",
+        visualActionArgs("left_click", { coordinate: [10, 20] }),
+        ""
+      ),
+    ];
+    const ctx = computeVisualActionContext(nodes, 2);
+    expect(ctx.selfAnnotation).toEqual({
+      action: "left_click",
+      coordinate: [10, 20],
+      text: undefined,
+      scrollDirection: undefined,
+    });
+    expect(ctx.inputScreenshot).toEqual([TEXT, IMAGE]);
+  });
+
+  it("returns {} for the screenshot event itself", () => {
+    const nodes = [
+      toolNode("s1", "browser", visualActionArgs("screenshot"), [IMAGE]),
+    ];
+    expect(computeVisualActionContext(nodes, 0)).toEqual({});
+  });
+
+  it("returns {} when a non-browser tool intervenes before any screenshot", () => {
+    const nodes = [
+      toolNode("b1", "bash", { cmd: "ls" }, "files"),
+      toolNode(
+        "c1",
+        "browser",
+        visualActionArgs("left_click", { coordinate: [1, 1] }),
+        ""
+      ),
+    ];
+    expect(computeVisualActionContext(nodes, 1)).toEqual({});
+  });
+
+  it("returns {} for a non-tool node", () => {
+    expect(computeVisualActionContext([infoNode("m1")], 0)).toEqual({});
+  });
+
+  it("pairs across many intervening non-tool events (no lookback cap)", () => {
+    const nodes: EventNode[] = [
+      toolNode("s1", "browser", visualActionArgs("screenshot"), [IMAGE]),
+    ];
+    for (let i = 0; i < 50; i++) {
+      nodes.push(infoNode(`m${i}`));
+    }
+    nodes.push(
+      toolNode(
+        "c1",
+        "browser",
+        visualActionArgs("left_click", { coordinate: [3, 4] }),
+        ""
+      )
+    );
+    const ctx = computeVisualActionContext(nodes, nodes.length - 1);
+    expect(ctx.inputScreenshot).toEqual([IMAGE]);
+    expect(ctx.selfAnnotation).toEqual({
+      action: "left_click",
+      coordinate: [3, 4],
+      text: undefined,
+      scrollDirection: undefined,
+    });
+  });
+});

--- a/packages/inspect-components/src/transcript/transcriptVisualActions.ts
+++ b/packages/inspect-components/src/transcript/transcriptVisualActions.ts
@@ -1,0 +1,76 @@
+import type {
+  ContentAudio,
+  ContentImage,
+  ContentText,
+  ContentVideo,
+  ToolEvent,
+} from "@tsmono/inspect-common/types";
+
+import type { ToolAnnotation } from "../chat/tools/AnnotatedToolOutput";
+import {
+  BROWSER_TOOL_FUNCTIONS,
+  buildSelfAnnotation,
+  isBrowserScreenshot,
+  isVisualBrowserAction,
+} from "../chat/tools/browserActionUtils";
+
+import type { EventNode } from "./types";
+
+export interface VisualActionContext {
+  inputScreenshot?: (
+    | ContentText
+    | ContentImage
+    | ContentAudio
+    | ContentVideo
+  )[];
+  selfAnnotation?: ToolAnnotation;
+}
+
+export function computeVisualActionContext(
+  eventNodes: EventNode[],
+  index: number
+): VisualActionContext {
+  const node = eventNodes[index];
+  if (!node || node.event.event !== "tool") return {};
+
+  const toolEvent = node.event;
+  if (!isVisualBrowserAction(toolEvent.function, toolEvent.arguments))
+    return {};
+
+  const selfAnnotation = buildSelfAnnotation(
+    toolEvent.function,
+    toolEvent.arguments
+  );
+
+  for (let i = index - 1; i >= 0; i--) {
+    const candidate = eventNodes[i];
+    if (!candidate || candidate.event.event !== "tool") continue;
+    const candEvent = candidate.event;
+    if (!BROWSER_TOOL_FUNCTIONS.has(candEvent.function)) break;
+    if (isBrowserScreenshot(candEvent.function, candEvent.arguments)) {
+      const inputScreenshot = normalizeScreenshotResult(candEvent.result);
+      return inputScreenshot ? { inputScreenshot, selfAnnotation } : {};
+    }
+  }
+
+  return {};
+}
+
+export function normalizeScreenshotResult(
+  result: ToolEvent["result"]
+): (ContentText | ContentImage | ContentAudio | ContentVideo)[] | undefined {
+  if (Array.isArray(result)) {
+    const filtered = result.filter(
+      (
+        item
+      ): item is ContentText | ContentImage | ContentAudio | ContentVideo =>
+        item.type !== "document"
+    );
+    return filtered.length > 0 ? filtered : undefined;
+  }
+  if (result && typeof result === "object" && "type" in result) {
+    if (result.type === "document") return undefined;
+    return [result];
+  }
+  return undefined;
+}

--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -4,6 +4,10 @@ import type {
   BranchEvent,
   CheckpointEvent,
   CompactionEvent,
+  ContentAudio,
+  ContentImage,
+  ContentText,
+  ContentVideo,
   ErrorEvent,
   InfoEvent,
   InputEvent,
@@ -24,6 +28,8 @@ import type {
   SubtaskEvent,
   ToolEvent,
 } from "@tsmono/inspect-common/types";
+
+import type { ToolAnnotation } from "../chat/tools/AnnotatedToolOutput";
 
 import { SPAN_BEGIN, STEP, TYPE_SUBTASK, TYPE_TOOL } from "./transform/utils";
 
@@ -189,4 +195,11 @@ export interface EventNodeContext {
   toolApprovals?: Map<string, EventNode<ApprovalEvent>>;
   /** Retry attempts paired to their successful ModelEvent via `retryAttemptKey(event)`. `ModelEventView` reads from this to render the inline retry chip and swap bodies between attempts. */
   retryAttempts?: Map<string, ModelEvent[]>;
+  selfAnnotation?: ToolAnnotation;
+  inputScreenshot?: (
+    | ContentText
+    | ContentImage
+    | ContentAudio
+    | ContentVideo
+  )[];
 }


### PR DESCRIPTION
Re-implements closed Inspect viewer PRs #3379/#3380, ported into `ts-mono` after the `_view/www` → submodule migration.

## What
Adds an "Action" tab for visual browser/computer tool actions (click / scroll / type / key) in the transcript, overlaying a scaled SVG/HTML annotation on the preceding screenshot — a macOS cursor + red ring at click coordinates, a blue directional-arrow disc at scroll coordinates, or a monospace typed-text badge — measured against the rendered `<img>` via `ResizeObserver` + `MutationObserver`. All edits are in `packages/inspect-components` and behavior-gated on `isVisualBrowserAction(...)`, so non-browser tools and `apps/scout` are unaffected.

## Verification
- `pnpm --filter @tsmono/inspect-components test` (incl. pure-renderer + pairing tests) — green (530 tests)
- `pnpm --filter scout typecheck` + `pnpm --filter @meridianlabs/log-viewer typecheck` — green

Independent change off `main`. One of a 7-PR series re-porting the closed Inspect viewer PRs into ts-mono.
