### PR TITLE
Constrain automatic log loading to trusted locations

### DIFF
--- a/apps/inspect/e2e/fixtures/handlers.ts
+++ b/apps/inspect/e2e/fixtures/handlers.ts
@@ -28,6 +28,11 @@ export const defaultHandlers = [
     return HttpResponse.json({ log_dir: "/home/test/logs" });
   }),
 
+  // Legacy combined log root
+  http.get("*/api/logs", () => {
+    return HttpResponse.json({ logs: [], log_dir: "/home/test/logs" });
+  }),
+
   // Log file listing
   http.get("*/api/log-files*", () => {
     return HttpResponse.json({
@@ -48,6 +53,11 @@ export const defaultHandlers = [
 
   // Flow (optional, 404 is acceptable)
   http.get("*/api/flow*", () => {
+    return new HttpResponse(null, { status: 404 });
+  }),
+
+  // No live samples in the default completed-log fixture
+  http.get("*/api/pending-samples*", () => {
     return new HttpResponse(null, { status: 404 });
   }),
 ];

--- a/apps/inspect/e2e/security-log-selection.spec.ts
+++ b/apps/inspect/e2e/security-log-selection.spec.ts
@@ -1,0 +1,386 @@
+import { http, HttpResponse } from "msw";
+
+import { expect, test } from "./fixtures/app";
+import { createEvalLog } from "./fixtures/test-data";
+
+declare global {
+  interface Window {
+    __LOG_SELECTION_FETCHES__?: string[];
+  }
+}
+
+test.describe("URL-selected log loading", () => {
+  for (const target of [
+    "http://127.0.0.1:9/run.json",
+    "http://10.0.0.1/run.json",
+    "http://169.254.169.254/run.json",
+    "https://logs.example.invalid/run.json",
+  ]) {
+    test(`does not request ${target} before approval`, async ({ page }) => {
+      const targetRequests: string[] = [];
+      page.on("request", (request) => {
+        if (request.url().startsWith(new URL(target).origin)) {
+          targetRequests.push(request.url());
+        }
+      });
+
+      await page.goto(`/?log_file=${encodeURIComponent(target)}`);
+
+      await expect(page.getByTestId("log-location-gate")).toBeVisible();
+      await expect(
+        page.getByText(new URL(target).origin, { exact: true })
+      ).toBeVisible();
+      expect(targetRequests).toEqual([]);
+    });
+  }
+
+  test("does not request a same-origin API target before approval", async ({
+    page,
+  }) => {
+    const target =
+      "http://localhost:5174/api/log-delete/attacker-selected.eval";
+    const targetRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url() === target) {
+        targetRequests.push(request.url());
+      }
+    });
+
+    await page.goto(`/?log_file=${encodeURIComponent(target)}`);
+
+    await expect(page.getByTestId("log-location-gate")).toBeVisible();
+    expect(targetRequests).toEqual([]);
+  });
+
+  for (const target of [
+    "file:///tmp/run.eval",
+    "data:application/json,{}",
+    "blob:https://viewer.example/id",
+    "command:run.eval",
+    "vscode://file/run.eval",
+  ]) {
+    test(`blocks unsupported location ${target} without calling fetch`, async ({
+      page,
+    }) => {
+      await page.addInitScript(() => {
+        const originalFetch = window.fetch.bind(window);
+        window.__LOG_SELECTION_FETCHES__ = [];
+        window.fetch = (input, init) => {
+          window.__LOG_SELECTION_FETCHES__?.push(String(input));
+          return originalFetch(input, init);
+        };
+      });
+
+      await page.goto(`/?log_file=${encodeURIComponent(target)}`);
+
+      await expect(page.getByTestId("log-location-gate")).toBeVisible();
+      await expect(page.getByText(target)).toBeVisible();
+      await expect(page.getByTestId("approve-log-location")).toHaveCount(0);
+      expect(
+        await page.evaluate(() => window.__LOG_SELECTION_FETCHES__)
+      ).toEqual([]);
+    });
+  }
+
+  test("loads only the exact approved file after the action", async ({
+    page,
+    network,
+  }) => {
+    const target =
+      "http://localhost:5174/remote/approved-run.json?token=current";
+    const requests: string[] = [];
+    page.on("request", (request) => {
+      if (new URL(request.url()).pathname.startsWith("/remote/")) {
+        requests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/remote/approved-run.json", () =>
+        HttpResponse.json(
+          createEvalLog({
+            eval: {
+              task: "approved-task",
+              task_id: "approved-task-id",
+            },
+          })
+        )
+      )
+    );
+
+    await page.goto(`/?log_file=${encodeURIComponent(target)}`);
+    expect(requests).toEqual([]);
+
+    await page.getByTestId("approve-log-location").click();
+
+    await expect(page.locator("#task-title")).toHaveText("approved-task", {
+      timeout: 10_000,
+    });
+    expect(requests.length).toBeGreaterThan(0);
+    expect(new Set(requests)).toEqual(new Set([target]));
+  });
+
+  test("does not follow an approved log redirect to another target", async ({
+    page,
+    network,
+  }) => {
+    const target = "http://localhost:5174/remote/redirect.json";
+    const redirectedRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().startsWith("http://127.0.0.1:9")) {
+        redirectedRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/remote/redirect.json", () =>
+        HttpResponse.redirect("http://127.0.0.1:9/private.json", 302)
+      )
+    );
+
+    await page.goto(`/?log_file=${encodeURIComponent(target)}`);
+    const initialRequest = page.waitForRequest(target);
+    await page.getByTestId("approve-log-location").click();
+    await initialRequest;
+    await page.waitForTimeout(100);
+
+    expect(redirectedRequests).toEqual([]);
+  });
+
+  test("does not fetch a query-selected directory before approval", async ({
+    page,
+    network,
+  }) => {
+    const listingRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes("/remote-logs/")) {
+        listingRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/remote-logs/listing.json", () => HttpResponse.json({})),
+      http.get(
+        "*/remote-logs/eval-set.json",
+        () => new HttpResponse(null, { status: 404 })
+      ),
+      http.get(
+        "*/remote-logs/flow.yaml",
+        () => new HttpResponse(null, { status: 404 })
+      )
+    );
+
+    await page.goto(
+      `/?inspect_server=true&log_dir=${encodeURIComponent(
+        "http://localhost:5174/remote-logs"
+      )}`
+    );
+
+    await expect(page.getByTestId("log-location-gate")).toBeVisible();
+    expect(listingRequests).toEqual([]);
+
+    await page.getByTestId("approve-log-location").click();
+    await expect(page.locator(".ag-root")).toBeVisible({ timeout: 10_000 });
+    expect(listingRequests).toContain(
+      "http://localhost:5174/remote-logs/listing.json"
+    );
+    expect(
+      listingRequests.every((url) =>
+        url.startsWith("http://localhost:5174/remote-logs/")
+      )
+    ).toBe(true);
+  });
+
+  test("keeps bundled hash selection automatic within the embedded root", async ({
+    page,
+    network,
+  }) => {
+    const logRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes("/logs/")) {
+        logRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/logs/listing.json", () =>
+        HttpResponse.json({
+          "bundled.json": {
+            task: "bundled-task",
+            task_id: "bundled-task-id",
+          },
+        })
+      ),
+      http.get("*/logs/bundled.json", () =>
+        HttpResponse.json(
+          createEvalLog({
+            eval: {
+              task: "bundled-task",
+              task_id: "bundled-task-id",
+            },
+          })
+        )
+      ),
+      http.get(
+        "*/logs/eval-set.json",
+        () => new HttpResponse(null, { status: 404 })
+      ),
+      http.get(
+        "*/logs/flow.yaml",
+        () => new HttpResponse(null, { status: 404 })
+      )
+    );
+    await page.route("http://localhost:5174/", async (route) => {
+      const response = await route.fetch();
+      const body = (await response.text()).replace(
+        "</head>",
+        '<script id="log_dir_context" type="application/json">{"log_dir":"logs"}</script></head>'
+      );
+      await route.fulfill({ response, body });
+    });
+
+    await page.goto("/#/logs/bundled.json");
+
+    await expect(page.locator("#task-title")).toHaveText("bundled-task", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("log-location-gate")).toHaveCount(0);
+    expect(logRequests).toContain("http://localhost:5174/logs/listing.json");
+    expect(logRequests).toContain("http://localhost:5174/logs/bundled.json");
+  });
+
+  test("automatically loads an exact publisher-configured hosted log", async ({
+    page,
+    network,
+  }) => {
+    const logUrl = "http://localhost:5174/hosted/fixed.json";
+    network.use(
+      http.get("*/hosted/fixed.json", () =>
+        HttpResponse.json(
+          createEvalLog({
+            eval: {
+              task: "fixed-hosted-task",
+              task_id: "fixed-hosted-task-id",
+            },
+          })
+        )
+      )
+    );
+    await page.route("http://localhost:5174/", async (route) => {
+      const response = await route.fetch();
+      const body = (await response.text()).replace(
+        "</head>",
+        `<script id="log_dir_context" type="application/json">${JSON.stringify({
+          log_file: logUrl,
+        })}</script></head>`
+      );
+      await route.fulfill({ response, body });
+    });
+
+    await page.goto("/");
+
+    await expect(page.locator("#task-title")).toHaveText("fixed-hosted-task", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("log-location-gate")).toHaveCount(0);
+  });
+
+  test("treats an absolute hash route as untrusted selection", async ({
+    page,
+    network,
+  }) => {
+    const target = "http://127.0.0.1:9/run.eval";
+    const targetRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().startsWith("http://127.0.0.1:9")) {
+        targetRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/api/logs", () =>
+        HttpResponse.json({ logs: [], log_dir: "/home/test/logs" })
+      ),
+      http.get("*/api/log-files*", () =>
+        HttpResponse.json({ files: [], response_type: "full" })
+      )
+    );
+
+    await page.goto(`/#/logs/${encodeURIComponent(target)}`);
+
+    await expect(page.getByTestId("log-location-gate")).toBeVisible({
+      timeout: 10_000,
+    });
+    expect(targetRequests).toEqual([]);
+  });
+
+  test("ignores window log updates outside VS Code", async ({
+    page,
+    network,
+  }) => {
+    const targetRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().startsWith("http://127.0.0.1:9")) {
+        targetRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/api/logs", () =>
+        HttpResponse.json({ logs: [], log_dir: "/home/test/logs" })
+      ),
+      http.get("*/api/log-files*", () =>
+        HttpResponse.json({ files: [], response_type: "full" })
+      )
+    );
+
+    await page.goto("/");
+    await expect(page.locator(".ag-root")).toBeVisible({ timeout: 10_000 });
+    await page.evaluate(() => {
+      window.postMessage(
+        {
+          type: "backgroundUpdate",
+          url: "http://127.0.0.1:9/run.eval",
+          log_dir: "/home/test/logs",
+        },
+        "*"
+      );
+    });
+    await page.waitForTimeout(100);
+
+    expect(targetRequests).toEqual([]);
+    await expect(page.getByTestId("log-location-gate")).toHaveCount(0);
+  });
+
+  test("ignores embedded VS Code state in a normal page", async ({
+    page,
+    network,
+  }) => {
+    const target = "http://127.0.0.1:9/run.eval";
+    const targetRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().startsWith("http://127.0.0.1:9")) {
+        targetRequests.push(request.url());
+      }
+    });
+    network.use(
+      http.get("*/api/logs", () =>
+        HttpResponse.json({ logs: [], log_dir: "/home/test/logs" })
+      ),
+      http.get("*/api/log-files*", () =>
+        HttpResponse.json({ files: [], response_type: "full" })
+      )
+    );
+    await page.route("http://localhost:5174/", async (route) => {
+      const response = await route.fetch();
+      const body = (await response.text()).replace(
+        "</head>",
+        `<script id="logview-state" type="application/json">${JSON.stringify({
+          type: "updateState",
+          url: target,
+        })}</script></head>`
+      );
+      await route.fulfill({ response, body });
+    });
+
+    await page.goto("/");
+
+    await expect(page.locator(".ag-root")).toBeVisible({ timeout: 10_000 });
+    expect(targetRequests).toEqual([]);
+    await expect(page.getByTestId("log-location-gate")).toHaveCount(0);
+  });
+});

