### PR TITLE
Enable inspect e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,6 +146,10 @@ jobs:
   e2e:
     continue-on-error: true  # TODO: remove once e2e tests prove stable
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [scout, inspect]
     steps:
       - uses: actions/checkout@v7
 
@@ -162,7 +166,7 @@ jobs:
 
       - name: Get Playwright version
         id: pw-version
-        run: echo "version=$(pnpm --filter scout exec playwright --version)" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(pnpm --filter ./apps/${{ matrix.app }} exec playwright --version)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         id: pw-cache
@@ -173,19 +177,19 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter scout exec playwright install --with-deps chromium
+        run: pnpm --filter ./apps/${{ matrix.app }} exec playwright install --with-deps chromium
 
       - name: Install Playwright system deps (on cache hit)
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter scout exec playwright install-deps chromium
+        run: pnpm --filter ./apps/${{ matrix.app }} exec playwright install-deps chromium
 
       - name: Run e2e tests
-        run: pnpm --filter scout e2e
+        run: pnpm --filter ./apps/${{ matrix.app }} e2e
 
       - name: Upload test results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report
-          path: apps/scout/playwright-report/
+          name: playwright-report-${{ matrix.app }}
+          path: apps/${{ matrix.app }}/playwright-report/
           retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,13 +143,56 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      e2e-apps: ${{ steps.apps.outputs.apps }}
+    steps:
+      # An app's e2e tests are implicated by any change outside the *other*
+      # app (its own code, shared packages, tooling, lockfile, workflows),
+      # excluding docs.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: every
+          filters: |
+            scout:
+              - '!apps/inspect/**'
+              - '!docs/**'
+              - '!**/*.md'
+            inspect:
+              - '!apps/scout/**'
+              - '!docs/**'
+              - '!**/*.md'
+
+      - name: Compute affected apps
+        id: apps
+        env:
+          EVENT: ${{ github.event_name }}
+          SCOUT: ${{ steps.filter.outputs.scout }}
+          INSPECT: ${{ steps.filter.outputs.inspect }}
+        run: |
+          apps=()
+          if [[ "$EVENT" != "pull_request" ]]; then
+            apps=(scout inspect)
+          else
+            if [[ "$SCOUT" == "true" ]]; then apps+=(scout); fi
+            if [[ "$INSPECT" == "true" ]]; then apps+=(inspect); fi
+          fi
+          echo "apps=$(jq -nc '$ARGS.positional' --args -- "${apps[@]}")" >> "$GITHUB_OUTPUT"
+
   e2e:
+    needs: changes
+    if: needs.changes.outputs.e2e-apps != '[]'
     continue-on-error: true  # TODO: remove once e2e tests prove stable
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        app: [scout, inspect]
+        app: ${{ fromJSON(needs.changes.outputs.e2e-apps) }}
     steps:
       - uses: actions/checkout@v7
 
@@ -193,3 +236,22 @@ jobs:
           name: playwright-report-${{ matrix.app }}
           path: apps/${{ matrix.app }}/playwright-report/
           retention-days: 7
+
+  # Fan-in for branch protection: the required check is named "e2e", but the
+  # matrix reports per-app checks whose names (and presence) vary with the
+  # paths filter. This job always runs and reports a single stable status.
+  e2e-status:
+    name: e2e
+    needs: e2e
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check e2e matrix result
+        env:
+          RESULT: ${{ needs.e2e.result }}
+        run: |
+          echo "e2e matrix result: $RESULT"
+          if [[ "$RESULT" == "success" || "$RESULT" == "skipped" ]]; then
+            exit 0
+          fi
+          exit 1


### PR DESCRIPTION
CI previously ran e2e tests only for the `scout` app. This enables the `inspect` app's e2e suite in CI as well, skips e2e legs a PR doesn't implicate, and fixes the required `e2e` check that the matrix rename orphaned.

## Changes

- Converted the e2e job to a matrix over `app: [scout, inspect]` with `fail-fast: false` so one app's failure doesn't cancel the other
- Switched pnpm filters from `--filter scout` to directory-based `--filter ./apps/${{ matrix.app }}` (the inspect package is named `@meridianlabs/log-viewer`)
- Suffixed the Playwright report artifact per app (`playwright-report-${{ matrix.app }}`) so uploads don't collide
- Added a `changes` job (dorny/paths-filter) that feeds the e2e matrix dynamically: changes confined to `apps/scout/**` skip the inspect leg and vice versa; anything shared (packages, tooling, lockfile, workflows) runs both; docs/markdown-only changes run neither. Non-PR events (push to main, manual dispatch) always run both.
- Added an always-run `e2e` fan-in job for branch protection: the required check is named `e2e`, but the matrix reports per-app checks whose names (and presence, with the paths filter) vary — so PRs were stuck on "Expected — waiting for status to be reported". The fan-in job reports a single stable `e2e` status and treats a fully-skipped matrix as success.

Both apps pin the same Playwright version, so the two matrix legs share one browser cache entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f9sq5id4h8Az6WYYEt74k