### PR TITLE
Fix broken commit links for ssh-style GitHub origins

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -76,15 +76,11 @@ export const TaskTab: FC<TaskTabProps> = ({
   };
 
   if (revision) {
-    taskInformation[
-      `${revision.type ? `${toTitleCase(revision.type)} ` : ""}Revision`
-    ] = {
-      _html: (
-        <a href={ghCommitUrl(revision.origin, revision.commit)}>
-          {revision.commit}
-        </a>
-      ),
-    };
+    const revisionKey = `${revision.type ? `${toTitleCase(revision.type)} ` : ""}Revision`;
+    const commitUrl = ghCommitUrl(revision.origin, revision.commit);
+    taskInformation[revisionKey] = commitUrl
+      ? { _html: <a href={commitUrl}>{revision.commit}</a> }
+      : revision.commit;
   }
   if (packages) {
     const names = Object.keys(packages).map((key) => {

--- a/packages/util/src/git.test.ts
+++ b/packages/util/src/git.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { ghCommitUrl } from "./git";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+const EXPECTED = `https://github.com/owner/repo/commit/${SHA}`;
+
+describe("ghCommitUrl", () => {
+  test.each([
+    ["https", "https://github.com/owner/repo"],
+    ["https + .git", "https://github.com/owner/repo.git"],
+    ["https + trailing slash", "https://github.com/owner/repo/"],
+    ["ssh://", "ssh://git@github.com/owner/repo"],
+    ["ssh:// + .git", "ssh://git@github.com/owner/repo.git"],
+    ["scp", "git@github.com:owner/repo"],
+    ["scp + .git", "git@github.com:owner/repo.git"],
+    ["git://", "git://github.com/owner/repo"],
+    ["git+https", "git+https://github.com/owner/repo"],
+    ["git+ssh", "git+ssh://git@github.com/owner/repo"],
+    ["with credentials", "https://x-access-token:TOKEN@github.com/owner/repo"],
+  ])("links a %s origin", (_label, origin) => {
+    expect(ghCommitUrl(origin, SHA)).toBe(EXPECTED);
+  });
+
+  test.each([
+    ["non-github host", "https://gitlab.com/owner/repo"],
+    ["lookalike host", "https://github.com.evil.com/owner/repo"],
+    ["empty origin", ""],
+    ["garbage", "not-a-url"],
+  ])("returns undefined for %s", (_label, origin) => {
+    expect(ghCommitUrl(origin, SHA)).toBeUndefined();
+  });
+});

--- a/packages/util/src/git.ts
+++ b/packages/util/src/git.ts
@@ -1,9 +1,22 @@
 /**
- * Generates a GitHub commit URL based on the repository origin URL and the commit hash.
+ * Builds a GitHub commit URL from a repository origin and commit hash.
+ *
+ * Accepts the GitHub origin forms that appear in eval `revision.origin`:
+ * https, `ssh://git@github.com/…`, scp `git@github.com:…`, `git://…`, an
+ * optional `git+` prefix, optional credentials, and an optional `.git` suffix.
+ * Returns undefined when the origin is not a GitHub repository URL, so callers
+ * can render the commit as plain text instead of a broken link.
  */
-export const ghCommitUrl = (origin: string, commit: string): string => {
-  const baseUrl = origin
-    .replace(/\.git$/, "")
-    .replace(/^git@github.com:/, "https://github.com/");
-  return `${baseUrl}/commit/${commit}`;
+export const ghCommitUrl = (
+  origin: string,
+  commit: string
+): string | undefined => {
+  const match = origin.match(
+    /(?:^|[@/])github\.com[/:]([^/]+)\/([^/]+?)(?:\.git)?\/?$/i
+  );
+  if (!match) {
+    return undefined;
+  }
+  const [, owner, repo] = match;
+  return `https://github.com/${owner}/${repo}/commit/${commit}`;
 };


### PR DESCRIPTION
## Summary

The eval viewer renders a task's `revision` as a link to its GitHub commit, but `ghCommitUrl` only handled the scp form (`git@github.com:owner/repo`) and a trailing `.git`. An `ssh://git@github.com/owner/repo` origin, which you get for tasks installed over ssh, was left unchanged, so the viewer rendered a dead `ssh://…/commit/<sha>` link. And because the commit is always wrapped in an `<a>`, non-GitHub or unparseable origins also rendered as broken links.

This rewrites `ghCommitUrl` to extract `owner/repo` from any GitHub origin form (https, `ssh://`, scp, `git://`, optional `git+` prefix, credentials, `.git` suffix) and build a canonical `https://github.com/owner/repo/commit/<sha>` link. It returns `undefined` for origins that aren't GitHub repository URLs, and the viewer now renders the commit as plain text in that case instead of a broken link.