--- a/apps/inspect/e2e/viewer-xss.spec.ts
+++ b/apps/inspect/e2e/viewer-xss.spec.ts
@@ -117,8 +117,12 @@ test("print metadata remains literal and the print tab has no opener", async ({
   await page.getByRole("button", { name: "Print" }).click();
   const printPage = await popupPromise;
 
-  await expect(printPage.getByText(task, { exact: true })).toBeVisible();
-  await expect(printPage.getByText(model, { exact: true })).toBeVisible();
+  await expect(printPage.getByText(task, { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(printPage.getByText(model, { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
 
   expect(await printPage.evaluate(() => window.opener)).toBeNull();
   expect(

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -19,7 +19,13 @@ import "./App.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ClipboardJS from "clipboard";
-import { FC, useCallback, useEffect, useLayoutEffect } from "react";
+import {
+  FC,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useSyncExternalStore,
+} from "react";
 import { RouterProvider } from "react-router-dom";
 
 import { defaultRetry } from "@tsmono/react";
@@ -29,7 +35,7 @@ import {
   PulsingDots,
 } from "@tsmono/react/components";
 import { ComponentStateProvider } from "@tsmono/react/state";
-import { basename, dirname } from "@tsmono/util";
+import { basename, dirname, getVscodeApi } from "@tsmono/util";
 
 import { ClientAPI, HostMessage } from "../client/api/types.ts";
 import { inspectStateHooks } from "../state/componentStateAdapter";
@@ -41,6 +47,7 @@ import {
 import { isUri } from "../utils/uri.ts";
 
 import { ApplicationIcons } from "./appearance/icons.ts";
+import { LogLocationGate } from "./LogLocationGate";
 import { AppRouter } from "./routing/AppRouter.tsx";
 import { useAppConfigAsync } from "./server/useAppConfig.ts";
 
@@ -121,7 +128,6 @@ const AppContent: FC = () => {
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
   const setLogDir = useStore((state) => state.logsActions.setLogDir);
-  const setLogFiles = useStore((state) => state.logsActions.setLogHandles);
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
   );
@@ -136,15 +142,45 @@ const AppContent: FC = () => {
       if (!selectedLogFile) {
         return;
       }
-
-      if (selectedLogFile === loadedLogFile && selectedLogDetails) {
-        // The log is already loaded and we have the data
+      if (
+        api.log_locations?.getActiveBrowserFile() &&
+        !api.log_locations.matchesActiveBrowserFile(selectedLogFile)
+      ) {
         return;
       }
 
       try {
         // Set loading first and wait for it to update
         setLoading(true);
+
+        // Refresh the trusted listing/scope only when rehydrated state has not
+        // already been authorized by a route, host, or static grant.
+        if (
+          api.log_locations?.transportForFile(selectedLogFile) === "blocked"
+        ) {
+          const restoredLogDir = await initLogDir();
+          if (
+            api.log_locations.transportForFile(selectedLogFile) === "blocked"
+          ) {
+            const decision = api.log_locations.requestFileSelection(
+              selectedLogFile,
+              {
+                source: "restored",
+                logDir: restoredLogDir,
+              }
+            );
+            if (decision.status !== "approved") {
+              setLoading(false);
+              return;
+            }
+          }
+        }
+
+        if (selectedLogFile === loadedLogFile && selectedLogDetails) {
+          // Cached data is usable only after its location is authorized.
+          setLoading(false);
+          return;
+        }
 
         // Then load the log
         await loadLog(selectedLogFile);
@@ -158,7 +194,15 @@ const AppContent: FC = () => {
     };
 
     void loadSpecificLog();
-  }, [selectedLogFile, loadedLogFile, selectedLogDetails, loadLog, setLoading]);
+  }, [
+    selectedLogFile,
+    loadedLogFile,
+    selectedLogDetails,
+    api.log_locations,
+    initLogDir,
+    loadLog,
+    setLoading,
+  ]);
 
   useEffect(() => {
     // If the component re-mounts and there is a running load loaded
@@ -171,12 +215,12 @@ const AppContent: FC = () => {
     }
   }, [pollLog, selectedLogDetails?.status]);
 
-  const onMessage = useCallback(
-    (e: HostMessage) => {
-      switch (e.data.type) {
+  const applyHostMessage = useCallback(
+    (data: HostMessage["data"]) => {
+      switch (data.type) {
         case "updateState": {
-          if (e.data.url) {
-            const decodedUrl = decodeURIComponent(e.data.url);
+          if (data.url) {
+            const decodedUrl = decodeURIComponent(data.url);
 
             let targetFile = decodedUrl;
             if (isUri(targetFile)) {
@@ -187,24 +231,20 @@ const AppContent: FC = () => {
             }
 
             if (!rehydrated) {
-              setInitialState(
-                targetFile,
-                e.data.sample_id,
-                e.data.sample_epoch
-              );
+              setInitialState(targetFile, data.sample_id, data.sample_epoch);
             }
           }
           break;
         }
         case "backgroundUpdate": {
-          const decodedUrl = decodeURIComponent(e.data.url);
-          const log_dir = e.data.log_dir;
+          const decodedUrl = decodeURIComponent(data.url);
+          const log_dir = data.log_dir;
           const isFocused = document.hasFocus();
           if (!isFocused) {
             if (log_dir === logDir) {
-              setSelectedLogFile(decodedUrl);
+              void setSelectedLogFile(decodedUrl);
             } else {
-              void api.open_log_file(e.data.url, e.data.log_dir);
+              void api.open_log_file(data.url, data.log_dir);
             }
           } else {
             void syncLogs();
@@ -224,46 +264,58 @@ const AppContent: FC = () => {
     ]
   );
 
-  // listen for updateState messages from vscode
+  // Runtime host messages are meaningful only inside the VS Code webview.
   useEffect(() => {
+    if (!getVscodeApi()) {
+      return;
+    }
+
+    const onMessage = (event: MessageEvent<unknown>) => {
+      if (isHostMessageData(event.data)) {
+        applyHostMessage(event.data);
+      }
+    };
     window.addEventListener("message", onMessage);
     return () => {
       window.removeEventListener("message", onMessage);
     };
-  }, [onMessage]);
+  }, [applyHostMessage]);
 
   useEffect(() => {
     const loadLogsAndState = async () => {
       // First see if there is embedded state and if so, use that
       const embeddedState = document.getElementById("logview-state");
-      if (embeddedState) {
-        const state = JSON5.parse<HostMessage["data"]>(
-          embeddedState.textContent || ""
-        );
-        onMessage({ data: state } as HostMessage);
+      if (embeddedState && getVscodeApi()) {
+        const state = JSON5.parse<unknown>(embeddedState.textContent || "");
+        if (isHostMessageData(state)) {
+          api.log_locations?.trustHostFile(decodeURIComponent(state.url));
+          applyHostMessage(state);
+        }
       } else {
-        // For non-route URL params support (legacy)
         const urlParams = new URLSearchParams(window.location.search);
+        const queryFile =
+          urlParams.get("task_file") ?? urlParams.get("log_file");
+        const approvedQueryFile =
+          queryFile &&
+          api.log_locations?.transportForFile(queryFile) !== "blocked"
+            ? queryFile
+            : undefined;
+        const trustedBrowserFile = api.log_locations?.getActiveBrowserFile();
 
-        // If the URL provides a task file, load that
-        const logPath = urlParams.get("task_file");
-
-        // Replace spaces with a '+' sign:
-        const resolvedLogPath = logPath ? logPath.replace(" ", "+") : logPath;
-
-        if (resolvedLogPath) {
-          // Clear any log dir
-          setLogDir(undefined);
-          // Load just the passed file
-          setLogFiles([{ name: resolvedLogPath }]);
-        } else {
-          // If a log file was passed, select it
-          const log_file = urlParams.get("log_file");
-          if (log_file) {
+        if (approvedQueryFile) {
+          if (api.log_locations) {
+            await setSelectedLogFile(approvedQueryFile);
+            setLogDir(undefined);
             await initLogDir();
-            setSelectedLogFile(log_file);
+          } else {
+            setLogDir(undefined);
+            await initLogDir();
+            await setSelectedLogFile(approvedQueryFile);
           }
-          // Else do nothing - RouteProvider will handle it
+        } else if (trustedBrowserFile) {
+          await setSelectedLogFile(trustedBrowserFile);
+          setLogDir(undefined);
+          await initLogDir();
         }
       }
 
@@ -272,12 +324,12 @@ const AppContent: FC = () => {
 
     void loadLogsAndState();
   }, [
-    setLogDir,
-    setLogFiles,
     setSelectedLogFile,
+    setLogDir,
     initLogDir,
     syncLogs,
-    onMessage,
+    api.log_locations,
+    applyHostMessage,
   ]);
 
   return (
@@ -310,6 +362,24 @@ const AppConfigGate: FC = () => {
   return <AppContent />;
 };
 
+const noopSubscribe = () => () => {};
+const nullSnapshot = () => null;
+
+const AppBootstrapGate: FC = () => {
+  const api = useApi();
+  const locations = api.log_locations;
+  const request = useSyncExternalStore(
+    locations?.subscribe ?? noopSubscribe,
+    locations?.getRequestSnapshot ?? nullSnapshot,
+    locations?.getRequestSnapshot ?? nullSnapshot
+  );
+
+  if (locations && request) {
+    return <LogLocationGate locations={locations} request={request} />;
+  }
+  return <AppConfigGate />;
+};
+
 /**
  * Renders the Main Application. Owns the query client + api providers so the
  * exported <App> stays self-contained for external embedders.
@@ -318,9 +388,28 @@ export const App: FC<AppProps> = ({ api }) => {
   return (
     <QueryClientProvider client={queryClient}>
       <ApiProvider value={api}>
-        <AppConfigGate />
+        <AppBootstrapGate />
       </ApiProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 };
+
+function isHostMessageData(value: unknown): value is HostMessage["data"] {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const data = value as Record<string, unknown>;
+  if (data.type === "updateState") {
+    return (
+      typeof data.url === "string" &&
+      (data.sample_id === undefined || typeof data.sample_id === "string") &&
+      (data.sample_epoch === undefined || typeof data.sample_epoch === "string")
+    );
+  }
+  return (
+    data.type === "backgroundUpdate" &&
+    typeof data.url === "string" &&
+    typeof data.log_dir === "string"
+  );
+}

--- a/apps/inspect/src/app/LogLocationGate.module.css
+++ b/apps/inspect/src/app/LogLocationGate.module.css
@@ -1,0 +1,57 @@
+.gate {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.content {
+  width: min(680px, 100%);
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 14px 16px;
+  align-items: start;
+}
+
+.icon {
+  margin-top: 2px;
+  font-size: 1.35rem;
+  color: var(--bs-warning-text-emphasis);
+}
+
+.body {
+  min-width: 0;
+}
+
+.body h1 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.body p {
+  margin: 0 0 10px;
+  line-height: 1.45;
+}
+
+.destination {
+  display: block;
+  max-width: 100%;
+  margin: 8px 0 10px;
+  padding: 8px 10px;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  border-left: 3px solid var(--bs-border-color);
+  background: var(--bs-tertiary-bg);
+  font-size: 0.82rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}

--- a/apps/inspect/src/app/LogLocationGate.tsx
+++ b/apps/inspect/src/app/LogLocationGate.tsx
@@ -1,0 +1,86 @@
+import { VscodeButton } from "@vscode-elements/react-elements";
+import { FC, useLayoutEffect } from "react";
+
+import type {
+  LogLocationController,
+  LogLocationRequest,
+} from "../client/api/log-location";
+
+import { ApplicationIcons } from "./appearance/icons";
+import styles from "./LogLocationGate.module.css";
+
+interface LogLocationGateProps {
+  locations: LogLocationController;
+  request: LogLocationRequest;
+}
+
+export const LogLocationGate: FC<LogLocationGateProps> = ({
+  locations,
+  request,
+}) => {
+  const isApproval = request.status === "approval" && !!request.url;
+  const label = request.kind === "directory" ? "directory" : "log";
+
+  useLayoutEffect(() => {
+    const previousMinWidth = document.body.style.minWidth;
+    document.body.style.minWidth = "0";
+    return () => {
+      document.body.style.minWidth = previousMinWidth;
+    };
+  }, []);
+
+  return (
+    <main className={styles.gate} data-testid="log-location-gate">
+      <div className={styles.content}>
+        <i
+          className={`${ApplicationIcons.approve} ${styles.icon}`}
+          aria-hidden="true"
+        />
+        <div className={styles.body}>
+          <h1>
+            {isApproval
+              ? `Remote ${label} is not loaded`
+              : `This ${label} location cannot be loaded`}
+          </h1>
+          {isApproval ? (
+            <>
+              <p>
+                Loading this {label} contacts <strong>{request.origin}</strong>.
+              </p>
+              <code className={styles.destination}>{request.url}</code>
+              <p>
+                Approval applies only to this exact {label} for the current
+                page.
+              </p>
+            </>
+          ) : (
+            <>
+              <code className={styles.destination}>{request.raw}</code>
+              <p>{request.reason}</p>
+            </>
+          )}
+          <div className={styles.actions}>
+            {isApproval ? (
+              <VscodeButton
+                onClick={() => {
+                  locations.approveRequest();
+                }}
+                data-testid="approve-log-location"
+              >
+                Open {label}
+              </VscodeButton>
+            ) : null}
+            <VscodeButton
+              secondary
+              onClick={() => {
+                locations.dismissRequest();
+              }}
+            >
+              Continue without loading
+            </VscodeButton>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -78,7 +78,7 @@ export const LogSampleDetailView: FC = () => {
         await initLogDir();
 
         // Set the selected log file
-        setSelectedLogFile(routeLogPath);
+        await setSelectedLogFile(routeLogPath);
 
         // Sync logs to ensure we have the latest data
         void syncLogs();
@@ -178,7 +178,7 @@ export const LogSampleDetailView: FC = () => {
         currentPath: logPath ? `${logPath}/sample` : undefined,
         fnNavigationUrl,
         bordered: true,
-        breadcrumbsEnabled: !isSingleFileMode,
+        breadcrumbsEnabled: !isSingleFileMode(),
       }}
     />
   );

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -129,7 +129,7 @@ export const LogViewContainer: FC = () => {
     const loadLogFromPath = async () => {
       if (logPath) {
         await initLogDir();
-        setSelectedLogFile(logPath);
+        await setSelectedLogFile(logPath);
         void syncLogs();
       }
     };

--- a/apps/inspect/src/app/log-view/LogViewLayout.tsx
+++ b/apps/inspect/src/app/log-view/LogViewLayout.tsx
@@ -80,13 +80,13 @@ export const LogViewLayout: FC = () => {
           className={clsx(
             "app-main-grid",
             fullScreen ? "full-screen" : undefined,
-            isSingleFileMode ? "single-file-mode" : undefined,
+            isSingleFileMode() ? "single-file-mode" : undefined,
             "log-view"
           )}
           tabIndex={0}
         >
           {showFind ? <FindBand /> : ""}
-          {!isSingleFileMode ? (
+          {!isSingleFileMode() ? (
             <ApplicationNavbar
               fnNavigationUrl={navigationUrl}
               currentPath={logPath}

--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -11,7 +11,7 @@ import { Card, CardBody, CardHeader } from "@tsmono/react/components";
 import { formatNumber, ghCommitUrl, toTitleCase } from "@tsmono/util";
 
 import { kLogViewTaskTabId } from "../../../constants";
-import { useApi } from "../../../state/store";
+import { useApi, useStore } from "../../../state/store";
 import { formatDateTime, formatDuration } from "../../../utils/format";
 import { TagsField } from "../title-view/TagsField";
 
@@ -57,7 +57,11 @@ export const TaskTab: FC<TaskTabProps> = ({
   // metadata grid for an empty log — TagsField owns the actual gating
   // (in-progress, dialog state, save flow, refresh).
   const api = useApi();
-  const canEditTags = Boolean(api.edit_log);
+  const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
+  const canEditTags =
+    Boolean(api.edit_log) &&
+    (!selectedLogFile ||
+      api.log_locations?.transportForFile(selectedLogFile) !== "browser");
   const tagList = tags ?? [];
 
   const config: Record<string, unknown> = {};

--- a/apps/inspect/src/app/log-view/title-view/PrimaryBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/PrimaryBar.tsx
@@ -10,7 +10,8 @@ import { RunningMetric } from "../../../client/api/types";
 import { DownloadLogButton } from "../../../components/DownloadLogButton";
 import { kModelNone } from "../../../constants";
 import { toDisplayScorers } from "../../../scoring/metrics";
-import { useStore } from "../../../state/store";
+import { useApi, useStore } from "../../../state/store";
+import { isEvalLogFile } from "../../../utils/uri";
 
 import { ModelRolesView } from "./ModelRolesView";
 import styles from "./PrimaryBar.module.css";
@@ -36,13 +37,17 @@ export const PrimaryBar: FC<PrimaryBarProps> = ({
   sampleCount,
   tags,
 }) => {
+  const api = useApi();
   const streamSamples = useStore((state) => state.capabilities.streamSamples);
   const downloadLogs = useStore((state) => state.capabilities.downloadLogs);
   const absLogDir = useStore((state) => state.logs.absLogDir);
   const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
   const logDir = useStore((state) => state.logs.logDir);
   const logFileName = selectedLogFile ? filename(selectedLogFile) : "";
-  const isEvalFile = selectedLogFile?.endsWith(".eval");
+  const isEvalFile = selectedLogFile ? isEvalLogFile(selectedLogFile) : false;
+  const browserHosted =
+    !!selectedLogFile &&
+    api.log_locations?.transportForFile(selectedLogFile) === "browser";
   const tagList = tags ?? [];
 
   const copyValue = (() => {
@@ -107,7 +112,10 @@ export const PrimaryBar: FC<PrimaryBarProps> = ({
             </div>
             <div className={styles.buttonGroup}>
               {copyValue ? <CopyButton value={copyValue} /> : ""}
-              {downloadLogs && selectedLogFile && isEvalFile ? (
+              {downloadLogs &&
+              selectedLogFile &&
+              isEvalFile &&
+              !browserHosted ? (
                 <DownloadLogButton log_file={selectedLogFile} />
               ) : null}
             </div>

--- a/apps/inspect/src/app/routing/AppRouter.tsx
+++ b/apps/inspect/src/app/routing/AppRouter.tsx
@@ -51,10 +51,9 @@ const AppLayout = () => {
   // Get route params to check for sample detail routes
   const { sampleId, epoch, sampleUuid } = useLogRouteParams();
 
-  // Single file mode is a legacy mode that is used when an explicit
-  // file is passed via URL (task_file or log_file params) or via
-  // embedded state (VSCode)
-  if (isSingleFileMode) {
+  // Single-file mode is used for a trusted/approved exact file or VS Code
+  // embedded state.
+  if (isSingleFileMode()) {
     // Check if this is a sample detail URL
     const isSampleDetail = (sampleId && epoch) || sampleUuid;
 

--- a/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
+++ b/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
@@ -141,7 +141,7 @@ export const SampleDetailView: FC = () => {
         currentPath: routeLogPath,
         fnNavigationUrl: samplesUrl,
         bordered: true,
-        breadcrumbsEnabled: !isSingleFileMode,
+        breadcrumbsEnabled: !isSingleFileMode(),
       }}
     />
   );

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -63,7 +63,7 @@ export const SamplePrintView: FC = () => {
     const loadLogAndSample = async () => {
       if (logPath && sampleId && epoch) {
         await initLogDir();
-        setSelectedLogFile(logPath);
+        await setSelectedLogFile(logPath);
         void syncLogs();
 
         const targetEpoch = parseInt(epoch, 10);

--- a/apps/inspect/src/app/samples/transcript/search/inspectSearchAdapters.ts
+++ b/apps/inspect/src/app/samples/transcript/search/inspectSearchAdapters.ts
@@ -86,6 +86,9 @@ export const useInspectSearchContext = (
     // to logDir, so we may have to reconstruct it.
     const logFile = selectedLogFile ?? urlLogPath;
     if (!logFile) return null;
+    if (api.log_locations?.transportForFile(logFile) === "browser") {
+      return null;
+    }
     const logPath = urlLogPath ?? makeLogsPath(logFile, logDir);
     if (!logPath) return null;
     return {

--- a/apps/inspect/src/app/singleFileMode.test.ts
+++ b/apps/inspect/src/app/singleFileMode.test.ts
@@ -15,25 +15,23 @@ const docWithEmbedded = (
 const emptyDoc = docWithEmbedded(false);
 
 describe("detectInitialSingleFileMode", () => {
-  it.each([
-    ["?log_file=foo.eval", true],
-    ["?task_file=foo.eval", true],
-    ["?log_file=foo.eval&other=1", true],
-    ["?other=1", false],
-    ["", false],
-  ])("returns %s for query %s", (search, expected) => {
-    expect(detectInitialSingleFileMode({ search }, emptyDoc)).toBe(expected);
+  it("does not trust URL selection before approval", () => {
+    expect(detectInitialSingleFileMode(emptyDoc, false)).toBe(false);
+  });
+
+  it("uses an approved URL selection", () => {
+    expect(detectInitialSingleFileMode(emptyDoc, true)).toBe(true);
   });
 
   it("returns true when embedded logview-state element is present", () => {
     expect(
-      detectInitialSingleFileMode({ search: "" }, docWithEmbedded(true))
+      detectInitialSingleFileMode(docWithEmbedded(true), false, true)
     ).toBe(true);
   });
 
-  it("does not match log_file as a substring of another param", () => {
+  it("does not trust embedded host state outside VS Code", () => {
     expect(
-      detectInitialSingleFileMode({ search: "?my_log_file=foo" }, emptyDoc)
+      detectInitialSingleFileMode(docWithEmbedded(true), false, false)
     ).toBe(false);
   });
 });

--- a/apps/inspect/src/app/singleFileMode.ts
+++ b/apps/inspect/src/app/singleFileMode.ts
@@ -1,4 +1,6 @@
-import { dirname } from "@tsmono/util";
+import { dirname, getVscodeApi } from "@tsmono/util";
+
+import { hasApprovedSingleFileMode } from "../client/api/log-location";
 
 /**
  * Single-file mode is set when the viewer is opened against a specific log
@@ -8,14 +10,14 @@ import { dirname } from "@tsmono/util";
  * kick off directory-wide replication for every log in the directory.
  */
 export const detectInitialSingleFileMode = (
-  location: { search: string },
-  doc: Pick<Document, "getElementById">
+  doc: Pick<Document, "getElementById">,
+  approvedFileSelection = hasApprovedSingleFileMode(),
+  hasHostApi = !!getVscodeApi()
 ): boolean => {
-  if (doc.getElementById("logview-state")) {
+  if (hasHostApi && doc.getElementById("logview-state")) {
     return true;
   }
-  const params = new URLSearchParams(location.search);
-  return params.has("log_file") || params.has("task_file");
+  return approvedFileSelection;
 };
 
 /**
@@ -31,12 +33,8 @@ export const deriveSingleFileLogDir = (
 };
 
 /**
- * Resolved once at module import. Whether the viewer is in single-file mode
- * is a startup-time property: it's a function of the URL the page loaded with
- * (or embedded state injected by VSCode) and never flips during the session,
- * so we don't need to thread it through application state.
+ * Single-file mode becomes active only for a trusted host/file bootstrap or
+ * after the location controller validates or explicitly approves a file.
  */
-export const isSingleFileMode: boolean =
-  typeof window !== "undefined"
-    ? detectInitialSingleFileMode(window.location, document)
-    : false;
+export const isSingleFileMode = (): boolean =>
+  typeof window !== "undefined" ? detectInitialSingleFileMode(document) : false;

--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -47,6 +47,28 @@ const baseApi = (): LogViewAPI => ({
     .mockResolvedValue({ inspect_version: "test", scout_version: null }),
 });
 
+describe("clientApi log format detection", () => {
+  test("uses the eval range reader for a signed eval URL", async () => {
+    const readLogSummary = vi.fn().mockResolvedValue({
+      eval: { task: "task", model: "model" },
+      sampleSummaries: [],
+    });
+    const openMock = vi.mocked(openRemoteLogFile);
+    openMock.mockReset();
+    openMock.mockResolvedValue({
+      readLogSummary,
+    } as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>);
+    const lowLevel = baseApi();
+    const client = clientApi(lowLevel);
+    const file = "https://logs.example/run.eval?token=current";
+
+    await client.get_log_details(file);
+
+    expect(openMock).toHaveBeenCalledWith(lowLevel, file, 5);
+    expect(lowLevel.get_log_contents).not.toHaveBeenCalled();
+  });
+});
+
 describe("clientApi.get_log_sample_data path selection", () => {
   test("pins to direct on the first call when the probe succeeds", async () => {
     const direct = vi.fn().mockResolvedValue(okResponse(true));

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -5,7 +5,7 @@ import {
 } from "@tsmono/inspect-common/types";
 
 import { sampleIdsEqual } from "../../app/shared/sample";
-import { encodePathParts } from "../../utils/uri";
+import { encodePathParts, isEvalLogFile } from "../../utils/uri";
 import {
   openRemoteLogFile,
   RemoteLogFile,
@@ -25,10 +25,6 @@ import {
   ProgressCallback,
   SampleDataResponse,
 } from "./types";
-
-const isEvalFile = (file: string) => {
-  return file.endsWith(".eval");
-};
 
 /**
  * Represents an error thrown when a file exceeds the maximum allowed size.
@@ -138,7 +134,7 @@ export const clientApi = (
     log_file: string,
     cached = true
   ): Promise<LogDetails> => {
-    if (isEvalFile(log_file)) {
+    if (isEvalLogFile(log_file)) {
       const remoteLogFile = await remoteEvalFile(log_file, cached);
       if (remoteLogFile) {
         return await remoteLogFile.readLogSummary();
@@ -190,7 +186,7 @@ export const clientApi = (
     epoch: number,
     onProgress?: ProgressCallback
   ): Promise<EvalSample | undefined> => {
-    if (isEvalFile(log_file)) {
+    if (isEvalLogFile(log_file)) {
       async function fetchSample(useCache: boolean) {
         const remoteLogFile = await remoteEvalFile(log_file, useCache);
         if (!remoteLogFile) {
@@ -273,7 +269,7 @@ export const clientApi = (
 
     // Separate files into eval_files and json_files
     for (const file of log_files) {
-      if (isEvalFile(file)) {
+      if (isEvalLogFile(file)) {
         eval_files[file] = index;
       } else {
         json_files[file] = index;

--- a/apps/inspect/src/client/api/index.ts
+++ b/apps/inspect/src/client/api/index.ts
@@ -1,11 +1,13 @@
 import JSON5 from "json5";
 
 import { AppConfig } from "@tsmono/inspect-common/types";
-import { dirname, getVscodeApi } from "@tsmono/util";
+import { getVscodeApi } from "@tsmono/util";
 
 import { clientApi } from "./client-api";
+import { locationAwareClientApi } from "./location-aware-client-api";
+import { LogLocationController } from "./log-location";
 import staticHttpApi from "./static-http/api-static-http";
-import { ClientAPI } from "./types";
+import { ClientAPI, LogViewAPI } from "./types";
 import { viewServerApi } from "./view-server/api-view-server";
 import vscodeApi from "./vscode/api-vscode";
 
@@ -18,71 +20,106 @@ interface LogDirContext {
 }
 
 /**
- * Resolves the client API
+ * Resolve transport only from trusted environment signals. URL parameters are
+ * inspected by the location controller as untrusted selections after the
+ * clients have been constructed.
  */
-const resolveApi = (): ClientAPI => {
+export const resolveApi = (): ClientAPI => {
   const debug = false;
-  if (getVscodeApi()) {
-    // This is VSCode
-    return clientApi(vscodeApi, undefined, debug);
+  const vscode = getVscodeApi();
+  const embedded = vscode ? undefined : readLogDirContext();
+
+  let locations: LogLocationController;
+  let baseViewApi: LogViewAPI;
+  let browserViewApi: LogViewAPI;
+
+  if (vscode) {
+    locations = new LogLocationController({
+      transport: "vscode",
+      baseUrl: document.baseURI,
+    });
+    baseViewApi = vscodeApi;
+    browserViewApi = staticHttpApi(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+  } else if (embedded && (embedded.log_dir || embedded.log_file)) {
+    locations = new LogLocationController({
+      transport: "static",
+      baseUrl: document.baseURI,
+      staticLogDir: embedded.log_dir,
+      staticLogFile: embedded.log_file,
+    });
+    const appConfig: AppConfig | undefined =
+      embedded.inspect_version !== undefined
+        ? {
+            inspect_version: embedded.inspect_version,
+            scout_version: null,
+          }
+        : undefined;
+    browserViewApi = staticHttpApi(
+      embedded.log_dir,
+      embedded.log_file,
+      embedded.abs_log_dir,
+      appConfig,
+      locations
+    );
+    baseViewApi = browserViewApi;
   } else {
-    // See if there is an log_file, log_dir embedded in the
-    // document or passed via URL (could be hosted)
-    const scriptEl = document.getElementById("log_dir_context");
-    if (scriptEl) {
-      // Read the contents
-      const context = scriptEl.textContent;
-      if (context !== null) {
-        const data = JSON5.parse<LogDirContext>(context);
-        if (data.log_dir || data.log_file) {
-          const log_dir = data.log_dir || dirname(data.log_file ?? "");
-          const app_config: AppConfig | undefined =
-            data.inspect_version !== undefined
-              ? {
-                  inspect_version: data.inspect_version,
-                  scout_version: null,
-                }
-              : undefined;
-          const api = staticHttpApi(
-            log_dir,
-            data.log_file,
-            data.abs_log_dir,
-            app_config
-          );
-          return clientApi(api, data.log_file, debug);
-        }
-      }
-    }
-
-    // See if there is url params passing info (could be hosted)
-    const urlParams = new URLSearchParams(window.location.search);
-    const log_file = urlParams.get("log_file");
-    const log_dir = urlParams.get("log_dir");
-    const forceViewServerApi = urlParams.get("inspect_server") === "true";
-
-    const resolved_log_dir = log_dir ?? undefined;
-    const resolved_log_file = log_file ?? undefined;
-
-    if (forceViewServerApi) {
-      return clientApi(
-        viewServerApi({ logDir: resolved_log_dir }),
-        resolved_log_file,
-        debug
-      );
-    }
-
-    if (resolved_log_dir !== undefined || resolved_log_file !== undefined) {
-      return clientApi(
-        staticHttpApi(resolved_log_dir, resolved_log_file),
-        resolved_log_file,
-        debug
-      );
-    }
-
-    // No signal information so use the standard
-    // view server API (inspect view)
-    return clientApi(viewServerApi(), undefined, debug);
+    locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl: document.baseURI,
+    });
+    baseViewApi = viewServerApi();
+    browserViewApi = staticHttpApi(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
   }
+
+  const browserClient = clientApi(browserViewApi, undefined, debug);
+  const baseClient =
+    baseViewApi === browserViewApi
+      ? browserClient
+      : clientApi(baseViewApi, undefined, debug);
+  const api = locationAwareClientApi(baseClient, browserClient, locations);
+
+  locations.initializeUrlSelection(window.location.search);
+  return api;
 };
+
+function readLogDirContext(): LogDirContext | undefined {
+  const scriptEl = document.getElementById("log_dir_context");
+  const context = scriptEl?.textContent;
+  if (!context) {
+    return undefined;
+  }
+
+  const value = JSON5.parse<unknown>(context);
+  if (!isRecord(value)) {
+    throw new Error("Invalid embedded log directory configuration.");
+  }
+
+  return {
+    log_dir: optionalString(value.log_dir),
+    log_file: optionalString(value.log_file),
+    abs_log_dir: optionalString(value.abs_log_dir),
+    inspect_version: optionalString(value.inspect_version),
+  };
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 export default resolveApi();

--- a/apps/inspect/src/client/api/location-aware-client-api.test.ts
+++ b/apps/inspect/src/client/api/location-aware-client-api.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { locationAwareClientApi } from "./location-aware-client-api";
+import { LogLocationController } from "./log-location";
+import type { ClientAPI } from "./types";
+
+const baseUrl = "https://viewer.example/index.html";
+
+const client = (): ClientAPI => ({
+  get_log_dir: vi.fn().mockResolvedValue("/logs"),
+  get_log_dir_handle: vi.fn(
+    (value: string | undefined): string => value ?? "default"
+  ),
+  get_logs: vi.fn().mockResolvedValue({ files: [], response_type: "full" }),
+  get_log_root: vi.fn().mockResolvedValue({ logs: [], log_dir: "/logs" }),
+  get_eval_set: vi.fn().mockResolvedValue(undefined),
+  get_flow: vi.fn().mockResolvedValue(undefined),
+  get_log_summaries: vi.fn().mockResolvedValue([]),
+  get_log_details: vi.fn().mockResolvedValue({
+    eval: { task: "task", model: "model" },
+    sampleSummaries: [],
+  }),
+  get_log_sample: vi.fn().mockResolvedValue(undefined),
+  client_events: vi.fn().mockResolvedValue([]),
+  download_file: vi.fn(),
+  open_log_file: vi.fn(),
+  get_app_config: vi
+    .fn()
+    .mockResolvedValue({ inspect_version: "test", scout_version: null }),
+});
+
+describe("locationAwareClientApi", () => {
+  test("dispatches server-listed logs to the base client", async () => {
+    const base = client();
+    const browser = client();
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    locations.registerListedLocations([{ name: "/logs/run.eval" }], "/logs");
+    const api = locationAwareClientApi(base, browser, locations);
+
+    await api.get_log_details("/logs/run.eval");
+
+    expect(base.get_log_details).toHaveBeenCalledWith(
+      "/logs/run.eval",
+      undefined
+    );
+    expect(browser.get_log_details).not.toHaveBeenCalled();
+  });
+
+  test("dispatches the scoped form of a relative server listing", async () => {
+    const base = client();
+    const browser = client();
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    locations.registerListedLocations([{ name: "run.eval" }], "/logs");
+    const api = locationAwareClientApi(base, browser, locations);
+
+    await api.get_log_sample("/logs/run.eval", 1, 1);
+
+    expect(base.get_log_sample).toHaveBeenCalledWith(
+      "/logs/run.eval",
+      1,
+      1,
+      undefined
+    );
+    expect(browser.get_log_sample).not.toHaveBeenCalled();
+  });
+
+  test("dispatches an explicitly approved URL only to the browser client", async () => {
+    const base = client();
+    const browser = client();
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    locations.requestFileSelection("https://logs.example/run.eval", {
+      source: "query",
+      singleFile: true,
+    });
+    locations.approveRequest();
+    const api = locationAwareClientApi(base, browser, locations);
+
+    await api.get_log_details("https://logs.example/run.eval");
+
+    expect(browser.get_log_details).toHaveBeenCalledWith(
+      "https://logs.example/run.eval",
+      undefined
+    );
+    expect(base.get_log_details).not.toHaveBeenCalled();
+  });
+
+  test("blocks persisted or unlisted locations before either client", async () => {
+    const base = client();
+    const browser = client();
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    const api = locationAwareClientApi(base, browser, locations);
+
+    await expect(
+      api.get_log_details("http://127.0.0.1/run.eval")
+    ).rejects.toThrow("outside the active capability");
+    expect(base.get_log_details).not.toHaveBeenCalled();
+    expect(browser.get_log_details).not.toHaveBeenCalled();
+  });
+
+  test("does not forward edits for a browser-hosted log", async () => {
+    const base = { ...client(), edit_log: vi.fn() };
+    const browser = client();
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    locations.requestFileSelection("https://logs.example/run.eval", {
+      source: "query",
+    });
+    locations.approveRequest();
+    const api = locationAwareClientApi(base, browser, locations);
+
+    await expect(
+      api.edit_log?.("https://logs.example/run.eval", {
+        edits: [],
+        provenance: { author: "a", timestamp: "t", metadata: {} },
+      })
+    ).rejects.toThrow("not supported");
+    expect(base.edit_log).not.toHaveBeenCalled();
+  });
+});

--- a/apps/inspect/src/client/api/location-aware-client-api.ts
+++ b/apps/inspect/src/client/api/location-aware-client-api.ts
@@ -1,0 +1,197 @@
+import type { LogFilesResponse } from "@tsmono/inspect-common/types";
+
+import { LogLocationController } from "./log-location";
+import {
+  ClientAPI,
+  LogPreview,
+  PendingSampleResponse,
+  SampleDataResponse,
+} from "./types";
+
+/**
+ * Dispatches each operation to either the configured host/server client or the
+ * browser-direct static client. File-bearing operations fail closed when the
+ * location controller recognizes neither capability.
+ */
+export const locationAwareClientApi = (
+  base: ClientAPI,
+  browser: ClientAPI,
+  locations: LogLocationController
+): ClientAPI => {
+  const listingClient = (): ClientAPI =>
+    locations.usesBrowserListing() ? browser : base;
+
+  const fileClient = (file: string): ClientAPI => {
+    const transport = locations.transportForFile(file);
+    if (transport === "browser") {
+      return browser;
+    }
+    if (transport === "base") {
+      return base;
+    }
+    throw new Error(`Log location is outside the active capability: ${file}`);
+  };
+
+  const get_log_summaries = async (files: string[]): Promise<LogPreview[]> => {
+    const baseFiles: Array<{ file: string; index: number }> = [];
+    const browserFiles: Array<{ file: string; index: number }> = [];
+    files.forEach((file, index) => {
+      const target = fileClient(file) === browser ? browserFiles : baseFiles;
+      target.push({ file, index });
+    });
+
+    const result = new Array<LogPreview | undefined>(files.length);
+    const loadBatch = async (
+      client: ClientAPI,
+      entries: Array<{ file: string; index: number }>
+    ) => {
+      if (entries.length === 0) {
+        return;
+      }
+      const previews = await client.get_log_summaries(
+        entries.map(({ file }) => file)
+      );
+      entries.forEach(({ index }, previewIndex) => {
+        result[index] = previews[previewIndex];
+      });
+    };
+    await Promise.all([
+      loadBatch(base, baseFiles),
+      loadBatch(browser, browserFiles),
+    ]);
+    return result.filter((preview): preview is LogPreview => !!preview);
+  };
+
+  const api: ClientAPI = {
+    log_locations: locations,
+    get_log_dir: () => listingClient().get_log_dir(),
+    get_log_dir_handle: (logDir) => listingClient().get_log_dir_handle(logDir),
+    get_logs: async (mtime, clientFileCount): Promise<LogFilesResponse> =>
+      listingClient().get_logs(mtime, clientFileCount),
+    get_log_root: () => listingClient().get_log_root(),
+    get_eval_set: (dir) => listingClient().get_eval_set(dir),
+    get_flow: (dir) => listingClient().get_flow(dir),
+    get_log_summaries,
+    get_log_details: async (file, cached) =>
+      fileClient(file).get_log_details(file, cached),
+    get_log_sample: async (file, id, epoch, onProgress) =>
+      fileClient(file).get_log_sample(file, id, epoch, onProgress),
+    client_events: () => listingClient().client_events(),
+    log_message: async (file, message) => {
+      const client = fileClient(file);
+      await client.log_message?.(file, message);
+    },
+    download_file: (fileName, contents) =>
+      listingClient().download_file(fileName, contents),
+    open_log_file: (file, logDir) => base.open_log_file(file, logDir),
+    get_app_config: () => listingClient().get_app_config(),
+  };
+
+  if (base.get_log_pending_samples || browser.get_log_pending_samples) {
+    api.get_log_pending_samples = async (
+      file: string,
+      etag?: string
+    ): Promise<PendingSampleResponse> => {
+      const client = fileClient(file);
+      if (!client.get_log_pending_samples) {
+        return { status: "NotFound" };
+      }
+      return client.get_log_pending_samples(file, etag);
+    };
+  }
+
+  if (base.get_log_sample_data || browser.get_log_sample_data) {
+    api.get_log_sample_data = async (
+      file,
+      id,
+      epoch,
+      lastEvent,
+      lastAttachment,
+      lastMessagePool,
+      lastCallPool
+    ): Promise<SampleDataResponse | undefined> => {
+      const client = fileClient(file);
+      if (!client.get_log_sample_data) {
+        return undefined;
+      }
+      return client.get_log_sample_data(
+        file,
+        id,
+        epoch,
+        lastEvent,
+        lastAttachment,
+        lastMessagePool,
+        lastCallPool
+      );
+    };
+  }
+
+  if (base.download_log || browser.download_log) {
+    api.download_log = async (file) => {
+      const client = fileClient(file);
+      if (!client.download_log) {
+        throw new Error(
+          "Downloading this browser-hosted log is not supported."
+        );
+      }
+      return client.download_log(file);
+    };
+  }
+
+  if (base.edit_log || browser.edit_log) {
+    api.edit_log = async (file, update, etag) => {
+      const client = fileClient(file);
+      if (!client.edit_log) {
+        throw new Error("Editing this browser-hosted log is not supported.");
+      }
+      return client.edit_log(file, update, etag);
+    };
+  }
+
+  if (base.get_user_info || browser.get_user_info) {
+    api.get_user_info = async () =>
+      (await listingClient().get_user_info?.()) ?? {};
+  }
+
+  if (base.list_searches || browser.list_searches) {
+    api.list_searches = async (searchType, count) => {
+      const client = listingClient();
+      if (!client.list_searches) {
+        throw new Error("Search is not supported for browser-hosted logs.");
+      }
+      return client.list_searches(searchType, count);
+    };
+  }
+
+  if (base.post_search || browser.post_search) {
+    api.post_search = async (transcriptDir, transcriptId, request) => {
+      const client = listingClient();
+      if (!client.post_search) {
+        throw new Error("Search is not supported for browser-hosted logs.");
+      }
+      return client.post_search(transcriptDir, transcriptId, request);
+    };
+  }
+
+  if (base.get_search_result || browser.get_search_result) {
+    api.get_search_result = async (
+      transcriptDir,
+      transcriptId,
+      searchId,
+      scope
+    ) => {
+      const client = listingClient();
+      if (!client.get_search_result) {
+        throw new Error("Search is not supported for browser-hosted logs.");
+      }
+      return client.get_search_result(
+        transcriptDir,
+        transcriptId,
+        searchId,
+        scope
+      );
+    };
+  }
+
+  return api;
+};

--- a/apps/inspect/src/client/api/log-location.test.ts
+++ b/apps/inspect/src/client/api/log-location.test.ts
@@ -1,0 +1,490 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  grantedLogUrlHref,
+  hasApprovedSingleFileMode,
+  LogLocationController,
+  resetApprovedSingleFileModeForTest,
+} from "./log-location";
+
+const baseUrl = "https://viewer.example/app/index.html";
+
+beforeEach(() => {
+  resetApprovedSingleFileModeForTest();
+});
+
+describe("LogLocationController static grants", () => {
+  test.each([
+    ["run.eval", "https://viewer.example/app/logs/run.eval"],
+    ["team/run.json", "https://viewer.example/app/logs/team/run.json"],
+    ["logs/run.eval", "https://viewer.example/app/logs/run.eval"],
+    ["/app/logs/run.eval", "https://viewer.example/app/logs/run.eval"],
+    [
+      "https://viewer.example/app/logs/run.eval",
+      "https://viewer.example/app/logs/run.eval",
+    ],
+  ])("allows %s inside the configured root", (selection, expected) => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+
+    expect(
+      locations.requestFileSelection(selection, { source: "route" })
+    ).toEqual({ status: "approved", value: expected });
+    expect(locations.getRequestSnapshot()).toBeNull();
+  });
+
+  test.each([
+    "../api/delete.eval",
+    "%2e%2e/api/delete.eval",
+    "%252e%252e/api/delete.eval",
+    "team/sub/../run.eval",
+    "team%2frun.eval",
+    "team%252frun.eval",
+    "team\\run.eval",
+    "https:logs/run.eval",
+    "https://other.example/run.eval",
+    "https://viewer.example/api/delete.eval",
+  ])("does not automatically allow %s outside the configured root", (value) => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+
+    const decision = locations.requestFileSelection(value, { source: "route" });
+    expect(decision.status).not.toBe("approved");
+  });
+
+  test("keeps an exact configured URL exact", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogFile: "https://cdn.example/run.eval?token=one",
+    });
+    expect(hasApprovedSingleFileMode()).toBe(true);
+
+    expect(
+      locations.requestFileSelection("https://cdn.example/run.eval?token=one", {
+        source: "route",
+      })
+    ).toEqual({
+      status: "approved",
+      value: "https://cdn.example/run.eval?token=one",
+    });
+    expect(
+      locations.requestFileSelection("run.eval?token=one", {
+        source: "route",
+      })
+    ).toEqual({
+      status: "approved",
+      value: "https://cdn.example/run.eval?token=one",
+    });
+    expect(locations.matchesActiveBrowserFile("run.eval?token=one")).toBe(true);
+    expect(
+      locations.requestFileSelection("https://cdn.example/run.eval?token=two", {
+        source: "route",
+      }).status
+    ).toBe("pending");
+  });
+
+  test("an approved exact file becomes the active browser listing", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+
+    locations.requestFileSelection("https://cdn.example/run.eval", {
+      source: "route",
+      singleFile: true,
+    });
+    locations.approveRequest();
+
+    expect(locations.getActiveBrowserDirectory()).toBeUndefined();
+    expect(locations.getActiveBrowserFile()).toBe(
+      "https://cdn.example/run.eval"
+    );
+  });
+
+  test("an embedded exact file takes initial precedence over its directory", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+      staticLogFile: "logs/run.eval",
+    });
+
+    expect(locations.getActiveBrowserDirectory()).toBeUndefined();
+    expect(locations.getActiveBrowserFile()).toBe(
+      "https://viewer.example/app/logs/run.eval"
+    );
+
+    locations.requestDirectorySelection("logs", "query");
+
+    expect(locations.getActiveBrowserDirectory()).toBe(
+      "https://viewer.example/app/logs/"
+    );
+    expect(locations.getActiveBrowserFile()).toBeUndefined();
+  });
+
+  test("does not collapse nested percent encodings across a directory root", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs/%25",
+    });
+
+    expect(
+      locations.requestFileSelection("run.eval", { source: "route" })
+    ).toEqual({
+      status: "approved",
+      value: "https://viewer.example/app/logs/%25/run.eval",
+    });
+    expect(
+      locations.requestFileSelection("/app/logs/%2525/run.eval", {
+        source: "route",
+      }).status
+    ).not.toBe("approved");
+  });
+
+  test("treats a query-selected bundle member as approved single-file mode", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+
+    locations.initializeUrlSelection("?log_file=logs%2Frun.eval");
+
+    expect(locations.getRequestSnapshot()).toBeNull();
+    expect(
+      locations.transportForFile("https://viewer.example/app/logs/run.eval")
+    ).toBe("browser");
+    expect(hasApprovedSingleFileMode()).toBe(true);
+  });
+
+  test("rejects unsafe manifest entries", () => {
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+
+    expect(
+      grantedLogUrlHref(locations.requireManifestEntry("team/run.eval"))
+    ).toBe("https://viewer.example/app/logs/team/run.eval");
+    expect(() => locations.requireManifestEntry("../api/delete.eval")).toThrow(
+      "outside the approved root"
+    );
+    expect(() =>
+      locations.requireManifestEntry("https://other.example/run.eval")
+    ).toThrow("absolute log entry");
+    expect(() =>
+      locations.requireManifestEntry(
+        "https://viewer.example/app/logs/team/run.eval"
+      )
+    ).toThrow("absolute log entry");
+  });
+});
+
+describe("LogLocationController explicit approval", () => {
+  test("does not grant a query-selected URL before approval", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.initializeUrlSelection(
+      "?log_file=http%3A%2F%2F127.0.0.1%3A9000%2Frun.eval"
+    );
+
+    expect(locations.getRequestSnapshot()).toMatchObject({
+      kind: "file",
+      status: "approval",
+      url: "http://127.0.0.1:9000/run.eval",
+      singleFile: true,
+    });
+    expect(locations.transportForFile("http://127.0.0.1:9000/run.eval")).toBe(
+      "blocked"
+    );
+    expect(hasApprovedSingleFileMode()).toBe(false);
+
+    locations.approveRequest();
+
+    expect(locations.transportForFile("http://127.0.0.1:9000/run.eval")).toBe(
+      "browser"
+    );
+    expect(hasApprovedSingleFileMode()).toBe(true);
+  });
+
+  test("approves only the exact file and does not add host-wide trust", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.requestFileSelection("https://logs.example/a.eval", {
+      source: "query",
+      singleFile: true,
+    });
+    locations.approveRequest();
+
+    expect(locations.transportForFile("https://logs.example/a.eval")).toBe(
+      "browser"
+    );
+    expect(locations.transportForFile("https://logs.example/b.eval")).toBe(
+      "blocked"
+    );
+  });
+
+  test("keeps an active browser grant when the approved file enters the list", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    const file = "https://logs.example/a.eval";
+
+    locations.requestFileSelection(file, { source: "query" });
+    locations.approveRequest();
+    locations.registerListedLocations([{ name: file }]);
+
+    expect(locations.requestFileSelection(file, { source: "listing" })).toEqual(
+      { status: "approved", value: file }
+    );
+    expect(locations.transportForFile(file)).toBe("browser");
+  });
+
+  test("does not convert browser-listed files into server capabilities", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    const file = "https://logs.example/a.eval";
+
+    locations.requestFileSelection(file, { source: "query" });
+    locations.approveRequest();
+    locations.registerListedLocations([{ name: file }]);
+    locations.requestFileSelection("https://other.example/b.eval", {
+      source: "route",
+    });
+
+    expect(locations.transportForFile(file)).toBe("blocked");
+    expect(locations.listedFileForSelection(file)).toBeUndefined();
+  });
+
+  test("drops the prior ad hoc grant when the candidate changes", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.requestFileSelection("https://logs.example/a.eval", {
+      source: "query",
+    });
+    locations.approveRequest();
+    locations.requestFileSelection("https://logs.example/b.eval", {
+      source: "route",
+    });
+
+    expect(locations.transportForFile("https://logs.example/a.eval")).toBe(
+      "blocked"
+    );
+    expect(locations.transportForFile("https://logs.example/b.eval")).toBe(
+      "blocked"
+    );
+
+    locations.approveRequest();
+
+    expect(locations.transportForFile("https://logs.example/b.eval")).toBe(
+      "browser"
+    );
+  });
+
+  test.each([
+    "file:///tmp/run.eval",
+    "data:application/json,{}",
+    "blob:https://viewer.example/id",
+    "command:run.eval",
+    "vscode://file/run.eval",
+    "//logs.example/run.eval",
+    "https://user:pass@logs.example/run.eval",
+  ])("never offers approval for %s", (value) => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    const decision = locations.requestFileSelection(value, {
+      source: "query",
+      singleFile: true,
+    });
+    expect(decision.status).toBe("rejected");
+    expect(locations.getRequestSnapshot()).toMatchObject({
+      status: "blocked",
+      raw: value,
+    });
+  });
+
+  test("dismissal prevents the same URL from immediately reopening the gate", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.requestFileSelection("https://logs.example/run.eval", {
+      source: "query",
+    });
+    locations.dismissRequest();
+
+    expect(
+      locations.requestFileSelection("https://logs.example/run.eval", {
+        source: "query",
+      })
+    ).toEqual({
+      status: "rejected",
+      reason: "The log location was dismissed for this page.",
+    });
+    expect(locations.getRequestSnapshot()).toBeNull();
+  });
+
+  test("a dismissed candidate clears any stale prompt for another location", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    const dismissed = "https://logs.example/dismissed.eval";
+
+    locations.requestFileSelection(dismissed, { source: "query" });
+    locations.dismissRequest();
+    locations.requestFileSelection("https://logs.example/other.eval", {
+      source: "query",
+    });
+    locations.requestFileSelection(dismissed, { source: "query" });
+
+    expect(locations.getRequestSnapshot()).toBeNull();
+  });
+});
+
+describe("LogLocationController server and host scopes", () => {
+  test("keeps an unlisted relative hash route server-scoped", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    expect(
+      locations.requestFileSelection("run.eval", {
+        source: "route",
+        logDir: "/logs",
+      })
+    ).toEqual({ status: "approved", value: "/logs/run.eval" });
+    expect(locations.transportForFile("/logs/run.eval")).toBe("base");
+  });
+
+  test("keeps an exact route grant across listing refreshes in the same scope", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.requestFileSelection("run.eval", {
+      source: "route",
+      logDir: "/logs",
+    });
+    locations.registerListedLocations([], "/logs");
+
+    expect(locations.transportForFile("/logs/run.eval")).toBe("base");
+
+    locations.registerListedLocations([], "/other-logs");
+
+    expect(locations.transportForFile("/logs/run.eval")).toBe("blocked");
+  });
+
+  test("recognizes the scoped form of a relative server listing", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    locations.registerListedLocations([{ name: "run.eval" }], "/logs");
+
+    expect(locations.transportForFile("run.eval")).toBe("base");
+    expect(locations.transportForFile("/logs/run.eval")).toBe("base");
+    expect(locations.listedFileForSelection("/logs/run.eval")).toBe("run.eval");
+    expect(locations.transportForFile("/other-logs/run.eval")).toBe("blocked");
+  });
+
+  test("does not silently server-scope an absolute HTTP route", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    expect(
+      locations.requestFileSelection("http://127.0.0.1/run.eval", {
+        source: "route",
+        logDir: "/logs",
+      }).status
+    ).toBe("pending");
+    expect(locations.transportForFile("http://127.0.0.1/run.eval")).toBe(
+      "blocked"
+    );
+  });
+
+  test("matches listed files exactly or by their scoped relative path", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    locations.registerListedLocations(
+      [
+        { name: "s3://bucket/logs/team/run.eval" },
+        { name: "s3://bucket/logs/team-run.eval" },
+      ],
+      "s3://bucket/logs"
+    );
+
+    expect(
+      locations.requestFileSelection("team/run.eval", { source: "route" })
+    ).toEqual({
+      status: "approved",
+      value: "s3://bucket/logs/team/run.eval",
+    });
+    expect(
+      locations.requestFileSelection("run.eval", { source: "route" })
+    ).toEqual({ status: "approved", value: "run.eval" });
+  });
+
+  test("does not trust persisted or unlisted server paths", () => {
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+
+    expect(locations.transportForFile("http://127.0.0.1/run.eval")).toBe(
+      "blocked"
+    );
+    expect(locations.transportForFile("s3://other/run.eval")).toBe("blocked");
+  });
+
+  test("preserves a trusted VS Code exact-file selection", () => {
+    const locations = new LogLocationController({
+      transport: "vscode",
+      baseUrl,
+    });
+    locations.trustHostFile("file:///tmp/run.eval");
+
+    expect(
+      locations.requestFileSelection("run.eval", {
+        source: "host",
+        logDir: "file:///tmp",
+      })
+    ).toEqual({
+      status: "approved",
+      value: "file:///tmp/run.eval",
+    });
+  });
+});

--- a/apps/inspect/src/client/api/log-location.ts
+++ b/apps/inspect/src/client/api/log-location.ts
@@ -1,0 +1,992 @@
+import type { LogHandle } from "@tsmono/inspect-common/types";
+
+export type LogTransport = "static" | "view-server" | "vscode" | "host";
+export type LogSelectionSource =
+  | "query"
+  | "route"
+  | "listing"
+  | "host"
+  | "restored";
+
+const grantedLogUrlBrand: unique symbol = Symbol("GrantedLogUrl");
+
+export interface GrantedLogUrl {
+  readonly href: string;
+  readonly [grantedLogUrlBrand]: () => boolean;
+}
+
+export const grantedLogUrlHref = (value: GrantedLogUrl): string => {
+  const isActive =
+    typeof value === "object" && value !== null
+      ? value[grantedLogUrlBrand]
+      : undefined;
+  if (
+    typeof isActive !== "function" ||
+    typeof value.href !== "string" ||
+    !isActive()
+  ) {
+    throw new Error("Static log request requires a granted URL.");
+  }
+  return value.href;
+};
+
+export interface LogLocationRequest {
+  kind: "file" | "directory";
+  status: "approval" | "blocked";
+  raw: string;
+  url?: string;
+  origin?: string;
+  reason?: string;
+  singleFile: boolean;
+}
+
+export type LogSelectionDecision =
+  | { status: "approved"; value: string }
+  | { status: "pending" }
+  | { status: "rejected"; reason: string };
+
+interface BrowserFileGrant {
+  kind: "file";
+  url: URL;
+}
+
+interface BrowserDirectoryGrant {
+  kind: "directory";
+  url: URL;
+}
+
+type BrowserGrant = BrowserFileGrant | BrowserDirectoryGrant;
+
+export interface LogLocationControllerOptions {
+  transport: LogTransport;
+  baseUrl?: string;
+  staticLogDir?: string;
+  staticLogFile?: string;
+}
+
+let approvedSingleFileMode = false;
+
+export const hasApprovedSingleFileMode = (): boolean => approvedSingleFileMode;
+
+export const resetApprovedSingleFileModeForTest = (): void => {
+  approvedSingleFileMode = false;
+};
+
+const approveSingleFileMode = (): void => {
+  approvedSingleFileMode = true;
+};
+
+const clearApprovedSingleFileMode = (): void => {
+  approvedSingleFileMode = false;
+};
+
+const kSupportedLogExtensions = [".eval", ".json"];
+
+export class LogLocationController {
+  readonly transport: LogTransport;
+
+  private readonly baseUrl: URL;
+  private readonly bootstrapGrants: BrowserGrant[] = [];
+  private readonly listeners = new Set<() => void>();
+  private readonly dismissedRequests = new Set<string>();
+  private readonly listedLocations = new Set<string>();
+  private readonly listedAliases = new Map<string, string>();
+  private readonly ambiguousAliases = new Set<string>();
+  private readonly trustedHostFiles = new Set<string>();
+  private readonly trustedBaseFiles = new Set<string>();
+
+  private activeSessionGrant: BrowserGrant | undefined;
+  private bootstrapFilePreferred = false;
+  private baseScope: string | undefined;
+  private baseScopeInitialized = false;
+  private request: LogLocationRequest | null = null;
+
+  constructor(options: LogLocationControllerOptions) {
+    this.transport = options.transport;
+    this.baseUrl = new URL(
+      options.baseUrl ??
+        (typeof window !== "undefined"
+          ? window.location.href
+          : "http://localhost/")
+    );
+
+    if (options.staticLogDir) {
+      this.bootstrapGrants.push(
+        createDirectoryGrant(options.staticLogDir, this.baseUrl)
+      );
+    }
+    if (options.staticLogFile) {
+      this.bootstrapGrants.push(
+        createFileGrant(options.staticLogFile, this.baseUrl)
+      );
+      this.bootstrapFilePreferred = true;
+      approveSingleFileMode();
+    }
+  }
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  readonly getRequestSnapshot = (): LogLocationRequest | null => this.request;
+
+  initializeUrlSelection(search: string): void {
+    const params = new URLSearchParams(search);
+    const taskFile = params.get("task_file");
+    const logFile = params.get("log_file");
+    const logDir = params.get("log_dir");
+
+    if (taskFile || logFile) {
+      const decision = this.requestFileSelection(taskFile ?? logFile ?? "", {
+        source: "query",
+        singleFile: true,
+      });
+      if (decision.status === "approved") {
+        approveSingleFileMode();
+      }
+    } else if (logDir) {
+      this.requestDirectorySelection(logDir, "query");
+    }
+  }
+
+  requestFileSelection(
+    raw: string,
+    options: {
+      source: LogSelectionSource;
+      logDir?: string;
+      singleFile?: boolean;
+    }
+  ): LogSelectionDecision {
+    const singleFile = options.singleFile ?? false;
+
+    const hostFile = this.resolveTrustedHostFile(raw, options.logDir);
+    if (hostFile) {
+      this.clearActiveSessionGrant();
+      this.clearRequest();
+      return { status: "approved", value: hostFile };
+    }
+
+    const activeGrantMatch = this.activeSessionGrant
+      ? resolveFileAgainstGrant(raw, this.activeSessionGrant, this.baseUrl)
+      : undefined;
+    const grantedFile = this.resolveGrantedBrowserFile(raw);
+    if (grantedFile) {
+      if (!activeGrantMatch) {
+        this.clearActiveSessionGrant();
+      }
+      this.clearRequest();
+      if (singleFile) {
+        approveSingleFileMode();
+      }
+      return { status: "approved", value: grantedFile };
+    }
+
+    const listedFile = this.listedFileForSelection(raw);
+    if (listedFile) {
+      this.clearActiveSessionGrant();
+      this.clearRequest();
+      return { status: "approved", value: listedFile };
+    }
+
+    const baseRoute = this.resolveBaseRoute(raw, options);
+    if (baseRoute) {
+      this.clearActiveSessionGrant();
+      this.clearRequest();
+      this.trustedBaseFiles.add(normalizeServerValue(baseRoute));
+      return { status: "approved", value: baseRoute };
+    }
+
+    const parsed = parseBrowserFile(raw, this.baseUrl);
+    if ("url" in parsed) {
+      return this.requestApproval({
+        kind: "file",
+        raw,
+        url: parsed.url,
+        singleFile,
+      });
+    }
+
+    return this.requestBlocked({
+      kind: "file",
+      raw,
+      reason: parsed.reason,
+      singleFile,
+    });
+  }
+
+  requestDirectorySelection(
+    raw: string,
+    _source: LogSelectionSource
+  ): LogSelectionDecision {
+    const parsed = parseBrowserDirectory(raw, this.baseUrl);
+    if (!("url" in parsed)) {
+      return this.requestBlocked({
+        kind: "directory",
+        raw,
+        reason: parsed.reason,
+        singleFile: false,
+      });
+    }
+
+    const existing = this.browserGrants().find(
+      (grant): grant is BrowserDirectoryGrant =>
+        grant.kind === "directory" && grant.url.href === parsed.url.href
+    );
+    if (existing) {
+      if (existing !== this.activeSessionGrant) {
+        this.clearActiveSessionGrant();
+      }
+      this.bootstrapFilePreferred = false;
+      clearApprovedSingleFileMode();
+      this.clearRequest();
+      return { status: "approved", value: existing.url.href };
+    }
+
+    return this.requestApproval({
+      kind: "directory",
+      raw,
+      url: parsed.url,
+      singleFile: false,
+    });
+  }
+
+  approveRequest(): void {
+    if (this.request?.status !== "approval" || !this.request.url) {
+      return;
+    }
+
+    const grant =
+      this.request.kind === "file"
+        ? createFileGrant(this.request.url, this.baseUrl)
+        : createDirectoryGrant(this.request.url, this.baseUrl);
+    this.activeSessionGrant = grant;
+    if (grant.kind === "file") {
+      approveSingleFileMode();
+    }
+    this.clearRequest();
+  }
+
+  dismissRequest(): void {
+    if (this.request) {
+      this.dismissedRequests.add(requestKey(this.request));
+    }
+    this.clearRequest();
+  }
+
+  trustHostFile(file: string): void {
+    this.trustedHostFiles.add(normalizeServerValue(file));
+  }
+
+  registerListedLocations(logs: LogHandle[], logDir?: string): void {
+    this.updateBaseScope(logDir);
+    this.listedLocations.clear();
+    this.listedAliases.clear();
+    this.ambiguousAliases.clear();
+
+    for (const log of logs) {
+      // Browser-listed artifacts remain governed by their browser grant. Do
+      // not let displaying them in the shared log list turn them into base
+      // server capabilities if that grant is later replaced.
+      if (this.resolveGrantedBrowserFile(log.name)) {
+        continue;
+      }
+
+      const canonical = normalizeServerValue(log.name);
+      const scoped = normalizeServerValue(serverScopedPath(log.name, logDir));
+      this.listedLocations.add(canonical);
+      this.listedLocations.add(scoped);
+      this.addListedAlias(canonical, log.name);
+      this.addListedAlias(scoped, log.name);
+
+      const relative = relativeServerPath(log.name, logDir);
+      if (relative) {
+        this.addListedAlias(normalizeServerValue(relative), log.name);
+      }
+    }
+  }
+
+  listedFileForSelection(raw: string): string | undefined {
+    const normalized = normalizeServerValue(raw);
+    if (this.ambiguousAliases.has(normalized)) {
+      return undefined;
+    }
+    return this.listedAliases.get(normalized);
+  }
+
+  transportForFile(file: string): "browser" | "base" | "blocked" {
+    if (this.resolveGrantedBrowserFile(file)) {
+      return "browser";
+    }
+
+    const normalized = normalizeServerValue(file);
+    if (
+      (this.listedLocations.has(normalized) &&
+        !this.ambiguousAliases.has(normalized)) ||
+      this.trustedHostFiles.has(normalized) ||
+      this.trustedBaseFiles.has(normalized)
+    ) {
+      return "base";
+    }
+
+    return "blocked";
+  }
+
+  usesBrowserListing(): boolean {
+    return (
+      this.activeSessionGrant !== undefined ||
+      (this.transport === "static" && this.bootstrapGrants.length > 0)
+    );
+  }
+
+  getActiveBrowserDirectory(): string | undefined {
+    const active = this.activeSessionGrant;
+    if (active) {
+      return active.kind === "directory" ? active.url.href : undefined;
+    }
+    if (this.bootstrapFilePreferred) {
+      return undefined;
+    }
+    return this.bootstrapGrants.find(
+      (grant): grant is BrowserDirectoryGrant => grant.kind === "directory"
+    )?.url.href;
+  }
+
+  getActiveBrowserFile(): string | undefined {
+    const active = this.activeSessionGrant;
+    if (active) {
+      return active.kind === "file" ? active.url.href : undefined;
+    }
+    if (!this.bootstrapFilePreferred) {
+      return undefined;
+    }
+    return this.bootstrapGrants.find(
+      (grant): grant is BrowserFileGrant => grant.kind === "file"
+    )?.url.href;
+  }
+
+  matchesActiveBrowserFile(raw: string): boolean {
+    const active = this.activeSessionGrant;
+    const fileGrant =
+      active?.kind === "file"
+        ? active
+        : this.bootstrapFilePreferred
+          ? this.bootstrapGrants.find(
+              (grant): grant is BrowserFileGrant => grant.kind === "file"
+            )
+          : undefined;
+    return fileGrant
+      ? resolveFileAgainstGrant(raw, fileGrant, this.baseUrl)?.href ===
+          fileGrant.url.href
+      : false;
+  }
+
+  requireBrowserFile(raw: string): GrantedLogUrl {
+    const resolved = this.resolveGrantedBrowserFile(raw);
+    if (!resolved) {
+      throw new Error(
+        `Log location is not approved for browser loading: ${raw}`
+      );
+    }
+    return createGrantedLogUrl(
+      resolved,
+      () => this.resolveGrantedBrowserFile(resolved) === resolved
+    );
+  }
+
+  requireManifestEntry(raw: string): GrantedLogUrl {
+    const directory = this.activeDirectoryGrant();
+    if (!directory) {
+      throw new Error("No approved static log directory is active.");
+    }
+    if (isAbsoluteBrowserReference(raw)) {
+      throw new Error(
+        `Invalid absolute log entry in the approved root: ${raw}`
+      );
+    }
+
+    const parsed = parseBrowserFile(raw, directory.url, {
+      relativeBase: directory.url,
+      allowDocumentBase: false,
+      allowQuery: false,
+    });
+    if (!("url" in parsed) || !isWithinDirectory(directory.url, parsed.url)) {
+      throw new Error(`Invalid log entry outside the approved root: ${raw}`);
+    }
+    const href = parsed.url.href;
+    return createGrantedLogUrl(
+      href,
+      () => this.resolveGrantedBrowserFile(href) === href
+    );
+  }
+
+  requireAuxiliaryFile(...segments: Array<string | undefined>): GrantedLogUrl {
+    const directory = this.activeDirectoryGrant();
+    if (!directory) {
+      throw new Error("No approved static log directory is active.");
+    }
+
+    const value = segments.filter((segment) => segment).join("/");
+    const parsed = parseHttpUrl(value, directory.url, {
+      relativeBase: directory.url,
+      allowDocumentBase: false,
+      allowQuery: false,
+      requireLogExtension: false,
+    });
+    if (!("url" in parsed) || !isWithinDirectory(directory.url, parsed.url)) {
+      throw new Error(
+        `Invalid auxiliary path outside the approved root: ${value}`
+      );
+    }
+    const href = parsed.url.href;
+    return createGrantedLogUrl(href, () => {
+      const activeDirectory = this.activeDirectoryGrant();
+      return (
+        activeDirectory !== undefined &&
+        isWithinDirectory(activeDirectory.url, new URL(href))
+      );
+    });
+  }
+
+  private resolveGrantedBrowserFile(raw: string): string | undefined {
+    for (const grant of this.browserGrants()) {
+      const resolved = resolveFileAgainstGrant(raw, grant, this.baseUrl);
+      if (resolved) {
+        return resolved.href;
+      }
+    }
+    return undefined;
+  }
+
+  private resolveTrustedHostFile(
+    raw: string,
+    logDir?: string
+  ): string | undefined {
+    const direct = normalizeServerValue(raw);
+    if (this.trustedHostFiles.has(direct)) {
+      return raw;
+    }
+
+    if (logDir) {
+      const joined = normalizeServerValue(joinServerPath(logDir, raw));
+      if (this.trustedHostFiles.has(joined)) {
+        return joinServerPath(logDir, raw);
+      }
+    }
+    return undefined;
+  }
+
+  private resolveBaseRoute(
+    raw: string,
+    options: {
+      source: LogSelectionSource;
+      logDir?: string;
+    }
+  ): string | undefined {
+    if (
+      options.source !== "route" ||
+      (this.transport !== "view-server" && this.transport !== "vscode")
+    ) {
+      return undefined;
+    }
+    this.updateBaseScope(options.logDir);
+    if (isAbsoluteServerValue(raw) || raw.startsWith("//")) {
+      return undefined;
+    }
+    return options.logDir ? joinServerPath(options.logDir, raw) : raw;
+  }
+
+  private updateBaseScope(logDir?: string): void {
+    const nextScope = logDir
+      ? normalizeServerValue(logDir).replace(/\/$/, "")
+      : undefined;
+    if (this.baseScopeInitialized && this.baseScope !== nextScope) {
+      this.trustedBaseFiles.clear();
+    }
+    this.baseScope = nextScope;
+    this.baseScopeInitialized = true;
+  }
+
+  private requestApproval(options: {
+    kind: "file" | "directory";
+    raw: string;
+    url: URL;
+    singleFile: boolean;
+  }): LogSelectionDecision {
+    this.clearActiveSessionGrant();
+    clearApprovedSingleFileMode();
+    const request: LogLocationRequest = {
+      kind: options.kind,
+      status: "approval",
+      raw: options.raw,
+      url: options.url.href,
+      origin: options.url.origin,
+      singleFile: options.singleFile,
+    };
+    if (this.dismissedRequests.has(requestKey(request))) {
+      this.clearRequest();
+      return {
+        status: "rejected",
+        reason: "The log location was dismissed for this page.",
+      };
+    }
+    this.setRequest(request);
+    return { status: "pending" };
+  }
+
+  private requestBlocked(options: {
+    kind: "file" | "directory";
+    raw: string;
+    reason: string;
+    singleFile: boolean;
+  }): LogSelectionDecision {
+    this.clearActiveSessionGrant();
+    clearApprovedSingleFileMode();
+    const request: LogLocationRequest = {
+      kind: options.kind,
+      status: "blocked",
+      raw: options.raw,
+      reason: options.reason,
+      singleFile: options.singleFile,
+    };
+    if (this.dismissedRequests.has(requestKey(request))) {
+      this.clearRequest();
+    } else {
+      this.setRequest(request);
+    }
+    return { status: "rejected", reason: options.reason };
+  }
+
+  private activeDirectoryGrant(): BrowserDirectoryGrant | undefined {
+    if (this.activeSessionGrant) {
+      return this.activeSessionGrant.kind === "directory"
+        ? this.activeSessionGrant
+        : undefined;
+    }
+    if (this.bootstrapFilePreferred) {
+      return undefined;
+    }
+    return this.bootstrapGrants.find(
+      (grant): grant is BrowserDirectoryGrant => grant.kind === "directory"
+    );
+  }
+
+  private clearActiveSessionGrant(): void {
+    if (this.activeSessionGrant) {
+      this.activeSessionGrant = undefined;
+      clearApprovedSingleFileMode();
+    }
+  }
+
+  private browserGrants(): BrowserGrant[] {
+    return this.activeSessionGrant
+      ? [this.activeSessionGrant, ...this.bootstrapGrants]
+      : [...this.bootstrapGrants];
+  }
+
+  private addListedAlias(alias: string, canonical: string): void {
+    if (!alias || this.ambiguousAliases.has(alias)) {
+      return;
+    }
+    const existing = this.listedAliases.get(alias);
+    if (existing && existing !== canonical) {
+      this.listedAliases.delete(alias);
+      this.ambiguousAliases.add(alias);
+    } else {
+      this.listedAliases.set(alias, canonical);
+    }
+  }
+
+  private setRequest(request: LogLocationRequest): void {
+    if (
+      this.request &&
+      requestKey(this.request) === requestKey(request) &&
+      this.request.status === request.status
+    ) {
+      return;
+    }
+    this.request = request;
+    this.emit();
+  }
+
+  private clearRequest(): void {
+    if (this.request !== null) {
+      this.request = null;
+      this.emit();
+    }
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+function createFileGrant(raw: string, baseUrl: URL): BrowserFileGrant {
+  const parsed = parseBrowserFile(raw, baseUrl);
+  if (!("url" in parsed)) {
+    throw new Error(`Invalid trusted log file: ${parsed.reason}`);
+  }
+  return { kind: "file", url: parsed.url };
+}
+
+function createGrantedLogUrl(
+  href: string,
+  isActive: () => boolean
+): GrantedLogUrl {
+  return Object.freeze({
+    href,
+    [grantedLogUrlBrand]: isActive,
+  });
+}
+
+function createDirectoryGrant(
+  raw: string,
+  baseUrl: URL
+): BrowserDirectoryGrant {
+  const parsed = parseBrowserDirectory(raw, baseUrl);
+  if (!("url" in parsed)) {
+    throw new Error(`Invalid trusted log directory: ${parsed.reason}`);
+  }
+  return { kind: "directory", url: parsed.url };
+}
+
+function resolveFileAgainstGrant(
+  raw: string,
+  grant: BrowserGrant,
+  documentBase: URL
+): URL | undefined {
+  if (grant.kind === "file") {
+    for (const base of [documentBase, new URL(".", grant.url)]) {
+      const parsed = parseBrowserFile(raw, base);
+      if ("url" in parsed && parsed.url.href === grant.url.href) {
+        return parsed.url;
+      }
+    }
+    return undefined;
+  }
+
+  for (const base of [documentBase, grant.url]) {
+    const parsed = parseBrowserFile(raw, base, {
+      allowDocumentBase: true,
+      allowQuery: false,
+    });
+    if ("url" in parsed && isWithinDirectory(grant.url, parsed.url)) {
+      return parsed.url;
+    }
+  }
+  return undefined;
+}
+
+function parseBrowserFile(
+  raw: string,
+  documentBase: URL,
+  options: {
+    relativeBase?: URL;
+    allowDocumentBase?: boolean;
+    allowQuery?: boolean;
+  } = {}
+): { url: URL } | { reason: string } {
+  return parseHttpUrl(raw, documentBase, {
+    relativeBase: options.relativeBase,
+    allowDocumentBase: options.allowDocumentBase ?? true,
+    allowQuery: options.allowQuery ?? true,
+    requireLogExtension: true,
+  });
+}
+
+function parseBrowserDirectory(
+  raw: string,
+  documentBase: URL
+): { url: URL } | { reason: string } {
+  const parsed = parseHttpUrl(raw, documentBase, {
+    allowDocumentBase: true,
+    allowQuery: false,
+    requireLogExtension: false,
+  });
+  if (!("url" in parsed)) {
+    return parsed;
+  }
+  if (!parsed.url.pathname.endsWith("/")) {
+    parsed.url.pathname = `${parsed.url.pathname}/`;
+  }
+  return parsed;
+}
+
+function parseHttpUrl(
+  raw: string,
+  documentBase: URL,
+  options: {
+    relativeBase?: URL;
+    allowDocumentBase: boolean;
+    allowQuery: boolean;
+    requireLogExtension: boolean;
+  }
+): { url: URL } | { reason: string } {
+  if (!raw || raw.trim() !== raw) {
+    return {
+      reason: "The log location is empty or contains outer whitespace.",
+    };
+  }
+  if (hasControlCharacter(raw)) {
+    return { reason: "Control characters are not supported in log URLs." };
+  }
+  if (raw.startsWith("//")) {
+    return { reason: "Protocol-relative log locations are not supported." };
+  }
+  if (
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(raw) &&
+    !/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(raw)
+  ) {
+    return {
+      reason: "Absolute log URLs must include an explicit authority.",
+    };
+  }
+  if (raw.includes("\\")) {
+    return {
+      reason: "Backslashes are not supported in browser log locations.",
+    };
+  }
+  if (!hasSafeRawPath(raw)) {
+    return { reason: "The log location contains an unsafe path segment." };
+  }
+
+  const bases: URL[] = [];
+  if (options.allowDocumentBase) {
+    bases.push(documentBase);
+  }
+  if (options.relativeBase) {
+    bases.push(options.relativeBase);
+  }
+  if (bases.length === 0) {
+    bases.push(documentBase);
+  }
+
+  let firstReason = "The log location is not a valid URL.";
+  for (const base of bases) {
+    let url: URL;
+    try {
+      url = new URL(raw, base);
+    } catch {
+      continue;
+    }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      firstReason = `The ${url.protocol || "unknown"} scheme is not supported.`;
+      continue;
+    }
+    if (url.username || url.password) {
+      firstReason = "Credential-bearing log URLs are not supported.";
+      continue;
+    }
+    if (url.hash) {
+      firstReason = "Log URLs may not contain a fragment.";
+      continue;
+    }
+    if (!options.allowQuery && url.search) {
+      firstReason = "This log location may not add a query string.";
+      continue;
+    }
+    if (!hasSafePathSegments(url)) {
+      firstReason = "The log location contains an unsafe path segment.";
+      continue;
+    }
+    if (
+      options.requireLogExtension &&
+      !kSupportedLogExtensions.some((extension) =>
+        url.pathname.toLowerCase().endsWith(extension)
+      )
+    ) {
+      firstReason = "Only .eval and .json log files are supported.";
+      continue;
+    }
+    return { url };
+  }
+
+  return { reason: firstReason };
+}
+
+function hasSafePathSegments(url: URL): boolean {
+  for (const segment of url.pathname.split("/")) {
+    if (!segment) {
+      continue;
+    }
+    if (decodeSafePathSegment(segment) === undefined) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isWithinDirectory(root: URL, candidate: URL): boolean {
+  if (
+    root.protocol !== candidate.protocol ||
+    root.hostname !== candidate.hostname ||
+    effectivePort(root) !== effectivePort(candidate)
+  ) {
+    return false;
+  }
+
+  const rootSegments = canonicalPathSegments(root);
+  const candidateSegments = canonicalPathSegments(candidate);
+  if (!rootSegments || !candidateSegments) {
+    return false;
+  }
+  return rootSegments.every(
+    (segment, index) => candidateSegments[index] === segment
+  );
+}
+
+function effectivePort(url: URL): string {
+  if (url.port) {
+    return url.port;
+  }
+  return url.protocol === "https:" ? "443" : "80";
+}
+
+function normalizeServerValue(value: string): string {
+  let decoded = value;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    // Keep the original value when it is not valid percent encoding.
+  }
+  return decoded.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function hasSafeRawPath(raw: string): boolean {
+  let path = raw;
+  const absoluteUrl = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.exec(raw);
+  if (absoluteUrl) {
+    const pathStart = raw.indexOf("/", absoluteUrl[0].length);
+    path = pathStart >= 0 ? raw.substring(pathStart) : "";
+  }
+  path = path.split(/[?#]/, 1)[0] ?? "";
+
+  return path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .every((segment) => decodeSafePathSegment(segment) !== undefined);
+}
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || code === 0x7f;
+  });
+}
+
+function canonicalPathSegments(url: URL): string[] | undefined {
+  const rawSegments = url.pathname.split("/");
+  if (rawSegments[0] === "") {
+    rawSegments.shift();
+  }
+  if (rawSegments.at(-1) === "") {
+    rawSegments.pop();
+  }
+
+  const result: string[] = [];
+  for (const segment of rawSegments) {
+    const decoded = decodeCanonicalPathSegment(segment);
+    if (decoded === undefined) {
+      return undefined;
+    }
+    result.push(decoded);
+  }
+  return result;
+}
+
+function decodeCanonicalPathSegment(segment: string): string | undefined {
+  if (decodeSafePathSegment(segment) === undefined) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeSafePathSegment(segment: string): string | undefined {
+  let decoded = segment;
+  for (let depth = 0; depth <= segment.length; depth++) {
+    if (decoded === ".." || decoded.includes("/") || decoded.includes("\\")) {
+      return undefined;
+    }
+    if (!/%[0-9A-Fa-f]{2}/.test(decoded)) {
+      if (depth === 0 && decoded.includes("%")) {
+        return undefined;
+      }
+      return decoded;
+    }
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function isAbsoluteBrowserReference(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value);
+}
+
+function relativeServerPath(
+  file: string,
+  directory?: string
+): string | undefined {
+  if (!directory) {
+    return undefined;
+  }
+
+  const normalizedFile = normalizeServerValue(file);
+  const normalizedDirectory = normalizeServerValue(directory).replace(
+    /\/$/,
+    ""
+  );
+  const prefix = `${normalizedDirectory}/`;
+  return normalizedFile.startsWith(prefix)
+    ? normalizedFile.substring(prefix.length)
+    : undefined;
+}
+
+function serverScopedPath(file: string, directory?: string): string {
+  if (!directory || isAbsoluteServerValue(file)) {
+    return file;
+  }
+
+  const normalizedFile = normalizeServerValue(file);
+  const normalizedDirectory = normalizeServerValue(directory).replace(
+    /\/$/,
+    ""
+  );
+  if (
+    normalizedFile === normalizedDirectory ||
+    normalizedFile.startsWith(`${normalizedDirectory}/`)
+  ) {
+    return file;
+  }
+  return joinServerPath(directory, file);
+}
+
+function joinServerPath(directory: string, file: string): string {
+  const normalizedDirectory = directory.replace(/[\\/]$/, "");
+  const normalizedFile = file.replace(/^[\\/]/, "");
+  return `${normalizedDirectory}/${normalizedFile}`;
+}
+
+function isAbsoluteServerValue(value: string): boolean {
+  return (
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)
+  );
+}
+
+function requestKey(request: LogLocationRequest): string {
+  return `${request.kind}:${request.url ?? request.raw}`;
+}

--- a/apps/inspect/src/client/api/static-http/api-static-http.test.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { LogLocationController, type GrantedLogUrl } from "../log-location";
+
+import staticHttpApi from "./api-static-http";
+import { fetchTextFile } from "./fetch";
+
+const baseUrl = "https://viewer.example/index.html";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("staticHttpApi location enforcement", () => {
+  test("rejects a forged granted URL at the request helper", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fetchTextFile(
+        "https://viewer.example/logs/run.eval" as unknown as GrantedLogUrl
+      )
+    ).rejects.toThrow("requires a granted URL");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects an ungranted file before fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+    const api = staticHttpApi(
+      "logs",
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+
+    await expect(
+      api.get_log_contents("http://127.0.0.1/run.json")
+    ).rejects.toThrow("not approved");
+    await expect(
+      api.get_log_info("https://other.example/run.eval")
+    ).rejects.toThrow("not approved");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("loads a granted JSON log with restricted request metadata", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          version: 2,
+          status: "success",
+          eval: { task: "task", model: "model" },
+        }),
+        { status: 200 }
+      )
+    );
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+    const api = staticHttpApi(
+      "logs",
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+
+    await api.get_log_contents("run.json");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://viewer.example/logs/run.json",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+        referrerPolicy: "no-referrer",
+        redirect: "error",
+      })
+    );
+  });
+
+  test("guards HEAD and range requests for eval logs", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 200,
+          headers: { "Content-Length": "42" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1, 2, 3]), { status: 206 })
+      );
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogFile: "https://cdn.example/run.eval",
+    });
+    const api = staticHttpApi(
+      undefined,
+      "https://cdn.example/run.eval",
+      undefined,
+      undefined,
+      locations
+    );
+
+    await expect(
+      api.get_log_info("https://cdn.example/run.eval")
+    ).resolves.toEqual({ size: 42 });
+    await api.get_log_bytes("https://cdn.example/run.eval", 2, 4);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://cdn.example/run.eval",
+      expect.objectContaining({
+        method: "HEAD",
+        credentials: "same-origin",
+        referrerPolicy: "no-referrer",
+        redirect: "error",
+      })
+    );
+    const rangeInit = fetchMock.mock.calls[1]?.[1];
+    expect(new Headers(rangeInit?.headers).get("Range")).toBe("bytes=2-4");
+  });
+
+  test("rechecks a grant before the range size probe", async () => {
+    let resolveHead: ((response: Response) => void) | undefined;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveHead = resolve;
+        })
+    );
+    const locations = new LogLocationController({
+      transport: "view-server",
+      baseUrl,
+    });
+    const file = "https://cdn.example/run.eval";
+    locations.requestFileSelection(file, { source: "query" });
+    locations.approveRequest();
+    const api = staticHttpApi(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+
+    const info = api.get_log_info(file);
+    locations.requestFileSelection("https://other.example/run.eval", {
+      source: "route",
+    });
+    resolveHead?.(
+      new Response(null, {
+        status: 200,
+        headers: { "Accept-Ranges": "bytes" },
+      })
+    );
+
+    await expect(info).rejects.toThrow("requires a granted URL");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("filters manifest entries through the configured root", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          "team/run.eval": { task: "valid", task_id: "one" },
+          "../api/delete.eval": { task: "escape", task_id: "two" },
+          "https://other.example/run.eval": {
+            task: "external",
+            task_id: "three",
+          },
+        }),
+        { status: 200 }
+      )
+    );
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+    const api = staticHttpApi(
+      "logs",
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+
+    await expect(api.get_log_root()).resolves.toEqual({
+      logs: [
+        {
+          name: "https://viewer.example/logs/team/run.eval",
+          task: "valid",
+          task_id: "one",
+        },
+      ],
+      log_dir: "https://viewer.example/logs/",
+      abs_log_dir: undefined,
+    });
+  });
+
+  test("ignores duplicate canonical manifest entries", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          "team/run.eval": { task: "valid", task_id: "one" },
+          "team/./run.eval": { task: "duplicate", task_id: "two" },
+        }),
+        { status: 200 }
+      )
+    );
+    const locations = new LogLocationController({
+      transport: "static",
+      baseUrl,
+      staticLogDir: "logs",
+    });
+    const api = staticHttpApi(
+      "logs",
+      undefined,
+      undefined,
+      undefined,
+      locations
+    );
+
+    await expect(api.get_log_root()).resolves.toMatchObject({
+      logs: [
+        {
+          name: "https://viewer.example/logs/team/run.eval",
+          task: "valid",
+          task_id: "one",
+        },
+      ],
+    });
+  });
+});

