### PR TITLE
Prevent automatic loading of untrusted media

### DIFF
--- a/apps/inspect/e2e/chat-components.spec.ts
+++ b/apps/inspect/e2e/chat-components.spec.ts
@@ -17,6 +17,7 @@ import {
 } from "./fixtures/test-data";
 
 const LOG_FILE = "test-chat.json";
+const MEDIA_ORIGIN = "https://media.invalid";
 
 /**
  * Set up mock handlers for a single log file containing one sample,
@@ -172,6 +173,73 @@ test.describe("chat message rendering", () => {
 
     await expect(page.getByText("Describe this image:")).toBeVisible();
     await expect(page.locator("img[src^='data:image']")).toBeVisible();
+  });
+
+  test("does not automatically load remote message media", async ({
+    page,
+    network,
+  }) => {
+    const mediaRequests: string[] = [];
+    await page.context().route(`${MEDIA_ORIGIN}/**`, async (route) => {
+      mediaRequests.push(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<title>media</title>",
+      });
+    });
+
+    await openSample(page, network, [
+      {
+        role: "assistant",
+        source: "generate",
+        content: [
+          {
+            type: "text",
+            text: `![markdown image](${MEDIA_ORIGIN}/markdown.png)`,
+          },
+          {
+            type: "image",
+            image: `${MEDIA_ORIGIN}/image.png`,
+            detail: "auto",
+          },
+          {
+            type: "audio",
+            audio: `${MEDIA_ORIGIN}/audio.mp3`,
+            format: "mp3",
+          },
+          {
+            type: "video",
+            video: `${MEDIA_ORIGIN}/video.mp4`,
+            format: "mp4",
+          },
+          {
+            type: "document",
+            document: `${MEDIA_ORIGIN}/document.png`,
+            filename: "document.png",
+            mime_type: "image/png",
+          },
+        ],
+      },
+    ]);
+
+    const markdownLink = page.locator(`a[href="${MEDIA_ORIGIN}/markdown.png"]`);
+    await expect(markdownLink).toBeVisible();
+    await expect(page.locator(`a[href^="${MEDIA_ORIGIN}/"]`)).toHaveCount(5);
+    await expect(
+      page.locator(
+        `img[src^="${MEDIA_ORIGIN}/"], audio source[src^="${MEDIA_ORIGIN}/"], video source[src^="${MEDIA_ORIGIN}/"]`
+      )
+    ).toHaveCount(0);
+    expect(mediaRequests).toEqual([]);
+
+    const popupPromise = page.waitForEvent("popup");
+    await markdownLink.click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState("domcontentloaded");
+
+    expect(mediaRequests).toEqual([`${MEDIA_ORIGIN}/markdown.png`]);
+    await popup.close();
   });
 });
 

--- a/apps/scout/e2e/chat-components.spec.ts
+++ b/apps/scout/e2e/chat-components.spec.ts
@@ -25,6 +25,7 @@ import {
 
 const TRANSCRIPTS_DIR = "/home/test/project/.transcripts";
 const TRANSCRIPT_ID = "t-chat-001";
+const MEDIA_ORIGIN = "https://media.invalid";
 
 /** Navigate to a transcript detail page with the given mock data. */
 async function openTranscript(
@@ -226,6 +227,83 @@ test.describe("chat message rendering", () => {
     await expect(page.getByText("Describe this image:")).toBeVisible();
     // Image should render as an img element
     await expect(page.locator("img[src^='data:image']")).toBeVisible();
+  });
+
+  test("does not automatically load remote message media", async ({
+    page,
+    network,
+  }) => {
+    const mediaRequests: string[] = [];
+    await page.context().route(`${MEDIA_ORIGIN}/**`, async (route) => {
+      mediaRequests.push(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<title>media</title>",
+      });
+    });
+
+    await openMessages(
+      page,
+      network,
+      createMessagesEventsResponse({
+        messages: [
+          {
+            role: "assistant",
+            id: null,
+            content: [
+              {
+                type: "text",
+                text: `![markdown image](${MEDIA_ORIGIN}/markdown.png)`,
+                refusal: null,
+                internal: null,
+                citations: null,
+              },
+              {
+                type: "image",
+                image: `${MEDIA_ORIGIN}/image.png`,
+                detail: "auto",
+              },
+              {
+                type: "audio",
+                audio: `${MEDIA_ORIGIN}/audio.mp3`,
+                format: "mp3",
+              },
+              {
+                type: "video",
+                video: `${MEDIA_ORIGIN}/video.mp4`,
+                format: "mp4",
+              },
+              {
+                type: "document",
+                document: `${MEDIA_ORIGIN}/document.png`,
+                filename: "document.png",
+                mime_type: "image/png",
+              },
+            ],
+          },
+        ],
+        events: [],
+      })
+    );
+
+    const markdownLink = page.locator(`a[href="${MEDIA_ORIGIN}/markdown.png"]`);
+    await expect(markdownLink).toBeVisible();
+    await expect(page.locator(`a[href^="${MEDIA_ORIGIN}/"]`)).toHaveCount(5);
+    await expect(
+      page.locator(
+        `img[src^="${MEDIA_ORIGIN}/"], audio source[src^="${MEDIA_ORIGIN}/"], video source[src^="${MEDIA_ORIGIN}/"]`
+      )
+    ).toHaveCount(0);
+    expect(mediaRequests).toEqual([]);
+
+    const popupPromise = page.waitForEvent("popup");
+    await markdownLink.click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState("domcontentloaded");
+
+    expect(mediaRequests).toEqual([`${MEDIA_ORIGIN}/markdown.png`]);
+    await popup.close();
   });
 });
 

