### PR TITLE
Regenerate scout types for the widened events filter enum

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1758,7 +1758,7 @@ export interface components {
          */
         GrepSearchRequest: {
             /** Events */
-            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "span_begin" | "span_end") | string)[] | null;
+            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "input" | "sample_init" | "sample_limit" | "score" | "score_edit" | "state" | "anchor" | "checkpoint" | "interrupt" | "span_begin" | "span_end") | string)[] | null;
             /**
              * Ignore Case
              * @default true
@@ -2083,7 +2083,7 @@ export interface components {
          */
         LlmSearchRequest: {
             /** Events */
-            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "span_begin" | "span_end") | string)[] | null;
+            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "input" | "sample_init" | "sample_limit" | "score" | "score_edit" | "state" | "anchor" | "checkpoint" | "interrupt" | "span_begin" | "span_end") | string)[] | null;
             /** Messages */
             messages?: "all" | ("system" | "user" | "assistant" | "tool")[] | null;
             /** Model */


### PR DESCRIPTION
## Summary

Regenerates `apps/scout/src/types/generated.ts` so the `events` enum in `GrepSearchRequest`/`LlmSearchRequest` matches the `openapi.json` committed in meridianlabs-ai/inspect_scout#492, which inspect_scout CI compares byte for byte.

That PR widens `EventType` to cover every member of inspect_ai's `Event` union bar the deprecated `step`/`subtask`. `generated.ts` is derived, so the change originates there; this is the matching regeneration.

No functional change: the property already fell back to `| string`, so this only narrows what autocompletes.