### PR TITLE
Avoid stale content on log navigation

### DIFF
--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { kLogViewSamplesTabId } from "../../constants";
 import { useSampleSummaries } from "../../state/hooks";
+import { useClearStaleLogStateOnNav } from "../../state/log";
 import { useStore } from "../../state/store";
 import { useLoadSample } from "../../state/useLoadSample";
 import { usePollSample } from "../../state/usePollSample";
@@ -41,6 +42,8 @@ export const LogSampleDetailView: FC = () => {
     sampleTabId,
     sampleUuid,
   } = useLogRouteParams();
+
+  useClearStaleLogStateOnNav(routeLogPath);
 
   // Load sample data (depends on selectedLogFile and selectedSampleHandle being set)
   useLoadSample();

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -10,7 +10,12 @@ import {
   useRef,
 } from "react";
 
-import { EmptyPanel, TabPanel, TabSet } from "@tsmono/react/components";
+import {
+  EmptyPanel,
+  PulsingDots,
+  TabPanel,
+  TabSet,
+} from "@tsmono/react/components";
 import { useScrollDirection } from "@tsmono/react/hooks";
 
 import { useEvalSpec, useRefreshLog } from "../../state/hooks";
@@ -34,6 +39,7 @@ export const LogView: FC = () => {
   const navigation = useLogNavigation();
 
   const selectedLogDetails = useStore((state) => state.log.selectedLogDetails);
+  const loading = useStore((state) => state.app.status.loading);
   const evalSpec = useEvalSpec();
   const runningMetrics = useStore(
     (state) => state.log.pendingSampleSummaries?.metrics
@@ -116,7 +122,11 @@ export const LogView: FC = () => {
   );
 
   if (evalSpec === undefined) {
-    return <EmptyPanel />;
+    return (
+      <EmptyPanel>
+        {loading > 0 ? <PulsingDots size="large" text="Loading log…" /> : null}
+      </EmptyPanel>
+    );
   } else {
     const tabTools = Object.values(tabs)
       .filter((tab) => tab !== undefined)

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -1,9 +1,9 @@
-import { FC, useEffect, useLayoutEffect, useRef } from "react";
+import { FC, useEffect } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import { kLogViewSamplesTabId } from "../../constants";
 import { useEvalSpec, useSampleSummaries } from "../../state/hooks";
-import { useUnloadLog } from "../../state/log";
+import { useClearStaleLogStateOnNav, useUnloadLog } from "../../state/log";
 import { useStore } from "../../state/store";
 import {
   baseUrl,
@@ -30,14 +30,6 @@ export const LogViewContainer: FC = () => {
 
   const setSelectedLogFile = useStore(
     (state) => state.logsActions.setSelectedLogFile
-  );
-
-  const clearSelectedLogSummary = useStore(
-    (state) => state.logActions.clearSelectedLogDetails
-  );
-
-  const clearSelectedSample = useStore(
-    (state) => state.sampleActions.clearSelectedSample
   );
 
   const navigate = useNavigate();
@@ -101,21 +93,10 @@ export const LogViewContainer: FC = () => {
     }
   }, [initialState, evalSpec, clearInitialState, navigate, prefix]);
 
-  const prevLogPathRef = useRef<string | undefined>(undefined);
   const syncLogs = useStore((state) => state.logsActions.syncLogs);
   const initLogDir = useStore((state) => state.logsActions.initLogDir);
 
-  // Clear the previous eval's data before paint when the route changes, so the
-  // old eval doesn't flash while the new one loads. A useEffect would run after
-  // the browser has already painted the stale eval.
-  useLayoutEffect(() => {
-    const prevLogPath = prevLogPathRef.current;
-    prevLogPathRef.current = logPath;
-    if (prevLogPath && logPath && logPath !== prevLogPath) {
-      clearSelectedSample();
-      clearSelectedLogSummary();
-    }
-  }, [logPath, clearSelectedSample, clearSelectedLogSummary]);
+  useClearStaleLogStateOnNav(logPath);
 
   // Sync the workspace tab from the URL synchronously. Kept separate from
   // the async log-loading effect below so a tab click can't race with a

--- a/apps/inspect/src/state/log.ts
+++ b/apps/inspect/src/state/log.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 
 import { useStore } from "./store";
 
@@ -10,11 +10,52 @@ export const useUnloadLog = () => {
     (state) => state.logsActions.clearSelectedLogFile
   );
   const clearLog = useStore((state) => state.logActions.clearLog);
+  const clearPendingSampleSummaries = useStore(
+    (state) => state.logActions.clearPendingSampleSummaries
+  );
 
   const unloadLog = useCallback(() => {
     clearSelectedLogDetails();
     clearSelectedLogFile();
     clearLog();
-  }, [clearLog, clearSelectedLogDetails, clearSelectedLogFile]);
+    clearPendingSampleSummaries();
+  }, [
+    clearLog,
+    clearSelectedLogDetails,
+    clearSelectedLogFile,
+    clearPendingSampleSummaries,
+  ]);
   return { unloadLog };
+};
+
+/**
+ * Clear log-bound state before paint when routing to another log. Pending
+ * summaries live outside selectedLogDetails but are merged into sample lists,
+ * so they must be reset with the selected sample/details.
+ */
+export const useClearStaleLogStateOnNav = (logPath: string | undefined) => {
+  const clearSelectedSample = useStore(
+    (state) => state.sampleActions.clearSelectedSample
+  );
+  const clearSelectedLogDetails = useStore(
+    (state) => state.logActions.clearSelectedLogDetails
+  );
+  const clearPendingSampleSummaries = useStore(
+    (state) => state.logActions.clearPendingSampleSummaries
+  );
+  const prevLogPathRef = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    const prevLogPath = prevLogPathRef.current;
+    prevLogPathRef.current = logPath;
+    if (prevLogPath && logPath && logPath !== prevLogPath) {
+      clearSelectedSample();
+      clearSelectedLogDetails();
+      clearPendingSampleSummaries();
+    }
+  }, [
+    logPath,
+    clearSelectedSample,
+    clearSelectedLogDetails,
+    clearPendingSampleSummaries,
+  ]);
 };


### PR DESCRIPTION
fix of a cache invalidation bug showing previous eval after navigating to a different log

fixed while working on https://github.com/meridianlabs-ai/ts-mono/pull/354 because it drove me crazy trying to re-test different logs many times per day, but it was out of scope of that features, so separate PR