--- a/packages/inspect-components/src/chat/MessageContent.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.tsx
@@ -19,6 +19,14 @@ import { usePrismHighlight } from "@tsmono/react/hooks";
 import { isJson } from "@tsmono/util";
 
 import { RenderedText } from "../content/RenderedText";
+import { MediaReference } from "../media/MediaReference";
+import {
+  audioMimeTypeForFormat,
+  isRenderableAudioSource,
+  isRenderableImageSource,
+  isRenderableVideoSource,
+  videoMimeTypeForFormat,
+} from "../media/mediaSource";
 
 import { ContentDataView } from "./content-data/ContentDataView";
 import { ContentDocumentView } from "./documents/ContentDocumentView";
@@ -233,19 +241,22 @@ const messageRenderers: Record<string, MessageRenderer> = {
   image: {
     render: (key, content) => {
       const c = content as ContentImage;
-      if (c.image.startsWith("data:")) {
+      if (isRenderableImageSource(c.image)) {
         return <img src={c.image} className={styles.contentImage} key={key} />;
       } else {
-        return <code key={key}>{c.image}</code>;
+        return <MediaReference source={c.image} key={key} />;
       }
     },
   },
   audio: {
     render: (key, content) => {
       const c = content as ContentAudio;
+      if (!isRenderableAudioSource(c.audio, c.format)) {
+        return <MediaReference source={c.audio} key={key} />;
+      }
       return (
         <audio controls key={key}>
-          <source src={c.audio} type={mimeTypeForFormat(c.format)} />
+          <source src={c.audio} type={audioMimeTypeForFormat(c.format)} />
         </audio>
       );
     },
@@ -253,9 +264,12 @@ const messageRenderers: Record<string, MessageRenderer> = {
   video: {
     render: (key, content) => {
       const c = content as ContentVideo;
+      if (!isRenderableVideoSource(c.video, c.format)) {
+        return <MediaReference source={c.video} key={key} />;
+      }
       return (
         <video width="500" height="375" controls key={key}>
-          <source src={c.video} type={mimeTypeForFormat(c.format)} />
+          <source src={c.video} type={videoMimeTypeForFormat(c.format)} />
         </video>
       );
     },
@@ -293,25 +307,6 @@ const messageRenderers: Record<string, MessageRenderer> = {
  * Renders message content based on its type.
  * Supports rendering strings, images, and tools using specific renderers.
  */
-const mimeTypeForFormat = (
-  format: ContentAudio["format"] | ContentVideo["format"]
-): string => {
-  switch (format) {
-    case "mov":
-      return "video/quicktime";
-    case "wav":
-      return "audio/wav";
-    case "mp3":
-      return "audio/mpeg";
-    case "mp4":
-      return "video/mp4";
-    case "mpeg":
-      return "video/mpeg";
-    default:
-      return "video/mp4"; // Default to mp4 for unknown formats
-  }
-};
-
 // This collapses sequential runs of text content into a single text content,
 // adding citations as superscript counters at the end of the text for each block
 // containing citations. The citations are then attached to the content where

--- a/packages/inspect-components/src/chat/documents/ContentDocumentView.tsx
+++ b/packages/inspect-components/src/chat/documents/ContentDocumentView.tsx
@@ -5,6 +5,8 @@ import type { ContentDocument } from "@tsmono/inspect-common/types";
 import { isImage } from "@tsmono/util";
 
 import { useContentIcons } from "../../content/IconsContext";
+import { MediaReference } from "../../media/MediaReference";
+import { isRenderableImageDocument } from "../../media/mediaSource";
 
 import styles from "./ContentDocumentView.module.css";
 
@@ -20,14 +22,23 @@ export const ContentDocumentView: FC<ContentDocumentProps> = ({
   onDownloadFile,
 }) => {
   if (isImage(document.mime_type || "")) {
+    const preview = isRenderableImageDocument(
+      document.document,
+      document.mime_type || ""
+    ) ? (
+      <img
+        className={clsx(styles.imageDocument)}
+        src={document.document}
+        alt={document.filename}
+        id={id}
+      />
+    ) : (
+      <MediaReference source={document.document} />
+    );
+
     return (
       <ContentDocumentFrame document={document} onDownloadFile={onDownloadFile}>
-        <img
-          className={clsx(styles.imageDocument)}
-          src={document.document}
-          alt={document.filename}
-          id={id}
-        />
+        {preview}
       </ContentDocumentFrame>
     );
   } else {

--- a/packages/inspect-components/src/chat/tools/ToolOutput.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolOutput.tsx
@@ -6,6 +6,8 @@ import { ANSIDisplay } from "@tsmono/react/components";
 import { isAnsiOutput, isJson } from "@tsmono/util";
 
 import { cappedText } from "../../content/cappedText";
+import { MediaReference } from "../../media/MediaReference";
+import { isRenderableImageSource } from "../../media/mediaSource";
 import { ContentDocumentView } from "../documents/ContentDocumentView";
 import { JsonMessageContent } from "../JsonMessageContent";
 
@@ -47,12 +49,12 @@ export const ToolOutput: FC<ToolOutputProps> = ({
           />
         );
       } else if (out.type === "image") {
-        if (out.image.startsWith("data:")) {
+        if (isRenderableImageSource(out.image)) {
           outputs.push(
             <img className={clsx(styles.toolImage)} src={out.image} key={key} />
           );
         } else {
-          outputs.push(<ToolTextOutput text={String(out.image)} key={key} />);
+          outputs.push(<MediaReference source={out.image} key={key} />);
         }
       } else if (out.type === "reasoning") {
         if (out.reasoning) {

--- a/packages/inspect-components/src/content/RenderedContent.tsx
+++ b/packages/inspect-components/src/content/RenderedContent.tsx
@@ -11,6 +11,8 @@ import {
 } from "@tsmono/react/components";
 import { formatNumber, isJson } from "@tsmono/util";
 
+import { isRenderableImageSource } from "../media/mediaSource";
+
 import { useContentRenderers } from "./ContentRenderersContext";
 import { useContentIcons } from "./IconsContext";
 import { MetaDataGrid } from "./MetaDataGrid";
@@ -312,7 +314,7 @@ const contentRenderers: (
       canRender: (entry) => {
         return (
           typeof entry.value === "string" &&
-          entry.value.startsWith("data:image/")
+          isRenderableImageSource(entry.value)
         );
       },
       render: (_id, entry, _options) => {

--- a/packages/inspect-components/src/media/MediaReference.module.css
+++ b/packages/inspect-components/src/media/MediaReference.module.css
@@ -1,0 +1,4 @@
+.reference {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}

--- a/packages/inspect-components/src/media/MediaReference.test.tsx
+++ b/packages/inspect-components/src/media/MediaReference.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MediaReference } from "./MediaReference";
+
+describe("MediaReference", () => {
+  it("renders absolute HTTP URLs as external links", () => {
+    render(<MediaReference source="https://example.com/image.png" />);
+
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("https://example.com/image.png");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it.each([
+    "/relative/image.png",
+    "//example.com/image.png",
+    "file:///tmp/image.png",
+    "blob:https://example.com/id",
+    "custom://asset/1",
+  ])("renders %s as text", (source) => {
+    const { container } = render(<MediaReference source={source} />);
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.querySelector("code")?.textContent).toBe(source);
+  });
+
+  it("abbreviates inline data", () => {
+    const { container } = render(
+      <MediaReference source="data:image/svg+xml;base64,PHN2Zz4=" />
+    );
+
+    expect(container.querySelector("code")?.textContent).toBe(
+      "data:image/svg+xml;base64,..."
+    );
+  });
+});

--- a/packages/inspect-components/src/media/MediaReference.tsx
+++ b/packages/inspect-components/src/media/MediaReference.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+import { parseAbsoluteHttpUrl, parseDataUri } from "@tsmono/util";
+
+import styles from "./MediaReference.module.css";
+
+interface MediaReferenceProps {
+  source: string;
+  className?: string;
+}
+
+export const MediaReference: FC<MediaReferenceProps> = ({
+  source,
+  className,
+}) => {
+  const href = parseAbsoluteHttpUrl(source);
+  const dataUri = parseDataUri(source);
+  const label = dataUri
+    ? `data:${dataUri.mimeType}${dataUri.base64 ? ";base64" : ""},...`
+    : source;
+  const classes = clsx(styles.reference, className);
+
+  return href ? (
+    <a
+      className={classes}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {href}
+    </a>
+  ) : (
+    <code className={classes}>{label}</code>
+  );
+};

--- a/packages/inspect-components/src/media/mediaRendering.test.tsx
+++ b/packages/inspect-components/src/media/mediaRendering.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  ContentAudio,
+  ContentDocument,
+  ContentImage,
+  ContentVideo,
+} from "@tsmono/inspect-common/types";
+
+import { ContentDocumentView } from "../chat/documents/ContentDocumentView";
+import { MessageContent } from "../chat/MessageContent";
+import { defaultContext } from "../chat/MessageContents";
+import { ToolOutput } from "../chat/tools/ToolOutput";
+
+const remoteUrl = "https://example.com/media";
+const remoteMediaCases: [ContentImage | ContentAudio | ContentVideo, string][] =
+  [
+    [{ type: "image", image: remoteUrl, detail: "auto" }, "img"],
+    [{ type: "audio", audio: remoteUrl, format: "mp3" }, "audio"],
+    [{ type: "video", video: remoteUrl, format: "mp4" }, "video"],
+  ];
+
+describe("typed media rendering", () => {
+  it.each(remoteMediaCases)(
+    "renders remote %s content as a link",
+    (content, mediaTag) => {
+      const { container } = render(
+        <MessageContent contents={[content]} context={defaultContext()} />
+      );
+
+      const link = container.querySelector("a");
+      expect(container.querySelector(mediaTag)).toBeNull();
+      expect(container.querySelector("source")).toBeNull();
+      expect(link?.getAttribute("href")).toBe(remoteUrl);
+      expect(link?.getAttribute("target")).toBe("_blank");
+      expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+  );
+
+  it("renders matching inline media", () => {
+    const { container } = render(
+      <MessageContent
+        contents={[
+          {
+            type: "image",
+            image: "data:image/png;base64,AAAA",
+            detail: "auto",
+          },
+          {
+            type: "audio",
+            audio: "data:audio/mpeg;base64,AAAA",
+            format: "mp3",
+          },
+          {
+            type: "video",
+            video: "data:video/mp4;base64,AAAA",
+            format: "mp4",
+          },
+        ]}
+        context={defaultContext()}
+      />
+    );
+
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(container.querySelector("audio")).not.toBeNull();
+    expect(container.querySelector("video")).not.toBeNull();
+    expect(container.querySelectorAll("source")).toHaveLength(2);
+  });
+
+  it("does not preview remote image documents", () => {
+    const document = {
+      type: "document",
+      document: `${remoteUrl}.png`,
+      filename: "remote.png",
+      mime_type: "image/png",
+    } as ContentDocument;
+    const { container } = render(
+      <ContentDocumentView id="document" document={document} />
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      `${remoteUrl}.png`
+    );
+  });
+
+  it("previews matching inline image documents", () => {
+    const document = {
+      type: "document",
+      document: "data:image/png;base64,AAAA",
+      filename: "inline.png",
+      mime_type: "image/png",
+    } as ContentDocument;
+    const { container } = render(
+      <ContentDocumentView id="document" document={document} />
+    );
+
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("renders remote legacy tool images as links", () => {
+    const { container } = render(
+      <ToolOutput
+        output={[
+          {
+            type: "image",
+            image: `${remoteUrl}.png`,
+            detail: "auto",
+          },
+        ]}
+      />
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      `${remoteUrl}.png`
+    );
+  });
+});

--- a/packages/inspect-components/src/media/mediaSource.test.ts
+++ b/packages/inspect-components/src/media/mediaSource.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isRenderableAudioSource,
+  isRenderableImageDocument,
+  isRenderableImageSource,
+  isRenderableVideoSource,
+} from "./mediaSource";
+
+describe("inline media policy", () => {
+  it.each([
+    "data:image/png;base64,AAAA",
+    "data:image/jpeg;base64,AAAA",
+    "data:image/jpg;base64,AAAA",
+    "data:image/webp;base64,AAAA",
+  ])("allows raster image data URI %s", (source) => {
+    expect(isRenderableImageSource(source)).toBe(true);
+  });
+
+  it.each([
+    "https://example.com/image.png",
+    "file:///tmp/image.png",
+    "blob:https://example.com/id",
+    "data:image/svg+xml;base64,AAAA",
+    "data:text/html;base64,AAAA",
+    "data:image/png,AAAA",
+  ])("rejects image source %s", (source) => {
+    expect(isRenderableImageSource(source)).toBe(false);
+  });
+
+  it.each([
+    ["data:audio/mpeg;base64,AAAA", "mp3"],
+    ["data:audio/wav;base64,AAAA", "wav"],
+    ["data:video/mp4;base64,AAAA", "mp4"],
+    ["data:video/mpeg;base64,AAAA", "mpeg"],
+    ["data:video/quicktime;base64,AAAA", "mov"],
+  ] as const)("allows matching %s as %s", (source, format) => {
+    if (format === "mp3" || format === "wav") {
+      expect(isRenderableAudioSource(source, format)).toBe(true);
+    } else {
+      expect(isRenderableVideoSource(source, format)).toBe(true);
+    }
+  });
+
+  it("rejects mismatched audio and video formats", () => {
+    expect(isRenderableAudioSource("data:audio/wav;base64,AAAA", "mp3")).toBe(
+      false
+    );
+    expect(isRenderableVideoSource("data:video/mp4;base64,AAAA", "mov")).toBe(
+      false
+    );
+  });
+
+  it("requires image document metadata to match the data URI", () => {
+    expect(
+      isRenderableImageDocument("data:image/jpeg;base64,AAAA", "image/jpeg")
+    ).toBe(true);
+    expect(
+      isRenderableImageDocument("data:image/jpeg;base64,AAAA", "image/png")
+    ).toBe(false);
+    expect(
+      isRenderableImageDocument(
+        "data:image/svg+xml;base64,AAAA",
+        "image/svg+xml"
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/inspect-components/src/media/mediaSource.ts
+++ b/packages/inspect-components/src/media/mediaSource.ts
@@ -1,0 +1,98 @@
+import type { ContentAudio, ContentVideo } from "@tsmono/inspect-common/types";
+import { parseDataUri } from "@tsmono/util";
+
+const rasterImageMimeTypes = new Set([
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/x-icon",
+]);
+
+const imageMimeAliases = new Map([
+  ["image/jpg", "image/jpeg"],
+  ["image/vnd.microsoft.icon", "image/x-icon"],
+]);
+
+const primaryAudioMimeTypes: Record<ContentAudio["format"], string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+};
+
+const audioMimeTypes: Record<ContentAudio["format"], Set<string>> = {
+  mp3: new Set(["audio/mp3", "audio/mpeg"]),
+  wav: new Set(["audio/vnd.wave", "audio/wav", "audio/wave", "audio/x-wav"]),
+};
+
+const primaryVideoMimeTypes: Record<ContentVideo["format"], string> = {
+  mov: "video/quicktime",
+  mp4: "video/mp4",
+  mpeg: "video/mpeg",
+};
+
+const videoMimeTypes: Record<ContentVideo["format"], Set<string>> = {
+  mov: new Set(["video/quicktime"]),
+  mp4: new Set(["video/mp4"]),
+  mpeg: new Set(["video/mpeg"]),
+};
+
+const normalizedImageMimeType = (mimeType: string): string => {
+  const normalized = mimeType.trim().toLowerCase();
+  return imageMimeAliases.get(normalized) ?? normalized;
+};
+
+const base64DataUriMimeType = (source: string): string | undefined => {
+  const dataUri = parseDataUri(source);
+  return dataUri?.base64 ? dataUri.mimeType : undefined;
+};
+
+export const isRenderableImageSource = (source: string): boolean => {
+  const mimeType = base64DataUriMimeType(source);
+  return (
+    mimeType !== undefined &&
+    rasterImageMimeTypes.has(normalizedImageMimeType(mimeType))
+  );
+};
+
+export const isRenderableAudioSource = (
+  source: string,
+  format: ContentAudio["format"]
+): boolean => {
+  const mimeType = base64DataUriMimeType(source);
+  return mimeType !== undefined && audioMimeTypes[format].has(mimeType);
+};
+
+export const isRenderableVideoSource = (
+  source: string,
+  format: ContentVideo["format"]
+): boolean => {
+  const mimeType = base64DataUriMimeType(source);
+  return mimeType !== undefined && videoMimeTypes[format].has(mimeType);
+};
+
+export const audioMimeTypeForFormat = (
+  format: ContentAudio["format"]
+): string => primaryAudioMimeTypes[format];
+
+export const videoMimeTypeForFormat = (
+  format: ContentVideo["format"]
+): string => primaryVideoMimeTypes[format];
+
+export const isRenderableImageDocument = (
+  source: string,
+  declaredMimeType: string
+): boolean => {
+  const sourceMimeType = base64DataUriMimeType(source);
+  if (sourceMimeType === undefined) {
+    return false;
+  }
+
+  const normalizedSource = normalizedImageMimeType(sourceMimeType);
+  const normalizedDeclared = normalizedImageMimeType(declaredMimeType);
+  return (
+    rasterImageMimeTypes.has(normalizedSource) &&
+    normalizedSource === normalizedDeclared
+  );
+};

--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -40,7 +40,42 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     expect(container.innerHTML).not.toContain("javascript:");
   });
 
-  it("allows data image URLs without allowing non-image data links", async () => {
+  it("adds opener protection to new-context links", async () => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="safe"
+        postProcess={() =>
+          '<a href="https://example.com" target="_blank">external</a>'
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("a")).not.toBeNull();
+    });
+
+    expect(container.querySelector("a")?.getAttribute("rel")).toBe(
+      "noopener noreferrer"
+    );
+  });
+
+  it("replaces remote markdown images with external links", async () => {
+    const { container } = render(
+      <MarkdownDiv markdown="![pixel](https://example.com/pixel.png)" />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("a")).not.toBeNull();
+    });
+
+    const anchor = container.querySelector("a");
+    expect(container.querySelector("img")).toBeNull();
+    expect(anchor?.getAttribute("href")).toBe("https://example.com/pixel.png");
+    expect(anchor?.getAttribute("target")).toBe("_blank");
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("does not render data-image markdown or post-processed image tags", async () => {
     const dataImage =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ";
     const dataLink =
@@ -48,16 +83,17 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     const { container } = render(
       <MarkdownDiv
         markdown={`![pixel](${dataImage})`}
-        postProcess={(html) => `${html}<a href="${dataLink}">unsafe</a>`}
+        postProcess={(html) =>
+          `${html}<img src="${dataImage}"><a href="${dataLink}">unsafe</a>`
+        }
       />
     );
 
     await waitFor(() => {
-      expect(container.querySelector("img")).not.toBeNull();
       expect(container.querySelector("a")).not.toBeNull();
     });
 
-    expect(container.querySelector("img")?.getAttribute("src")).toBe(dataImage);
+    expect(container.querySelector("img")).toBeNull();
     expect(container.querySelector("a")?.hasAttribute("href")).toBe(false);
   });
 });

--- a/packages/react/src/components/markdownRendering.ts
+++ b/packages/react/src/components/markdownRendering.ts
@@ -6,6 +6,8 @@
 import MarkdownIt from "markdown-it";
 import markdownitMathjax3 from "markdown-it-mathjax3";
 
+import { parseAbsoluteHttpUrl, parseDataUri } from "@tsmono/util";
+
 // Module-level cache for lazy-initialized markdown-it instances
 const mdInstanceCache: Record<string, MarkdownIt> = {};
 
@@ -40,6 +42,31 @@ export const getMarkdownInstance = (renderer: MarkdownRenderer): MarkdownIt => {
   }
 
   const md = new MarkdownIt({ breaks: true, html: true });
+  md.renderer.rules.image = (tokens, idx) => {
+    const token = tokens[idx];
+    if (!token) {
+      return "";
+    }
+
+    const source = token.attrGet("src") ?? "";
+    const href = parseAbsoluteHttpUrl(source);
+    const dataUri = parseDataUri(source);
+    const visibleSource =
+      href ??
+      (dataUri
+        ? `data:${dataUri.mimeType}${dataUri.base64 ? ";base64" : ""},...`
+        : source);
+    const alt = token.content.trim();
+    const label = alt ? `${alt} (${visibleSource})` : visibleSource;
+    const escapedLabel = md.utils.escapeHtml(label);
+
+    if (!href) {
+      return escapedLabel;
+    }
+
+    return `<a href="${md.utils.escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapedLabel}</a>`;
+  };
+
   if (renderer === "full" || renderer === "fragment") {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- plugin has no type declarations
     md.use(markdownitMathjax3);
@@ -70,9 +97,6 @@ export const getMarkdownInstance = (renderer: MarkdownRenderer): MarkdownIt => {
         return origBlock(tokens, idx, options, env, self);
       };
     }
-  }
-  if (renderer === "fragment") {
-    md.disable(["image"]);
   }
   mdInstanceCache[renderer] = md;
 

--- a/packages/react/src/components/markdownSecurity.test.ts
+++ b/packages/react/src/components/markdownSecurity.test.ts
@@ -128,13 +128,35 @@ describe("MarkdownDiv XSS security", () => {
   });
 
   describe("renderer scenarios", () => {
-    it("fragment renderer omits markdown images", () => {
+    it.each(["full", "fragment"] as const)(
+      "%s renderer replaces remote markdown images with links",
+      (renderer) => {
+        const result = renderPipeline(
+          "![alt](https://example.com/image.png)",
+          renderer
+        );
+        expect(result).not.toContain("<img");
+        expect(result).toContain('href="https://example.com/image.png"');
+        expect(result).toContain('target="_blank"');
+        expect(result).toContain('rel="noopener noreferrer"');
+        expect(result).toContain("alt");
+      }
+    );
+
+    it("does not link data-image markdown", () => {
       const result = renderPipeline(
-        "![alt](https://example.com/image.png)",
-        "fragment"
+        "![alt](data:image/png;base64,AAAA)",
+        "full"
       );
       expect(result).not.toContain("<img");
+      expect(result).not.toContain("<a ");
       expect(result).toContain("alt");
+    });
+
+    it("does not auto-link plain URL text", () => {
+      const result = renderPipeline("https://example.com/image.png", "full");
+      expect(result).not.toContain("<a ");
+      expect(result).toContain("https://example.com/image.png");
     });
 
     it("textOnly renderer supports emphasis and newlines only", () => {

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -16,11 +16,14 @@ const FORBIDDEN_TAGS = [
   "foreignobject",
   "form",
   "iframe",
+  "image",
+  "img",
   "input",
   "link",
   "meta",
   "mpath",
   "object",
+  "picture",
   "script",
   "select",
   "set",
@@ -101,8 +104,7 @@ const UNSAFE_CSS_PATTERN =
   /@import|behavior\s*:|binding\s*:|expression\s*\(|javascript\s*:|vbscript\s*:|url\s*\(/i;
 
 const PURIFY_CONFIG: Config = {
-  ADD_ATTR: MATHJAX_ATTRS,
-  ADD_DATA_URI_TAGS: ["img", "image"],
+  ADD_ATTR: [...MATHJAX_ATTRS, "target"],
   ADD_TAGS: MATHJAX_TAGS,
   ALLOW_DATA_ATTR: true,
   ALLOW_UNKNOWN_PROTOCOLS: false,
@@ -179,10 +181,20 @@ const installHooks = (purify: DOMPurifyInstance): void => {
       sanitizeStyleAttributeHook(node, hookEvent);
     } else if (
       URL_ATTRIBUTES.has(hookEvent.attrName) &&
-      !isSafeUrlAttribute(node, hookEvent.attrValue)
+      !isSafeUrlAttribute(hookEvent.attrValue)
     ) {
       hookEvent.keepAttr = false;
       node.removeAttribute(hookEvent.attrName);
+    }
+  });
+
+  purify.addHook("afterSanitizeAttributes", (node) => {
+    if (
+      node instanceof Element &&
+      node.tagName.toLowerCase() === "a" &&
+      node.getAttribute("target") === "_blank"
+    ) {
+      node.setAttribute("rel", "noopener noreferrer");
     }
   });
 };
@@ -200,7 +212,7 @@ const sanitizeStyleAttributeHook = (
   }
 };
 
-const isSafeUrlAttribute = (node: Element, value: string): boolean => {
+const isSafeUrlAttribute = (value: string): boolean => {
   const trimmed = value.trim();
   if (!trimmed) {
     return true;
@@ -218,10 +230,7 @@ const isSafeUrlAttribute = (node: Element, value: string): boolean => {
     .join("");
 
   if (/^data:/i.test(normalized)) {
-    return (
-      ["img", "image"].includes(node.tagName.toLowerCase()) &&
-      /^data:image\//i.test(normalized)
-    );
+    return false;
   }
 
   return !/^(?:javascript|vbscript):/i.test(normalized);

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -18,6 +18,7 @@ export * from "./json";
 export * from "./json-value";
 export * from "./json-worker";
 export * from "./logger";
+export * from "./media";
 export * from "./numeric";
 export * from "./mime";
 export * from "./object";

--- a/packages/util/src/media.test.ts
+++ b/packages/util/src/media.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAbsoluteHttpUrl, parseDataUri } from "./media";
+
+describe("parseDataUri", () => {
+  it.each([
+    ["data:image/png;base64,AAAA", "image/png", true],
+    ["DATA:audio/mpeg;BASE64,AAAA", "audio/mpeg", true],
+    ["data:text/plain;charset=utf-8,hello", "text/plain", false],
+  ])("parses %s", (value, mimeType, base64) => {
+    expect(parseDataUri(value)).toEqual({ mimeType, base64 });
+  });
+
+  it.each([
+    "",
+    "https://example.com/image.png",
+    "data:,missing-type",
+    "data:image/png",
+  ])("rejects %s", (value) => {
+    expect(parseDataUri(value)).toBeUndefined();
+  });
+});
+
+describe("parseAbsoluteHttpUrl", () => {
+  it.each([
+    ["https://example.com/image.png", "https://example.com/image.png"],
+    ["http://example.com:8080/a?b=c", "http://example.com:8080/a?b=c"],
+    [" HTTPS://EXAMPLE.COM/a ", "https://example.com/a"],
+  ])("accepts %s", (value, expected) => {
+    expect(parseAbsoluteHttpUrl(value)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "/relative/image.png",
+    "//example.com/image.png",
+    "file:///tmp/image.png",
+    "blob:https://example.com/id",
+    "data:image/png;base64,AAAA",
+    "javascript:alert(1)",
+    "custom://asset/1",
+  ])("rejects %s", (value) => {
+    expect(parseAbsoluteHttpUrl(value)).toBeUndefined();
+  });
+});

--- a/packages/util/src/media.ts
+++ b/packages/util/src/media.ts
@@ -1,0 +1,55 @@
+export interface DataUri {
+  mimeType: string;
+  base64: boolean;
+}
+
+export const parseDataUri = (value: string): DataUri | undefined => {
+  let uri: URL;
+  try {
+    uri = new URL(value);
+  } catch {
+    return undefined;
+  }
+
+  if (uri.protocol.toLowerCase() !== "data:") {
+    return undefined;
+  }
+
+  const comma = uri.pathname.indexOf(",");
+  if (comma < 0) {
+    return undefined;
+  }
+
+  const [rawMimeType = "", ...parameters] = uri.pathname
+    .slice(0, comma)
+    .split(";");
+  const mimeType = rawMimeType.trim().toLowerCase();
+  if (!mimeType) {
+    return undefined;
+  }
+
+  return {
+    mimeType,
+    base64: parameters.some(
+      (parameter) => parameter.trim().toLowerCase() === "base64"
+    ),
+  };
+};
+
+export const parseAbsoluteHttpUrl = (value: string): string | undefined => {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    !url.hostname
+  ) {
+    return undefined;
+  }
+
+  return url.href;
+};


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [x] Code refactor

### What is the current behavior?

Markdown image syntax is rendered as an `<img src="...">`. Typed audio and
video create `<source src="...">` elements, and image documents create an
`<img src="...">`.

When the viewer displays this content, the browser automatically requests those
URLs. No click or other user interaction is required.

This allows model-, tool-, or scanner-controlled content to make the reviewer's
browser contact a chosen external, same-origin, local, or private-network
address.

### What is the new behavior?

Markdown images no longer create media elements. Absolute HTTP and HTTPS
destinations are shown as visible external links and load only after a click.

Typed media previews only when it contains validated base64 data with a MIME
type matching the media type. HTTP and HTTPS references become visible external
links, while other references remain text.

### What rendering policy does this establish?

> Rendering untrusted content does not perform network or filesystem access.
> Automatic media rendering is limited to media bytes already present in an
> approved inline representation. Remote media requires a separate, explicit
> user action.

A typed media block describes how content should be displayed. It does not give
the content permission to make a browser request.

The implementation establishes this policy in shared code:

- one parser handles data URIs and absolute HTTP/HTTPS URLs;
- one media policy validates image, audio, video, and document sources;
- Markdown image rendering never creates an image element;
- shared media components use the same validation rather than separate prefix
  checks; and
- links opened in a new tab use `noopener noreferrer`.

### Does this PR introduce a breaking change?

Remote media and Markdown images no longer preview automatically. Their
destinations remain available as links or text. Valid inline image, audio, and
video data continues to render normally.

### Other information:

The policy is shared by Inspect and Scout.

Testing includes unit tests, typecheck, lint and formatting checks, production
builds, and browser tests confirming that media URLs receive no request before
an explicit click.
