### PR TITLE
fix(view): reopen a sample from the log list after navigating back to it

### DIFF
--- a/apps/inspect/src/app/samples/list/SampleList.tsx
+++ b/apps/inspect/src/app/samples/list/SampleList.tsx
@@ -14,8 +14,9 @@ import { MessageBand } from "../../../components/MessageBand";
 import { useDocumentTitle } from "../../../state/hooks";
 import { useStore } from "../../../state/store";
 import { useSampleNavigation } from "../../routing/sampleNavigation";
+import { useLogRouteParams } from "../../routing/url";
 import { openInNewTab } from "../../shared/openInNewTab";
-import { isCurrentSample } from "../../shared/sample";
+import { isSampleOpenInRoute } from "../../shared/sample";
 import { SamplesGrid } from "../../shared/samples-grid/SamplesGrid";
 import { SampleRow } from "../../shared/samples-grid/types";
 
@@ -76,6 +77,7 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
   }, [listHandle, selectedLogFile]);
 
   const sampleNavigation = useSampleNavigation();
+  const { sampleId: routeSampleId, epoch: routeEpoch } = useLogRouteParams();
   const selectedSampleHandle = useStore(
     (state) => state.log.selectedSampleHandle
   );
@@ -93,15 +95,24 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
         const url = sampleNavigation.getSampleUrl(row.sampleId, row.epoch);
         if (url) openInNewTab(url);
       } else {
-        // Re-clicking the open sample would re-run selectSample + navigate and
-        // trigger a redundant reload of the same sample — skip it.
-        if (isCurrentSample(selectedSampleHandle, row.sampleId, row.epoch)) {
+        // Re-clicking the sample that's currently open in the detail view
+        // would re-run selectSample + navigate redundantly — skip only that.
+        // Keyed off the route (not selectedSampleHandle, which persists after
+        // navigating back to the log and would wrongly ignore the re-click).
+        if (
+          isSampleOpenInRoute(
+            routeSampleId,
+            routeEpoch,
+            row.sampleId,
+            row.epoch
+          )
+        ) {
           return;
         }
         sampleNavigation.showSample(row.sampleId, row.epoch);
       }
     },
-    [sampleNavigation, selectedSampleHandle]
+    [sampleNavigation, routeSampleId, routeEpoch]
   );
 
   const getRowId = useCallback(

--- a/apps/inspect/src/app/shared/sample.test.ts
+++ b/apps/inspect/src/app/shared/sample.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isCurrentSample } from "./sample";
+import { isCurrentSample, isSampleOpenInRoute } from "./sample";
 
 const handle = (id: string | number, epoch: number) => ({
   id,
@@ -18,5 +18,23 @@ describe("isCurrentSample", () => {
     expect(isCurrentSample(handle(1, 0), 2, 0)).toBe(false);
     expect(isCurrentSample(handle(1, 0), 1, 1)).toBe(false);
     expect(isCurrentSample(undefined, 1, 0)).toBe(false);
+  });
+});
+
+describe("isSampleOpenInRoute", () => {
+  it("is false when no sample is in the route (log list showing)", () => {
+    // Regression: selectedSampleHandle persists after navigating back to the
+    // log, but no sample is in the route — re-clicking must not be skipped.
+    expect(isSampleOpenInRoute(undefined, undefined, "s1", 0)).toBe(false);
+  });
+
+  it("is true when the route's sample matches the row", () => {
+    expect(isSampleOpenInRoute("s1", "0", "s1", 0)).toBe(true);
+    expect(isSampleOpenInRoute("1", "2", 1, 2)).toBe(true);
+  });
+
+  it("is false when the route's sample differs from the row", () => {
+    expect(isSampleOpenInRoute("s2", "0", "s1", 0)).toBe(false);
+    expect(isSampleOpenInRoute("s1", "1", "s1", 0)).toBe(false);
   });
 });

--- a/apps/inspect/src/app/shared/sample.ts
+++ b/apps/inspect/src/app/shared/sample.ts
@@ -27,6 +27,24 @@ export const isCurrentSample = (
   handle.epoch === epoch &&
   sampleIdsEqual(handle.id, id);
 
+/**
+ * Whether a row is the sample currently open in the detail route.
+ *
+ * Keyed off the route (undefined id/epoch means the log list is showing), not
+ * the persisted selectedSampleHandle — that lingers after navigating back to
+ * the log, so using it would wrongly skip re-opening the same sample.
+ */
+export const isSampleOpenInRoute = (
+  routeSampleId: string | undefined,
+  routeEpoch: string | undefined,
+  rowSampleId: string | number,
+  rowEpoch: number
+): boolean =>
+  routeSampleId !== undefined &&
+  routeEpoch !== undefined &&
+  sampleIdsEqual(routeSampleId, rowSampleId) &&
+  Number(routeEpoch) === rowEpoch;
+
 export const sampleHandlesEqual = (
   sample1?: SampleHandle,
   sample2?: SampleHandle


### PR DESCRIPTION
## Summary

Clicking a sample in the log's samples list, navigating back to the log, then clicking the **same** sample again did nothing — the click was silently ignored.

## Current behavior

`SampleList`'s row-open handler skips the click when the row matches `selectedSampleHandle` (an optimization to avoid re-opening the sample you're already viewing). But `selectedSampleHandle` **persists after navigating back to the log** — it deliberately drives the list's row highlight and prev/next navigation — so the guard treats a re-click of that same sample *from the list* as "already open" and ignores it.

## New behavior

The "skip re-click" guard is keyed off the **detail route** (`isSampleOpenInRoute(routeSampleId, routeEpoch, …)`), which is the real source of truth for which sample is currently open. On the log list (no sample in the route) a click always navigates; when a sample is open, re-clicking that same one is still skipped. `selectedSampleHandle` is left untouched, so row highlight and prev/next still work.

## Breaking changes

None.

## Other info

- Pre-existing bug (this file is unchanged from `main`).
- Added `isSampleOpenInRoute` helper with unit tests, including the regression case (no sample in route → don't skip).
- `pnpm check` green (24/24); tests pass.
