### PR TITLE
Guard Inspect view mutation requests

### DIFF
--- a/apps/inspect/src/client/api/view-server/api-view-server.test.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { viewServerApi } from "./api-view-server";
+import { VIEW_REQUEST_HEADER, VIEW_REQUEST_HEADER_VALUE } from "./request";
 
 describe("viewServerApi.eval_log_sample_data_direct", () => {
   const realFetch = globalThis.fetch;
@@ -49,6 +50,72 @@ describe("viewServerApi.eval_log_sample_data_direct", () => {
       },
       has_more: false,
       complete: true,
+    });
+  });
+});
+
+describe("viewServerApi mutation requests", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("posts client messages with the viewer request header", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        text: () => Promise.resolve(""),
+      } as unknown as Response)
+    );
+    globalThis.fetch = fetchMock;
+
+    const api = viewServerApi({ apiBaseUrl: "https://viewer.test" });
+    await api.log_message("log.eval", "hello");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/log-message?");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        [VIEW_REQUEST_HEADER]: VIEW_REQUEST_HEADER_VALUE,
+      },
+    });
+  });
+
+  test("adds the viewer request header to log edits", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        text: () => Promise.resolve("{}"),
+      } as unknown as Response)
+    );
+    globalThis.fetch = fetchMock;
+
+    const api = viewServerApi({ apiBaseUrl: "https://viewer.test" });
+    await api.edit_log!("log.eval", {
+      edits: [],
+      provenance: {
+        author: "a",
+        metadata: {},
+        timestamp: "2026-01-01T00:00:00Z",
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        [VIEW_REQUEST_HEADER]: VIEW_REQUEST_HEADER_VALUE,
+      },
     });
   });
 });

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -39,6 +39,8 @@ import {
   Request,
   serverRequestApi,
   unwrapFastapiDetail,
+  VIEW_REQUEST_HEADER,
+  VIEW_REQUEST_HEADER_VALUE,
 } from "./request";
 
 // The time that the view was initially loaded
@@ -278,7 +280,7 @@ export function viewServerApi(
       },
     };
     await requestApi.fetchType<void>(
-      "GET",
+      "POST",
       `/log-message?${params.toString()}`,
       request
     );
@@ -487,6 +489,7 @@ export function viewServerApi(
     if (headerProvider) {
       Object.assign(headers, await headerProvider());
     }
+    headers[VIEW_REQUEST_HEADER] = VIEW_REQUEST_HEADER_VALUE;
 
     const isCrossOrigin = Boolean(
       apiBaseUrl &&

--- a/apps/inspect/src/client/api/view-server/request.ts
+++ b/apps/inspect/src/client/api/view-server/request.ts
@@ -2,6 +2,9 @@ import { asyncJsonParse } from "../../../utils/json-worker";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
 
+export const VIEW_REQUEST_HEADER = "X-Inspect-View-Request";
+export const VIEW_REQUEST_HEADER_VALUE = "true";
+
 export class ApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -74,6 +77,15 @@ export function serverRequestApi(
 ): ServerRequestApi {
   const apiUrl = baseUrl || "";
 
+  function addViewRequestHeader(
+    method: HttpMethod,
+    headers: Record<string, string>
+  ): void {
+    if (method !== "GET") {
+      headers[VIEW_REQUEST_HEADER] = VIEW_REQUEST_HEADER_VALUE;
+    }
+  }
+
   function buildApiUrl(path: string): string {
     if (!apiUrl) {
       return path;
@@ -100,7 +112,7 @@ export function serverRequestApi(
   ): Promise<{ raw: string; parsed: T }> => {
     const url = buildApiUrl(path);
 
-    const responseHeaders: HeadersInit = {
+    const responseHeaders: Record<string, string> = {
       Accept: "application/json",
       Pragma: "no-cache",
       Expires: "0",
@@ -116,6 +128,7 @@ export function serverRequestApi(
     if (request.body) {
       responseHeaders["Content-Type"] = "application/json";
     }
+    addViewRequestHeader(method, responseHeaders);
 
     const response = await fetch(url, {
       method,
@@ -156,7 +169,7 @@ export function serverRequestApi(
   ): Promise<{ parsed: unknown; raw: string }> => {
     const url = buildApiUrl(path);
 
-    const requestHeaders: HeadersInit = {
+    const requestHeaders: Record<string, string> = {
       Accept: "application/json",
       Pragma: "no-cache",
       Expires: "0",
@@ -172,6 +185,7 @@ export function serverRequestApi(
     if (body) {
       requestHeaders["Content-Type"] = "application/json";
     }
+    addViewRequestHeader(method, requestHeaders);
 
     const response = await fetch(url, {
       method,
@@ -198,7 +212,7 @@ export function serverRequestApi(
   ): Promise<Uint8Array> => {
     const url = buildApiUrl(path);
 
-    const headers: HeadersInit = {
+    const headers: Record<string, string> = {
       Accept: "application/octet-stream",
       Pragma: "no-cache",
       Expires: "0",
@@ -209,6 +223,7 @@ export function serverRequestApi(
       const globalHeaders = await getHeaders();
       Object.assign(headers, globalHeaders);
     }
+    addViewRequestHeader(method, headers);
 
     const response = await fetch(url, {
       method,

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -164,11 +164,11 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Api Log Delete */
-        get: operations["api_log_delete_log_delete__log__get"];
+        get?: never;
         put?: never;
         post?: never;
-        delete?: never;
+        /** Api Log Delete */
+        delete: operations["api_log_delete_log_delete__log__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -283,10 +283,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Api Log Message */
-        get: operations["api_log_message_log_message_get"];
+        get?: never;
         put?: never;
-        post?: never;
+        /** Api Log Message */
+        post: operations["api_log_message_log_message_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4167,7 +4167,7 @@ export interface operations {
             };
         };
     };
-    api_log_delete_log_delete__log__get: {
+    api_log_delete_log_delete__log__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -4325,7 +4325,7 @@ export interface operations {
             };
         };
     };
-    api_log_message_log_message_get: {
+    api_log_message_log_message_post: {
         parameters: {
             query: {
                 log_file: string;


### PR DESCRIPTION
## Summary

- add the viewer request header to non-GET API requests
- send client log messages with POST
- regenerate API types

## Testing

- unit tests
- typecheck
- lint and formatting checks