### PR TITLE
Add 'manual' to ConnectionLimitChange reason type

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1029,11 +1029,8 @@ export interface components {
             new_limit: number;
             /** Old Limit */
             old_limit: number;
-            /**
-             * Reason
-             * @enum {string}
-             */
-            reason: "slow_start" | "steady_state_up" | "rate_limit";
+            /** Reason */
+            reason: ("slow_start" | "steady_state_up" | "rate_limit") | "manual";
             /** Timestamp */
             timestamp: number;
         };


### PR DESCRIPTION
Regenerated `generated.ts` from `inspect-openapi.json`: control-channel `max_connections` retunes (reason=`manual`) are now captured into the eval log's `connection_limit_history` instead of being skipped, so the schema's `reason` type gains `"manual"`.

Companion to UKGovernmentBEIS/inspect_ai#4410 (the inspect_ai side regenerates `inspect-openapi.json` and bumps the submodule pointer once this lands on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)