### PR TITLE
Refine sample retry attempt cards (Direction B)

### DIFF
--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.module.css
@@ -20,20 +20,34 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 11px 14px;
+  padding: 13px 14px;
   cursor: pointer;
 }
 
 .attemptLabel {
+  flex: none;
   font-weight: 700;
   font-size: 13.5px;
   color: var(--bs-body-color);
   white-space: nowrap;
 }
 
+/* Right-aligned per-attempt metadata; tabular-nums keeps the timestamps from
+   jittering as digits change. */
+.timestamp {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+  color: var(--bs-tertiary-color);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
 .errorChip {
   display: inline-flex;
   align-items: center;
+  flex: none;
   font-family: var(--bs-font-monospace);
   font-size: 12px;
   font-weight: 600;
@@ -54,36 +68,41 @@
   white-space: nowrap;
 }
 
-/* Right-aligned group: the (expanded-only) Error/Events toggle, duration, and
-   chevron. */
-.headerRight {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.headerToggle {
-  display: flex;
-}
-
-.duration {
-  font-family: var(--bs-font-monospace);
-  font-size: 12px;
-  color: var(--bs-tertiary-color);
-  white-space: nowrap;
-}
-
 .chevron {
+  flex: none;
   color: var(--bs-tertiary-color);
   font-size: 14px;
 }
 
 /* No horizontal padding: the Events transcript goes edge-to-edge so its row
-   borders meet the card edges. The error panel re-adds its own inset. */
+   borders meet the card edges. The divider band and error panel re-add their
+   own inset. */
 .body {
-  padding-top: 10px;
-  padding-bottom: 16px;
+  padding: 2px 0 16px;
+}
+
+/* Centered Error/Events control on a hairline that extends to both card edges,
+   reading as a labeled section divider between the header and the content. */
+.dividerBand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 14px;
+}
+
+.hairline {
+  flex: 1;
+  height: 1px;
+  background: var(--bs-border-color);
+}
+
+.toggle {
+  flex: none;
+  display: flex;
+}
+
+.content {
+  padding-top: 14px;
 }
 
 .errorPanel {

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -11,9 +11,9 @@ import {
   ExpandablePanel,
   SegmentedControl,
 } from "@tsmono/react/components";
-import { formatTime } from "@tsmono/util";
+import { formatDateTime } from "@tsmono/util";
 
-import { attemptDuration, deriveErrorType } from "./retryAttempt";
+import { attemptStartTime, deriveErrorType } from "./retryAttempt";
 import styles from "./RetryAttemptCard.module.css";
 
 export type RetryView = "error" | "events";
@@ -41,7 +41,7 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
   scrollRef,
 }) => {
   const errorType = useMemo(() => deriveErrorType(retry), [retry]);
-  const durationSec = useMemo(() => attemptDuration(retry), [retry]);
+  const startTime = useMemo(() => attemptStartTime(retry), [retry]);
   const hasEvents = !!retry.events?.length;
   const [view, setView] = useState<RetryView>("error");
 
@@ -72,54 +72,57 @@ export const RetryAttemptCard: FC<RetryAttemptCardProps> = ({
         {retry.message && (
           <span className={styles.message}>{retry.message}</span>
         )}
-        <div className={styles.headerRight}>
-          {isOpen && hasEvents && (
-            // Stop propagation so toggling the view doesn't collapse the card.
-            <div
-              className={styles.headerToggle}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <SegmentedControl
-                segments={kViewSegments}
-                selectedId={view}
-                onSegmentChange={(id) => setView(id as RetryView)}
-              />
-            </div>
+        {startTime && (
+          <span className={styles.timestamp}>{formatDateTime(startTime)}</span>
+        )}
+        <i
+          className={clsx(
+            "bi",
+            isOpen ? "bi-chevron-down" : "bi-chevron-right",
+            styles.chevron
           )}
-          {durationSec != null && (
-            <span className={styles.duration}>{formatTime(durationSec)}</span>
-          )}
-          <i
-            className={clsx(
-              "bi",
-              isOpen ? "bi-chevron-down" : "bi-chevron-right",
-              styles.chevron
-            )}
-            aria-hidden="true"
-          />
-        </div>
+          aria-hidden="true"
+        />
       </div>
 
       {isOpen && (
         <div className={styles.body}>
-          {view === "error" || !hasEvents ? (
-            <ExpandablePanel
-              id={`retry-error-${listId}`}
-              collapse={true}
-              className={styles.errorPanel}
-            >
-              <ANSIDisplay
-                output={retry.traceback_ansi}
-                className={styles.ansi}
-              />
-            </ExpandablePanel>
-          ) : (
-            <RetryEventsView
-              retry={retry}
-              listId={listId}
-              scrollRef={scrollRef}
-            />
+          {hasEvents && (
+            // Error/Events control lives on a hairline divider band at the top
+            // of the body (not the header) so it stays put under a long
+            // traceback instead of scrolling away.
+            <div className={styles.dividerBand}>
+              <span className={styles.hairline} aria-hidden="true" />
+              <div className={styles.toggle}>
+                <SegmentedControl
+                  segments={kViewSegments}
+                  selectedId={view}
+                  onSegmentChange={(id) => setView(id as RetryView)}
+                />
+              </div>
+              <span className={styles.hairline} aria-hidden="true" />
+            </div>
           )}
+          <div className={styles.content}>
+            {view === "error" || !hasEvents ? (
+              <ExpandablePanel
+                id={`retry-error-${listId}`}
+                collapse={true}
+                className={styles.errorPanel}
+              >
+                <ANSIDisplay
+                  output={retry.traceback_ansi}
+                  className={styles.ansi}
+                />
+              </ExpandablePanel>
+            ) : (
+              <RetryEventsView
+                retry={retry}
+                listId={listId}
+                scrollRef={scrollRef}
+              />
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryTerminalAnchor.tsx
@@ -19,7 +19,9 @@ export const RetryTerminalAnchor: FC<RetryTerminalAnchorProps> = ({
       </span>
       <div className={styles.copy}>
         <span className={styles.success}>This run succeeded</span>
-        <span className={styles.detail}>{`after ${retriesLabel}`}</span>
+        <span
+          className={styles.detail}
+        >{`after ${retriesLabel} — the sample you're viewing`}</span>
       </div>
     </div>
   );

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
 
-import { attemptDuration, deriveErrorType } from "./retryAttempt";
+import { attemptStartTime, deriveErrorType } from "./retryAttempt";
 
 function retry(partial: Partial<EvalRetryError>): EvalRetryError {
   return {
@@ -46,33 +46,28 @@ describe("deriveErrorType", () => {
   });
 });
 
-describe("attemptDuration", () => {
-  it("returns the span in seconds between first and last event timestamps", () => {
+describe("attemptStartTime", () => {
+  it("returns the earliest event timestamp regardless of event order", () => {
     const events = [
-      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
       { event: "error", timestamp: "2024-01-01T00:00:04.200Z" },
+      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
     ] as unknown as EvalRetryError["events"];
-    expect(attemptDuration(retry({ events }))).toBeCloseTo(4.2, 3);
+    expect(attemptStartTime(retry({ events }))?.toISOString()).toBe(
+      "2024-01-01T00:00:00.000Z"
+    );
   });
 
-  it("returns null when there are no events", () => {
-    expect(attemptDuration(retry({ events: null }))).toBeNull();
-    expect(attemptDuration(retry({ events: [] }))).toBeNull();
-  });
-
-  it("returns null when fewer than two events carry a timestamp", () => {
+  it("returns a start time from a single timestamped event", () => {
     const events = [
       { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
     ] as unknown as EvalRetryError["events"];
-    expect(attemptDuration(retry({ events }))).toBeNull();
+    expect(attemptStartTime(retry({ events }))?.toISOString()).toBe(
+      "2024-01-01T00:00:00.000Z"
+    );
   });
 
-  it("returns 0 when all events share the same timestamp", () => {
-    const ts = "2024-01-01T00:00:00.000Z";
-    const events = [
-      { event: "sample_init", timestamp: ts },
-      { event: "error", timestamp: ts },
-    ] as unknown as EvalRetryError["events"];
-    expect(attemptDuration(retry({ events }))).toBe(0);
+  it("returns null when no event carries a parseable timestamp", () => {
+    expect(attemptStartTime(retry({ events: null }))).toBeNull();
+    expect(attemptStartTime(retry({ events: [] }))).toBeNull();
   });
 });

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
@@ -25,11 +25,11 @@ export function deriveErrorType(retry: EvalRetryError): string | null {
 }
 
 /**
- * Best-effort attempt duration in seconds, derived ONLY from the event
- * timestamps. `EvalRetryError` carries no top-level duration; never fabricate
- * one. Returns null when it can't be computed.
+ * Best-effort attempt start time — the earliest event timestamp. `EvalRetryError`
+ * carries no top-level timing, so the events are the only source; never
+ * fabricate one. Returns null when no event carries a parseable timestamp.
  */
-export function attemptDuration(retry: EvalRetryError): number | null {
+export function attemptStartTime(retry: EvalRetryError): Date | null {
   const events = retry.events;
   if (!events || events.length === 0) return null;
 
@@ -39,7 +39,6 @@ export function attemptDuration(retry: EvalRetryError): number | null {
     .map((t) => Date.parse(t))
     .filter((n) => Number.isFinite(n));
 
-  if (times.length < 2) return null;
-  const span = (Math.max(...times) - Math.min(...times)) / 1000;
-  return span >= 0 ? span : null;
+  if (times.length === 0) return null;
+  return new Date(Math.min(...times));
 }


### PR DESCRIPTION
Refines the sample **Retries** panel to match the Direction B design handoff.

## This PR contains
- [x] Bug fix or new feature (UI refinement)
- [ ] Breaking change
- [x] Tests

## Current vs. new behavior
- **Attempt header** — was a two-line title with the start time stacked under "Attempt N" and a derived per-attempt duration on the right. Now a single line: **Attempt N** · error chip · truncated message, with the attempt's **start timestamp** right-aligned (monospace, `tabular-nums`). The confusing derived duration is removed.
- **Error / Events control** — moved out of the header's top-right corner and onto a **centered hairline divider band** at the top of the expanded card, so it stays visible under a long traceback instead of scrolling away.
- **Terminal anchor** — copy now reads "This run succeeded · after N retries — the sample you're viewing".

The panel chrome (timeline rail, status markers) and the reused `SegmentedControl` / transcript renderers are unchanged.

## Screenshot
![Sample retries panel](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/assets/retry-display-screenshot/retry-display.png)

## Breaking changes
None.

## Other information
- `attemptDuration()` (and its tests) removed as dead code once the duration display was dropped; the timestamp-parsing is inlined into the new `attemptStartTime()` helper.
- Verified with `pnpm check` (24/24 tasks) and the `retry-display` vitest suite (18 tests).
