### PR TITLE
Implement transcript search methods in the vscode API client

### DIFF
--- a/apps/inspect/src/client/api/vscode/api-vscode.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.ts
@@ -6,6 +6,10 @@ import {
   LogFilesResponse,
   LogInfo,
   LogUpdate,
+  Result,
+  SearchInputListResponse,
+  SearchRequest,
+  SearchResponse,
 } from "@tsmono/inspect-common/types";
 import {
   getVscodeApi,
@@ -26,6 +30,7 @@ import {
   PendingSamples,
   SampleData,
   SampleDataResponse,
+  SearchResultScope,
   UserInfo,
 } from "../types";
 import { ApiError } from "../view-server/request";
@@ -40,9 +45,12 @@ import {
   kMethodEvalLogHeaders,
   kMethodEvalLogInfo,
   kMethodEvalLogs,
+  kMethodGetSearchResult,
   kMethodGetUserInfo,
+  kMethodListSearches,
   kMethodLogMessage,
   kMethodPendingSamples,
+  kMethodPostSearch,
   kMethodSampleData,
 } from "./jsonrpc";
 
@@ -69,6 +77,15 @@ const vscodeClient: JsonRpcClient = (method, params) => {
   }
   return _vscodeClient(method, params);
 };
+
+// Existing RPC methods are inconsistent about whether their payload is
+// wire-encoded (string) or returned as an already-parsed object. Accept
+// both so callers aren't coupled to which form the extension chooses.
+const parsePayload = <T>(response: unknown): T =>
+  typeof response === "string" ? JSON5.parse<T>(response) : (response as T);
+
+const kSearchUnsupportedMessage =
+  "Transcript search requires a newer Inspect VS Code extension.";
 
 function client_events(): Promise<string[]> {
   return Promise.resolve([]);
@@ -365,6 +382,82 @@ async function get_app_config(): Promise<AppConfig> {
   }
 }
 
+/**
+ * Transcript search methods, forwarded to inspect_ai's /scout/* endpoints by
+ * the VS Code extension. The viewer passes the structured arguments and lets
+ * the extension build the request URLs (base64url-encoding the transcript
+ * dir, etc.), mirroring how the view server's request layer does it.
+ *
+ * Defining these is what surfaces the Search affordance: `useInspectSearchContext`
+ * gates the toolbar Search button on the presence of all three. Older extensions
+ * lack the handlers and report `kJsonRpcMethodNotFound`; the action methods turn
+ * that into an actionable "newer extension required" error.
+ */
+async function list_searches(
+  search_type: "grep" | "llm",
+  count: number
+): Promise<SearchInputListResponse> {
+  try {
+    const response = await vscodeClient(kMethodListSearches, [
+      search_type,
+      count,
+    ]);
+    return parsePayload<SearchInputListResponse>(response);
+  } catch (e: unknown) {
+    if (asRpcError(e).code === kJsonRpcMethodNotFound) {
+      throw new Error(kSearchUnsupportedMessage);
+    }
+    throw e;
+  }
+}
+
+async function post_search(
+  transcriptDir: string,
+  transcriptId: string,
+  request: SearchRequest
+): Promise<SearchResponse> {
+  try {
+    const response = await vscodeClient(kMethodPostSearch, [
+      transcriptDir,
+      transcriptId,
+      request,
+    ]);
+    return parsePayload<SearchResponse>(response);
+  } catch (e: unknown) {
+    if (asRpcError(e).code === kJsonRpcMethodNotFound) {
+      throw new Error(kSearchUnsupportedMessage);
+    }
+    throw e;
+  }
+}
+
+async function get_search_result(
+  transcriptDir: string,
+  transcriptId: string,
+  search_id: string,
+  scope: SearchResultScope
+): Promise<Result | null> {
+  try {
+    const response = await vscodeClient(kMethodGetSearchResult, [
+      transcriptDir,
+      transcriptId,
+      search_id,
+      scope,
+    ]);
+    // A result that isn't ready yet comes back as 404 (view-server parity) or
+    // an empty payload; both mean "keep polling", not an error.
+    if (!response) return null;
+    return parsePayload<Result>(response);
+  } catch (e: unknown) {
+    const err = asRpcError(e);
+    if (err.code === 404) return null;
+    if (err.code === kJsonRpcMethodNotFound) {
+      throw new Error(kSearchUnsupportedMessage);
+    }
+    throw e;
+  }
+}
+
 function open_log_file(log_file: string, log_dir: string): Promise<void> {
   const msg = {
     type: "displayLogFile",
@@ -394,6 +487,9 @@ const api: LogViewAPI = {
   edit_log,
   get_user_info,
   get_app_config,
+  list_searches,
+  post_search,
+  get_search_result,
 };
 
 export default api;

--- a/apps/inspect/src/client/api/vscode/jsonrpc.ts
+++ b/apps/inspect/src/client/api/vscode/jsonrpc.ts
@@ -21,3 +21,6 @@ export const kMethodLogMessage = "log_message";
 export const kMethodEditLog = "edit_log";
 export const kMethodGetUserInfo = "get_user_info";
 export const kMethodAppConfig = "app_config";
+export const kMethodListSearches = "list_searches";
+export const kMethodPostSearch = "post_search";
+export const kMethodGetSearchResult = "get_search_result";


### PR DESCRIPTION
The Search rail button in the inspect log viewer is gated on the API client exposing list_searches/post_search/get_search_result (via useInspectSearchContext). The vscode client omitted all three, so the button never appeared when embedded in VS Code -- neither the panel nor the "install Scout" fallback was reachable.

Add the three methods, proxied over the existing JSON-RPC client to the extension (which forwards to inspect_ai's /scout/* endpoints). Follow the established patterns: accept both wire shapes, map kJsonRpcMethodNotFound to a clear "newer extension required" error, and treat 404/empty results from get_search_result as null (view-server polling parity).

These changes in addition to [some changes in the extension](https://github.com/meridianlabs-ai/inspect_vscode/pull/121) will put Inspect in a position to use Scout's search functionality when embedded in vscode.