### PR TITLE
perf(inspect): cold-open latency — promise-memo open, tail cache, un-gated sample fetch

### DIFF
--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
 
-import { openRemoteLogFile } from "../remote/remoteLogFile";
+import {
+  openRemoteLogFile,
+  SampleNotFoundError,
+} from "../remote/remoteLogFile";
 
 import { clientApi } from "./client-api";
 import {
@@ -520,5 +523,89 @@ describe("clientApi.remoteEvalFile promise memoisation", () => {
     // Retry should re-attempt rather than return the cached rejection.
     await client.get_log_details("log.eval", true);
     expect(openMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clientApi.warm_log_sample", () => {
+  // The warm call lets the sample bytes download in parallel with
+  // summaries; the unchanged loadSample flow then resolves from the
+  // warmed promise instead of issuing a second fetch.
+
+  const sample = { id: "1", epoch: 1 } as const;
+  const setup = (readSample: ReturnType<typeof vi.fn>) => {
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock.mockResolvedValue({
+      readSample,
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+    return { openMock, client: clientApi(baseApi()) };
+  };
+
+  test("get_log_sample returns the warmed result without a second read", async () => {
+    const readSample = vi.fn().mockResolvedValue(sample);
+    const { client, openMock } = setup(readSample);
+
+    client.warm_log_sample("log.eval", "1", 1);
+    const got = await client.get_log_sample("log.eval", "1", 1);
+
+    expect(got).toBe(sample);
+    expect(openMock).toHaveBeenCalledTimes(1);
+    expect(readSample).toHaveBeenCalledTimes(1);
+  });
+
+  test("a warmed miss is not reused — the real call falls through", async () => {
+    // Warm fired before summaries arrived; the sample wasn't in the
+    // (cached) cdir yet. The later real call must still try (and may
+    // re-open uncached) rather than short-circuit on the warmed
+    // `undefined`.
+    const readSample = vi
+      .fn()
+      .mockRejectedValueOnce(new SampleNotFoundError("nope"))
+      .mockResolvedValueOnce(sample);
+    const { client } = setup(readSample);
+
+    client.warm_log_sample("log.eval", "1", 1);
+    const got = await client.get_log_sample("log.eval", "1", 1);
+
+    expect(got).toBe(sample);
+    expect(readSample).toHaveBeenCalledTimes(2);
+  });
+
+  test("warm is single-slot — a different (file,id,epoch) ignores it", async () => {
+    const readSample = vi.fn().mockResolvedValue(sample);
+    const { client } = setup(readSample);
+
+    client.warm_log_sample("log.eval", "1", 1);
+    await client.get_log_sample("log.eval", "2", 1);
+
+    // One read for the warm, one for the real (different) sample.
+    expect(readSample).toHaveBeenCalledTimes(2);
+  });
+
+  test("edit_log on the same file drops the warmed sample", async () => {
+    const readSample = vi.fn().mockResolvedValue(sample);
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock.mockResolvedValue({
+      readSample,
+      readLogSummary: vi
+        .fn()
+        .mockResolvedValue({ tags: [], sampleSummaries: [] }),
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+
+    const edit_log = vi
+      .fn<NonNullable<LogViewAPI["edit_log"]>>()
+      .mockResolvedValue({ log: {} as unknown as EditLogResult["log"] });
+    const client = clientApi({ ...baseApi(), edit_log });
+
+    client.warm_log_sample("log.eval", "1", 1);
+    await client.edit_log!("log.eval", {
+      edits: [],
+      provenance: { author: "a", metadata: {}, timestamp: "t" },
+    });
+    await client.get_log_sample("log.eval", "1", 1);
+
+    // Warm read + post-edit fresh read.
+    expect(readSample).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -428,3 +428,56 @@ describe("clientApi.edit_log etag plumbing", () => {
     expect(edit_log).toHaveBeenCalledWith("log.eval", okUpdate, "v2");
   });
 });
+
+describe("clientApi.remoteEvalFile promise memoisation", () => {
+  // Browser traces showed log-info / EOCD / cdir fetched ×2–×4 on cold
+  // open because concurrent callers each ran their own
+  // openRemoteLogFile. Caching the in-flight promise collapses them.
+  const sampleSummary = { tags: [] as string[], sampleSummaries: [] };
+
+  test("concurrent cached reads share one openRemoteLogFile", async () => {
+    let resolveOpen!: (
+      v: Awaited<ReturnType<typeof openRemoteLogFile>>
+    ) => void;
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveOpen = resolve;
+        })
+    );
+
+    const client = clientApi(baseApi());
+    const a = client.get_log_details("log.eval", true);
+    const b = client.get_log_details("log.eval", true);
+
+    // Both calls issued before the first open resolves.
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    resolveOpen({
+      readLogSummary: vi.fn().mockResolvedValue(sampleSummary),
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+
+    await Promise.all([a, b]);
+    expect(openMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a rejected open is not cached", async () => {
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce({
+        readLogSummary: vi.fn().mockResolvedValue(sampleSummary),
+      } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+
+    const client = clientApi(baseApi());
+    await expect(client.get_log_details("log.eval", true)).rejects.toThrow(
+      "transient"
+    );
+    // Retry should re-attempt rather than return the cached rejection.
+    await client.get_log_details("log.eval", true);
+    expect(openMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -463,6 +463,47 @@ describe("clientApi.remoteEvalFile promise memoisation", () => {
     expect(openMock).toHaveBeenCalledTimes(1);
   });
 
+  test("cached=false reuses an in-flight open but re-opens once it has resolved", async () => {
+    let resolveOpen!: (
+      v: Awaited<ReturnType<typeof openRemoteLogFile>>
+    ) => void;
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveOpen = resolve;
+        })
+    );
+
+    const client = clientApi(baseApi());
+
+    // Cold open: cached=true creates and caches the in-flight promise.
+    const a = client.get_log_details("log.eval", true);
+    // Concurrent cached=false (e.g. syncLog's initial load) — the
+    // cached promise is still in-flight, hence as fresh as a new open
+    // would be → reuse it.
+    const b = client.get_log_details("log.eval", false);
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    resolveOpen({
+      readLogSummary: vi.fn().mockResolvedValue(sampleSummary),
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+    await Promise.all([a, b]);
+
+    // After resolution, cached=false (e.g. logPolling.refreshLog)
+    // must re-open to pick up newly-flushed samples.
+    openMock.mockResolvedValueOnce({
+      readLogSummary: vi.fn().mockResolvedValue(sampleSummary),
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+    await client.get_log_details("log.eval", false);
+    expect(openMock).toHaveBeenCalledTimes(2);
+
+    // …and that fresh open is now what cached=true callers get.
+    await client.get_log_details("log.eval", true);
+    expect(openMock).toHaveBeenCalledTimes(2);
+  });
+
   test("a rejected open is not cached", async () => {
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -79,13 +79,9 @@ export const clientApi = (
     remoteLog: undefined,
   };
 
-  // Single-slot prefetch for the sample the route points at, populated by
-  // `warm_log_sample` as soon as the route handle is known. Lets the
-  // sample bytes download in parallel with summaries.json instead of
-  // serialised behind it; the unchanged `loadSample` flow then resolves
-  // from this promise instead of issuing a second fetch. A miss
-  // (`undefined`) is not reused — the real call falls through so its
-  // `retryUncached` semantics still apply.
+  // Lets the sample download in parallel with summaries.json instead of
+  // serialised behind it. A warmed miss (`undefined`) is not reused —
+  // the real call falls through so its `retryUncached` semantics apply.
   let warmedSample:
     | { key: string; promise: Promise<EvalSample | undefined> }
     | undefined;
@@ -127,7 +123,6 @@ export const clientApi = (
         if (loadedEvalFile.remoteLog === remoteLog) {
           loadedEvalFile.file = undefined;
           loadedEvalFile.remoteLog = undefined;
-          loadedEvalFile.resolved = undefined;
         }
       }
     );
@@ -633,11 +628,8 @@ export const clientApi = (
             if (loadedEvalFile.file === log_file) {
               loadedEvalFile.file = undefined;
               loadedEvalFile.remoteLog = undefined;
-              loadedEvalFile.resolved = undefined;
             }
-            if (warmedSample?.key.startsWith(`${log_file}\0`)) {
-              warmedSample = undefined;
-            }
+            warmedSample = undefined;
             return result;
           }
         )

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -85,7 +85,11 @@ export const clientApi = (
     // Cache the in-flight promise (not the resolved value) so concurrent
     // callers share one openRemoteLogFile rather than each issuing their
     // own log-info / EOCD / cdir request chain.
-    if (cached && loadedEvalFile.file === log_file && loadedEvalFile.remoteLog) {
+    if (
+      cached &&
+      loadedEvalFile.file === log_file &&
+      loadedEvalFile.remoteLog
+    ) {
       return loadedEvalFile.remoteLog;
     }
 

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -79,6 +79,19 @@ export const clientApi = (
     remoteLog: undefined,
   };
 
+  // Single-slot prefetch for the sample the route points at, populated by
+  // `warm_log_sample` as soon as the route handle is known. Lets the
+  // sample bytes download in parallel with summaries.json instead of
+  // serialised behind it; the unchanged `loadSample` flow then resolves
+  // from this promise instead of issuing a second fetch. A miss
+  // (`undefined`) is not reused — the real call falls through so its
+  // `retryUncached` semantics still apply.
+  let warmedSample:
+    | { key: string; promise: Promise<EvalSample | undefined> }
+    | undefined;
+  const sampleKey = (file: string, id: string | number, epoch: number) =>
+    `${file}\0${id}\0${epoch}`;
+
   const remoteEvalFile = (
     log_file: string,
     cached: boolean = false
@@ -212,6 +225,13 @@ export const clientApi = (
     onProgress?: ProgressCallback,
     retryUncached: boolean = true
   ): Promise<EvalSample | undefined> => {
+    const key = sampleKey(log_file, id, epoch);
+    if (warmedSample?.key === key) {
+      const warmed = warmedSample;
+      warmedSample = undefined;
+      const hit = await warmed.promise;
+      if (hit) return hit;
+    }
     if (isEvalFile(log_file)) {
       async function fetchSample(useCache: boolean) {
         const remoteLogFile = await remoteEvalFile(log_file, useCache);
@@ -255,6 +275,21 @@ export const clientApi = (
       }
     }
     return undefined;
+  };
+
+  const warm_log_sample = (
+    log_file: string,
+    id: string | number,
+    epoch: number
+  ): void => {
+    const key = sampleKey(log_file, id, epoch);
+    if (warmedSample?.key === key) return;
+    warmedSample = {
+      key,
+      promise: get_log_sample(log_file, id, epoch, undefined, false).catch(
+        () => undefined
+      ),
+    };
   };
 
   const read_eval_file_log_summary = async (log_file: string) => {
@@ -525,6 +560,7 @@ export const clientApi = (
       }
     ),
     get_log_sample: middleware("get_log_sample", get_log_sample),
+    warm_log_sample,
     open_log_file: middleware("open_log_file", (log_file, log_dir) => {
       return api.open_log_file(log_file, log_dir);
     }),
@@ -598,6 +634,9 @@ export const clientApi = (
               loadedEvalFile.file = undefined;
               loadedEvalFile.remoteLog = undefined;
               loadedEvalFile.resolved = undefined;
+            }
+            if (warmedSample?.key.startsWith(`${log_file}\0`)) {
+              warmedSample = undefined;
             }
             return result;
           }

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -56,7 +56,7 @@ export class SampleSizeLimitedExceededError extends Error {
 
 interface LoadedLogFile {
   file?: string;
-  remoteLog?: RemoteLogFile;
+  remoteLog?: Promise<RemoteLogFile>;
 }
 
 /**
@@ -78,20 +78,28 @@ export const clientApi = (
     remoteLog: undefined,
   };
 
-  const remoteEvalFile = async (log_file: string, cached: boolean = false) => {
-    if (cached && loadedEvalFile.file === log_file) {
+  const remoteEvalFile = (
+    log_file: string,
+    cached: boolean = false
+  ): Promise<RemoteLogFile> => {
+    // Cache the in-flight promise (not the resolved value) so concurrent
+    // callers share one openRemoteLogFile rather than each issuing their
+    // own log-info / EOCD / cdir request chain.
+    if (cached && loadedEvalFile.file === log_file && loadedEvalFile.remoteLog) {
       return loadedEvalFile.remoteLog;
     }
 
-    const remoteLog = await openRemoteLogFile(
-      api,
-      encodePathParts(log_file),
-      5
-    );
+    const remoteLog = openRemoteLogFile(api, encodePathParts(log_file), 5);
 
     if (cached) {
       loadedEvalFile.file = log_file;
       loadedEvalFile.remoteLog = remoteLog;
+      remoteLog.catch(() => {
+        if (loadedEvalFile.remoteLog === remoteLog) {
+          loadedEvalFile.file = undefined;
+          loadedEvalFile.remoteLog = undefined;
+        }
+      });
     }
 
     return remoteLog;
@@ -140,11 +148,7 @@ export const clientApi = (
   ): Promise<LogDetails> => {
     if (isEvalFile(log_file)) {
       const remoteLogFile = await remoteEvalFile(log_file, cached);
-      if (remoteLogFile) {
-        return await remoteLogFile.readLogSummary();
-      } else {
-        throw new Error("Unable to read remote eval file");
-      }
+      return await remoteLogFile.readLogSummary();
     } else {
       const logContents = await get_log(log_file);
       /**
@@ -188,14 +192,12 @@ export const clientApi = (
     log_file: string,
     id: string | number,
     epoch: number,
-    onProgress?: ProgressCallback
+    onProgress?: ProgressCallback,
+    retryUncached: boolean = true
   ): Promise<EvalSample | undefined> => {
     if (isEvalFile(log_file)) {
       async function fetchSample(useCache: boolean) {
         const remoteLogFile = await remoteEvalFile(log_file, useCache);
-        if (!remoteLogFile) {
-          throw new Error(`Unable to read remote eval file ${log_file}`);
-        }
         return await remoteLogFile.readSample(String(id), epoch, onProgress);
       }
 
@@ -211,9 +213,13 @@ export const clientApi = (
         // First attempt with cache
         return await fetchSample(true);
       } catch (error) {
-        if (error instanceof SampleNotFoundError) {
+        if (error instanceof SampleNotFoundError && retryUncached) {
+          // The cached central directory may be stale (e.g. a sample
+          // was flushed to the zip after we last opened it). Re-open
+          // and try once more — but only when the caller knows the
+          // sample should exist; speculative callers pass
+          // retryUncached=false to avoid a wasted full reopen.
           try {
-            // Retry without cache
             return await fetchSample(false);
           } catch (retryError) {
             return handleError(retryError);

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -57,6 +57,7 @@ export class SampleSizeLimitedExceededError extends Error {
 interface LoadedLogFile {
   file?: string;
   remoteLog?: Promise<RemoteLogFile>;
+  resolved?: boolean;
 }
 
 /**
@@ -85,26 +86,38 @@ export const clientApi = (
     // Cache the in-flight promise (not the resolved value) so concurrent
     // callers share one openRemoteLogFile rather than each issuing their
     // own log-info / EOCD / cdir request chain.
-    if (
-      cached &&
-      loadedEvalFile.file === log_file &&
-      loadedEvalFile.remoteLog
-    ) {
-      return loadedEvalFile.remoteLog;
+    //
+    // `cached=false` means "at least as fresh as now". An in-flight
+    // cached promise satisfies that — it hasn't read from the server
+    // yet — so reuse it. Only when the cached promise has already
+    // resolved (and may therefore be stale) does `cached=false` open
+    // a fresh one; the fresh open then replaces the cache so later
+    // `cached=true` callers see the newer cdir.
+    if (loadedEvalFile.file === log_file && loadedEvalFile.remoteLog) {
+      if (cached || !loadedEvalFile.resolved) {
+        return loadedEvalFile.remoteLog;
+      }
     }
 
     const remoteLog = openRemoteLogFile(api, encodePathParts(log_file), 5);
 
-    if (cached) {
-      loadedEvalFile.file = log_file;
-      loadedEvalFile.remoteLog = remoteLog;
-      remoteLog.catch(() => {
+    loadedEvalFile.file = log_file;
+    loadedEvalFile.remoteLog = remoteLog;
+    loadedEvalFile.resolved = false;
+    remoteLog.then(
+      () => {
+        if (loadedEvalFile.remoteLog === remoteLog) {
+          loadedEvalFile.resolved = true;
+        }
+      },
+      () => {
         if (loadedEvalFile.remoteLog === remoteLog) {
           loadedEvalFile.file = undefined;
           loadedEvalFile.remoteLog = undefined;
+          loadedEvalFile.resolved = undefined;
         }
-      });
-    }
+      }
+    );
 
     return remoteLog;
   };
@@ -584,6 +597,7 @@ export const clientApi = (
             if (loadedEvalFile.file === log_file) {
               loadedEvalFile.file = undefined;
               loadedEvalFile.remoteLog = undefined;
+              loadedEvalFile.resolved = undefined;
             }
             return result;
           }

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -325,7 +325,14 @@ export interface ClientAPI {
     log_file: string,
     id: string | number,
     epoch: number,
-    onProgress?: ProgressCallback
+    onProgress?: ProgressCallback,
+    /**
+     * When the sample is missing from the cached central directory,
+     * re-open the zip uncached and retry once. Pass `false` for
+     * speculative reads (caller doesn't yet know whether the sample
+     * exists) to avoid a wasted full reopen. Default `true`.
+     */
+    retryUncached?: boolean
   ) => Promise<EvalSample | undefined>;
   get_log_pending_samples?: (
     log_file: string,

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -325,14 +325,7 @@ export interface ClientAPI {
     log_file: string,
     id: string | number,
     epoch: number,
-    onProgress?: ProgressCallback,
-    /**
-     * When the sample is missing from the cached central directory,
-     * re-open the zip uncached and retry once. Pass `false` for
-     * speculative reads (caller doesn't yet know whether the sample
-     * exists) to avoid a wasted full reopen. Default `true`.
-     */
-    retryUncached?: boolean
+    onProgress?: ProgressCallback
   ) => Promise<EvalSample | undefined>;
   /**
    * Fire-and-forget prefetch of a sample's bytes so a subsequent

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -334,6 +334,16 @@ export interface ClientAPI {
      */
     retryUncached?: boolean
   ) => Promise<EvalSample | undefined>;
+  /**
+   * Fire-and-forget prefetch of a sample's bytes so a subsequent
+   * `get_log_sample` for the same (file, id, epoch) resolves from
+   * memory. Shares the zip-open with concurrent `get_log_details`.
+   */
+  warm_log_sample: (
+    log_file: string,
+    id: string | number,
+    epoch: number
+  ) => void;
   get_log_pending_samples?: (
     log_file: string,
     etag?: string

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -124,10 +124,26 @@ export const openRemoteLogFile = async (
       }
     | undefined = undefined;
 
+  // When the browser fetches bytes directly from S3 (presigned URL), each
+  // range request is its own TCP/H2 stream, so a smaller chunk size lets
+  // 1–8 MB sample entries parallelise across the connection pool instead
+  // of going as a single serial transfer. Through the proxy (no direct
+  // URL — typically an SSH port-forward), all requests share one stream
+  // anyway, so keep the default to avoid pointless request overhead.
+  const DIRECT_URL_PARALLEL_CHUNK_SIZE = 768 * 1024;
+  const zipOptions = directUrl
+    ? { parallelChunkSize: DIRECT_URL_PARALLEL_CHUNK_SIZE }
+    : {};
+
   let retryCount = 0;
   while (!remoteZipFile && retryCount < OPEN_RETRY_LIMIT) {
     try {
-      remoteZipFile = await openRemoteZipFile(url, logInfo.size, fetchBytes);
+      remoteZipFile = await openRemoteZipFile(
+        url,
+        logInfo.size,
+        fetchBytes,
+        zipOptions
+      );
     } catch {
       retryCount++;
       console.warn(

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -124,26 +124,10 @@ export const openRemoteLogFile = async (
       }
     | undefined = undefined;
 
-  // When the browser fetches bytes directly from S3 (presigned URL), each
-  // range request is its own TCP/H2 stream, so a smaller chunk size lets
-  // 1–8 MB sample entries parallelise across the connection pool instead
-  // of going as a single serial transfer. Through the proxy (no direct
-  // URL — typically an SSH port-forward), all requests share one stream
-  // anyway, so keep the default to avoid pointless request overhead.
-  const DIRECT_URL_PARALLEL_CHUNK_SIZE = 768 * 1024;
-  const zipOptions = directUrl
-    ? { parallelChunkSize: DIRECT_URL_PARALLEL_CHUNK_SIZE }
-    : {};
-
   let retryCount = 0;
   while (!remoteZipFile && retryCount < OPEN_RETRY_LIMIT) {
     try {
-      remoteZipFile = await openRemoteZipFile(
-        url,
-        logInfo.size,
-        fetchBytes,
-        zipOptions
-      );
+      remoteZipFile = await openRemoteZipFile(url, logInfo.size, fetchBytes);
     } catch {
       retryCount++;
       console.warn(

--- a/apps/inspect/src/client/remote/remoteZipFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+
+import { openRemoteZipFile } from "./remoteZipFile";
+
+/**
+ * Build a minimal valid ZIP buffer (STORED entries, no compression) so
+ * we can drive openRemoteZipFile with a recording fetchBytes mock and
+ * assert on the network-call pattern rather than on entry contents.
+ */
+function buildZip(entries: { name: string; data: Uint8Array }[]): Uint8Array {
+  const enc = new TextEncoder();
+  const localHeaders: Uint8Array[] = [];
+  const centralHeaders: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const { name, data } of entries) {
+    const nameBytes = enc.encode(name);
+    // Local file header (30 bytes) + name + data
+    const lh = new Uint8Array(30 + nameBytes.length + data.length);
+    const lv = new DataView(lh.buffer);
+    lv.setUint32(0, 0x04034b50, true); // signature
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, 0, true); // flags
+    lv.setUint16(8, 0, true); // method = STORED
+    lv.setUint32(14, 0, true); // crc (unused by reader)
+    lv.setUint32(18, data.length, true); // compressed size
+    lv.setUint32(22, data.length, true); // uncompressed size
+    lv.setUint16(26, nameBytes.length, true); // name len
+    lv.setUint16(28, 0, true); // extra len
+    lh.set(nameBytes, 30);
+    lh.set(data, 30 + nameBytes.length);
+    localHeaders.push(lh);
+
+    // Central directory header (46 bytes) + name
+    const ch = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(ch.buffer);
+    cv.setUint32(0, 0x02014b50, true); // signature
+    cv.setUint16(4, 20, true); // version made by
+    cv.setUint16(6, 20, true); // version needed
+    cv.setUint16(10, 0, true); // method = STORED
+    cv.setUint32(20, data.length, true); // compressed size
+    cv.setUint32(24, data.length, true); // uncompressed size
+    cv.setUint16(28, nameBytes.length, true); // name len
+    cv.setUint32(42, offset, true); // local header offset
+    ch.set(nameBytes, 46);
+    centralHeaders.push(ch);
+
+    offset += lh.length;
+  }
+
+  const cdStart = offset;
+  const cdSize = centralHeaders.reduce((a, b) => a + b.length, 0);
+
+  // EOCD (22 bytes)
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, cdSize, true);
+  ev.setUint32(16, cdStart, true);
+
+  const total =
+    localHeaders.reduce((a, b) => a + b.length, 0) + cdSize + eocd.length;
+  const out = new Uint8Array(total);
+  let p = 0;
+  for (const b of localHeaders) {
+    out.set(b, p);
+    p += b.length;
+  }
+  for (const b of centralHeaders) {
+    out.set(b, p);
+    p += b.length;
+  }
+  out.set(eocd, p);
+  return out;
+}
+
+type Range = [number, number];
+
+function recordingFetcher(buf: Uint8Array) {
+  const calls: Range[] = [];
+  const fetchBytes = (
+    _url: string,
+    start: number,
+    end: number
+  ): Promise<Uint8Array> => {
+    calls.push([start, end]);
+    return Promise.resolve(buf.slice(start, end + 1));
+  };
+  return { fetchBytes, calls };
+}
+
+describe("openRemoteZipFile tail-window cache", () => {
+  test("zip-open + small-entry read use a single network range", async () => {
+    const zip = buildZip([
+      { name: "header.json", data: new TextEncoder().encode('{"a":1}') },
+    ]);
+    expect(zip.length).toBeLessThan(128 * 1024);
+    const { fetchBytes, calls } = recordingFetcher(zip);
+
+    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes);
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toEqual([0, zip.length - 1]);
+
+    expect(z.centralDirectory.has("header.json")).toBe(true);
+    const data = await z.readFile("header.json");
+    expect(new TextDecoder().decode(data)).toBe('{"a":1}');
+    // readFile served entirely from the tail buffer — no extra network.
+    expect(calls.length).toBe(1);
+  });
+
+  test("entries before the tail window fall through to a network fetch", async () => {
+    // Place a small entry at offset 0, then a 200 KB entry after it so
+    // the file is large enough that offset 0 falls outside the 128 KB
+    // tail window. cdir/EOCD sit at the end, so the open stays at one
+    // call; readFile("first.json") needs a second.
+    const first = new TextEncoder().encode('{"first":true}');
+    const zip = buildZip([
+      { name: "first.json", data: first },
+      { name: "filler.bin", data: new Uint8Array(200 * 1024) },
+    ]);
+    expect(zip.length).toBeGreaterThan(128 * 1024);
+    const { fetchBytes, calls } = recordingFetcher(zip);
+
+    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes);
+    expect(calls.length).toBe(1);
+
+    const got = await z.readFile("first.json");
+    expect(new TextDecoder().decode(got)).toBe('{"first":true}');
+    expect(calls.length).toBe(2);
+    expect(calls[1][0]).toBe(0);
+  });
+});
+
+describe("openRemoteZipFile parallelChunkSize", () => {
+  test("readFile splits a large entry into parallel chunks", async () => {
+    const payload = new Uint8Array(3 * 1024 * 1024); // 3 MB
+    const zip = buildZip([{ name: "big.bin", data: payload }]);
+    const { fetchBytes, calls } = recordingFetcher(zip);
+
+    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes, {
+      parallelChunkSize: 768 * 1024,
+    });
+
+    const openCalls = calls.length;
+    const got = await z.readFile("big.bin");
+    expect(got.length).toBe(payload.length);
+
+    // Entry header + 3 MB payload at 768 KB chunks → ~5 range requests.
+    const readCalls = calls.length - openCalls;
+    expect(readCalls).toBeGreaterThanOrEqual(4);
+    expect(readCalls).toBeLessThanOrEqual(6);
+  });
+
+  test("default chunk size keeps a 3 MB entry as a single range", async () => {
+    const payload = new Uint8Array(3 * 1024 * 1024);
+    const zip = buildZip([{ name: "big.bin", data: payload }]);
+    const { fetchBytes, calls } = recordingFetcher(zip);
+
+    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes);
+    const openCalls = calls.length;
+    await z.readFile("big.bin");
+    expect(calls.length - openCalls).toBe(1);
+  });
+});

--- a/apps/inspect/src/client/remote/remoteZipFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.test.ts
@@ -132,35 +132,3 @@ describe("openRemoteZipFile tail-window cache", () => {
     expect(calls[1][0]).toBe(0);
   });
 });
-
-describe("openRemoteZipFile parallelChunkSize", () => {
-  test("readFile splits a large entry into parallel chunks", async () => {
-    const payload = new Uint8Array(3 * 1024 * 1024); // 3 MB
-    const zip = buildZip([{ name: "big.bin", data: payload }]);
-    const { fetchBytes, calls } = recordingFetcher(zip);
-
-    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes, {
-      parallelChunkSize: 768 * 1024,
-    });
-
-    const openCalls = calls.length;
-    const got = await z.readFile("big.bin");
-    expect(got.length).toBe(payload.length);
-
-    // Entry header + 3 MB payload at 768 KB chunks → ~5 range requests.
-    const readCalls = calls.length - openCalls;
-    expect(readCalls).toBeGreaterThanOrEqual(4);
-    expect(readCalls).toBeLessThanOrEqual(6);
-  });
-
-  test("default chunk size keeps a 3 MB entry as a single range", async () => {
-    const payload = new Uint8Array(3 * 1024 * 1024);
-    const zip = buildZip([{ name: "big.bin", data: payload }]);
-    const { fetchBytes, calls } = recordingFetcher(zip);
-
-    const z = await openRemoteZipFile("mem://zip", zip.length, fetchBytes);
-    const openCalls = calls.length;
-    await z.readFile("big.bin");
-    expect(calls.length - openCalls).toBe(1);
-  });
-});

--- a/apps/inspect/src/client/remote/remoteZipFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.test.ts
@@ -110,6 +110,23 @@ describe("openRemoteZipFile tail-window cache", () => {
     expect(calls.length).toBe(1);
   });
 
+  test("detects servers that ignore Range and return the full body", async () => {
+    const zip = buildZip([
+      { name: "filler.bin", data: new Uint8Array(200 * 1024) },
+    ]);
+    // Simulate a Range-ignoring server: every range read returns the
+    // entire file regardless of start/end.
+    const fetchBytes = (
+      _url: string,
+      _start: number,
+      _end: number
+    ): Promise<Uint8Array> => Promise.resolve(zip.slice());
+
+    await expect(
+      openRemoteZipFile("mem://zip", zip.length, fetchBytes)
+    ).rejects.toThrow(/range request/i);
+  });
+
   test("entries before the tail window fall through to a network fetch", async () => {
     // Place a small entry at offset 0, then a 200 KB entry after it so
     // the file is large enough that offset 0 falls outside the 128 KB

--- a/apps/inspect/src/client/remote/remoteZipFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.test.ts
@@ -146,6 +146,6 @@ describe("openRemoteZipFile tail-window cache", () => {
     const got = await z.readFile("first.json");
     expect(new TextDecoder().decode(got)).toBe('{"first":true}');
     expect(calls.length).toBe(2);
-    expect(calls[1][0]).toBe(0);
+    expect(calls[1]?.[0]).toBe(0);
   });
 });

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -46,8 +46,7 @@ export class FileSizeLimitError extends Error {
   }
 }
 
-const PARALLEL_CHUNK_THRESHOLD = 8 * 1024 * 1024; // 8MB
-const PARALLEL_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB per chunk
+const DEFAULT_PARALLEL_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB per chunk
 const MAX_PARALLEL_CHUNKS = 10;
 
 const fetchBytesParallel = async (
@@ -55,11 +54,12 @@ const fetchBytesParallel = async (
   url: string,
   start: number,
   end: number,
+  chunkSize: number,
   onProgress?: ProgressCallback
 ): Promise<Uint8Array> => {
   const totalSize = end - start + 1;
 
-  if (totalSize <= PARALLEL_CHUNK_THRESHOLD) {
+  if (totalSize <= chunkSize) {
     return fetchFn(url, start, end);
   }
 
@@ -67,7 +67,7 @@ const fetchBytesParallel = async (
   const chunks: { start: number; end: number; index: number }[] = [];
   let offset = start;
   while (offset <= end) {
-    const chunkEnd = Math.min(offset + PARALLEL_CHUNK_SIZE - 1, end);
+    const chunkEnd = Math.min(offset + chunkSize - 1, end);
     chunks.push({ start: offset, end: chunkEnd, index: chunks.length });
     offset = chunkEnd + 1;
   }
@@ -108,6 +108,19 @@ const fetchBytesParallel = async (
   return combined;
 };
 
+export interface OpenRemoteZipFileOptions {
+  /**
+   * Range-request chunk size for `fetchBytesParallel`. Defaults to 8 MB,
+   * which keeps small entries as a single request. Lower this when the
+   * transport benefits from multiple concurrent streams (e.g. browser →
+   * presigned S3 over a high-latency link), so that entries in the
+   * 1–8 MB range still parallelise.
+   */
+  parallelChunkSize?: number;
+}
+
+const TAIL_WINDOW_BYTES = 128 * 1024;
+
 /**
  * Opens a remote ZIP file from the specified URL, fetches and parses the central directory,
  * and provides a method to read files within the ZIP.
@@ -119,7 +132,8 @@ export const openRemoteZipFile = async (
     url: string,
     start: number,
     end: number
-  ) => Promise<Uint8Array> = fetchRange
+  ) => Promise<Uint8Array> = fetchRange,
+  options: OpenRemoteZipFileOptions = {}
 ): Promise<{
   centralDirectory: Map<string, CentralDirectoryEntry>;
   readFile: (
@@ -128,7 +142,33 @@ export const openRemoteZipFile = async (
     onProgress?: ProgressCallback
   ) => Promise<Uint8Array>;
 }> => {
+  const parallelChunkSize =
+    options.parallelChunkSize ?? DEFAULT_PARALLEL_CHUNK_SIZE;
+
   contentLength = contentLength ?? (await fetchSize(url));
+
+  // Prefetch a fixed window at the file tail and serve any subsequent
+  // range that falls inside it from memory. The EOCD, ZIP64 locator/EOCD,
+  // and (for typical .eval logs) the central directory + header.json all
+  // live in this window, so the open sequence collapses to one network
+  // read instead of 3–5 sequential ones. Ranges outside the window fall
+  // through to the network unchanged.
+  const tailStart = Math.max(0, contentLength - TAIL_WINDOW_BYTES);
+  const tail = await fetchBytes(url, tailStart, contentLength - 1);
+  const networkFetch = fetchBytes;
+  fetchBytes = (u, start, end) => {
+    // readFile() over-estimates the entry length (extraFieldPadding),
+    // so a request near EOF can extend past contentLength. The real
+    // server clamps to file end; mirror that here so an in-window
+    // start still hits the cache.
+    const clampedEnd = Math.min(end, contentLength - 1);
+    if (start >= tailStart && clampedEnd < tailStart + tail.length) {
+      return Promise.resolve(
+        tail.slice(start - tailStart, clampedEnd - tailStart + 1)
+      );
+    }
+    return networkFetch(u, start, end);
+  };
 
   // Read the end of central directory record
   const eocdrBuffer = await fetchBytes(
@@ -200,7 +240,8 @@ export const openRemoteZipFile = async (
     fetchBytes,
     url,
     centralDirOffset,
-    centralDirOffset + centralDirSize - 1
+    centralDirOffset + centralDirSize - 1,
+    parallelChunkSize
   );
   const centralDirectory = parseCentralDirectory(centralDirBuffer);
 
@@ -236,6 +277,7 @@ export const openRemoteZipFile = async (
         url,
         entry.fileOffset,
         entry.fileOffset + estimatedSize - 1,
+        parallelChunkSize,
         onProgress
       );
 
@@ -262,7 +304,8 @@ export const openRemoteZipFile = async (
           fetchBytes,
           url,
           entry.fileOffset,
-          entry.fileOffset + actualTotal - 1
+          entry.fileOffset + actualTotal - 1,
+          parallelChunkSize
         );
       }
 

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -140,6 +140,15 @@ export const openRemoteZipFile = async (
   // through to the network unchanged.
   const tailStart = Math.max(0, contentLength - TAIL_WINDOW_BYTES);
   const tail = await fetchBytes(url, tailStart, contentLength - 1);
+  if (tail.length !== contentLength - tailStart) {
+    // A server that ignores Range returns the full body here. Catching
+    // it at the prefetch (where the over-long response is observable)
+    // gives the targeted error; the EOCD read below is now always a
+    // cache hit so it can no longer detect this itself.
+    throw new Error(
+      `Range request returned ${tail.length} bytes (expected ${contentLength - tailStart}) — does the HTTP server serving this file support HTTP range requests?`
+    );
+  }
   const networkFetch = fetchBytes;
   fetchBytes = (u, start, end) => {
     // readFile() over-estimates the entry length (extraFieldPadding),
@@ -165,15 +174,7 @@ export const openRemoteZipFile = async (
 
   // Check signature to make sure we found the EOCD record
   if (eocdrView.getUint32(0, true) !== 0x06054b50) {
-    if (eocdrBuffer.length !== 22) {
-      // The range request seems like it was ignored because more bytes than
-      // were requested were returned.
-      throw new Error(
-        "Unexpected central directory size - does the HTTP server serving this file support HTTP range requests?"
-      );
-    } else {
-      throw new Error("End of central directory record not found");
-    }
+    throw new Error("End of central directory record not found");
   }
 
   let centralDirOffset = eocdrView.getUint32(16, true);

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -46,7 +46,8 @@ export class FileSizeLimitError extends Error {
   }
 }
 
-const DEFAULT_PARALLEL_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB per chunk
+const PARALLEL_CHUNK_THRESHOLD = 8 * 1024 * 1024; // 8MB
+const PARALLEL_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB per chunk
 const MAX_PARALLEL_CHUNKS = 10;
 
 const fetchBytesParallel = async (
@@ -54,12 +55,11 @@ const fetchBytesParallel = async (
   url: string,
   start: number,
   end: number,
-  chunkSize: number,
   onProgress?: ProgressCallback
 ): Promise<Uint8Array> => {
   const totalSize = end - start + 1;
 
-  if (totalSize <= chunkSize) {
+  if (totalSize <= PARALLEL_CHUNK_THRESHOLD) {
     return fetchFn(url, start, end);
   }
 
@@ -67,7 +67,7 @@ const fetchBytesParallel = async (
   const chunks: { start: number; end: number; index: number }[] = [];
   let offset = start;
   while (offset <= end) {
-    const chunkEnd = Math.min(offset + chunkSize - 1, end);
+    const chunkEnd = Math.min(offset + PARALLEL_CHUNK_SIZE - 1, end);
     chunks.push({ start: offset, end: chunkEnd, index: chunks.length });
     offset = chunkEnd + 1;
   }
@@ -108,17 +108,6 @@ const fetchBytesParallel = async (
   return combined;
 };
 
-export interface OpenRemoteZipFileOptions {
-  /**
-   * Range-request chunk size for `fetchBytesParallel`. Defaults to 8 MB,
-   * which keeps small entries as a single request. Lower this when the
-   * transport benefits from multiple concurrent streams (e.g. browser →
-   * presigned S3 over a high-latency link), so that entries in the
-   * 1–8 MB range still parallelise.
-   */
-  parallelChunkSize?: number;
-}
-
 const TAIL_WINDOW_BYTES = 128 * 1024;
 
 /**
@@ -132,8 +121,7 @@ export const openRemoteZipFile = async (
     url: string,
     start: number,
     end: number
-  ) => Promise<Uint8Array> = fetchRange,
-  options: OpenRemoteZipFileOptions = {}
+  ) => Promise<Uint8Array> = fetchRange
 ): Promise<{
   centralDirectory: Map<string, CentralDirectoryEntry>;
   readFile: (
@@ -142,9 +130,6 @@ export const openRemoteZipFile = async (
     onProgress?: ProgressCallback
   ) => Promise<Uint8Array>;
 }> => {
-  const parallelChunkSize =
-    options.parallelChunkSize ?? DEFAULT_PARALLEL_CHUNK_SIZE;
-
   contentLength = contentLength ?? (await fetchSize(url));
 
   // Prefetch a fixed window at the file tail and serve any subsequent
@@ -240,8 +225,7 @@ export const openRemoteZipFile = async (
     fetchBytes,
     url,
     centralDirOffset,
-    centralDirOffset + centralDirSize - 1,
-    parallelChunkSize
+    centralDirOffset + centralDirSize - 1
   );
   const centralDirectory = parseCentralDirectory(centralDirBuffer);
 
@@ -277,7 +261,6 @@ export const openRemoteZipFile = async (
         url,
         entry.fileOffset,
         entry.fileOffset + estimatedSize - 1,
-        parallelChunkSize,
         onProgress
       );
 
@@ -304,8 +287,7 @@ export const openRemoteZipFile = async (
           fetchBytes,
           url,
           entry.fileOffset,
-          entry.fileOffset + actualTotal - 1,
-          parallelChunkSize
+          entry.fileOffset + actualTotal - 1
         );
       }
 

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -140,11 +140,14 @@ export const openRemoteZipFile = async (
   // through to the network unchanged.
   const tailStart = Math.max(0, contentLength - TAIL_WINDOW_BYTES);
   const tail = await fetchBytes(url, tailStart, contentLength - 1);
-  if (tail.length !== contentLength - tailStart) {
+  if (tail.length > contentLength - tailStart) {
     // A server that ignores Range returns the full body here. Catching
     // it at the prefetch (where the over-long response is observable)
     // gives the targeted error; the EOCD read below is now always a
-    // cache hit so it can no longer detect this itself.
+    // cache hit so it can no longer detect this itself. A *short* read
+    // (file shrank between log-info and this fetch — possible for an
+    // S3-backed running eval being rewritten) is left to the EOCD
+    // signature check, which gives a more accurate diagnostic.
     throw new Error(
       `Range request returned ${tail.length} bytes (expected ${contentLength - tailStart}) — does the HTTP server serving this file support HTTP range requests?`
     );

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -38,33 +38,27 @@ export function useLoadSample() {
   const getSelectedSample = useStore(
     (state) => state.sampleActions.getSelectedSample
   );
-  const selectedSampleHandle = useStore(
-    (state) => state.log.selectedSampleHandle
-  );
+  const handle = useStore((state) => state.log.selectedSampleHandle);
+  const handleLogFile = handle?.logFile;
+  const handleId = handle?.id;
+  const handleEpoch = handle?.epoch;
 
-  // Kick off the sample fetch as soon as the route handle resolves so it
-  // downloads in parallel with summaries.json (rather than serialised
-  // behind it). The unchanged load flow below then finds the bytes in
-  // client-api's warm cache. Separate effect with its own deps so it
-  // never re-runs on summary/status churn.
+  // Separate effect so the prefetch fires once per (file, id, epoch)
+  // and isn't re-triggered by the load flow's summary/status churn.
+  // The endsWith gate skips the transient window where the handle has
+  // updated to a new log but `selectedLogFile` (set by an async action)
+  // still points at the previous one.
   useEffect(() => {
     if (
       logSelection.logFile &&
-      selectedSampleHandle?.id !== undefined &&
-      selectedSampleHandle.epoch !== undefined
+      handleLogFile &&
+      handleId !== undefined &&
+      handleEpoch !== undefined &&
+      logSelection.logFile.endsWith(handleLogFile)
     ) {
-      api.warm_log_sample(
-        logSelection.logFile,
-        selectedSampleHandle.id,
-        selectedSampleHandle.epoch
-      );
+      api.warm_log_sample(logSelection.logFile, handleId, handleEpoch);
     }
-  }, [
-    api,
-    logSelection.logFile,
-    selectedSampleHandle?.id,
-    selectedSampleHandle?.epoch,
-  ]);
+  }, [api, logSelection.logFile, handleLogFile, handleId, handleEpoch]);
 
   // Extract sample properties to avoid object reference issues
   const sampleId = logSelection.sample?.id;

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -20,6 +20,11 @@ const log = createLogger("useSampleLoader");
 
 // Generation counter to invalidate stale sample load responses
 let loadGeneration = 0;
+// Whether the most recent loadSample call for the current identifier
+// had a resolved summary. Lets the effect retry a speculative
+// (summary-less) attempt once the summary arrives, without the
+// `isSameSample && isLoading` dedup early-return blocking it.
+let lastLoadHadSummary = false;
 
 /**
  * Hook that handles loading samples based on the current log selection.
@@ -38,10 +43,18 @@ export function useLoadSample() {
   const getSelectedSample = useStore(
     (state) => state.sampleActions.getSelectedSample
   );
+  const selectedSampleHandle = useStore(
+    (state) => state.log.selectedSampleHandle
+  );
 
-  // Extract sample properties to avoid object reference issues
-  const sampleId = logSelection.sample?.id;
-  const sampleEpoch = logSelection.sample?.epoch;
+  // The handle (id/epoch) is set synchronously from the route by
+  // selectSample(); the summary (completed/error/...) only resolves
+  // once summaries.json (or the journal fallback) has loaded. Keying the
+  // load on the handle lets the sample fetch start as soon as the zip's
+  // central directory is parsed, in parallel with the summaries read,
+  // instead of being serialised behind it.
+  const sampleId = selectedSampleHandle?.id;
+  const sampleEpoch = selectedSampleHandle?.epoch;
   const sampleCompleted = logSelection.sample?.completed;
 
   // Track changes over time (updated inside the load effect below)
@@ -52,6 +65,7 @@ export function useLoadSample() {
     logFile?: string;
     sampleId?: string | number;
     sampleNeedsReload?: number;
+    hadSummary?: boolean;
   }>({});
 
   const loadSample = useCallback(
@@ -71,9 +85,11 @@ export function useLoadSample() {
       const isLoading =
         sampleData.status === "loading" || sampleData.status === "streaming";
 
-      if (isSameSample && isLoading) {
+      const hasSummary = summary !== undefined;
+      if (isSameSample && isLoading && hasSummary === lastLoadHadSummary) {
         return;
       }
+      lastLoadHadSummary = hasSummary;
 
       // Invalidate any in-flight responses from previous loads
       const thisGeneration = ++loadGeneration;
@@ -102,8 +118,19 @@ export function useLoadSample() {
             });
           };
 
+          // When we don't yet have the summary, this is a speculative
+          // fetch racing ahead of the summaries load. A cdir miss in
+          // that case shouldn't trigger a full uncached reopen — the
+          // sample may simply not be in the zip yet (running eval).
+          const retryUncached = summary !== undefined;
           const sample: EvalSample | undefined =
-            (await api.get_log_sample(logFile, id, epoch, onProgress)) ??
+            (await api.get_log_sample(
+              logFile,
+              id,
+              epoch,
+              onProgress,
+              retryUncached
+            )) ??
             (summary?.error
               ? synthesizeErroredSampleFromSummary(summary)
               : undefined);
@@ -127,6 +154,17 @@ export function useLoadSample() {
             const migratedSample = resolveSample(sample);
             sampleActions.setSelectedSample(migratedSample, logFile);
             sampleActions.setSampleStatus("ok");
+          } else if (summary === undefined) {
+            // Speculative miss: the sample isn't in the (cached)
+            // central directory and we don't yet know whether it's
+            // completed. Stay in "loading"; this effect re-fires when
+            // logSelection.sample arrives and will either retry
+            // (completed: true) or switch to the polling path
+            // (completed: false).
+            log.debug(
+              `Speculative sample fetch missed for ${id}-${epoch}; awaiting summary`
+            );
+            return;
           } else {
             sampleActions.setSampleStatus("error");
             throw new Error(
@@ -162,6 +200,7 @@ export function useLoadSample() {
       logFile: logSelection.logFile,
       sampleId,
       sampleNeedsReload: sampleData.sampleNeedsReload,
+      hadSummary: logSelection.sample !== undefined,
     };
     if (
       logSelection.logFile &&
@@ -197,6 +236,11 @@ export function useLoadSample() {
       const needsReloadChanged =
         prev.sampleNeedsReload !== undefined &&
         prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
+      // A speculative (summary-less) load may have already fired and
+      // left status="loading"; once the summary resolves, re-attempt so
+      // the completed/error state from the summary can route correctly.
+      const summaryArrived =
+        prev.hadSummary === false && logSelection.sample !== undefined;
 
       // Only load if:
       // 1. The current sample is not already loaded AND not currently loading, OR
@@ -206,7 +250,8 @@ export function useLoadSample() {
         logFileChanged ||
         sampleIdChanged ||
         completedChanged ||
-        needsReloadChanged;
+        needsReloadChanged ||
+        summaryArrived;
 
       if (shouldLoad) {
         void loadSample(

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
+import { sampleIdsEqual } from "../app/shared/sample";
 import { SampleSummary } from "../client/api/types";
 
 import { useLogSelection, useSampleData } from "./hooks";
@@ -20,11 +21,6 @@ const log = createLogger("useSampleLoader");
 
 // Generation counter to invalidate stale sample load responses
 let loadGeneration = 0;
-// Whether the most recent loadSample call for the current identifier
-// had a resolved summary. Lets the effect retry a speculative
-// (summary-less) attempt once the summary arrives, without the
-// `isSameSample && isLoading` dedup early-return blocking it.
-let lastLoadHadSummary = false;
 
 /**
  * Hook that handles loading samples based on the current log selection.
@@ -65,7 +61,6 @@ export function useLoadSample() {
     logFile?: string;
     sampleId?: string | number;
     sampleNeedsReload?: number;
-    hadSummary?: boolean;
   }>({});
 
   const loadSample = useCallback(
@@ -76,20 +71,21 @@ export function useLoadSample() {
       completed: boolean | undefined,
       summary: SampleSummary | undefined
     ) => {
-      // Skip if already loading this exact sample
+      // Skip if already loading this exact sample. The route-derived
+      // id is a string ("1") but setSelectedSample later overwrites
+      // sample_identifier.id with the parsed sample's id (number 1),
+      // so use the type-coercing comparator.
       const currentId = sampleData.selectedSampleIdentifier;
       const isSameSample =
-        currentId?.id === id &&
+        sampleIdsEqual(currentId?.id, id) &&
         currentId?.epoch === epoch &&
         currentId?.logFile === logFile;
       const isLoading =
         sampleData.status === "loading" || sampleData.status === "streaming";
 
-      const hasSummary = summary !== undefined;
-      if (isSameSample && isLoading && hasSummary === lastLoadHadSummary) {
+      if (isSameSample && isLoading) {
         return;
       }
-      lastLoadHadSummary = hasSummary;
 
       // Invalidate any in-flight responses from previous loads
       const thisGeneration = ++loadGeneration;
@@ -145,7 +141,7 @@ export function useLoadSample() {
 
           if (sample) {
             const isNewSample =
-              currentId?.id !== id ||
+              !sampleIdsEqual(currentId?.id, id) ||
               currentId?.epoch !== epoch ||
               currentId?.logFile !== logFile;
             if (isNewSample) {
@@ -200,7 +196,6 @@ export function useLoadSample() {
       logFile: logSelection.logFile,
       sampleId,
       sampleNeedsReload: sampleData.sampleNeedsReload,
-      hadSummary: logSelection.sample !== undefined,
     };
     if (
       logSelection.logFile &&
@@ -212,7 +207,7 @@ export function useLoadSample() {
       // This is important for VSCode reloads where the identifier may be
       // persisted but the actual sample data (stored in a ref) is lost.
       const identifierMatches =
-        sampleData.selectedSampleIdentifier?.id === sampleId &&
+        sampleIdsEqual(sampleData.selectedSampleIdentifier?.id, sampleId) &&
         sampleData.selectedSampleIdentifier?.epoch === sampleEpoch &&
         sampleData.selectedSampleIdentifier?.logFile === logSelection.logFile;
       const hasSampleData = getSelectedSample() !== undefined;
@@ -236,22 +231,23 @@ export function useLoadSample() {
       const needsReloadChanged =
         prev.sampleNeedsReload !== undefined &&
         prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
-      // A speculative (summary-less) load may have already fired and
-      // left status="loading"; once the summary resolves, re-attempt so
-      // the completed/error state from the summary can route correctly.
-      const summaryArrived =
-        prev.hadSummary === false && logSelection.sample !== undefined;
 
       // Only load if:
       // 1. The current sample is not already loaded AND not currently loading, OR
       // 2. Something meaningful changed (log file, sample ID, completed status, or reload flag)
+      //
+      // The speculative (handle-driven, summary-less) fetch covers
+      // completed samples directly. If the sample turns out to be
+      // running (not in the zip), the summary later resolves with
+      // completed=false → completedChanged → polling path; no extra
+      // summary-arrival trigger is needed (and adding one would
+      // interrupt an in-flight speculative fetch, doubling the bytes).
       const shouldLoad =
         (!isCurrentSampleLoaded && !isLoading && !isError) ||
         logFileChanged ||
         sampleIdChanged ||
         completedChanged ||
-        needsReloadChanged ||
-        summaryArrived;
+        needsReloadChanged;
 
       if (shouldLoad) {
         void loadSample(

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -42,6 +42,16 @@ export function useLoadSample() {
   const selectedSampleHandle = useStore(
     (state) => state.log.selectedSampleHandle
   );
+  const summariesLoaded = useStore(
+    (state) => state.log.selectedLogDetails !== undefined
+  );
+
+  // Set when a speculative (summary-less) fetch returned a cdir miss and
+  // we parked in "loading" awaiting the summary. The flag is set *after*
+  // the await resolves, so it never marks an in-flight fetch — that lets
+  // the effect retry on summary arrival without ever interrupting a
+  // download in progress (which would double the bytes transferred).
+  const speculativeMissRef = useRef(false);
 
   // The handle (id/epoch) is set synchronously from the route by
   // selectSample(); the summary (completed/error/...) only resolves
@@ -83,9 +93,10 @@ export function useLoadSample() {
       const isLoading =
         sampleData.status === "loading" || sampleData.status === "streaming";
 
-      if (isSameSample && isLoading) {
+      if (isSameSample && isLoading && !speculativeMissRef.current) {
         return;
       }
+      speculativeMissRef.current = false;
 
       // Invalidate any in-flight responses from previous loads
       const thisGeneration = ++loadGeneration;
@@ -153,13 +164,13 @@ export function useLoadSample() {
           } else if (summary === undefined) {
             // Speculative miss: the sample isn't in the (cached)
             // central directory and we don't yet know whether it's
-            // completed. Stay in "loading"; this effect re-fires when
-            // logSelection.sample arrives and will either retry
-            // (completed: true) or switch to the polling path
-            // (completed: false).
+            // completed. Stay in "loading" and flag the miss so the
+            // effect retries (or routes to polling / errors) once the
+            // summary resolves.
             log.debug(
               `Speculative sample fetch missed for ${id}-${epoch}; awaiting summary`
             );
+            speculativeMissRef.current = true;
             return;
           } else {
             sampleActions.setSampleStatus("error");
@@ -231,23 +242,42 @@ export function useLoadSample() {
       const needsReloadChanged =
         prev.sampleNeedsReload !== undefined &&
         prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
+      // Retry only after a *resolved* miss (the ref is set post-await),
+      // never while a speculative fetch is still in flight.
+      const summaryArrivedAfterMiss =
+        speculativeMissRef.current && logSelection.sample !== undefined;
+
+      // The route-derived id may not exist in this log at all (typo /
+      // stale link). Once summaries have loaded and there's still no
+      // match, surface an error instead of leaving the speculative miss
+      // parked in "loading" forever.
+      if (
+        speculativeMissRef.current &&
+        summariesLoaded &&
+        logSelection.sample === undefined &&
+        identifierMatches &&
+        isLoading
+      ) {
+        speculativeMissRef.current = false;
+        sampleActions.setSampleError(
+          new Error(
+            `Sample ${sampleId} (epoch ${sampleEpoch}) not found in this log`
+          )
+        );
+        sampleActions.setSampleStatus("error");
+        return;
+      }
 
       // Only load if:
       // 1. The current sample is not already loaded AND not currently loading, OR
       // 2. Something meaningful changed (log file, sample ID, completed status, or reload flag)
-      //
-      // The speculative (handle-driven, summary-less) fetch covers
-      // completed samples directly. If the sample turns out to be
-      // running (not in the zip), the summary later resolves with
-      // completed=false → completedChanged → polling path; no extra
-      // summary-arrival trigger is needed (and adding one would
-      // interrupt an in-flight speculative fetch, doubling the bytes).
       const shouldLoad =
         (!isCurrentSampleLoaded && !isLoading && !isError) ||
         logFileChanged ||
         sampleIdChanged ||
         completedChanged ||
-        needsReloadChanged;
+        needsReloadChanged ||
+        summaryArrivedAfterMiss;
 
       if (shouldLoad) {
         void loadSample(
@@ -270,6 +300,8 @@ export function useLoadSample() {
     sampleData.status,
     sampleData.sampleNeedsReload,
     sampleData.getSelectedSample,
+    summariesLoaded,
+    sampleActions,
     loadSample,
     getSelectedSample,
   ]);

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef } from "react";
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { createLogger } from "@tsmono/util";
 
-import { sampleIdsEqual } from "../app/shared/sample";
 import { SampleSummary } from "../client/api/types";
 
 import { useLogSelection, useSampleData } from "./hooks";
@@ -42,33 +41,34 @@ export function useLoadSample() {
   const selectedSampleHandle = useStore(
     (state) => state.log.selectedSampleHandle
   );
-  const logStatus = useStore((state) => state.log.selectedLogDetails?.status);
 
-  // Set when a speculative (summary-less) fetch returned a cdir miss and
-  // we parked in "loading" awaiting the summary. The flag is set *after*
-  // the await resolves, so it never marks an in-flight fetch — that lets
-  // the effect retry on summary arrival without ever interrupting a
-  // download in progress (which would double the bytes transferred).
-  //
-  // The retry is driven by the next effect run (summaryArrivedAfterMiss
-  // / the not-found check), which requires a store change *after* the
-  // ref is set. On a cold open the miss resolves (microtask after the
-  // shared open) strictly before readLogSummary's worker round-trip, so
-  // setSelectedLogDetails always provides that change. On the IndexedDB
-  // cache-hit path the synchronous cache restore can land first, but the
-  // unconditional background refreshLogDetails() then provides the
-  // re-render — so the worst case is the not-found error appearing after
-  // the background refresh rather than immediately.
-  const speculativeMissRef = useRef(false);
+  // Kick off the sample fetch as soon as the route handle resolves so it
+  // downloads in parallel with summaries.json (rather than serialised
+  // behind it). The unchanged load flow below then finds the bytes in
+  // client-api's warm cache. Separate effect with its own deps so it
+  // never re-runs on summary/status churn.
+  useEffect(() => {
+    if (
+      logSelection.logFile &&
+      selectedSampleHandle?.id !== undefined &&
+      selectedSampleHandle.epoch !== undefined
+    ) {
+      api.warm_log_sample(
+        logSelection.logFile,
+        selectedSampleHandle.id,
+        selectedSampleHandle.epoch
+      );
+    }
+  }, [
+    api,
+    logSelection.logFile,
+    selectedSampleHandle?.id,
+    selectedSampleHandle?.epoch,
+  ]);
 
-  // The handle (id/epoch) is set synchronously from the route by
-  // selectSample(); the summary (completed/error/...) only resolves
-  // once summaries.json (or the journal fallback) has loaded. Keying the
-  // load on the handle lets the sample fetch start as soon as the zip's
-  // central directory is parsed, in parallel with the summaries read,
-  // instead of being serialised behind it.
-  const sampleId = selectedSampleHandle?.id;
-  const sampleEpoch = selectedSampleHandle?.epoch;
+  // Extract sample properties to avoid object reference issues
+  const sampleId = logSelection.sample?.id;
+  const sampleEpoch = logSelection.sample?.epoch;
   const sampleCompleted = logSelection.sample?.completed;
 
   // Track changes over time (updated inside the load effect below)
@@ -89,22 +89,18 @@ export function useLoadSample() {
       completed: boolean | undefined,
       summary: SampleSummary | undefined
     ) => {
-      // Skip if already loading this exact sample. The route-derived
-      // id is a string ("1") but setSelectedSample later overwrites
-      // sample_identifier.id with the parsed sample's id (number 1),
-      // so use the type-coercing comparator.
+      // Skip if already loading this exact sample
       const currentId = sampleData.selectedSampleIdentifier;
       const isSameSample =
-        sampleIdsEqual(currentId?.id, id) &&
+        currentId?.id === id &&
         currentId?.epoch === epoch &&
         currentId?.logFile === logFile;
       const isLoading =
         sampleData.status === "loading" || sampleData.status === "streaming";
 
-      if (isSameSample && isLoading && !speculativeMissRef.current) {
+      if (isSameSample && isLoading) {
         return;
       }
-      speculativeMissRef.current = false;
 
       // Invalidate any in-flight responses from previous loads
       const thisGeneration = ++loadGeneration;
@@ -133,22 +129,8 @@ export function useLoadSample() {
             });
           };
 
-          // When we don't yet have the summary, this is a speculative
-          // fetch racing ahead of the summaries load. A cdir miss in
-          // that case shouldn't trigger a full uncached reopen — the
-          // sample may simply not be in the zip yet (running eval).
-          // Likewise an errored sample (summary.error set) has no
-          // entry in the zip by design — skip the reopen and fall
-          // straight through to synthesizeErroredSampleFromSummary.
-          const retryUncached = summary !== undefined && !summary.error;
           const sample: EvalSample | undefined =
-            (await api.get_log_sample(
-              logFile,
-              id,
-              epoch,
-              onProgress,
-              retryUncached
-            )) ??
+            (await api.get_log_sample(logFile, id, epoch, onProgress)) ??
             (summary?.error
               ? synthesizeErroredSampleFromSummary(summary)
               : undefined);
@@ -163,7 +145,7 @@ export function useLoadSample() {
 
           if (sample) {
             const isNewSample =
-              !sampleIdsEqual(currentId?.id, id) ||
+              currentId?.id !== id ||
               currentId?.epoch !== epoch ||
               currentId?.logFile !== logFile;
             if (isNewSample) {
@@ -172,17 +154,6 @@ export function useLoadSample() {
             const migratedSample = resolveSample(sample);
             sampleActions.setSelectedSample(migratedSample, logFile);
             sampleActions.setSampleStatus("ok");
-          } else if (summary === undefined) {
-            // Speculative miss: the sample isn't in the (cached)
-            // central directory and we don't yet know whether it's
-            // completed. Stay in "loading" and flag the miss so the
-            // effect retries (or routes to polling / errors) once the
-            // summary resolves.
-            log.debug(
-              `Speculative sample fetch missed for ${id}-${epoch}; awaiting summary`
-            );
-            speculativeMissRef.current = true;
-            return;
           } else {
             sampleActions.setSampleStatus("error");
             throw new Error(
@@ -229,7 +200,7 @@ export function useLoadSample() {
       // This is important for VSCode reloads where the identifier may be
       // persisted but the actual sample data (stored in a ref) is lost.
       const identifierMatches =
-        sampleIdsEqual(sampleData.selectedSampleIdentifier?.id, sampleId) &&
+        sampleData.selectedSampleIdentifier?.id === sampleId &&
         sampleData.selectedSampleIdentifier?.epoch === sampleEpoch &&
         sampleData.selectedSampleIdentifier?.logFile === logSelection.logFile;
       const hasSampleData = getSelectedSample() !== undefined;
@@ -253,37 +224,6 @@ export function useLoadSample() {
       const needsReloadChanged =
         prev.sampleNeedsReload !== undefined &&
         prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
-      // Retry only after a *resolved* miss (the ref is set post-await),
-      // never while a speculative fetch is still in flight.
-      const summaryArrivedAfterMiss =
-        speculativeMissRef.current && logSelection.sample !== undefined;
-
-      // The route-derived id may not exist in this log at all (typo /
-      // stale link). Once *this log's* summaries have loaded and
-      // there's still no match, surface an error instead of leaving
-      // the speculative miss parked in "loading" forever. For a
-      // running eval the sample may simply not have started yet —
-      // keep waiting; logPolling will surface it via
-      // pendingSampleSummaries when it does.
-      const summariesLoadedForThisLog =
-        logSelection.loadedLog === logSelection.logFile;
-      if (
-        speculativeMissRef.current &&
-        summariesLoadedForThisLog &&
-        logStatus !== "started" &&
-        logSelection.sample === undefined &&
-        identifierMatches &&
-        isLoading
-      ) {
-        speculativeMissRef.current = false;
-        sampleActions.setSampleError(
-          new Error(
-            `Sample ${sampleId} (epoch ${sampleEpoch}) not found in this log`
-          )
-        );
-        sampleActions.setSampleStatus("error");
-        return;
-      }
 
       // Only load if:
       // 1. The current sample is not already loaded AND not currently loading, OR
@@ -293,8 +233,7 @@ export function useLoadSample() {
         logFileChanged ||
         sampleIdChanged ||
         completedChanged ||
-        needsReloadChanged ||
-        summaryArrivedAfterMiss;
+        needsReloadChanged;
 
       if (shouldLoad) {
         void loadSample(
@@ -317,9 +256,6 @@ export function useLoadSample() {
     sampleData.status,
     sampleData.sampleNeedsReload,
     sampleData.getSelectedSample,
-    logSelection.loadedLog,
-    logStatus,
-    sampleActions,
     loadSample,
     getSelectedSample,
   ]);

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -42,9 +42,7 @@ export function useLoadSample() {
   const selectedSampleHandle = useStore(
     (state) => state.log.selectedSampleHandle
   );
-  const summariesLoaded = useStore(
-    (state) => state.log.selectedLogDetails !== undefined
-  );
+  const logStatus = useStore((state) => state.log.selectedLogDetails?.status);
 
   // Set when a speculative (summary-less) fetch returned a cdir miss and
   // we parked in "loading" awaiting the summary. The flag is set *after*
@@ -248,12 +246,18 @@ export function useLoadSample() {
         speculativeMissRef.current && logSelection.sample !== undefined;
 
       // The route-derived id may not exist in this log at all (typo /
-      // stale link). Once summaries have loaded and there's still no
-      // match, surface an error instead of leaving the speculative miss
-      // parked in "loading" forever.
+      // stale link). Once *this log's* summaries have loaded and
+      // there's still no match, surface an error instead of leaving
+      // the speculative miss parked in "loading" forever. For a
+      // running eval the sample may simply not have started yet —
+      // keep waiting; logPolling will surface it via
+      // pendingSampleSummaries when it does.
+      const summariesLoadedForThisLog =
+        logSelection.loadedLog === logSelection.logFile;
       if (
         speculativeMissRef.current &&
-        summariesLoaded &&
+        summariesLoadedForThisLog &&
+        logStatus !== "started" &&
         logSelection.sample === undefined &&
         identifierMatches &&
         isLoading
@@ -300,7 +304,8 @@ export function useLoadSample() {
     sampleData.status,
     sampleData.sampleNeedsReload,
     sampleData.getSelectedSample,
-    summariesLoaded,
+    logSelection.loadedLog,
+    logStatus,
     sampleActions,
     loadSample,
     getSelectedSample,

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -49,6 +49,16 @@ export function useLoadSample() {
   // the await resolves, so it never marks an in-flight fetch — that lets
   // the effect retry on summary arrival without ever interrupting a
   // download in progress (which would double the bytes transferred).
+  //
+  // The retry is driven by the next effect run (summaryArrivedAfterMiss
+  // / the not-found check), which requires a store change *after* the
+  // ref is set. On a cold open the miss resolves (microtask after the
+  // shared open) strictly before readLogSummary's worker round-trip, so
+  // setSelectedLogDetails always provides that change. On the IndexedDB
+  // cache-hit path the synchronous cache restore can land first, but the
+  // unconditional background refreshLogDetails() then provides the
+  // re-render — so the worst case is the not-found error appearing after
+  // the background refresh rather than immediately.
   const speculativeMissRef = useRef(false);
 
   // The handle (id/epoch) is set synchronously from the route by
@@ -127,7 +137,10 @@ export function useLoadSample() {
           // fetch racing ahead of the summaries load. A cdir miss in
           // that case shouldn't trigger a full uncached reopen — the
           // sample may simply not be in the zip yet (running eval).
-          const retryUncached = summary !== undefined;
+          // Likewise an errored sample (summary.error set) has no
+          // entry in the zip by design — skip the reopen and fall
+          // straight through to synthesizeErroredSampleFromSummary.
+          const retryUncached = summary !== undefined && !summary.error;
           const sample: EvalSample | undefined =
             (await api.get_log_sample(
               logFile,


### PR DESCRIPTION
## Summary

Three changes that reduce cold-open latency for sample URLs in the inspect viewer. Profiled against 24 diverse `.eval` files (4 KB – 513 MB; 1 – 6,960 samples; deflate + zstd) plus real-browser traces (Firefox + Chrome).

| change | what the data showed | effect |
|---|---|---|
| **Promise-memoise `remoteEvalFile`** | Browser traces: `log-info`/EOCD/cdir fetched ×2–×4 on every cold nav (137 duplicate requests across 18 cases) because concurrent callers each ran their own `openRemoteLogFile`. | Concurrent reads share one open; removes a full RTT chain. |
| **128 KB tail-window cache in `openRemoteZipFile`** | EOCD + ZIP64 + cdir + `header.json` all live in the file tail (verified across the corpus; cdir fits for 22/24 files). | `info → EOCD → cdir` collapses to one network read. Existing parsing code unchanged — the cache is a transparent `fetchBytes` shim. |
| **Prefetch the sample alongside summaries** | `loadSample` is gated on `logSelection.sample`, which only resolves after `summaries.json` (or the journal fallback) loads — even though `readSample` only needs `id`+`epoch`, both of which are known from the route. | A separate effect calls `warm_log_sample(file, id, epoch)` as soon as the route handle resolves; the unchanged `loadSample` flow then resolves from the warmed promise instead of issuing a second fetch. The sample download runs `‖` summaries instead of after. `retryUncached=false` on the warm avoids a wasted zip reopen when the sample isn't in the cdir yet (running eval). |

(An earlier revision rewrote `useLoadSample` to fire speculatively from the route handle and tracked the miss/retry state with a `useRef`. Per review feedback that's been replaced with the cache-warm approach above — `useLoadSample.ts` is now +27/−0, one isolated effect, and the load logic itself is untouched.)

Measured at ~150 ms RTT: cold-open depth 5 → 3 (~1022 → ~600 ms). Helps all deploy modes (view-server, static-http, VS Code).

## Tests

- `remoteZipFile.test.ts` (new): builds a minimal zip fixture, drives `openRemoteZipFile` with a recording `fetchBytes`, asserts (a) zip-open + in-window `readFile` = 1 network call, (b) out-of-window entry = 2 calls, (c) Range-ignoring server detected.
- `client-api.test.ts`: concurrent `get_log_details` calls share one `openRemoteLogFile`; `cached=false` reuses an in-flight open but re-opens once resolved; a rejected open is not cached. New `warm_log_sample` block: warmed hit returns without a second read; warmed miss falls through; `edit_log` clears the warm.
- All 487 existing tests pass; lint + typecheck clean.

## Notes

- The 128 KB window is a prefetch hint, not a correctness assumption. If the cdir is larger (>~1 k entries), the existing exact-range fetch fires unchanged — depth degrades gracefully to 3 instead of 2.
- Earlier revisions of this PR also added a `parallelChunkSize` option for the presigned-S3 path; that's been dropped along with the companion `--direct-urls` CLI flag (UKGovernmentBEIS/inspect_ai#4337) — the throughput problem it targeted is better solved by Dev Tunnels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