--- a/apps/inspect/src/client/api/static-http/api-static-http.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.ts
@@ -1,7 +1,10 @@
 import { AppConfig, EvalSet } from "@tsmono/inspect-common/types";
 import { fetchRange } from "@tsmono/util";
 
+import { openRemoteLogFile } from "../../remote/remoteLogFile";
 import { fetchSize } from "../../remote/remoteZipFile";
+import { toLogPreview } from "../../utils/type-utils";
+import { grantedLogUrlHref, LogLocationController } from "../log-location";
 import { download_file } from "../shared/api-shared";
 import { Capabilities, LogPreview, LogRoot, LogViewAPI } from "../types";
 
@@ -10,7 +13,7 @@ import {
   fetchLogFile,
   fetchManifest,
   fetchTextFile,
-  joinURI,
+  staticLogRequestInit,
 } from "./fetch";
 
 // Versions aren't reachable without a server; older bundles don't embed them.
@@ -20,132 +23,165 @@ const kFallbackAppConfig: AppConfig = {
 };
 
 /**
- * This provides an API implementation that will serve a single
- * file using an http parameter, designed to be deployed
- * to a webserver without inspect or the ability to enumerate log
- * files
+ * Browser-direct log API. Every request is resolved through the shared
+ * location controller immediately before the network call.
  */
 export default function staticHttpApi(
   log_dir?: string,
   log_file?: string,
   abs_log_dir?: string,
-  app_config?: AppConfig
+  app_config?: AppConfig,
+  locations?: LogLocationController
 ): LogViewAPI {
-  const resolved_log_dir = log_dir?.replace(" ", "+");
-  const resolved_log_path = log_file ? log_file.replace(" ", "+") : undefined;
-  return staticHttpApiForLog({
-    log_file: resolved_log_path,
-    log_dir: resolved_log_dir,
+  const locationController =
+    locations ??
+    new LogLocationController({
+      transport: "static",
+      baseUrl:
+        typeof document !== "undefined"
+          ? document.baseURI
+          : "http://localhost/",
+      staticLogDir: log_dir,
+      staticLogFile: log_file,
+    });
+
+  return staticHttpApiForLocations({
+    locations: locationController,
     abs_log_dir,
     app_config,
   });
 }
 
-/**
- * Fetches a file from the specified URL and parses its content.
- */
-function staticHttpApiForLog(logInfo: {
-  log_dir?: string;
-  log_file?: string;
+function staticHttpApiForLocations(options: {
+  locations: LogLocationController;
   abs_log_dir?: string;
   app_config?: AppConfig;
 }): LogViewAPI {
-  const log_dir = logInfo.log_dir;
-  const abs_log_dir = logInfo.abs_log_dir;
-  const app_config = logInfo.app_config ?? kFallbackAppConfig;
-  let manifest: Record<string, LogPreview> | undefined = undefined;
-  let manifestPromise: Promise<Record<string, LogPreview>> | undefined =
-    undefined;
+  const { locations, abs_log_dir } = options;
+  const app_config = options.app_config ?? kFallbackAppConfig;
 
-  const getManifest = async (): Promise<Record<string, LogPreview>> => {
-    if (!manifest && log_dir) {
-      if (!manifestPromise) {
-        manifestPromise = fetchManifest(log_dir).then((manifestRaw) => {
-          manifest = manifestRaw?.parsed || {};
-          return manifest;
-        });
-      }
-      await manifestPromise;
+  let manifestRoot: string | undefined;
+  let manifestPromise: Promise<Map<string, LogPreview>> | undefined = undefined;
+
+  const getManifest = async (): Promise<Map<string, LogPreview>> => {
+    const logDir = locations.getActiveBrowserDirectory();
+    if (!logDir) {
+      return new Map();
     }
-    return manifest || {};
+
+    if (manifestRoot !== logDir) {
+      manifestRoot = logDir;
+      manifestPromise = undefined;
+    }
+
+    if (!manifestPromise) {
+      manifestPromise = fetchManifest(
+        locations.requireAuxiliaryFile("listing.json")
+      ).then((manifestRaw) => {
+        const result = new Map<string, LogPreview>();
+        let invalidEntries = 0;
+        for (const [key, preview] of Object.entries(
+          manifestRaw?.parsed ?? {}
+        )) {
+          try {
+            const file = grantedLogUrlHref(locations.requireManifestEntry(key));
+            if (result.has(file)) {
+              throw new Error(
+                `Duplicate static log entry resolves to ${file}: ${key}`
+              );
+            }
+            result.set(file, preview);
+          } catch (error) {
+            invalidEntries++;
+            if (invalidEntries <= 5) {
+              console.warn(`Ignoring invalid static log entry ${key}`, error);
+            }
+          }
+        }
+        if (invalidEntries > 5) {
+          console.warn(
+            `Ignored ${invalidEntries - 5} additional invalid static log entries.`
+          );
+        }
+        return result;
+      });
+    }
+
+    return manifestPromise;
   };
 
-  async function open_log_file() {
-    // No op
-  }
-  return {
-    client_events: async () => {
-      // There are no client events in the case of serving via
-      // http
-      return Promise.resolve([]);
-    },
-    get_log_root: async (): Promise<LogRoot | undefined> => {
-      // First check based upon the log dir
-      if (log_dir) {
-        const manifest = await getManifest();
-        if (manifest) {
-          const logs = Object.entries(manifest).map(([key, preview]) => {
-            return {
-              name: joinURI(log_dir, key),
-              task: preview.task,
-              task_id: preview.task_id,
-            };
-          });
-          return Promise.resolve({
-            logs: logs,
-            log_dir,
-            abs_log_dir,
-          });
-        }
-      }
+  const get_log_root = async (): Promise<LogRoot | undefined> => {
+    const logDir = locations.getActiveBrowserDirectory();
+    if (logDir) {
+      const manifest = await getManifest();
+      return {
+        logs: Array.from(manifest.entries()).map(([name, preview]) => ({
+          name,
+          task: preview.task,
+          task_id: preview.task_id,
+        })),
+        log_dir: logDir,
+        abs_log_dir,
+      };
+    }
 
-      return undefined;
-    },
-    get_log_dir_handle: (log_dir: string | undefined): string => {
-      const currentDirUrl = `${window.location.origin}${window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"))}`;
-      return joinURI(currentDirUrl, log_dir || "default_log_dir");
-    },
+    const logFile = locations.getActiveBrowserFile();
+    if (logFile) {
+      return {
+        logs: [{ name: logFile }],
+        log_dir: directoryUrl(logFile),
+        abs_log_dir,
+      };
+    }
+
+    return undefined;
+  };
+
+  const get_log_summary = async (log_file: string): Promise<LogPreview> => {
+    const grantedUrl = locations.requireBrowserFile(log_file);
+    const granted = grantedLogUrlHref(grantedUrl);
+    const manifest = await getManifest();
+    const preview = manifest.get(granted);
+    if (preview) {
+      return preview;
+    }
+
+    if (new URL(granted).pathname.toLowerCase().endsWith(".json")) {
+      const response = await fetchLogFile(grantedUrl);
+      if (response) {
+        return toLogPreview(response.parsed);
+      }
+    } else {
+      const remote = await openRemoteLogFile(api, granted, 5);
+      return remote.readEvalBasicInfo();
+    }
+
+    throw new Error(`Unable to load eval log header for ${log_file}`);
+  };
+
+  const api: LogViewAPI = {
+    client_events: () => Promise.resolve([]),
+    get_log_root,
+    get_log_dir_handle: (logDir: string | undefined): string =>
+      logDir ??
+      locations.getActiveBrowserDirectory() ??
+      directoryUrl(locations.getActiveBrowserFile()),
     get_eval_set: async (dir?: string) => {
-      const dirSegments = [];
-      if (log_dir) {
-        dirSegments.push(log_dir);
+      if (!locations.getActiveBrowserDirectory()) {
+        return undefined;
       }
-      if (dir) {
-        dirSegments.push(dir);
-      }
-
-      const result = await fetchJsonFile<EvalSet>(
-        joinURI(...dirSegments, "eval-set.json"),
-        (response) => {
-          if (400 <= response.status && response.status < 500) {
-            // Couldn't find a header file
-            return true;
-          } else {
-            return false;
-          }
-        }
+      return fetchJsonFile<EvalSet>(
+        locations.requireAuxiliaryFile(dir, "eval-set.json"),
+        (response) => response.status >= 400 && response.status < 500
       );
-      return result;
     },
     get_flow: async (dir?: string) => {
-      const dirSegments = [];
-      if (log_dir) {
-        dirSegments.push(log_dir);
+      if (!locations.getActiveBrowserDirectory()) {
+        return undefined;
       }
-      if (dir) {
-        dirSegments.push(dir);
-      }
-
-      return await fetchTextFile(
-        joinURI(...dirSegments, "flow.yaml"),
-        (response) => {
-          if (400 <= response.status && response.status < 500) {
-            // Couldn't find a flow file
-            return true;
-          } else {
-            return false;
-          }
-        }
+      return fetchTextFile(
+        locations.requireAuxiliaryFile(dir, "flow.yaml"),
+        (response) => response.status >= 400 && response.status < 500
       );
     },
     log_message: (log_file: string, message: string) => {
@@ -157,64 +193,51 @@ function staticHttpApiForLog(logInfo: {
       _headerOnly?: number,
       _capabilities?: Capabilities
     ) => {
-      const response = await fetchLogFile(log_file);
-      if (response) {
-        return response;
-      } else {
-        throw new Error(`"Unable to load eval log ${log_file}`);
+      const response = await fetchLogFile(
+        locations.requireBrowserFile(log_file)
+      );
+      if (!response) {
+        throw new Error(`Unable to load eval log ${log_file}`);
       }
+      return response;
     },
     get_log_info: async (log_file: string) => {
-      const size = await fetchSize(log_file);
-      return { size };
+      const granted = locations.requireBrowserFile(log_file);
+      return {
+        size: await fetchSize(
+          grantedLogUrlHref(granted),
+          staticLogRequestInit,
+          () => {
+            grantedLogUrlHref(granted);
+          }
+        ),
+      };
     },
-    get_log_bytes: async (log_file: string, start: number, end: number) => {
-      return await fetchRange(log_file, start, end);
-    },
-    get_log_summary: async (log_file: string) => {
-      const manifest = await getManifest();
-      if (manifest) {
-        const manifestAbs: Record<string, LogPreview> = {};
-        Object.entries(manifest).forEach(([key, preview]) => {
-          manifestAbs[joinURI(log_dir || "", key)] = preview;
-        });
-        const header = manifestAbs[log_file];
-        if (header) {
-          return header;
-        }
-      }
-      throw new Error(`Unable to load eval log header for ${log_file}`);
-    },
-    get_log_summaries: async (files: string[]) => {
-      if (files.length === 0) {
-        return [];
-      }
-
-      if (log_dir) {
-        const manifest = await getManifest();
-        if (manifest) {
-          const keys = Object.keys(manifest);
-          const result: LogPreview[] = [];
-          files.forEach((file) => {
-            const fileKey = keys.find((key) => {
-              return file.endsWith(key);
-            });
-            if (fileKey) {
-              // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
-              result.push(manifest[fileKey]);
-            }
-          });
-          return result;
-        }
-      }
-
-      // No log.json could be found, and there isn't a log file,
-      throw new Error(
-        `Failed to load a listing file using the directory: ${log_dir}. Please be sure you have deployed a manifest file (listing.json).`
-      );
-    },
+    get_log_bytes: async (log_file: string, start: number, end: number) =>
+      fetchRange(
+        grantedLogUrlHref(locations.requireBrowserFile(log_file)),
+        start,
+        end,
+        staticLogRequestInit
+      ),
+    get_log_summary,
+    get_log_summaries: async (files: string[]) =>
+      Promise.all(files.map((file) => get_log_summary(file))),
     get_app_config: () => Promise.resolve(app_config),
     download_file,
-    open_log_file,
+    open_log_file: async () => {},
   };
+
+  return api;
+}
+
+function directoryUrl(file: string | undefined): string {
+  if (!file) {
+    return "default_log_dir";
+  }
+  const url = new URL(file);
+  url.pathname = url.pathname.substring(0, url.pathname.lastIndexOf("/") + 1);
+  url.search = "";
+  url.hash = "";
+  return url.href;
 }

--- a/apps/inspect/src/client/api/static-http/fetch.ts
+++ b/apps/inspect/src/client/api/static-http/fetch.ts
@@ -2,17 +2,27 @@ import { EvalLog } from "@tsmono/inspect-common/types";
 
 import { asyncJsonParse } from "../../../utils/json-worker";
 import { encodePathParts } from "../../../utils/uri";
+import { grantedLogUrlHref, type GrantedLogUrl } from "../log-location";
 import { LogContents, LogFilesFetchResponse, LogPreview } from "../types";
+
+export const staticLogRequestInit: RequestInit = Object.freeze({
+  credentials: "same-origin",
+  referrerPolicy: "no-referrer",
+  redirect: "error",
+});
 
 /**
  * Fetches a file from the specified URL as a string
  */
 export async function fetchTextFile(
-  url: string,
+  url: GrantedLogUrl,
   handleError?: (response: Response) => boolean
 ): Promise<string | undefined> {
-  const safe_url = encodePathParts(url);
-  const response = await fetch(`${safe_url}`, { method: "GET" });
+  const safe_url = encodePathParts(grantedLogUrlHref(url));
+  const response = await fetch(`${safe_url}`, {
+    ...staticLogRequestInit,
+    method: "GET",
+  });
   if (response.ok) {
     const text = await response.text();
     return text;
@@ -32,12 +42,15 @@ export async function fetchTextFile(
  * Fetches a file from the specified URL and parses its content.
  */
 export async function fetchFile<T>(
-  url: string,
+  url: GrantedLogUrl,
   parse: (text: string) => Promise<T>,
   handleError?: (response: Response) => boolean
 ): Promise<T | undefined> {
-  const safe_url = encodePathParts(url);
-  const response = await fetch(`${safe_url}`, { method: "GET" });
+  const safe_url = encodePathParts(grantedLogUrlHref(url));
+  const response = await fetch(`${safe_url}`, {
+    ...staticLogRequestInit,
+    method: "GET",
+  });
   if (response.ok) {
     const text = await response.text();
     return await parse(text);
@@ -57,7 +70,7 @@ export async function fetchFile<T>(
  * Fetches a log file and parses its content, updating the log structure if necessary.
  */
 export const fetchLogFile = async (
-  file: string
+  file: GrantedLogUrl
 ): Promise<LogContents | undefined> => {
   return fetchFile<LogContents>(file, async (text): Promise<LogContents> => {
     const log = await asyncJsonParse<EvalLog>(text);
@@ -99,23 +112,20 @@ export const fetchLogFile = async (
  * Fetches a log file and parses its content, updating the log structure if necessary.
  */
 export const fetchManifest = async (
-  log_dir: string
+  listingFile: GrantedLogUrl
 ): Promise<LogFilesFetchResponse | undefined> => {
   const parseListing = async (text: string): Promise<LogFilesFetchResponse> => {
     const parsed = await asyncJsonParse<Record<string, LogPreview>>(text);
     return { raw: text, parsed };
   };
-  return await fetchFile<LogFilesFetchResponse>(
-    log_dir + "/listing.json",
-    parseListing
-  );
+  return await fetchFile<LogFilesFetchResponse>(listingFile, parseListing);
 };
 
 /**
  * Fetches a file, parsing its content and returning the result.
  */
 export const fetchJsonFile = async <T>(
-  file: string,
+  file: GrantedLogUrl,
   handleError?: (response: Response) => boolean
 ): Promise<T | undefined> => {
   return fetchFile<T>(
@@ -126,15 +136,3 @@ export const fetchJsonFile = async <T>(
     handleError
   );
 };
-
-/**
- * Joins multiple URI segments into a single URI string.
- *
- * This function removes any leading or trailing slashes from each segment
- * and then joins them with a single slash (`/`).
- */
-export function joinURI(...segments: string[]): string {
-  return segments
-    .map((segment) => segment.replace(/(^\/+|\/+$)/g, "")) // Remove leading/trailing slashes from each segment
-    .join("/");
-}

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -48,6 +48,8 @@ import {
   EvalSampleTarget,
 } from "../../@types/extraInspect";
 
+import type { LogLocationController } from "./log-location";
+
 export type SearchResultScope = { events?: "all"; messages?: "all" };
 
 export type { CallPoolData, MessagePoolData };
@@ -296,6 +298,9 @@ export interface UserInfo {
 }
 
 export interface ClientAPI {
+  /** Browser/server log-location trust and approval state for this client. */
+  log_locations?: LogLocationController;
+
   // Basic initialization
   get_log_dir: () => Promise<string | undefined>;
 

--- a/apps/inspect/src/client/remote/remoteZipFile.ts
+++ b/apps/inspect/src/client/remote/remoteZipFile.ts
@@ -359,18 +359,27 @@ export const openZipFileFromBuffer = (
   });
 };
 
-export const fetchSize = async (url: string): Promise<number> => {
+export const fetchSize = async (
+  url: string,
+  init: RequestInit = {},
+  assertRequest: () => void = () => {}
+): Promise<number> => {
   // Make a HEAD request to find whether the server supports range requests
-  const acceptResponse = await fetch(url, { method: "HEAD" });
+  assertRequest();
+  const acceptResponse = await fetch(url, { ...init, method: "HEAD" });
   const acceptsRanges = acceptResponse.headers.get("Accept-Ranges");
   if (acceptsRanges === "bytes") {
     // attempt a range request to get the content length
     // Range requests are preferred since they bypass compression.
     // HEAD requests may return compressed content-length which doesn't
     // match the actual file size needed for downstream operations.
+    const headers = new Headers(init.headers);
+    headers.set("Range", "bytes=0-0");
+    assertRequest();
     const getResponse = await fetch(`${url}`, {
+      ...init,
       method: "GET",
-      headers: { Range: "bytes=0-0" },
+      headers,
     });
 
     const contentRange = getResponse.headers.get("Content-Range");

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -206,8 +206,11 @@ export const useLogEditAffordance = (): LogEditAffordance => {
   const logStatus = useStore((s) => s.log.selectedLogDetails?.status);
   const refreshLog = useRefreshLog();
   const isInProgress = logStatus === "started";
+  const browserHosted =
+    !!selectedLogFile &&
+    api.log_locations?.transportForFile(selectedLogFile) === "browser";
   return {
-    canEdit: hasEditApi && !!selectedLogFile && !isInProgress,
+    canEdit: hasEditApi && !!selectedLogFile && !isInProgress && !browserHosted,
     selectedLogFile,
     refreshOnSave: refreshLog,
   };
@@ -535,7 +538,7 @@ export const useSetSelectedLogIndex = () => {
 
       const logHandle = allLogFiles[index];
       // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
-      setSelectedLogFile(logHandle.name);
+      void setSelectedLogFile(logHandle.name);
     },
     [
       allLogFiles,

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -40,7 +40,7 @@ export interface LogsSlice {
     ensureReplication: () => Promise<void>;
     syncLogs: () => Promise<LogHandle[]>;
 
-    setSelectedLogFile: (logFile: string) => void;
+    setSelectedLogFile: (logFile: string) => Promise<void>;
     clearSelectedLogFile: () => void;
 
     // Cross-file sample operations
@@ -122,15 +122,15 @@ export const createLogsSlice = (
     // Actions
     logsActions: {
       setLogDir: (logDir?: string) => {
+        const prev = get().logs.logDir;
+        if (logDir === prev) return;
+        const realPrev = prev !== undefined && prev !== "";
+        const realNew = logDir !== undefined && logDir !== "";
         set((state) => {
-          const prev = state.logs.logDir;
-          if (logDir === prev) return;
           state.logs.logDir = logDir;
           // Only wipe on real dir-to-dir transitions. undefined/"" are
           // initialization signals (two competing sources race during load
           // and rehydration) — wiping then would clobber the persisted sort.
-          const realPrev = prev !== undefined && prev !== "";
-          const realNew = logDir !== undefined && logDir !== "";
           if (realPrev && realNew) {
             state.logs.samplesListState.byScope.samplesPanel.gridState =
               undefined;
@@ -141,11 +141,16 @@ export const createLogsSlice = (
             state.logs.listing.gridStateByScope = {};
           }
         });
+        if (realPrev) {
+          api.log_locations?.registerListedLocations([], logDir);
+        }
       },
-      setLogHandles: (logs: LogHandle[]) =>
+      setLogHandles: (logs: LogHandle[]) => {
         set((state) => {
           state.logs.logs = logs;
-        }),
+        });
+        api.log_locations?.registerListedLocations(logs, get().logs.logDir);
+      },
       syncLogPreviews: async (logs: LogHandle[]) => {
         const state = get();
         if (!state.replicationService) {
@@ -224,8 +229,9 @@ export const createLogsSlice = (
 
         let logDir: string | undefined;
         let absLogDir: string | undefined;
+        let logHandles: LogHandle[] | undefined;
 
-        if (isSingleFileMode) {
+        if (isSingleFileMode()) {
           // No directory listing to fetch — derive the log dir from the
           // selected file. Re-deriving against the same file would just
           // produce the same answer, so short-circuit if it's already set.
@@ -245,6 +251,7 @@ export const createLogsSlice = (
             const root = await api.get_log_root();
             logDir = root.log_dir;
             absLogDir = root.abs_log_dir;
+            logHandles = root.logs;
           } catch (e) {
             console.log(e);
             get().appActions.setLoading(false, e as Error);
@@ -259,6 +266,9 @@ export const createLogsSlice = (
           set((state) => {
             state.logs.absLogDir = absLogDir;
           });
+        }
+        if (logHandles) {
+          get().logsActions.setLogHandles(logHandles);
         }
         return logDir;
       },
@@ -310,7 +320,7 @@ export const createLogsSlice = (
           // catch block; the counter is clamped at zero so the extra decrement
           // here is safe, and we avoid overwriting a non-null error by only
           // calling setLoading(false) when no error was already recorded.
-          if (!logDir || isSingleFileMode) {
+          if (!logDir || isSingleFileMode()) {
             if (!get().app.status.error) {
               get().appActions.setLoading(false);
             }
@@ -329,22 +339,32 @@ export const createLogsSlice = (
             databaseService,
             api,
             {
-              setLogHandles: (logs: LogHandle[]) => {
+              setLogHandles: (logs: LogHandle[], trusted = true) => {
                 const state = get();
-                state.logsActions.setLogHandles(logs);
+                if (trusted) {
+                  state.logsActions.setLogHandles(logs);
+                } else {
+                  set((state) => {
+                    state.logs.logs = logs;
+                  });
+                }
               },
               getSelectedLog: () => {
                 const state = get();
                 if (!state.logs.selectedLogFile) {
                   return undefined;
                 }
+                const listedFile =
+                  api.log_locations?.listedFileForSelection(
+                    state.logs.selectedLogFile
+                  ) ?? state.logs.selectedLogFile;
                 return state.logs.logs.find((handle) => {
-                  return handle.name.endsWith(state.logs.selectedLogFile!);
+                  return handle.name === listedFile;
                 });
               },
               setSelectedLogFile: (logFile: string) => {
                 const state = get();
-                state.logsActions.setSelectedLogFile(logFile);
+                void state.logsActions.setSelectedLogFile(logFile);
               },
               updateLogPreviews: (previews: Record<string, LogPreview>) => {
                 const state = get();
@@ -397,28 +417,52 @@ export const createLogsSlice = (
       // Select a specific log file
       setSelectedLogFile: async (logFile: string) => {
         const state = get();
+        const decision = api.log_locations?.requestFileSelection(logFile, {
+          source: "route",
+          logDir: state.logs.logDir,
+        });
+        if (decision && decision.status !== "approved") {
+          return;
+        }
+        const resolvedLogFile =
+          decision?.status === "approved" ? decision.value : logFile;
+        const listedFile =
+          api.log_locations?.listedFileForSelection(resolvedLogFile);
+        const matchesSelectedFile = (value: string): boolean =>
+          api.log_locations
+            ? value === (listedFile ?? resolvedLogFile)
+            : value.endsWith(resolvedLogFile);
         const isInFileList =
           state.logs.logs.findIndex((val: { name: string }) =>
-            val.name.endsWith(logFile)
+            matchesSelectedFile(val.name)
           ) !== -1;
 
         if (!isInFileList) {
-          if (state.replicationService?.isReplicating() && !isSingleFileMode) {
+          if (
+            state.replicationService?.isReplicating() &&
+            !isSingleFileMode()
+          ) {
             await state.logsActions.syncLogs();
             const logHandle = get().logs.logs.find((val: { name: string }) =>
-              val.name.endsWith(logFile)
+              matchesSelectedFile(val.name)
             );
             if (!logHandle) {
-              throw new Error(`Log file not found: ${logFile}`);
+              return;
             }
           } else {
-            state.logsActions.setLogHandles([{ name: logFile }]);
+            // This is a route/host/browser selection, not a trusted listing.
+            // Keep it visible without registering it as server authority.
+            set((state) => {
+              state.logs.logs = [{ name: resolvedLogFile }];
+            });
           }
         }
         set((state) => {
-          const absoluteLogfile = isUri(logFile)
-            ? logFile
-            : join(logFile, state.logs.logDir);
+          const absoluteLogfile = decision
+            ? resolvedLogFile
+            : isUri(resolvedLogFile)
+              ? resolvedLogFile
+              : join(resolvedLogFile, state.logs.logDir);
           state.logs.selectedLogFile = absoluteLogfile;
         });
       },

--- a/apps/inspect/src/state/sync/replicationService.ts
+++ b/apps/inspect/src/state/sync/replicationService.ts
@@ -6,7 +6,7 @@ import { DatabaseService } from "../../client/database";
 import { WorkPriority, WorkQueue } from "../../utils/workQueue";
 
 export interface ApplicationContext {
-  setLogHandles: (logs: LogHandle[]) => void;
+  setLogHandles: (logs: LogHandle[], trusted?: boolean) => void;
   getSelectedLog: () => LogHandle | undefined;
   setSelectedLogFile: (fileName: string) => void;
   updateLogPreviews: (previews: Record<string, LogPreview>) => void;
@@ -238,7 +238,7 @@ export class ReplicationService {
     // those handles haven't been validated yet.
     const logHandles = await database.readLogs();
     if (logHandles) {
-      context.setLogHandles(logHandles);
+      context.setLogHandles(logHandles, false);
 
       const logPreviews = await database.readLogPreviews(logHandles);
       if (logPreviews && Object.keys(logPreviews).length > 0) {

--- a/apps/inspect/src/state/useLoadLog.ts
+++ b/apps/inspect/src/state/useLoadLog.ts
@@ -35,7 +35,7 @@ export const useLoadLog = () => {
         }
 
         if (selectedLogFile !== routeLogPath) {
-          setSelectedLogFile(routeLogPath);
+          await setSelectedLogFile(routeLogPath);
         }
 
         // Select the specific sample

--- a/apps/inspect/src/utils/evallog.ts
+++ b/apps/inspect/src/utils/evallog.ts
@@ -1,5 +1,7 @@
 import { filename } from "@tsmono/util";
 
+import { isEvalLogFile } from "./uri";
+
 const kLogFilePattern =
   /^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}[-+]\d{2}-\d{2})_(.+)_([0-9A-Za-z]+)\.(eval|json)$/;
 
@@ -18,7 +20,7 @@ export const parseLogFileName = (logFileName: string): ParsedLogFileName => {
       timestamp: undefined,
       name: filename(logFileName),
       taskId: undefined,
-      extension: logFileName.endsWith(".eval") ? "eval" : "json",
+      extension: isEvalLogFile(logFileName) ? "eval" : "json",
     };
   }
 

--- a/apps/inspect/src/utils/uri.ts
+++ b/apps/inspect/src/utils/uri.ts
@@ -114,3 +114,11 @@ export const prettyDirUri = (uri: string) => {
     return uri;
   }
 };
+
+export const isEvalLogFile = (value: string): boolean => {
+  try {
+    return new URL(value).pathname.toLowerCase().endsWith(".eval");
+  } catch {
+    return value.split(/[?#]/, 1)[0]?.toLowerCase().endsWith(".eval") ?? false;
+  }
+};

--- a/packages/util/src/http.ts
+++ b/packages/util/src/http.ts
@@ -4,10 +4,15 @@
 export const fetchRange = async (
   url: string,
   start: number,
-  end: number
+  end: number,
+  init: RequestInit = {}
 ): Promise<Uint8Array> => {
+  const headers = new Headers(init.headers);
+  headers.set("Range", `bytes=${start}-${end}`);
   const response = await fetch(url, {
-    headers: { Range: `bytes=${start}-${end}` },
+    ...init,
+    method: "GET",
+    headers,
   });
   const arrayBuffer = await response.arrayBuffer();
   return new Uint8Array(arrayBuffer);


### PR DESCRIPTION
### Current behavior

The viewer used the same strings for trusted deployment configuration and URL- or message-selected log locations. A crafted query, hash route, or window message could therefore replace the static log target and cause automatic GET, HEAD, or range requests to same-origin endpoints, local/private-network services, or external origins.

Supporting hosted absolute log URLs is intentional. Treating receipt of a viewer link as authority to contact any location is not.

### New behavior

Resolve transport and initial log authority only from trusted embedded configuration or the VS Code host. Query parameters, routes, listings, restored state, and host updates now select through a shared exact-file or canonical-directory policy.

Every browser-direct log request is guarded by a live runtime capability, including JSON GETs, manifests, auxiliary files, and `.eval` HEAD/range requests. Requests use same-origin credentials only, omit the referrer, and reject redirects that could change the approved destination.

A broader HTTP(S) file or directory can still be opened after a visible action approving that exact location for the current page. Unsupported, credential-bearing, protocol-relative, `file:`, `data:`, `blob:`, and custom-scheme locations remain non-loadable.

### Behavioral decisions

- Keep automatic loading for exact files and canonical directories configured by the publisher or VS Code host.
- Keep bundled and hosted relative selection automatic only within the declared scope.
- Do not let `log_file`, `log_dir`, `task_file`, hash routes, restored state, or `inspect_server=true` choose or widen the transport.
- Keep one in-memory ad hoc grant and revoke it when the candidate changes; do not add persistent or host-wide trust.
- Treat manifest entries and server listings as data: reject escaping, absolute, ambiguous, or duplicate-canonical browser entries, and do not let cached or browser-derived handles establish server authority.
- Keep view-server and VS Code paths on their separately scoped transports. Normal browser pages ignore VS Code state and runtime log-update messages.
- Hide server-only edit, search, and download affordances for browser-hosted ad hoc logs.

### Compatibility

Generated bundles, embedded directory roots, nested relative hash links, exact publisher-configured hosted logs, standalone server routes, VS Code selections, JSON logs, and range-readable `.eval` logs retain their declared behavior.

Query-only arbitrary remote links now require the explicit action. Publishers that need automatic hosted loading can embed the existing trusted log configuration.

### Testing

- Inspect typecheck and lint
- Inspect unit tests: 529 passed
- Inspect production build
- Util typecheck, lint, and tests: 91 passed
- Playwright end-to-end suite: 83 passed
- `git diff --check`