### PR TITLE
Fix inline MathJax stacking under inherited white-space: pre-wrap

### DIFF
--- a/packages/react/src/components/MarkdownDiv.css
+++ b/packages/react/src/components/MarkdownDiv.css
@@ -1,3 +1,14 @@
+/* Rendered markdown defines its own whitespace semantics, so neutralize any
+   `white-space: pre-wrap` inherited from an ancestor container. Without this,
+   markdown-it-mathjax3's pretty-printed math output (newlines/indentation
+   around each `<span id="mjx-…">` wrapper) is preserved as real line breaks,
+   stacking every inline formula onto its own line. Block elements that need
+   preserved whitespace (`pre`/`code`) carry their own directly-matching
+   white-space rules, which override this inherited value. */
+.markdown-content {
+  white-space: normal;
+}
+
 .markdown-ordered-list-item {
   margin-bottom: 0.2em;
 }

--- a/packages/react/src/components/MarkdownDiv.whitespace.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.whitespace.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { MarkdownDiv } from "./MarkdownDiv";
+
+// Load the shipped stylesheet text so getComputedStyle resolves the real
+// `.markdown-content` rule. The test runner stubs CSS imports to empty, so we
+// read the file directly and inject it into the jsdom document.
+const css = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "MarkdownDiv.css"),
+  "utf8"
+);
+
+describe("MarkdownDiv whitespace handling", () => {
+  beforeAll(() => {
+    document.head.innerHTML = `<style>${css}</style>`;
+  });
+
+  it("renders into a .markdown-content root", () => {
+    const { container } = render(<MarkdownDiv markdown="text" />);
+    expect(container.querySelector(".markdown-content")).not.toBeNull();
+  });
+
+  // Regression guard: markdown-it-mathjax3 pretty-prints its SVG output with
+  // newlines/indentation around each `<span id="mjx-…">`. If `.markdown-content`
+  // inherits `white-space: pre-wrap` from an ancestor, those newlines become
+  // real line breaks and every inline formula stacks onto its own line. The
+  // `.markdown-content { white-space: normal }` rule must neutralize that.
+  it("forces white-space: normal even inside a pre-wrap ancestor", () => {
+    document.body.innerHTML = `<div style="white-space: pre-wrap"><div class="markdown-content">x</div></div>`;
+    const markdown = document.querySelector(".markdown-content") as HTMLElement;
+    expect(getComputedStyle(markdown).whiteSpace).toBe("normal");
+  });
+});


### PR DESCRIPTION
markdown-it-mathjax3 pretty-prints its SVG output with newlines and indentation around each `<span id="mjx-…">` wrapper. When `.markdown-content` inherits `white-space: pre-wrap` from an ancestor container, those newlines become real line breaks and every inline formula is pushed onto its own indented line, making inline math look like display/block math.

Set `white-space: normal` on `.markdown-content` so rendered markdown defines its own whitespace regardless of the surrounding container. Block elements that need preserved whitespace (`pre`/`code`) keep their own directly-matching rules, which override the inherited value.