### PR TITLE
Normalize media rendering case checks

### DIFF
--- a/packages/inspect-components/src/media/mediaRendering.test.tsx
+++ b/packages/inspect-components/src/media/mediaRendering.test.tsx
@@ -86,20 +86,23 @@ describe("typed media rendering", () => {
     );
   });
 
-  it("previews matching inline image documents", () => {
-    const document = {
-      type: "document",
-      document: "data:image/png;base64,AAAA",
-      filename: "inline.png",
-      mime_type: "image/png",
-    } as ContentDocument;
-    const { container } = render(
-      <ContentDocumentView id="document" document={document} />
-    );
+  it.each(["image/png", "IMAGE/PNG"])(
+    "previews inline image documents with matching MIME type %s",
+    (mimeType) => {
+      const document = {
+        type: "document",
+        document: "data:image/png;base64,AAAA",
+        filename: "inline.png",
+        mime_type: mimeType,
+      } as ContentDocument;
+      const { container } = render(
+        <ContentDocumentView id="document" document={document} />
+      );
 
-    expect(container.querySelector("img")).not.toBeNull();
-    expect(container.querySelector("a")).toBeNull();
-  });
+      expect(container.querySelector("img")).not.toBeNull();
+      expect(container.querySelector("a")).toBeNull();
+    }
+  );
 
   it("renders remote legacy tool images as links", () => {
     const { container } = render(

--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -40,24 +40,27 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     expect(container.innerHTML).not.toContain("javascript:");
   });
 
-  it("adds opener protection to new-context links", async () => {
-    const { container } = render(
-      <MarkdownDiv
-        markdown="safe"
-        postProcess={() =>
-          '<a href="https://example.com" target="_blank">external</a>'
-        }
-      />
-    );
+  it.each(["_blank", "_BLANK", "_BlAnK"])(
+    "adds opener protection to %s new-context links",
+    async (target) => {
+      const { container } = render(
+        <MarkdownDiv
+          markdown="safe"
+          postProcess={() =>
+            `<a href="https://example.com" target="${target}">external</a>`
+          }
+        />
+      );
 
-    await waitFor(() => {
-      expect(container.querySelector("a")).not.toBeNull();
-    });
+      await waitFor(() => {
+        expect(container.querySelector("a")).not.toBeNull();
+      });
 
-    expect(container.querySelector("a")?.getAttribute("rel")).toBe(
-      "noopener noreferrer"
-    );
-  });
+      expect(container.querySelector("a")?.getAttribute("rel")).toBe(
+        "noopener noreferrer"
+      );
+    }
+  );
 
   it("replaces remote markdown images with external links", async () => {
     const { container } = render(

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -192,7 +192,7 @@ const installHooks = (purify: DOMPurifyInstance): void => {
     if (
       node instanceof Element &&
       node.tagName.toLowerCase() === "a" &&
-      node.getAttribute("target") === "_blank"
+      node.getAttribute("target")?.toLowerCase() === "_blank"
     ) {
       node.setAttribute("rel", "noopener noreferrer");
     }

--- a/packages/util/src/mime.test.ts
+++ b/packages/util/src/mime.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { isImage } from "./mime";
+
+describe("isImage", () => {
+  it.each(["image/png", "IMAGE/PNG", " Image/Png "])(
+    "recognizes image MIME type %s",
+    (mimeType) => {
+      expect(isImage(mimeType)).toBe(true);
+    }
+  );
+
+  it.each(["", "audio/mpeg", "application/image"])(
+    "rejects non-image MIME type %s",
+    (mimeType) => {
+      expect(isImage(mimeType)).toBe(false);
+    }
+  );
+});

--- a/packages/util/src/mime.ts
+++ b/packages/util/src/mime.ts
@@ -1,3 +1,3 @@
 export const isImage = (mimeType: string): boolean => {
-  return mimeType.startsWith("image/");
+  return mimeType.trim().toLowerCase().startsWith("image/");
 };


### PR DESCRIPTION
Follow-up to #362 and the unresolved review comment at https://github.com/meridianlabs-ai/ts-mono/pull/362#discussion_r3474217806.

Rendered HTML only adds `noopener noreferrer` when `target` exactly matches `_blank`, although the browsing-context keyword is case-insensitive. The image-document precheck likewise requires a lowercase `image/` MIME prefix, so mixed-case MIME types never reach the normalized inline-media matcher.

Normalize both comparisons and add regression coverage for lowercase, uppercase, and mixed-case values.

Tests:
- `corepack pnpm --filter @tsmono/util --filter @tsmono/react --filter @tsmono/inspect-components test`
- `corepack pnpm --filter @tsmono/util --filter @tsmono/react --filter @tsmono/inspect-components format:check`
- `corepack pnpm --filter @tsmono/util --filter @tsmono/react --filter @tsmono/inspect-components lint`
- `corepack pnpm --filter @tsmono/util --filter @tsmono/react --filter @tsmono/inspect-components typecheck`