### PR TITLE
fix(view): load a newly selected sample when leaving a running one

### DIFF
--- a/apps/inspect/src/state/useLoadSample.test.ts
+++ b/apps/inspect/src/state/useLoadSample.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldLoadSample } from "./useLoadSample";
+
+const base = {
+  identifierMatches: false,
+  hasSampleData: false,
+  isLoading: false,
+  isError: false,
+  logFileChanged: false,
+  sampleIdChanged: false,
+  completedChanged: false,
+  needsReloadChanged: false,
+};
+
+describe("shouldLoadSample", () => {
+  it("loads a newly selected sample even while a previous sample is still streaming", () => {
+    // Regression: navigating away from a running sample leaves status
+    // "streaming" (isLoading true) for the *previous* sample. On a remount the
+    // change flags are all false, so this must still trigger a load — the
+    // stale streaming status is for a different sample (identifier mismatch).
+    expect(
+      shouldLoadSample({ ...base, identifierMatches: false, isLoading: true })
+    ).toBe(true);
+  });
+
+  it("does not reload while the selected sample is itself loading", () => {
+    // Identifier matches but data not yet present: a load is in flight for
+    // this sample, so don't re-trigger.
+    expect(
+      shouldLoadSample({
+        ...base,
+        identifierMatches: true,
+        hasSampleData: false,
+        isLoading: true,
+      })
+    ).toBe(false);
+  });
+
+  it("does not reload when the selected sample is already loaded", () => {
+    expect(
+      shouldLoadSample({
+        ...base,
+        identifierMatches: true,
+        hasSampleData: true,
+      })
+    ).toBe(false);
+  });
+
+  it("loads a newly selected sample after a previous sample errored", () => {
+    expect(
+      shouldLoadSample({ ...base, identifierMatches: false, isError: true })
+    ).toBe(true);
+  });
+
+  it("does not reload the selected sample when it is the one in error", () => {
+    expect(
+      shouldLoadSample({ ...base, identifierMatches: true, isError: true })
+    ).toBe(false);
+  });
+
+  it("reloads when a meaningful change flag is set", () => {
+    expect(shouldLoadSample({ ...base, sampleIdChanged: true })).toBe(true);
+    expect(shouldLoadSample({ ...base, needsReloadChanged: true })).toBe(true);
+  });
+});

--- a/apps/inspect/src/state/useLoadSample.ts
+++ b/apps/inspect/src/state/useLoadSample.ts
@@ -22,6 +22,37 @@ const log = createLogger("useSampleLoader");
 let loadGeneration = 0;
 
 /**
+ * Decide whether the loader should (re)load the selected sample.
+ *
+ * A "loading"/"error" status left over from a previously viewed sample must
+ * not block loading a newly selected one, so those only suppress a load when
+ * they pertain to the selected sample itself (identifier matches). Without
+ * this, navigating away from a still-"streaming" running sample leaves the
+ * new sample unloaded and the tabs showing the previous sample's events.
+ */
+export const shouldLoadSample = (opts: {
+  identifierMatches: boolean;
+  hasSampleData: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  logFileChanged: boolean;
+  sampleIdChanged: boolean;
+  completedChanged: boolean;
+  needsReloadChanged: boolean;
+}): boolean => {
+  const isCurrentSampleLoaded = opts.identifierMatches && opts.hasSampleData;
+  const loadingSelected = opts.identifierMatches && opts.isLoading;
+  const errorSelected = opts.identifierMatches && opts.isError;
+  return (
+    (!isCurrentSampleLoaded && !loadingSelected && !errorSelected) ||
+    opts.logFileChanged ||
+    opts.sampleIdChanged ||
+    opts.completedChanged ||
+    opts.needsReloadChanged
+  );
+};
+
+/**
  * Hook that handles loading samples based on the current log selection.
  * Contains the full sample loading logic that was previously in sampleSlice.loadSample.
  */
@@ -177,7 +208,6 @@ export function useLoadSample() {
         sampleData.selectedSampleIdentifier?.epoch === sampleEpoch &&
         sampleData.selectedSampleIdentifier?.logFile === logSelection.logFile;
       const hasSampleData = getSelectedSample() !== undefined;
-      const isCurrentSampleLoaded = identifierMatches && hasSampleData;
 
       // Check if we're currently loading
       const isLoading =
@@ -198,15 +228,16 @@ export function useLoadSample() {
         prev.sampleNeedsReload !== undefined &&
         prev.sampleNeedsReload !== sampleData.sampleNeedsReload;
 
-      // Only load if:
-      // 1. The current sample is not already loaded AND not currently loading, OR
-      // 2. Something meaningful changed (log file, sample ID, completed status, or reload flag)
-      const shouldLoad =
-        (!isCurrentSampleLoaded && !isLoading && !isError) ||
-        logFileChanged ||
-        sampleIdChanged ||
-        completedChanged ||
-        needsReloadChanged;
+      const shouldLoad = shouldLoadSample({
+        identifierMatches,
+        hasSampleData,
+        isLoading,
+        isError,
+        logFileChanged,
+        sampleIdChanged,
+        completedChanged,
+        needsReloadChanged,
+      });
 
       if (shouldLoad) {
         void loadSample(


### PR DESCRIPTION
## Summary

Navigating from a **running** sample to a different **completed** sample showed the previous sample's data in the tabs while the header correctly showed the newly selected sample.

Root cause (found via instrumentation): the sample-detail view **remounts** on navigation, so `useLoadSample`'s `prevRef` resets and all the "meaningful change" load triggers (`sampleIdChanged`, `completedChanged`, …) evaluate false. The remaining fallback trigger `!isCurrentSampleLoaded && !isLoading && !isError` was defeated because the store's `status` was still `"streaming"` — left over from the *previous* running sample — so `isLoading` was true and the loader treated the new sample as "already loading." `loadSample` therefore never ran, `prepareForSampleLoad` never cleared the previous `runningEvents`, and the tabs rendered stale data.

## Current behavior

A `"streaming"`/`"error"` status belonging to a previously-viewed sample suppresses loading a newly selected one after a remount, leaving stale events in the transcript/messages tabs.

## New behavior

The load decision is extracted into a pure, tested `shouldLoadSample()`. A `loading`/`error` status only blocks a load when it pertains to the **selected** sample (its identifier matches) — a status lingering from a different sample no longer suppresses the load. `loadSample` now runs, clears the previous sample's data, and loads the new one.

## Breaking changes

None.

## Other info

- Pre-existing bug (this file is unchanged from `main`); it surfaces more readily now that live sample streaming works and users navigate away from genuinely-streaming samples.
- Regression test added (`useLoadSample.test.ts`) covering: load-on-navigation while a previous sample streams; no reload while the selected sample is itself loading; no reload when already loaded; load after a previous sample errored; and the meaningful-change triggers.
- `pnpm check` green (24/24); new tests pass (6).
