### PR TITLE
Preserve literal reasoning-like tags in chat output

### DIFF
--- a/apps/inspect/e2e/chat-components.spec.ts
+++ b/apps/inspect/e2e/chat-components.spec.ts
@@ -526,6 +526,28 @@ test.describe("message content types", () => {
     ).toBeVisible();
   });
 
+  test("renders reasoning-like tags as literal assistant text", async ({
+    page,
+    network,
+  }) => {
+    await openSample(page, network, [
+      { role: "user", content: "Show the evidence", source: "input" },
+      {
+        role: "assistant",
+        content:
+          "Before <think>reasoning evidence</think> " +
+          "<internal>legacy evidence</internal> " +
+          "<content-internal>metadata evidence</content-internal> after.",
+        source: "generate",
+      },
+    ]);
+
+    const messagesArea = page.locator("#messages-contents");
+    await expect(messagesArea.getByText("reasoning evidence")).toBeVisible();
+    await expect(messagesArea.getByText("legacy evidence")).toBeVisible();
+    await expect(messagesArea.getByText("metadata evidence")).toBeVisible();
+  });
+
   test("renders ANSI codes in tool output", async ({ page, network }) => {
     await openSample(page, network, [
       { role: "user", content: "Run a colored command", source: "input" },
@@ -614,6 +636,56 @@ test.describe("tool call with long content", () => {
 
     // Tool output should also render
     await expect(page.getByText("line1").first()).toBeVisible();
+  });
+});
+
+test.describe("Codex tool result display modes", () => {
+  test("shows the projection when rendered and exact payload when raw", async ({
+    page,
+    network,
+  }) => {
+    const toolOutput = JSON.stringify({
+      previous_status: {
+        completed: "answer<content-internal>eyJ4IjoxfQ==</content-internal>",
+      },
+    });
+
+    await openSample(page, network, [
+      { role: "user", content: "Delegate this", source: "input" },
+      {
+        role: "assistant",
+        content: "Closing the subagent.",
+        source: "generate",
+        id: "msg-a1",
+        tool_calls: [
+          {
+            id: "call_close_agent",
+            type: "function",
+            function: "close_agent",
+            arguments: { id: "agent-1" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_close_agent",
+        function: "close_agent",
+        content: toolOutput,
+        id: "msg-t1",
+      },
+    ]);
+
+    const messagesArea = page.locator("#messages-contents");
+    await expect(
+      messagesArea.getByText("answer", { exact: true })
+    ).toBeVisible();
+    await expect(messagesArea).not.toContainText("content-internal");
+
+    await page.getByRole("button", { name: "Raw" }).click();
+
+    await expect(
+      messagesArea.getByText(toolOutput, { exact: true })
+    ).toBeVisible();
   });
 });
 

--- a/apps/scout/e2e/chat-components.spec.ts
+++ b/apps/scout/e2e/chat-components.spec.ts
@@ -700,7 +700,10 @@ test.describe("message content types", () => {
     ).toBeVisible();
   });
 
-  test("strips internal tags from text content", async ({ page, network }) => {
+  test("renders internal tags as literal text content", async ({
+    page,
+    network,
+  }) => {
     await openMessages(
       page,
       network,
@@ -710,7 +713,9 @@ test.describe("message content types", () => {
           {
             role: "assistant",
             content:
-              "Visible text <internal>hidden internal content</internal> more visible text.",
+              "Visible text <internal>internal evidence</internal> " +
+              "<content-internal>provider metadata evidence</content-internal> " +
+              "more visible text.",
             id: null,
           },
         ],
@@ -721,7 +726,9 @@ test.describe("message content types", () => {
             endSec: 1,
             tokens: 20,
             content:
-              "Visible text <internal>hidden internal content</internal> more visible text.",
+              "Visible text <internal>internal evidence</internal> " +
+              "<content-internal>provider metadata evidence</content-internal> " +
+              "more visible text.",
           }),
         ],
       })
@@ -729,8 +736,8 @@ test.describe("message content types", () => {
 
     await expect(page.getByText("Visible text")).toBeVisible();
     await expect(page.getByText("more visible text")).toBeVisible();
-    // Internal content should NOT be visible
-    await expect(page.getByText("hidden internal content")).not.toBeVisible();
+    await expect(page.getByText("internal evidence")).toBeVisible();
+    await expect(page.getByText("provider metadata evidence")).toBeVisible();
   });
 
   test("renders ANSI codes in tool output", async ({ page, network }) => {
@@ -930,11 +937,11 @@ test.describe("label and numbering system", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Think tag stripping
+// Literal think tags
 // ---------------------------------------------------------------------------
 
-test.describe("think tag stripping", () => {
-  test("strips <think> tags from assistant text content", async ({
+test.describe("literal think tags", () => {
+  test("renders <think> tags as assistant text content", async ({
     page,
     network,
   }) => {
@@ -947,7 +954,7 @@ test.describe("think tag stripping", () => {
           {
             role: "assistant",
             content:
-              "Before thinking <think>internal reasoning that should be hidden</think> after thinking visible.",
+              "Before thinking <think>literal reasoning evidence</think> after thinking visible.",
             id: null,
           },
         ],
@@ -958,7 +965,7 @@ test.describe("think tag stripping", () => {
             endSec: 1,
             tokens: 20,
             content:
-              "Before thinking <think>internal reasoning that should be hidden</think> after thinking visible.",
+              "Before thinking <think>literal reasoning evidence</think> after thinking visible.",
           }),
         ],
       })
@@ -966,10 +973,7 @@ test.describe("think tag stripping", () => {
 
     await expect(page.getByText("Before thinking")).toBeVisible();
     await expect(page.getByText("after thinking visible")).toBeVisible();
-    // Think content must NOT be visible
-    await expect(
-      page.getByText("internal reasoning that should be hidden")
-    ).not.toBeVisible();
+    await expect(page.getByText("literal reasoning evidence")).toBeVisible();
   });
 });
 

--- a/design/migration/chat-migration.md
+++ b/design/migration/chat-migration.md
@@ -45,7 +45,7 @@ and exposes the differences as props/callbacks.
 | **Tool descriptor (`tool.ts`)** | Supports multi-arg fallback for bash (`["cmd", "command"]`); includes `shell_command` tool descriptor | Single `inputArg` string; handles `Task` tool with subagent type display | Merged: supports both `shell_command` and `Task`; multi-arg `inputArg` as `string \| string[]` |
 | **Custom tool rendering** | Not present; all tools use standard `ToolCallView` | `getCustomToolView` renders "answer" tool as code panel | `getCustomView` callback prop on `ChatViewToolOptions`; default answer-tool rendering in `customToolRendering.tsx` |
 | **Reasoning content** | Full title determination (redacted/summary states); detects OpenRouter JSON reasoning; renders as formatted code panel | Simplified: always "Reasoning" label; always renders as markdown | Merged: full reasoning detection + code panel rendering for OpenRouter format |
-| **Internal tag stripping** | Removes `<internal>`, `<content-internal>` tags | Removes `<internal>`, `<content-internal>`, `<think>` tags | Merged: strips all three tag types |
+| **Literal reasoning-like tags** | Preserves `<think>` text; removes `<internal>`, `<content-internal>` | Removes `<internal>`, `<content-internal>`, `<think>` | Shared renderer preserves all literal tag-like text; typed `ContentReasoning` renders separately |
 | **Timestamps** | Displays formatted timestamps via `formatDateTime` | No timestamp display | `formatDateTime` callback prop on `ChatViewDisplayOptions` (absent = hidden) |
 | **Message indentation** | Indented message content | No indentation | `indented` boolean prop on `ChatViewDisplayOptions` |
 | **Role headers** | Hides assistant role header via `unlabeledRoles` | Shows all role headers | `unlabeledRoles` array prop on `ChatViewDisplayOptions` |
@@ -157,8 +157,9 @@ Both apps deleted their entire local `chat/` directories and now import from
 - [ ] **Audio/video content** -- Verify media players render with correct MIME types.
 - [ ] **Document content** -- Verify document content renders with download option.
 - [ ] **ANSI output** -- Verify ANSI escape codes render with correct colors and styling.
-- [ ] **Think tag stripping** -- Verify `<think>`, `<internal>`, `<content-internal>`
-      tags are removed from assistant text.
+- [ ] **Literal reasoning-like tags** -- Verify `<think>`, `<internal>`, and
+      `<content-internal>` tags and their enclosed text remain visible. Verify
+      typed `ContentReasoning` still uses the reasoning presentation.
 
 ### Citations
 

--- a/packages/inspect-components/src/chat/ChatMessage.tsx
+++ b/packages/inspect-components/src/chat/ChatMessage.tsx
@@ -14,6 +14,7 @@ import {
   type MarkdownReference,
 } from "@tsmono/react/components";
 
+import { useDisplayMode } from "../content/DisplayModeContext";
 import { RecordTree } from "../content/RecordTree";
 
 import styles from "./ChatMessage.module.css";
@@ -55,6 +56,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
   const linkingEnabled = linking?.enabled ?? false;
   const getMessageUrl = linking?.getMessageUrl;
   const linkIcon = linking?.icon ?? "bi bi-link-45deg";
+  const displayMode = useDisplayMode();
 
   const messageUrl = getMessageUrl?.(message.id || "");
 
@@ -73,12 +75,17 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
     message.role === "tool";
   const hideRole = unlabeledRoles?.includes(message.role) ?? false;
 
-  // Codex tool results get friendlier rendering than the raw JSON/text dump:
+  // Codex tool results get friendlier rendering in rendered mode:
   // tool_search → a collapsible catalog component; sub-agent management answers
-  // → markdown. The raw content stays available in the JSON tab.
+  // → markdown. Raw mode keeps the original message content.
   let toolSearchNamespaces: ToolSearchNamespaceEntry[] | undefined;
   let toolMarkdown: string | undefined;
-  if (isNonSubagentTool && message.role === "tool" && message.function) {
+  if (
+    displayMode === "rendered" &&
+    isNonSubagentTool &&
+    message.role === "tool" &&
+    message.function
+  ) {
     if (message.function === "tool_search") {
       toolSearchNamespaces = parseToolSearchCatalog(message.content);
     } else {
@@ -88,9 +95,9 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
 
   // Codex sub-agent completion notifications (user messages) collapse to a
   // compact status line — the answer itself is shown by the paired wait/close
-  // result; the raw notification stays in the JSON tab.
+  // result. Raw mode keeps the original notification.
   const subagentNotifications =
-    message.role === "user"
+    displayMode === "rendered" && message.role === "user"
       ? formatSubagentNotifications(message.content)
       : undefined;
 

--- a/packages/inspect-components/src/chat/MessageContent.test.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { ComponentProps } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ContentText } from "@tsmono/inspect-common/types";
+import {
+  ComponentIconProvider,
+  ComponentNavigationProvider,
+  type ComponentIcons,
+} from "@tsmono/react/components";
+import {
+  ComponentStateProvider,
+  type ComponentStateHooks,
+} from "@tsmono/react/state";
+
+import { DisplayModeContext } from "../content/DisplayModeContext";
+
+import { MessageContent } from "./MessageContent";
+import { defaultContext } from "./MessageContents";
+
+type Contents = ComponentProps<typeof MessageContent>["contents"];
+
+const stateHooks: ComponentStateHooks = {
+  useValue: (_id, _prop, defaultValue) => defaultValue,
+  useSetValue: () => () => {},
+  useRemoveValue: () => () => {},
+  useEntries: () => undefined,
+  useRemoveAll: () => () => {},
+  useRemoveByPrefix: () => () => {},
+};
+
+const icons: ComponentIcons = {
+  chevronDown: "icon-chevron-down",
+  chevronUp: "icon-chevron-up",
+  clearText: "icon-clear-text",
+  close: "icon-close",
+  code: "icon-code",
+  confirm: "icon-confirm",
+  copy: "icon-copy",
+  error: "icon-error",
+  menu: "icon-menu",
+  next: "icon-next",
+  noSamples: "icon-no-samples",
+  play: "icon-play",
+  previous: "icon-previous",
+  toggleRight: "icon-toggle-right",
+};
+
+const renderMessage = (
+  contents: Contents,
+  displayMode: "rendered" | "raw" = "rendered"
+) =>
+  render(
+    <ComponentStateProvider hooks={stateHooks}>
+      <ComponentIconProvider icons={icons}>
+        <ComponentNavigationProvider navigation={{ navigate: () => {} }}>
+          <DisplayModeContext.Provider value={{ displayMode }}>
+            <MessageContent contents={contents} context={defaultContext()} />
+          </DisplayModeContext.Provider>
+        </ComponentNavigationProvider>
+      </ComponentIconProvider>
+    </ComponentStateProvider>
+  );
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MessageContent evidence fidelity", () => {
+  it("renders reasoning-like tags and their contents as literal text", async () => {
+    const text =
+      'before <think signature="sig">reasoning</think> ' +
+      "<internal>legacy</internal> " +
+      "<content-internal>metadata</content-internal> after";
+    const { container } = renderMessage(text);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain(text);
+    });
+    expect(container.querySelector("think")).toBeNull();
+    expect(container.querySelector("internal")).toBeNull();
+    expect(container.querySelector("content-internal")).toBeNull();
+  });
+
+  it("preserves raw JSON text, whitespace, and tag delimiters", () => {
+    const text = ' \n{"value":"<think>literal</think>"}\n ';
+    const { container } = renderMessage(text, "raw");
+
+    expect(container.querySelector("pre")?.textContent).toBe(text);
+  });
+
+  it("does not inject citation markers into raw text", () => {
+    const content: ContentText = {
+      type: "text",
+      text: "cited text",
+      citations: [
+        {
+          type: "url",
+          url: "https://example.test/source",
+          title: "Source",
+          cited_text: [0, 5],
+        },
+      ],
+    };
+    const { container } = renderMessage([content], "raw");
+
+    expect(container.querySelector("pre")?.textContent).toBe(content.text);
+    expect(container.querySelector("sup")).toBeNull();
+  });
+});

--- a/packages/inspect-components/src/chat/MessageContent.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.tsx
@@ -18,6 +18,10 @@ import type { MarkdownReference } from "@tsmono/react/components";
 import { usePrismHighlight } from "@tsmono/react/hooks";
 import { isJson } from "@tsmono/util";
 
+import {
+  useDisplayMode,
+  type DisplayMode,
+} from "../content/DisplayModeContext";
 import { RenderedText } from "../content/RenderedText";
 import { MediaReference } from "../media/MediaReference";
 import {
@@ -79,7 +83,8 @@ export const MessageContent: FC<MessageContentProps> = ({
   context,
   references,
 }) => {
-  const normalized = normalizeContent(contents);
+  const displayMode = useDisplayMode();
+  const normalized = normalizeContent(contents, displayMode);
   if (Array.isArray(normalized)) {
     return normalized.map((content, index) => {
       if (typeof content === "string") {
@@ -94,6 +99,7 @@ export const MessageContent: FC<MessageContentProps> = ({
           },
           index === contents.length - 1,
           context,
+          displayMode,
           references
         );
       } else {
@@ -105,6 +111,7 @@ export const MessageContent: FC<MessageContentProps> = ({
               content,
               index === contents.length - 1,
               context,
+              displayMode,
               references
             );
           } else {
@@ -127,6 +134,7 @@ export const MessageContent: FC<MessageContentProps> = ({
       contentText,
       true,
       context,
+      displayMode,
       references
     );
   }
@@ -138,13 +146,14 @@ interface MessageRenderer {
     content: ContentType,
     isLast: boolean,
     context: MessagesContext,
+    displayMode: DisplayMode,
     references?: MarkdownReference[]
   ) => ReactNode;
 }
 
 const messageRenderers: Record<string, MessageRenderer> = {
   text: {
-    render: (key, content, isLast, _context, references) => {
+    render: (key, content, isLast, _context, displayMode, references) => {
       // The context provides a way to share context between different
       // rendering. In this case, we'll use it to keep track of citations
       const c = content as ContentText;
@@ -154,25 +163,14 @@ const messageRenderers: Record<string, MessageRenderer> = {
         return undefined;
       }
 
-      const purgeInternalContainers = (text: string): string => {
-        // Remove any <internal>...</internal> tags and their contents
-        const internalTags = ["internal", "content-internal", "think"];
-        internalTags.forEach((tag) => {
-          const regex = new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, "gm");
-          text = text.replace(regex, "");
-        });
-
-        return text.trim();
-      };
-
-      if (isJson(c.text)) {
+      if (displayMode === "rendered" && isJson(c.text)) {
         const obj = JSON.parse(c.text) as Record<string, unknown>;
         return <JsonMessageContent id={`${key}-json`} json={obj} />;
       } else {
         return (
           <Fragment key={key}>
             <RenderedText
-              markdown={purgeInternalContainers(c.text) || ""}
+              markdown={c.text}
               className={clsx(
                 isLast ? "no-last-para-padding" : "",
                 styles.breakable
@@ -311,7 +309,16 @@ const messageRenderers: Record<string, MessageRenderer> = {
 // adding citations as superscript counters at the end of the text for each block
 // containing citations. The citations are then attached to the content where
 // they can be rendered separately (with coordinating numbers).
-const normalizeContent = (contents: Contents): Contents => {
+const normalizeContent = (
+  contents: Contents,
+  displayMode: DisplayMode
+): Contents => {
+  // Raw mode presents the logged content blocks without citation injection or
+  // other rendered-mode normalization.
+  if (displayMode === "raw") {
+    return contents;
+  }
+
   // its a string
   if (typeof contents === "string") {
     return contents;

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
@@ -7,6 +7,8 @@ import type {
 } from "@tsmono/inspect-common/types";
 import { ExpandablePanel } from "@tsmono/react/components";
 
+import { useDisplayMode } from "../../content/DisplayModeContext";
+
 import styles from "./ClientToolCall.module.css";
 import { getDefaultCustomToolView } from "./customToolRendering";
 import { iconForTool } from "./tool";
@@ -50,6 +52,8 @@ export const ClientToolCall: FC<ClientToolCallProps> = ({
   className,
   getCustomToolView,
 }) => {
+  const displayMode = useDisplayMode();
+
   // Custom views render the call and its result as one self-contained UI —
   // give them the block frame without the header.
   const viewProps: ToolCallViewProps = {
@@ -63,7 +67,9 @@ export const ClientToolCall: FC<ClientToolCallProps> = ({
     output,
   };
   const customView =
-    getCustomToolView?.(viewProps) ?? getDefaultCustomToolView(viewProps);
+    displayMode === "rendered"
+      ? (getCustomToolView?.(viewProps) ?? getDefaultCustomToolView(viewProps))
+      : undefined;
   if (customView) {
     return <div className={clsx(styles.custom, className)}>{customView}</div>;
   }

--- a/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ComponentStateHooks,
+  ComponentStateProvider,
+} from "@tsmono/react/state";
+
+import { DisplayModeContext } from "../../content/DisplayModeContext";
+
+import { ClientToolCall } from "./ClientToolCall";
+import { ToolCallView } from "./ToolCallView";
+import { ToolOutput } from "./ToolOutput";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+const stateHooks: ComponentStateHooks = {
+  useValue: (_id, _prop, defaultValue) => defaultValue,
+  useSetValue: () => () => {},
+  useRemoveValue: () => () => {},
+  useEntries: () => undefined,
+  useRemoveAll: () => () => {},
+  useRemoveByPrefix: () => () => {},
+};
+
+const renderToolCall = (output: string, displayMode: "rendered" | "raw") =>
+  render(
+    <ComponentStateProvider hooks={stateHooks}>
+      <DisplayModeContext.Provider value={{ displayMode }}>
+        <ToolCallView
+          id="tool-call"
+          tool="close_agent"
+          functionCall="close_agent"
+          contentType="markdown"
+          output={output}
+        />
+      </DisplayModeContext.Provider>
+    </ComponentStateProvider>
+  );
+
+const renderClientToolCall = (
+  output: string,
+  displayMode: "rendered" | "raw"
+) =>
+  render(
+    <ComponentStateProvider hooks={stateHooks}>
+      <DisplayModeContext.Provider value={{ displayMode }}>
+        <ClientToolCall
+          id="client-tool-call"
+          tool="tool_search"
+          functionCall="tool_search"
+          output={output}
+        />
+      </DisplayModeContext.Provider>
+    </ComponentStateProvider>
+  );
+
+const renderToolOutput = (output: string, displayMode: "rendered" | "raw") =>
+  render(
+    <DisplayModeContext.Provider value={{ displayMode }}>
+      <ToolOutput output={output} />
+    </DisplayModeContext.Provider>
+  );
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolCallView display modes", () => {
+  const rawOutput = JSON.stringify({
+    previous_status: {
+      completed: "answer<content-internal>eyJ4IjoxfQ==</content-internal>",
+    },
+  });
+
+  it("keeps the concise Codex answer projection in rendered mode", async () => {
+    const { container } = renderToolCall(rawOutput, "rendered");
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("answer");
+    });
+    expect(container.textContent).not.toContain("content-internal");
+  });
+
+  it("shows the exact Codex tool payload in raw mode", () => {
+    const { container } = renderToolCall(rawOutput, "raw");
+
+    expect(container.querySelector("pre")?.textContent).toBe(rawOutput);
+  });
+
+  it("bypasses custom tool projections in raw mode", () => {
+    const toolSearchOutput = JSON.stringify([
+      {
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: {} } },
+      },
+    ]);
+    const { container } = renderClientToolCall(toolSearchOutput, "raw");
+
+    expect(container.querySelector("pre")?.textContent).toBe(toolSearchOutput);
+  });
+
+  it("preserves ANSI control bytes and whitespace in raw tool output", () => {
+    const output = " \u001b[32mSuccess\u001b[0m \n";
+    const { container } = renderToolOutput(output, "raw");
+
+    expect(container.querySelector("code")?.textContent).toBe(output);
+  });
+});

--- a/packages/inspect-components/src/chat/tools/ToolCallView.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@tsmono/inspect-common/types";
 import { ExpandablePanel, MarkdownDiv } from "@tsmono/react/components";
 
+import { useDisplayMode } from "../../content/DisplayModeContext";
 import { MessageContent } from "../MessageContent";
 import { defaultContext, MessagesContext } from "../MessageContents";
 import { ContentTool } from "../types";
@@ -77,6 +78,8 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
   section = "all",
   getCustomToolView,
 }) => {
+  const displayMode = useDisplayMode();
+
   // don't collapse if output includes an image
   function isContentImage(
     value:
@@ -110,13 +113,13 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
   const collapse = Array.isArray(output)
     ? output.every((item) => !isContentImage(item))
     : !isContentImage(output);
-  // Render-time reshape of tool output (e.g. surface Codex sub-agent answers /
-  // tool_search catalog). Does not mutate stored data — the raw output remains
-  // visible in the JSON tab.
+  // Render-time reshape of tool output (e.g. surface Codex sub-agent answers).
+  // Raw mode keeps the original output.
   const normalizedContent = useMemo(() => {
-    const markdown = codexToolMarkdown(tool, output);
+    const markdown =
+      displayMode === "rendered" ? codexToolMarkdown(tool, output) : undefined;
     return normalizeContent(markdown !== undefined ? markdown : output);
-  }, [tool, output]);
+  }, [displayMode, tool, output]);
 
   const hasContent = normalizedContent.find((c) => {
     if (c.type === "tool") {
@@ -147,7 +150,9 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
     mode,
   };
   const customView =
-    getCustomToolView?.(props) ?? getDefaultCustomToolView(props);
+    displayMode === "rendered"
+      ? (getCustomToolView?.(props) ?? getDefaultCustomToolView(props))
+      : undefined;
   if (customView) {
     // A custom view renders the call and its result together, so it belongs to
     // the call section; the output section then contributes nothing.
@@ -184,7 +189,7 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
   );
 
   const outputSection =
-    contentType === "markdown" && hasContent ? (
+    displayMode === "rendered" && contentType === "markdown" && hasContent ? (
       <ExpandablePanel
         id={`${id}-tool-content`}
         collapse={collapse}

--- a/packages/inspect-components/src/chat/tools/ToolOutput.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolOutput.tsx
@@ -6,6 +6,7 @@ import { ANSIDisplay } from "@tsmono/react/components";
 import { isAnsiOutput, isJson } from "@tsmono/util";
 
 import { cappedText } from "../../content/cappedText";
+import { useDisplayMode } from "../../content/DisplayModeContext";
 import { MediaReference } from "../../media/MediaReference";
 import { isRenderableImageSource } from "../../media/mediaSource";
 import { ContentDocumentView } from "../documents/ContentDocumentView";
@@ -82,13 +83,15 @@ interface ToolTextOutputProps {
  * Renders the ToolTextOutput component.
  */
 const ToolTextOutput: FC<ToolTextOutputProps> = ({ text }) => {
-  if (isJson(text)) {
+  const displayMode = useDisplayMode();
+
+  if (displayMode === "rendered" && isJson(text)) {
     const obj = JSON.parse(text) as Record<string, unknown>;
     return <JsonMessageContent id={`1-json`} json={obj} />;
   }
 
   // It could have ANSI codes
-  if (isAnsiOutput(text)) {
+  if (displayMode === "rendered" && isAnsiOutput(text)) {
     return (
       <ANSIDisplay
         className={styles.ansiOutput}
@@ -108,7 +111,7 @@ const ToolTextOutput: FC<ToolTextOutputProps> = ({ text }) => {
     <>
       <pre className={clsx(styles.textOutput, "tool-output")}>
         <code className={clsx("sourceCode", styles.textCode)}>
-          {capped.trim()}
+          {displayMode === "raw" ? capped : capped.trim()}
         </code>
       </pre>
       {notice}

--- a/packages/inspect-components/src/chat/tools/tool.test.ts
+++ b/packages/inspect-components/src/chat/tools/tool.test.ts
@@ -113,13 +113,39 @@ describe("codexToolMarkdown", () => {
     );
   });
 
-  it("handles close_agent previous_status and strips content-internal", () => {
+  it("strips a valid trailing content-internal envelope", () => {
     const output = JSON.stringify({
       previous_status: {
         completed: "answer<content-internal>eyJ4IjoxfQ==</content-internal>",
       },
     });
     expect(codexToolMarkdown("close_agent", output)).toBe("answer");
+  });
+
+  it.each([
+    [
+      "non-trailing envelope",
+      "answer<content-internal>eyJ4IjoxfQ==</content-internal>after",
+    ],
+    [
+      "invalid base64",
+      "answer<content-internal>not-base64!</content-internal>",
+    ],
+    ["invalid JSON", "answer<content-internal>bm90IGpzb24=</content-internal>"],
+    [
+      "repeated envelopes",
+      "answer<content-internal>eyJ4IjoxfQ==</content-internal>" +
+        "<content-internal>eyJ5IjoyfQ==</content-internal>",
+    ],
+  ])("preserves %s in a Codex answer", (_name, completed) => {
+    const output = JSON.stringify({ previous_status: { completed } });
+    expect(codexToolMarkdown("close_agent", output)).toBe(completed);
+  });
+
+  it("preserves trailing whitespace when no valid envelope is present", () => {
+    const completed = "answer  \n";
+    const output = JSON.stringify({ previous_status: { completed } });
+    expect(codexToolMarkdown("close_agent", output)).toBe(completed);
   });
 
   it("returns undefined for non-codex tools and non-JSON", () => {

--- a/packages/inspect-components/src/chat/tools/tool.ts
+++ b/packages/inspect-components/src/chat/tools/tool.ts
@@ -620,10 +620,37 @@ const extractCodexAgentAnswers = (output: unknown): string | undefined => {
   return nonEmpty.length > 0 ? nonEmpty.join("\n\n---\n\n") : undefined;
 };
 
-// Strip Codex's internal `<content-internal>…</content-internal>` bookkeeping
-// tag (base64 message metadata) that trails the visible answer text.
-const cleanCodexAnswer = (text: string): string =>
-  text.replace(/<content-internal>[\s\S]*?<\/content-internal>/g, "").trimEnd();
+// Strip one valid trailing Codex bookkeeping envelope from the rendered
+// projection. Arbitrary or malformed tag-like answer text remains evidence.
+const cleanCodexAnswer = (text: string): string => {
+  const match =
+    /<content-internal>([A-Za-z0-9+/]+={0,2})<\/content-internal>\s*$/.exec(
+      text
+    );
+  const payload = match?.[1];
+  if (!match || payload === undefined) {
+    return text;
+  }
+
+  const visibleAnswer = text.slice(0, match.index);
+  if (
+    visibleAnswer.includes("<content-internal>") ||
+    visibleAnswer.includes("</content-internal>")
+  ) {
+    return text;
+  }
+
+  try {
+    const decoded = Uint8Array.from(atob(payload), (char) =>
+      char.charCodeAt(0)
+    );
+    JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(decoded));
+  } catch {
+    return text;
+  }
+
+  return visibleAnswer.trimEnd();
+};
 
 /**
  * Substitutes `{{param_name}}` placeholders in tool call content


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [x] Code refactor

### What is the current behavior?

The shared Inspect and Scout `MessageContent` renderer removes matched
`<think>`, `<internal>`, and `<content-internal>` blocks, including their
contents, from ordinary `ContentText`.

The removal occurs before `RenderedText`, so both rendered and raw display use
the altered string. The same helper also calls `trim()`, changing unrelated
leading and trailing whitespace.

This can hide model output or imported artifact evidence solely because it
resembles a provider transport envelope. It also duplicates reasoning
interpretation already performed by provider and bridge adapters.

Codex subagent tool results have a separate intentional rendered projection:
known result JSON is reduced to the completed answer, and a trailing
`<content-internal>` metadata envelope is omitted. Raw mode currently does not
consistently bypass that projection.

### What is the new behavior?

The viewer is type-driven:

- `ContentText` is rendered without inspecting or deleting tag-like text.
- `ContentReasoning` retains the existing collapsible reasoning, summary,
  redaction, and OpenRouter structured-reasoning presentation.
- In shared chat message and tool-output paths, raw mode bypasses JSON tree
  conversion, citation marker injection, ANSI rendering, Markdown tool output,
  and custom tool projections so the original logged text remains available.
- Rendered mode retains the current friendly Codex subagent result projection.
  It removes only one expected trailing `<content-internal>` envelope whose
  payload decodes as base64 UTF-8 JSON. Malformed, embedded, repeated, or merely
  tag-shaped answer text remains visible.

Provider and bridge parsing or serialization is unchanged. Current native,
OpenAI-compatible, emulated-reasoning, and agent-bridge paths continue to
convert reasoning at their declared protocol boundaries.

### Does this PR introduce a breaking change?

It intentionally changes presentation for logs or custom providers that leave
literal reasoning-like tags inside `ContentText`: those tags and their enclosed
text are now visible.

Custom providers that want reasoning-specific presentation should return typed
`ContentReasoning`. They should not rely on the viewer treating a plain string
as hidden provider state.

### Other information

This restores the Inspect behavior introduced by
[`inspect_ai#3520`](https://github.com/UKGovernmentBEIS/inspect_ai/pull/3520)
before the shared-chat migration selected Scout's older three-tag stripping
policy.

Regression coverage includes:

- literal `<think>`, `<internal>`, and `<content-internal>` text in Inspect and
  Scout;
- raw JSON, whitespace, citations, ANSI output, and custom tool projections;
- typed reasoning presentation;
- valid and malformed Codex metadata envelopes; and
- rendered versus raw Codex subagent tool results.

### Screenshots

The same mocked Inspect log was rendered before and after the change. It
contains typed `ContentReasoning` plus literal `<think>`, `<internal>`, and
`<content-internal>` text.

#### Before

![Before remediation](https://raw.githubusercontent.com/ericwinsor-aisi/ts-mono/60bfb23c5eb9b7a9a9076fa0f71229bdfee17093/issue-19-before.png)

Typed reasoning renders normally, but the literal blocks and their enclosed
text are absent.

#### After

![After remediation](https://raw.githubusercontent.com/ericwinsor-aisi/ts-mono/60bfb23c5eb9b7a9a9076fa0f71229bdfee17093/issue-19-after.png)

Typed reasoning is unchanged, while all literal tag-like text remains visible
as escaped evidence.

### Testing

- `pnpm --filter @tsmono/inspect-components test`
- `pnpm --filter @tsmono/inspect-components typecheck`
- `pnpm --filter @tsmono/inspect-components lint`
- `pnpm --filter @meridianlabs/log-viewer typecheck`
- `pnpm --filter scout typecheck`
- `pnpm --filter @meridianlabs/log-viewer lint`
- `pnpm --filter scout lint`
- `pnpm --filter @meridianlabs/log-viewer build`
- `pnpm --filter scout build`
- Targeted Inspect and Scout Playwright chat-component tests
