### PR TITLE
Prevent white flash on dark-theme load

### DIFF
--- a/packages/theme/src/bootstrap.test.ts
+++ b/packages/theme/src/bootstrap.test.ts
@@ -172,9 +172,11 @@ describe("resolveTheme", () => {
 
   it("VS Code clears readable DOM variant when Event Colors is turned off", () => {
     const attrs = new Map<string, string>();
+    const style: Partial<CSSStyleDeclaration> = {};
     let preference: ThemePreference = "readable-system";
     vi.stubGlobal("document", {
       documentElement: {
+        style,
         setAttribute: (name: string, value: string) => attrs.set(name, value),
         removeAttribute: (name: string) => attrs.delete(name),
       },
@@ -202,11 +204,13 @@ describe("resolveTheme", () => {
     applyTheme();
     expect(attrs.get("data-theme-variant")).toBe("readable");
     expect(attrs.get("data-bs-theme")).toBe("dark");
+    expect(style.colorScheme).toBe("dark");
 
     preference = "system";
     applyTheme();
     expect(attrs.has("data-theme-variant")).toBe(false);
     expect(attrs.get("data-bs-theme")).toBe("dark");
+    expect(style.colorScheme).toBe("dark");
   });
 
   it("standalone + readable-system follows OS scheme but keeps readable variant", () => {

--- a/packages/theme/src/bootstrap.ts
+++ b/packages/theme/src/bootstrap.ts
@@ -267,6 +267,14 @@ const installBodyClassObserver = (): void => {
   });
 };
 
+const setDocumentBaseScheme = (isDark: boolean): void => {
+  const scheme = isDark ? "dark" : "light";
+  document.documentElement.setAttribute("data-bs-theme", scheme);
+  // Set before the stylesheet loads so the UA canvas, scrollbars, and form
+  // controls do not flash white while the dark app background is still loading.
+  document.documentElement.style.colorScheme = scheme;
+};
+
 /**
  * Build (do not run) the apply-theme function. The returned function is
  * idempotent and safe to call repeatedly (e.g. on a matchMedia change or a
@@ -296,19 +304,13 @@ export const createApplyTheme = (options: ApplyThemeOptions): (() => void) => {
         document.documentElement.removeAttribute("data-theme-variant");
       }
       if (result.hostIsDark !== null) {
-        document.documentElement.setAttribute(
-          "data-bs-theme",
-          result.hostIsDark ? "dark" : "light"
-        );
+        setDocumentBaseScheme(result.hostIsDark);
       }
     } else if (result.kind === "apply") {
       // data-* attributes belong on <html> (CSS gates `:root[data-bs-theme]`);
       // the vscode-* class belongs on <body> (CSS gates `body[class^=...]`).
       // Splitting elements here is deliberate — keep them in lockstep.
-      document.documentElement.setAttribute(
-        "data-bs-theme",
-        result.isDark ? "dark" : "light"
-      );
+      setDocumentBaseScheme(result.isDark);
 
       // The readable skin is a small token-override block keyed on this
       // attribute (see base.css); absent attribute = the design-consistent


### PR DESCRIPTION
no more FOUC on manual reload of viewers from `pnpm dev` 👀🔦

fixed while working on https://github.com/meridianlabs-ai/ts-mono/pull/354 because it drove me crazy (HMR was not reliable so I reloaded _a lot_), but it was out of scope of that feature, so separate PR