### PR TITLE
fix(view): fall back to proxy when the browser can't fetch S3 segments

### DIFF
--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 
 import { openRemoteLogFile } from "../remote/remoteLogFile";
+import { DirectFetchError } from "../remote/remotePendingSampleData";
 
 import { clientApi } from "./client-api";
 import {
@@ -95,6 +96,28 @@ describe("clientApi.get_log_sample_data path selection", () => {
     await client.get_log_sample_data!("log.eval", "s1", 0);
 
     expect(proxy).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to proxy when the direct probe can't fetch segments (CORS)", async () => {
+    const direct = vi
+      .fn()
+      .mockRejectedValue(new DirectFetchError("Failed to fetch segment"));
+    const proxy = vi.fn().mockResolvedValue(okResponse());
+    const api: LogViewAPI = {
+      ...baseApi(),
+      eval_log_sample_data: proxy,
+      eval_log_sample_data_direct: direct,
+    };
+    const client = clientApi(api);
+
+    const first = await client.get_log_sample_data!("log.eval", "s1", 0);
+    const second = await client.get_log_sample_data!("log.eval", "s1", 0);
+
+    expect(first?.status).toBe("OK");
+    expect(second?.status).toBe("OK");
+    // Probed direct once, then pinned proxy for this log.
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(proxy).toHaveBeenCalledTimes(2);
   });
 
   test("real errors from the direct probe bubble up and don't pin a path", async () => {

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -11,6 +11,7 @@ import {
   RemoteLogFile,
   SampleNotFoundError,
 } from "../remote/remoteLogFile";
+import { DirectFetchError } from "../remote/remotePendingSampleData";
 import { FileSizeLimitError } from "../remote/remoteZipFile";
 
 import {
@@ -407,9 +408,8 @@ export const clientApi = (
       throw new Error("API doesn't supported streamed sample data");
     }
 
-    let path = sampleDataPathByLog.get(log_file);
-    if (path === undefined && api.eval_log_sample_data_direct) {
-      const probe = await api.eval_log_sample_data_direct(
+    const fetchViaProxy = () =>
+      api.eval_log_sample_data!(
         log_file,
         id,
         epoch,
@@ -418,9 +418,36 @@ export const clientApi = (
         last_message_pool,
         last_call_pool
       );
-      if (probe !== undefined) {
-        sampleDataPathByLog.set(log_file, "direct");
-        return probe;
+
+    // A presigned segment fetch that the browser couldn't complete (e.g. bucket
+    // CORS on the viewer origin) means direct is unusable here even though the
+    // view server can reach storage — pin proxy and stream same-origin instead.
+    const fallBackToProxy = (e: unknown) => {
+      if (!(e instanceof DirectFetchError)) {
+        throw e;
+      }
+      sampleDataPathByLog.set(log_file, "proxy");
+      return fetchViaProxy();
+    };
+
+    let path = sampleDataPathByLog.get(log_file);
+    if (path === undefined && api.eval_log_sample_data_direct) {
+      try {
+        const probe = await api.eval_log_sample_data_direct(
+          log_file,
+          id,
+          epoch,
+          last_event,
+          last_attachment,
+          last_message_pool,
+          last_call_pool
+        );
+        if (probe !== undefined) {
+          sampleDataPathByLog.set(log_file, "direct");
+          return probe;
+        }
+      } catch (e) {
+        return fallBackToProxy(e);
       }
     }
     if (path === undefined) {
@@ -429,33 +456,29 @@ export const clientApi = (
     }
 
     if (path === "direct") {
-      const result = await api.eval_log_sample_data_direct!(
-        log_file,
-        id,
-        epoch,
-        last_event,
-        last_attachment,
-        last_message_pool,
-        last_call_pool
-      );
-      if (result === undefined) {
-        // Probe succeeded but a later call says "not supported" — server state
-        // changed; fail loudly rather than silently switching paths.
-        throw new Error(
-          "Direct pending-sample-data path returned 'not supported' after probe"
+      try {
+        const result = await api.eval_log_sample_data_direct!(
+          log_file,
+          id,
+          epoch,
+          last_event,
+          last_attachment,
+          last_message_pool,
+          last_call_pool
         );
+        if (result === undefined) {
+          // Probe succeeded but a later call says "not supported" — server state
+          // changed; fail loudly rather than silently switching paths.
+          throw new Error(
+            "Direct pending-sample-data path returned 'not supported' after probe"
+          );
+        }
+        return result;
+      } catch (e) {
+        return fallBackToProxy(e);
       }
-      return result;
     }
-    return api.eval_log_sample_data(
-      log_file,
-      id,
-      epoch,
-      last_event,
-      last_attachment,
-      last_message_pool,
-      last_call_pool
-    );
+    return fetchViaProxy();
   };
 
   const middleware = debug

--- a/apps/inspect/src/client/remote/remotePendingSampleData.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.ts
@@ -10,6 +10,17 @@ import { openZipFileFromBuffer } from "./remoteZipFile";
 // under ~1s at typical segment sizes.
 const SEGMENT_CAP_PER_CALL = 25;
 
+// The browser reached the view server for presigned URLs but couldn't fetch the
+// segment bytes directly from storage (e.g. missing bucket CORS on the viewer
+// origin, or blocked network). Distinct from other failures so callers can
+// degrade to the proxy transport, which streams the same bytes same-origin.
+export class DirectFetchError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "DirectFetchError";
+  }
+}
+
 export type GetPendingSampleDataUrls = (
   log_file: string,
   id: string | number,
@@ -104,13 +115,28 @@ const readSegment = async (seg: SegmentRef): Promise<SampleData> => {
   const url = seg.direct_url as string;
   // Whole-zip fetch: segments contain one member per (sample, epoch), so
   // the zip is ~the member plus trivial framing — ranging buys nothing.
-  const resp = await fetch(url);
-  if (!resp.ok) {
-    throw new Error(
-      `Failed to fetch segment: ${resp.status} ${resp.statusText}`
-    );
+  let bytes: Uint8Array;
+  try {
+    const resp = await fetch(url);
+    // fetch() never rejects on HTTP status, so surface a non-ok response as a
+    // failed direct fetch too (falls back to proxy, same as a rejection).
+    if (!resp.ok) {
+      throw new DirectFetchError(
+        `Failed to fetch segment: ${resp.status} ${resp.statusText}`
+      );
+    }
+    bytes = new Uint8Array(await resp.arrayBuffer());
+  } catch (e) {
+    if (e instanceof DirectFetchError) {
+      throw e;
+    }
+    // fetch()/body reads reject with an opaque TypeError for any network-layer
+    // failure (CORS, DNS, connection, blocked) and never for HTTP status — we
+    // can't tell which, so treat any failure as "direct unusable" and use proxy.
+    throw new DirectFetchError(`Failed to fetch segment: ${String(e)}`, {
+      cause: e,
+    });
   }
-  const bytes = new Uint8Array(await resp.arrayBuffer());
   const zip = await openZipFileFromBuffer(bytes);
   const memberBytes = await zip.readFile(seg.member_name);
   return await asyncJsonParseBytes(memberBytes);


### PR DESCRIPTION
## Summary

The direct pending-sample transport hands the **browser** presigned S3 URLs and fetches segment bytes straight from storage. When those browser-side fetches fail (e.g. the bucket lacks a CORS rule for the viewer origin, or the network to S3 is blocked) — but the view server itself can still reach storage — live event streaming stalled entirely until the sample completed and the final `.eval` log could be read.

This makes the direct transport a best-effort optimization: browser-side segment-fetch failures now degrade to the proxy transport (which streams the same bytes same-origin, through the view server) instead of erroring the poll.

## Current behavior

A rejected `fetch` / non-OK response when pulling a presigned segment throws and propagates out of `get_log_sample_data` (the probe is not wrapped), so the poll keeps failing. Live viewing shows nothing until completion. There is no fallback to the proxy path even though the server can serve the data.

## New behavior

- Browser-side segment-fetch failures are tagged as a new `DirectFetchError`.
- `get_log_sample_data` catches `DirectFetchError` on both the probe and committed-direct calls and falls back to the proxy transport, pinning `proxy` for that log.
- All other errors still bubble up unchanged (genuine server/network faults are not masked; the existing "real errors bubble up and don't pin a path" behavior is preserved).

## Breaking changes

None.

## Other info

- Regression test added: a `DirectFetchError` from the probe falls back to proxy and pins it; the existing generic-error test confirms non-`DirectFetchError` errors still bubble.
- Note: the proxy transport does not emit `has_more`, so features driven by it (e.g. the live "loading events" indicator) are direct-path only; this change restores event streaming under the fallback, not those direct-only affordances. The durable fix for the indicator is bucket CORS on the viewer origin.
- `pnpm check` green (24/24); `client-api` + `remotePendingSampleData` suites pass (22 tests).
