### PR TITLE
Enable strict unnecessary condition linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,15 @@ TypeScript monorepo sharing code between inspect_ai, inspect_scout, vs code exte
   - A cast is a last resort for boundaries TypeScript can't express, with
     a comment saying why
 
+  **Parsed data: the types lie (#555).** Eval logs, journal files, API
+  responses, and persisted state are cast at the boundary, not validated —
+  old files omit fields the types declare required. Defensive `?.`/guards
+  on such data are intentional; do not remove them because the type (or
+  `no-unnecessary-condition`) says they're impossible. They carry
+  suppressions marked `intentional: data isn't validated at the wire
+  (#555)` and can only be removed by fixing issue #555 (validate at the
+  boundary).
+
 ## Code Style — Comments                                                       
                                                                                 
   Add comments only for non-obvious decisions:                                  

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -81,6 +81,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // a different scope (different dir), so each folder also remembers its
   // own state. `undefined` until logDir hydrates so we never write under
   // a half-initialized scope.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const scopeKey = logDir === undefined ? undefined : `${mode}::${currentDir}`;
 
   // Cache identity of the row universe: the listing/overview queries depend

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { useCallback, useMemo } from "react";
 

--- a/apps/inspect/src/app/log-list/grid/logListRow.ts
+++ b/apps/inspect/src/app/log-list/grid/logListRow.ts
@@ -17,7 +17,7 @@ export const buildLogListRow = (item: LogListItem): LogListRow => {
   const derived = log?.derived;
 
   const taskArgsSource =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     details?.eval?.task_args_passed ?? details?.eval?.task_args;
 
   const row: LogListRow = {
@@ -46,11 +46,11 @@ export const buildLogListRow = (item: LogListItem): LogListRow => {
     path: item.type === "file" ? item.name : undefined,
     totalSamples: details?.results?.total_samples,
     completedSamples: details?.results?.completed_samples,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     sandbox: details?.eval?.sandbox?.type,
     totalTokens: derived?.total_tokens,
     duration: derived?.duration,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     taskFile: details?.eval?.task_file ?? undefined,
     taskArgs: derived?.task_args,
     taskArgsRaw: taskArgsSource ?? undefined,

--- a/apps/inspect/src/app/log-list/grid/logListRow.ts
+++ b/apps/inspect/src/app/log-list/grid/logListRow.ts
@@ -17,6 +17,7 @@ export const buildLogListRow = (item: LogListItem): LogListRow => {
   const derived = log?.derived;
 
   const taskArgsSource =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     details?.eval?.task_args_passed ?? details?.eval?.task_args;
 
   const row: LogListRow = {
@@ -45,9 +46,11 @@ export const buildLogListRow = (item: LogListItem): LogListRow => {
     path: item.type === "file" ? item.name : undefined,
     totalSamples: details?.results?.total_samples,
     completedSamples: details?.results?.completed_samples,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     sandbox: details?.eval?.sandbox?.type,
     totalTokens: derived?.total_tokens,
     duration: derived?.duration,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     taskFile: details?.eval?.task_file ?? undefined,
     taskArgs: derived?.task_args,
     taskArgsRaw: taskArgsSource ?? undefined,

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -50,7 +50,9 @@ export const LogSampleDetailView: FC = () => {
 
   // Use route params if available, otherwise fall back to state
   const logPath = routeLogPath || selectedLogFile;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const sampleId = routeSampleId || selectedSampleHandle?.id?.toString();
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const epoch = routeEpoch || selectedSampleHandle?.epoch?.toString();
 
   // Load the log and select the sample when route params change

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -50,9 +50,9 @@ export const LogSampleDetailView: FC = () => {
 
   // Use route params if available, otherwise fall back to state
   const logPath = routeLogPath || selectedLogFile;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const sampleId = routeSampleId || selectedSampleHandle?.id?.toString();
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const epoch = routeEpoch || selectedSampleHandle?.epoch?.toString();
 
   // Load the log and select the sample when route params change

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -99,6 +99,7 @@ export const LogView: FC = () => {
   // in a contravariant position.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tabs: Record<string, TabDescriptor<any>> = {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     ...(samplesTabConfig ? { samples: samplesTabConfig } : {}),
     task: taskTabConfig,
     model: modelsTabConfig,
@@ -130,7 +131,7 @@ export const LogView: FC = () => {
 
   const onSelected = useCallback(
     (e: MouseEvent<HTMLElement>) => {
-      const id = e.currentTarget?.id;
+      const id = e.currentTarget.id;
       if (id) {
         setSelectedTab(id);
         navigation.selectTab(id);
@@ -147,6 +148,7 @@ export const LogView: FC = () => {
     );
   } else {
     const tabTools = Object.values(tabs)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       .filter((tab) => tab !== undefined)
       .filter((tab) => {
         return tab.id === selectedTab;

--- a/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
@@ -130,8 +130,8 @@ export const ModelTab: FC<ModelTabProps> = ({
         }}
       >
         <UsagePanel
-          model_usage={hasModelUsage ? evalStats?.model_usage : undefined}
-          role_usage={hasRoleUsage ? evalStats?.role_usage : undefined}
+          model_usage={hasModelUsage ? evalStats.model_usage : undefined}
+          role_usage={hasRoleUsage ? evalStats.role_usage : undefined}
           configs_by_model={configsByModel}
           configs_by_role={configsByRole}
           args_by_model={argsByModel}

--- a/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/TaskTab.tsx
@@ -75,6 +75,7 @@ export const TaskTab: FC<TaskTabProps> = ({
   };
 
   if (revision) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const revisionKey = `${revision.type ? `${toTitleCase(revision.type)} ` : ""}Revision`;
     const commitUrl = ghCommitUrl(revision.origin, revision.commit);
     taskInformation[revisionKey] = commitUrl
@@ -103,14 +104,14 @@ export const TaskTab: FC<TaskTabProps> = ({
   }
 
   if (evalSpec?.sandbox) {
-    if (Array.isArray(evalSpec?.sandbox)) {
+    if (Array.isArray(evalSpec.sandbox)) {
       taskInformation["sandbox"] = evalSpec.sandbox[0];
       if (evalSpec.sandbox[1]) {
         taskInformation["sandbox_config"] = evalSpec.sandbox[1];
       }
     } else {
-      taskInformation["sandbox"] = evalSpec?.sandbox.type;
-      taskInformation["sandbox_config"] = evalSpec?.sandbox.config;
+      taskInformation["sandbox"] = evalSpec.sandbox.type;
+      taskInformation["sandbox_config"] = evalSpec.sandbox.config;
     }
   }
 

--- a/apps/inspect/src/app/log-view/tabs/timeline/HistoryList.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/HistoryList.tsx
@@ -240,6 +240,7 @@ export const HistoryList: FC<HistoryListProps> = ({
                         matching limitLifted and changeText. */}
                     {change.value === null &&
                     change.previous !== null &&
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                     change.previous !== undefined ? (
                       <span className={styles.muted}> (limit lifted)</span>
                     ) : null}

--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
@@ -1310,7 +1310,7 @@ const scoreRowsFor = (
   return Object.entries(sample.scores).map(([name, score]) => ({
     key: name,
     name,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     value: formatShort(score?.value),
     scoreType: kScoreTypeOther,
   }));

--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
@@ -107,6 +107,7 @@ const sampleTokens = (sample: SampleSummary): number | undefined => {
   if (!usage) return undefined;
   let total = 0;
   for (const u of Object.values(usage)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     total += u.total_tokens ?? 0;
   }
   return total > 0 ? total : undefined;
@@ -1294,18 +1295,22 @@ const scoreRowsFor = (
 ): ScoreRow[] => {
   if (!sample.scores) return [];
   if (evalDescriptor && evalDescriptor.scores.length > 0) {
-    return evalDescriptor.scores
-      .map((label) => ({
-        key: `${label.scorer}.${label.name}`,
-        name: label.name,
-        value: evalDescriptor.score(sample, label)?.value,
-        scoreType: evalDescriptor.scoreDescriptor(label).scoreType,
-      }))
-      .filter((row) => row.value !== undefined && row.value !== null);
+    return (
+      evalDescriptor.scores
+        .map((label) => ({
+          key: `${label.scorer}.${label.name}`,
+          name: label.name,
+          value: evalDescriptor.score(sample, label)?.value,
+          scoreType: evalDescriptor.scoreDescriptor(label).scoreType,
+        }))
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        .filter((row) => row.value !== undefined && row.value !== null)
+    );
   }
   return Object.entries(sample.scores).map(([name, score]) => ({
     key: name,
     name,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     value: formatShort(score?.value),
     scoreType: kScoreTypeOther,
   }));

--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
@@ -247,12 +247,14 @@ const TimelineTabBody: FC<TimelineTabProps> = ({
     () =>
       window
         ? guideSegments(
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
             evalSpec?.config?.max_samples,
             "max_samples",
             markers,
             window
           )
         : [],
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     [evalSpec?.config?.max_samples, markers, window]
   );
 

--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
@@ -247,14 +247,14 @@ const TimelineTabBody: FC<TimelineTabProps> = ({
     () =>
       window
         ? guideSegments(
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
             evalSpec?.config?.max_samples,
             "max_samples",
             markers,
             window
           )
         : [],
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     [evalSpec?.config?.max_samples, markers, window]
   );
 

--- a/apps/inspect/src/app/log-view/tabs/timeline/timelineData.ts
+++ b/apps/inspect/src/app/log-view/tabs/timeline/timelineData.ts
@@ -155,6 +155,7 @@ const changeText = (change: ConfigValueChange): string => {
   if (
     change.value === null &&
     change.previous !== null &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     change.previous !== undefined
   ) {
     return `${change.name} lifted`;
@@ -220,6 +221,7 @@ export const configMarkers = (
         index,
         label,
         postRun: runEnd !== undefined && time > runEnd,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
         preRun: update.provenance.metadata?.["inherited"] === true,
       };
     })
@@ -505,6 +507,7 @@ export const historyRows = (inputs: HistoryInputs): HistoryRow[] => {
       kind: "config",
       time,
       postRun: runEnd !== undefined && time > runEnd,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
       preRun: update.provenance.metadata?.["inherited"] === true,
       update,
       index,
@@ -593,6 +596,7 @@ export const historyRows = (inputs: HistoryInputs): HistoryRow[] => {
         time,
         postRun: false,
         sample,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
         line: `${fallback.model} → ${fallback.fallback_model}${(fallback.count ?? 1) > 1 ? ` × ${fallback.count}` : ""}`,
       });
     }

--- a/apps/inspect/src/app/log-view/tabs/timeline/timelineData.ts
+++ b/apps/inspect/src/app/log-view/tabs/timeline/timelineData.ts
@@ -155,7 +155,7 @@ const changeText = (change: ConfigValueChange): string => {
   if (
     change.value === null &&
     change.previous !== null &&
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     change.previous !== undefined
   ) {
     return `${change.name} lifted`;
@@ -221,7 +221,7 @@ export const configMarkers = (
         index,
         label,
         postRun: runEnd !== undefined && time > runEnd,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
         preRun: update.provenance.metadata?.["inherited"] === true,
       };
     })
@@ -507,7 +507,7 @@ export const historyRows = (inputs: HistoryInputs): HistoryRow[] => {
       kind: "config",
       time,
       postRun: runEnd !== undefined && time > runEnd,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
       preRun: update.provenance.metadata?.["inherited"] === true,
       update,
       index,
@@ -596,7 +596,7 @@ export const historyRows = (inputs: HistoryInputs): HistoryRow[] => {
         time,
         postRun: false,
         sample,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
         line: `${fallback.model} → ${fallback.fallback_model}${(fallback.count ?? 1) > 1 ? ` × ${fallback.count}` : ""}`,
       });
     }

--- a/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.tsx
@@ -51,6 +51,7 @@ export const CollapsedTitleBar: FC<CollapsedTitleBarProps> = ({
     ? displayScorersFromRunningMetrics(runningMetrics)
     : toDisplayScorers(evalResults?.scores);
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const expandedScorers = expandGroupedMetrics(scorers ?? []);
   const totalMetrics = expandedScorers.reduce(
     (n, s) => n + s.metrics.length,
@@ -118,6 +119,7 @@ const InlineMetrics: FC<InlineMetricsProps> = ({ scorers }) => {
         key: `${scorerIdx}-${metricIdx}`,
         label: metricDisplayName(metric),
         value:
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           metric.value !== undefined && metric.value !== null
             ? formatPrettyDecimal(metric.value)
             : "n/a",

--- a/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
@@ -197,7 +197,7 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
   useEffect(() => {
     if (!showing) return;
     let cancelled = false;
-    if (api?.get_user_info) {
+    if (api.get_user_info) {
       api
         .get_user_info()
         .then((info) => {
@@ -301,13 +301,13 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
   };
 
   const canSave =
-    !submitting && hasChanges && author.trim().length > 0 && !!api?.edit_log;
+    !submitting && hasChanges && author.trim().length > 0 && !!api.edit_log;
 
   // Re-entry guard (see EditTagsDialog for rationale).
   const inFlightRef = useRef(false);
 
   const handleSave = async () => {
-    if (!canSave || inFlightRef.current || !api?.edit_log) return;
+    if (!canSave || inFlightRef.current || !api.edit_log) return;
     inFlightRef.current = true;
     // Don't clear `error` here — see EditTagsDialog for the no-flash
     // rationale. Delayed "Saving…" indicator likewise.

--- a/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
@@ -61,7 +61,7 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
   useEffect(() => {
     if (!showing) return;
     let cancelled = false;
-    if (api?.get_user_info) {
+    if (api.get_user_info) {
       api
         .get_user_info()
         .then((info) => {
@@ -117,7 +117,7 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
   };
 
   const canSave =
-    !submitting && hasChanges && author.trim().length > 0 && !!api?.edit_log;
+    !submitting && hasChanges && author.trim().length > 0 && !!api.edit_log;
 
   // Re-entry guard: prevents a second save from starting if the user
   // clicks twice before the first finishes. Kept in a ref (not state)
@@ -125,7 +125,7 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
   const inFlightRef = useRef(false);
 
   const handleSave = async () => {
-    if (!canSave || inFlightRef.current || !api?.edit_log) return;
+    if (!canSave || inFlightRef.current || !api.edit_log) return;
     inFlightRef.current = true;
     // NOTE: we intentionally do NOT call `setError(undefined)` here.
     // Clearing then re-setting the same error on a quick failure made

--- a/apps/inspect/src/app/log-view/title-view/PrimaryBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/PrimaryBar.tsx
@@ -89,9 +89,9 @@ export const PrimaryBar: FC<PrimaryBarProps> = ({
                   styles.taskModel,
                   "text-size-base"
                 )}
-                title={evalSpec?.model}
+                title={evalSpec.model}
               >
-                {evalSpec?.model}
+                {evalSpec.model}
               </div>
             ) : (
               ""

--- a/apps/inspect/src/app/log-view/title-view/ResultsPanel.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ResultsPanel.tsx
@@ -237,6 +237,7 @@ const VerticalMetric: FC<VerticalMetricProps> = ({
           styles.verticalMetricValue
         )}
       >
+        {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
         {metric.value !== undefined && metric.value !== null
           ? formatPrettyDecimal(metric.value)
           : "n/a"}

--- a/apps/inspect/src/app/log-view/title-view/ScoreGrid.test.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreGrid.test.tsx
@@ -56,7 +56,7 @@ const renderedScorers = () =>
   screen
     .getAllByRole("row")
     .slice(1)
-    .map((row) => within(row).getAllByRole("cell")[0]?.textContent?.trim());
+    .map((row) => within(row).getAllByRole("cell")[0]?.textContent.trim());
 
 describe("ScoreGrid", () => {
   // Auto-cleanup needs vitest `globals: true`, which this config doesn't set.

--- a/apps/inspect/src/app/log-view/title-view/SecondaryBar.tsx
+++ b/apps/inspect/src/app/log-view/title-view/SecondaryBar.tsx
@@ -79,6 +79,7 @@ export const SecondaryBar: FC<SecondaryBarProps> = ({
   const epochs = effectiveConfig.epochs || 1;
   const hyperparameters: Record<string, unknown> = {
     ...effectiveGenerateConfig(evalPlan?.config || {}, configUpdates),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     ...(evalSpec.task_args || {}),
   };
 
@@ -148,8 +149,8 @@ export const SecondaryBar: FC<SecondaryBarProps> = ({
 
   if (evalStats) {
     const totalDuration = formatDuration(
-      new Date(evalStats?.started_at),
-      new Date(evalStats?.completed_at)
+      new Date(evalStats.started_at),
+      new Date(evalStats.completed_at)
     );
     values.push({
       size: "minmax(12%, auto)",
@@ -260,6 +261,7 @@ interface ParamSummaryProps {
  * A component that displays a summary of parameters.
  */
 const ParamSummary: FC<ParamSummaryProps> = ({ params }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!params) {
     return null;
   }

--- a/apps/inspect/src/app/navbar/Navbar.tsx
+++ b/apps/inspect/src/app/navbar/Navbar.tsx
@@ -104,7 +104,7 @@ export const Navbar: FC<NavbarProps> = ({
           <div className={clsx(styles.pathContainer)} ref={pathContainerRef}>
             {logDir ? (
               <ol className={clsx("breadcrumb", styles.breadcrumbs)}>
-                {visibleSegments?.map((segment, index) => {
+                {visibleSegments.map((segment, index) => {
                   const isLast = index === visibleSegments.length - 1;
                   const shouldShowEllipsis =
                     showEllipsis && index === 1 && visibleSegments.length >= 2;

--- a/apps/inspect/src/app/plan/DatasetDetailView.tsx
+++ b/apps/inspect/src/app/plan/DatasetDetailView.tsx
@@ -20,6 +20,7 @@ export const DatasetDetailView: FC<DatasetDetailViewProps> = ({
     Object.entries(dataset).filter(([key]) => key !== "sample_ids")
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!dataset || Object.keys(filtered).length === 0) {
     return (
       <span className={clsx("text-size-base", styles.item)} style={style}>

--- a/apps/inspect/src/app/plan/ModelCard.tsx
+++ b/apps/inspect/src/app/plan/ModelCard.tsx
@@ -36,6 +36,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
       <CardHeader label="Models" />
       <CardBody id={"task-model-card-body"}>
         <div className={styles.container}>
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
           {Object.keys(modelsInfo || {}).map((modelKey) => {
             const modelInfo = modelsInfo[modelKey];
             if (modelInfo === undefined) {
@@ -66,6 +67,7 @@ export const ModelCard: FC<ModelCardProps> = ({ evalSpec }) => {
                 <div className={clsx(styles.sep)} />
                 <div className={clsx("text-style-label")}>Configuration</div>
                 <div className="text-size-small">
+                  {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
                   {modelInfo.config &&
                   Object.keys(modelInfo.config).length > 0 ? (
                     <MetaDataGrid entries={modelInfo.config} />

--- a/apps/inspect/src/app/plan/SolverDetailView.tsx
+++ b/apps/inspect/src/app/plan/SolverDetailView.tsx
@@ -18,7 +18,7 @@ export const SolversDetailView: FC<SolversDetailViewProps> = ({ steps }) => {
     </div>
   );
 
-  const details = steps?.map((step, index) => {
+  const details = steps.map((step, index) => {
     return (
       <Fragment key={`solver-step-${index}`}>
         <DetailStep

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -336,9 +336,9 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   // Fall back to store state for single-file mode where URL doesn't contain sample ID/epoch
   const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
   const printLogPath = urlLogPath || selectedLogFile;
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const printSampleId = urlSampleId || selectedSampleHandle?.id?.toString();
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const printEpoch = urlEpoch || selectedSampleHandle?.epoch?.toString();
 
   const handlePrintClick = useCallback(() => {

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import {
   CSSProperties,
@@ -335,7 +336,9 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   // Fall back to store state for single-file mode where URL doesn't contain sample ID/epoch
   const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
   const printLogPath = urlLogPath || selectedLogFile;
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const printSampleId = urlSampleId || selectedSampleHandle?.id?.toString();
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const printEpoch = urlEpoch || selectedSampleHandle?.epoch?.toString();
 
   const handlePrintClick = useCallback(() => {
@@ -1015,7 +1018,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 selected={effectiveSelectedTab === kSampleErrorTabId}
               >
                 <div className={clsx(styles.error)}>
-                  {sample?.error ? (
+                  {sample.error ? (
                     <Card key={`sample-error}`}>
                       <CardHeader label={`Sample Error`} />
                       <CardBody>
@@ -1287,14 +1290,14 @@ const metadataViewsForSample = (
     );
   }
 
-  if (Object.keys(sample?.metadata).length > 0) {
+  if (Object.keys(sample.metadata).length > 0) {
     sampleMetadatas.push(
       <Card key={`sample-metadata-${id}`}>
         <CardHeader label="Metadata" />
         <CardBody padded={false}>
           <RecordTree
             id={`task-sample-metadata-${id}`}
-            record={sample?.metadata}
+            record={sample.metadata}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
             copyButton={true}
@@ -1304,14 +1307,14 @@ const metadataViewsForSample = (
     );
   }
 
-  if (Object.keys(sample?.store).length > 0) {
+  if (Object.keys(sample.store).length > 0) {
     sampleMetadatas.push(
       <Card key={`sample-store-${id}`}>
         <CardHeader label="Store" />
         <CardBody padded={false}>
           <RecordTree
             id={`task-sample-store-${id}`}
-            record={sample?.store}
+            record={sample.store}
             className={clsx("tab-pane", styles.noTop)}
             scrollRef={scrollRef}
             processStore={true}

--- a/apps/inspect/src/app/samples/SampleSummaryView.tsx
+++ b/apps/inspect/src/app/samples/SampleSummaryView.tsx
@@ -168,14 +168,12 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
 
   // Filter out scores whose descriptor renders empty — they shouldn't
   // contribute to the count or layout decisions.
-  const visibleScores =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    selectedScores.filter((scoreLabel) => {
-      const rendered = sampleDescriptor.evalDescriptor
-        .score(sample, scoreLabel)
-        ?.render();
-      return rendered !== undefined && rendered !== "";
-    }) ?? [];
+  const visibleScores = selectedScores.filter((scoreLabel) => {
+    const rendered = sampleDescriptor.evalDescriptor
+      .score(sample, scoreLabel)
+      ?.render();
+    return rendered !== undefined && rendered !== "";
+  });
   const scoreCount = visibleScores.length;
 
   // Two-column grid widens the right side once the score panel needs

--- a/apps/inspect/src/app/samples/SampleSummaryView.tsx
+++ b/apps/inspect/src/app/samples/SampleSummaryView.tsx
@@ -88,6 +88,7 @@ const resolveSample = (
 
   const target = sample.target;
   const answer =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     sample && sampleDescriptor
       ? sampleDescriptor.selectedScorerDescriptor(sample)?.answer()
       : undefined;
@@ -168,7 +169,8 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
   // Filter out scores whose descriptor renders empty — they shouldn't
   // contribute to the count or layout decisions.
   const visibleScores =
-    selectedScores?.filter((scoreLabel) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    selectedScores.filter((scoreLabel) => {
       const rendered = sampleDescriptor.evalDescriptor
         .score(sample, scoreLabel)
         ?.render();
@@ -226,6 +228,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
   }
   if (
     fields.retries !== undefined &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     fields.retries !== null &&
     fields.retries > 0
   ) {

--- a/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { ReactNode } from "react";
 
 import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
@@ -371,7 +372,7 @@ export const createSamplesDescriptor = (
     }
   );
 
-  const firstSelectedScore = selectedScores?.[0];
+  const firstSelectedScore = selectedScores[0];
 
   return {
     evalDescriptor,
@@ -388,5 +389,5 @@ export const createSamplesDescriptor = (
 };
 
 const scoreLabelKey = (scoreLabel: ScoreLabel) => {
-  return `${scoreLabel?.scorer}.${scoreLabel.name}`;
+  return `${scoreLabel.scorer}.${scoreLabel.name}`;
 };

--- a/apps/inspect/src/app/samples/descriptor/score/ListScoreDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/score/ListScoreDescriptor.tsx
@@ -15,6 +15,7 @@ export const listScoreDescriptor = (_values: ScoreValue[]): ScoreDescriptor => {
       );
     },
     render: (score) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (score === null || score === undefined) {
         return "[null]";
       }
@@ -27,6 +28,7 @@ export const listScoreDescriptor = (_values: ScoreValue[]): ScoreDescriptor => {
           );
         }
         const formattedValue =
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           value && isNumeric(value)
             ? formatPrettyDecimal(
                 typeof value === "number"

--- a/apps/inspect/src/app/samples/descriptor/score/ObjectScoreDescriptor.tsx
+++ b/apps/inspect/src/app/samples/descriptor/score/ObjectScoreDescriptor.tsx
@@ -34,6 +34,7 @@ export const objectScoreDescriptor = (
       return 0;
     },
     render: (score) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (score === null || score === undefined) {
         return "[null]";
       }

--- a/apps/inspect/src/app/samples/header-v2/ScoreValueDisplay.tsx
+++ b/apps/inspect/src/app/samples/header-v2/ScoreValueDisplay.tsx
@@ -149,6 +149,7 @@ function toneMiniPillClass(tone: Tone): string | undefined {
 }
 
 function formatPlainValue(v: ScoreValue | undefined): string {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (v === undefined || v === null) return "";
   if (Array.isArray(v)) return v.join(", ");
   if (typeof v === "object") return JSON.stringify(v);

--- a/apps/inspect/src/app/samples/header-v2/scoreTone.ts
+++ b/apps/inspect/src/app/samples/header-v2/scoreTone.ts
@@ -17,6 +17,7 @@ export function scoreTone(
   value: ScoreValue | undefined,
   scoreType: string
 ): Tone {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (value === undefined || value === null) return "neutral";
 
   if (scoreType === kScoreTypePassFail) {

--- a/apps/inspect/src/app/samples/list/SampleList.tsx
+++ b/apps/inspect/src/app/samples/list/SampleList.tsx
@@ -150,7 +150,7 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
         msg: `INFO: ${limitCount} of ${sampleCount} samples (${formatNoDecimal(percentLimit)}%) completed due to exceeding a limit.`,
       });
     }
-    if (earlyStopping?.early_stops && earlyStopping?.early_stops?.length > 0) {
+    if (earlyStopping?.early_stops && earlyStopping.early_stops.length > 0) {
       result.push({
         type: "info",
         msg: `Skipped ${earlyStopping.early_stops.length} samples due to early stopping (${earlyStopping.manager}). `,

--- a/apps/inspect/src/app/samples/list/samplesView.converters.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.ts
@@ -47,10 +47,12 @@ export const liftEvalView = (
   return {
     name: wire.name,
     columns: wire.columns
-      ? wire.columns.map((c) => ({ id: c.id, visible: c.visible ?? true }))
+      ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        wire.columns.map((c) => ({ id: c.id, visible: c.visible ?? true }))
       : fallback.columns,
     sort: wire.sort
-      ? wire.sort.map((s) => ({ colId: s.column, dir: s.dir ?? "asc" }))
+      ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        wire.sort.map((s) => ({ colId: s.column, dir: s.dir ?? "asc" }))
       : fallback.sort,
     filters: { dsl: "", extraColumnFilters: {} },
     multiline: wire.multiline ?? fallback.multiline,
@@ -106,6 +108,7 @@ export const resolveSamplesView = (
 ): SamplesViewState => {
   if (!stored) return liftEvalView(evalDefault);
   const lifted = liftEvalView(evalDefault);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const overrides = stored.userOverrides ?? {};
   return {
     ...stored,

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -120,6 +120,7 @@ export const SamplePrintView: FC = () => {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const sampleMessages = sample.messages || [];
 
   return (
@@ -194,6 +195,7 @@ const PrintMetadata: FC<{ sample: EvalSample }> = ({ sample }) => {
       invalidationRecord["Reason"] = sample.invalidation.reason;
     }
     if (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       sample.invalidation.metadata &&
       Object.keys(sample.invalidation.metadata).length > 0
     ) {
@@ -209,6 +211,7 @@ const PrintMetadata: FC<{ sample: EvalSample }> = ({ sample }) => {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (sample.model_usage && Object.keys(sample.model_usage).length > 0) {
     sampleMetadatas.push(
       <Card key="print-usage">
@@ -241,23 +244,23 @@ const PrintMetadata: FC<{ sample: EvalSample }> = ({ sample }) => {
     );
   }
 
-  if (Object.keys(sample?.metadata).length > 0) {
+  if (Object.keys(sample.metadata).length > 0) {
     sampleMetadatas.push(
       <Card key="print-metadata">
         <CardHeader label="Metadata" />
         <CardBody>
-          <MetaDataGrid entries={sample?.metadata} />
+          <MetaDataGrid entries={sample.metadata} />
         </CardBody>
       </Card>
     );
   }
 
-  if (Object.keys(sample?.store).length > 0) {
+  if (Object.keys(sample.store).length > 0) {
     sampleMetadatas.push(
       <Card key="print-store">
         <CardHeader label="Store" />
         <CardBody>
-          <MetaDataGrid entries={sample?.store} />
+          <MetaDataGrid entries={sample.store} />
         </CardBody>
       </Card>
     );

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
@@ -7,7 +7,7 @@ import type { EvalRetryError } from "@tsmono/inspect-common";
  * so callers can omit the chip rather than render garbage.
  */
 export function deriveErrorType(retry: EvalRetryError): string | null {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const tb = retry.traceback?.trimEnd();
   if (!tb) return null;
   const lines = tb.split("\n");

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.ts
@@ -7,6 +7,7 @@ import type { EvalRetryError } from "@tsmono/inspect-common";
  * so callers can omit the chip rather than render garbage.
  */
 export function deriveErrorType(retry: EvalRetryError): string | null {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const tb = retry.traceback?.trimEnd();
   if (!tb) return null;
   const lines = tb.split("\n");

--- a/apps/inspect/src/app/samples/sample-tools/filterSpecRegistry.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterSpecRegistry.ts
@@ -84,6 +84,7 @@ export const buildSampleFilterSpecRegistry = (
       const scoreType = evalDescriptor.scoreDescriptor({
         name,
         scorer,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: scoreDescriptor() can return undefined despite its declared type
       })?.scoreType;
       // Only sync score column filters where the column's text/number
       // filter operates on values that match the runtime filtrex

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -26,6 +26,7 @@ export interface SampleFilterItem {
  * Coerces a value to the type expected by the score.
  */
 const coerceValue = (value: unknown, descriptor: ScoreDescriptor): unknown => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (descriptor && descriptor.scoreType === kScoreTypeBoolean) {
     return Boolean(value);
   } else {
@@ -169,6 +170,7 @@ export const sampleVariables = (
     id: sample.id,
     uuid: sample.uuid ?? null,
     input: inputString(sample.input).join(" "),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     target: arrayToString(sample.target ?? ""),
     answer:
       samplesDescriptor?.selectedScorerDescriptor(sample)?.answer() ?? null,
@@ -212,7 +214,8 @@ export const sampleFilterItems = (
       return;
     }
 
-    const scoreType = descriptor?.scoreType;
+    const scoreType = descriptor.scoreType;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!descriptor) {
       items.push({
         shortName,

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -19,7 +19,8 @@ export interface SampleFilterItem {
   canonicalName: string;
   tooltip?: string;
   categories: string[];
-  scoreType: string;
+  // undefined when the descriptor lookup fails at runtime (types lie at the wire)
+  scoreType: string | undefined;
 }
 
 /**
@@ -208,14 +209,7 @@ export const sampleFilterItems = (
       throw new Error("Unable to create a canonical name for a score");
     }
     const descriptor = evalDescriptor.scoreDescriptor(scoreLabel);
-
-    // This is not a filterable score
-    if (descriptor.filterable === false) {
-      return;
-    }
-
-    const scoreType = descriptor.scoreType;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: scoreDescriptor() can return undefined despite its declared type
     if (!descriptor) {
       items.push({
         shortName,
@@ -223,10 +217,17 @@ export const sampleFilterItems = (
         canonicalName,
         tooltip: undefined,
         categories: [],
-        scoreType,
+        scoreType: undefined,
       });
       return;
     }
+
+    // This is not a filterable score
+    if (descriptor.filterable === false) {
+      return;
+    }
+
+    const scoreType = descriptor.scoreType;
     let tooltip = `${canonicalName}: ${descriptor.scoreType}`;
     let categories: string[] = [];
     if (descriptor.min !== undefined || descriptor.max !== undefined) {

--- a/apps/inspect/src/app/samples/sample-tools/sample-filter/completions.ts
+++ b/apps/inspect/src/app/samples/sample-tools/sample-filter/completions.ts
@@ -41,13 +41,13 @@ interface CanonicalNameCompletionProps {
 }
 
 const isLiteral = (token: Token): boolean =>
-  ["string", "unterminatedString", "number"].includes(token?.type);
+  ["string", "unterminatedString", "number"].includes(token.type);
 
 const isLogicalOp = (token: Token): boolean =>
-  ["and", "or", "not"].includes(token?.text);
+  ["and", "or", "not"].includes(token.text);
 
 const autocompleteImmediatelyAfter = (token: Token): boolean =>
-  ["(", "."].includes(token?.text);
+  ["(", "."].includes(token.text);
 
 const applyWithCall = (
   view: EditorView,
@@ -160,7 +160,7 @@ const getMemberScoreItems = (
   filterItems: SampleFilterItem[],
   scorer: string
 ): SampleFilterItem[] =>
-  filterItems.filter((item) => item?.qualifiedName?.startsWith(`${scorer}.`));
+  filterItems.filter((item) => item.qualifiedName?.startsWith(`${scorer}.`));
 
 const getSampleIds = (samples: SampleSummary[]): Set<string | number> => {
   const ids = new Set<string | number>();
@@ -451,16 +451,20 @@ export function getCompletions(
   // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
   const prevToken = (index: number): Token => tokens[currentTokenIndex - index];
   const currentToken = prevToken(0);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const completionStart = currentToken ? currentToken.from : context.pos;
   const completingAtEnd = context.pos === doc.length;
 
   const findFilterItem = (endIndex: number): SampleFilterItem | undefined => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     if (prevToken(endIndex)?.type !== "variable") return undefined;
 
     let name = prevToken(endIndex).text;
     let i = endIndex;
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     while (prevToken(i + 1)?.text === ".") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
       if (prevToken(i + 2)?.type === "variable") {
         name = `${prevToken(i + 2).text}.${name}`;
         i += 2;
@@ -578,10 +582,12 @@ export function getCompletions(
     makeCompletions(options.map(makeLiteralCompletion));
 
   // Handle specific completion scenarios
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!prevToken(1)) return newExpressionCompletions();
 
   // Member access
-  if (prevToken(1)?.text === ".") {
+  if (prevToken(1).text === ".") {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     const varName = prevToken(2)?.text;
 
     // Check if this is metadata property access (metadata.* or metadata.*.*)
@@ -602,8 +608,10 @@ export function getCompletions(
   }
 
   // Function call or bracketed expression start
-  if (prevToken(1)?.text === "(") {
+  if (prevToken(1).text === "(") {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     if (prevToken(2)?.type === "mathFunction") return variableCompletions();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     if (prevToken(2)?.type === "sampleFunction") return noCompletions();
     return newExpressionCompletions();
   }
@@ -614,11 +622,11 @@ export function getCompletions(
   // comparing function call result to something) or with a logical connector
   // (if a new subexpression is starting). Very hard to figure out what is
   // going on without an AST, which we don't have here.
-  if (prevToken(1)?.text === ")") return noCompletions();
+  if (prevToken(1).text === ")") return noCompletions();
 
   // Variable type-based relation suggestions
-  if (prevToken(1)?.type === "variable") {
-    const varName = prevToken(1)?.text;
+  if (prevToken(1).type === "variable") {
+    const varName = prevToken(1).text;
 
     // Check if this is a metadata property access (metadata.property or metadata.nested.property)
     if (isMetadataProperty(tokens, currentTokenIndex)) {
@@ -665,7 +673,8 @@ export function getCompletions(
   }
 
   // RHS comparison suggestions
-  if (prevToken(1)?.type === "relation") {
+  if (prevToken(1).type === "relation") {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
     const varName = prevToken(2)?.text;
 
     // Check if this is a metadata property comparison (relation after metadata.property or metadata.nested.property)
@@ -680,6 +689,7 @@ export function getCompletions(
       );
 
       // Get the current query for prefix filtering
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
       const currentQuery = currentToken?.text || "";
 
       // Pre-filter values to only show prefix matches
@@ -712,6 +722,7 @@ export function getCompletions(
       const sampleIds = Array.from(getSampleIds(samples));
 
       // Get the current query for prefix filtering
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
       const currentQuery = currentToken?.text || "";
 
       // Pre-filter IDs to only show prefix matches
@@ -732,6 +743,7 @@ export function getCompletions(
     if (varName === kSampleUuidVariable && samples) {
       const sampleUuids = Array.from(getSampleUuids(samples));
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
       const currentQuery = currentToken?.text || "";
       const filteredUuids = currentQuery
         ? sampleUuids.filter((uuid) =>
@@ -748,6 +760,7 @@ export function getCompletions(
     // Epoch value completions (suggest actual epoch numbers from loaded samples)
     if (varName === "epoch" && samples) {
       const epochValues = Array.from(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         new Set(samples.map((s) => s.epoch).filter((e) => e !== undefined))
       ).sort((a, b) => a - b);
       const epochCompletions = epochValues.map((e) =>
@@ -759,13 +772,14 @@ export function getCompletions(
     }
 
     const item = findFilterItem(2);
-    if (item?.categories?.length) {
+    if (item?.categories.length) {
       return rhsCompletions(item.categories);
     }
     return variableCompletions();
   }
 
   // Post-subexpression connector suggestions
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: prevToken can return undefined despite its declared type
   if (isLiteral(prevToken(1)) && prevToken(2)?.type === "relation") {
     return logicalOpCompletions();
   }

--- a/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
+++ b/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
@@ -68,7 +68,9 @@ export function buildScanReferencePreviews(
     }
 
     if (event.event === "model") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       for (const msg of event.input ?? []) addMessage(msg);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
       for (const choice of event.output?.choices ?? []) {
         addMessage(choice.message);
       }

--- a/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
+++ b/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
@@ -70,7 +70,7 @@ export function buildScanReferencePreviews(
     if (event.event === "model") {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       for (const msg of event.input ?? []) addMessage(msg);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
       for (const choice of event.output?.choices ?? []) {
         addMessage(choice.message);
       }

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
@@ -60,10 +60,7 @@ const dragHeader = async (from: string, to: string) => {
 };
 
 const headerOrder = () =>
-  screen
-    .getAllByRole("columnheader")
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    .map((cell) => cell.textContent.trim() ?? "");
+  screen.getAllByRole("columnheader").map((cell) => cell.textContent.trim());
 
 const headerCell = (label: string) =>
   screen.getByText(label).closest('[role="columnheader"]') as HTMLElement;

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
@@ -62,7 +62,8 @@ const dragHeader = async (from: string, to: string) => {
 const headerOrder = () =>
   screen
     .getAllByRole("columnheader")
-    .map((cell) => cell.textContent?.trim() ?? "");
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    .map((cell) => cell.textContent.trim() ?? "");
 
 const headerCell = (label: string) =>
   screen.getByText(label).closest('[role="columnheader"]') as HTMLElement;

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.reorder.test.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.reorder.test.tsx
@@ -60,10 +60,7 @@ const dragHeader = async (from: string, to: string) => {
 };
 
 const headerOrder = () =>
-  screen
-    .getAllByRole("columnheader")
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    .map((cell) => cell.textContent.trim() ?? "");
+  screen.getAllByRole("columnheader").map((cell) => cell.textContent.trim());
 
 describe("DataGrid column reorder", () => {
   test("dropping a header on another column reorders and reports the order", async () => {

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.reorder.test.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.reorder.test.tsx
@@ -62,7 +62,8 @@ const dragHeader = async (from: string, to: string) => {
 const headerOrder = () =>
   screen
     .getAllByRole("columnheader")
-    .map((cell) => cell.textContent?.trim() ?? "");
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    .map((cell) => cell.textContent.trim() ?? "");
 
 describe("DataGrid column reorder", () => {
   test("dropping a header on another column reorders and reports the order", async () => {

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
@@ -835,7 +835,7 @@ export function DataGrid<TRow extends RowData>({
                     <ColumnFilterControl
                       columnId={header.column.id}
                       filterType={filterType}
-                      operators={columnDef.meta?.operators}
+                      operators={columnDef.meta.operators}
                       spec={filterSpec}
                       placement="bottom-start"
                       onChange={(spec) =>
@@ -1221,7 +1221,7 @@ function RotatedHeaderCell<TRow extends RowData>({
             <ColumnFilterControl
               columnId={header.column.id}
               filterType={filterType}
-              operators={columnDef.meta?.operators}
+              operators={columnDef.meta.operators}
               spec={filterSpec}
               anchorEl={anchorEl}
               placement="bottom-start"

--- a/apps/inspect/src/app/shared/data-grid/findMatches.ts
+++ b/apps/inspect/src/app/shared/data-grid/findMatches.ts
@@ -30,6 +30,7 @@ export function rowSearchText<TRow extends RowData>(
     let text: string | null = null;
     if (column.textValue) {
       text = column.textValue(row);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if ("accessorFn" in column && column.accessorFn) {
       text = primitiveText(column.accessorFn(row, 0));
     }

--- a/apps/inspect/src/app/shared/samples-grid/colorScale.ts
+++ b/apps/inspect/src/app/shared/samples-grid/colorScale.ts
@@ -104,6 +104,7 @@ const isPaletteName = (s: string): s is ScoreColorPalette =>
 // categorical branch and producing a nonsense `{ kind: "categorical",
 // colors: { palette: undefined } }` shape).
 const isScaleObject = (s: WireScoreColorScale): s is ScoreColorScaleObject =>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   typeof s === "object" && s !== null && "palette" in s;
 
 /**

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import type { CSSProperties } from "react";
 
@@ -540,6 +541,7 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
       const colId = perScorerFieldKey(label);
       const headerName = useLabelHeader ? labelFor(label.name) : "Score";
       const scoreDesc = descriptor.evalDescriptor.scoreDescriptor(label);
+      // intentional ?. — scoreDescriptor() can return undefined despite its declared type
       const scoreType = scoreDesc?.scoreType;
       const isNumeric = scoreType === kScoreTypeNumeric;
       // Pass/fail and boolean already render as semantically-coloured
@@ -549,6 +551,7 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
         scoreType !== kScoreTypePassFail && scoreType !== kScoreTypeBoolean;
       const valueToStyle = acceptsColorScale
         ? cellStyleFor(label.name, {
+            // intentional ?. — scoreDescriptor() can return undefined despite its declared type
             min: scoreDesc?.min,
             max: scoreDesc?.max,
           })

--- a/apps/inspect/src/app_config/resolveBackend.ts
+++ b/apps/inspect/src/app_config/resolveBackend.ts
@@ -198,6 +198,7 @@ export const resolveBackend = (source: UrlLogSource): BackendBootstrap => {
   if (scriptEl) {
     // Read the contents
     const context = scriptEl.textContent;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (context !== null) {
       const data = JSON5.parse<LogDirContext>(context);
       if (data.log_dir || data.log_file) {

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -153,7 +153,7 @@ export const clientApi = (api: LogViewAPI, debug = false): ClientAPI => {
        * @type {import("./Types.js").SampleSummary[]}
        */
       const sampleSummaries = logContents.parsed.samples
-        ? logContents.parsed.samples?.map((sample) => {
+        ? logContents.parsed.samples.map((sample) => {
             return {
               id: sample.id,
               epoch: sample.epoch,

--- a/apps/inspect/src/client/api/static-http/api-static-http.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.ts
@@ -181,6 +181,7 @@ function staticHttpApiForLog(logInfo: {
     },
     get_log_summary: async (log_file: string) => {
       const manifest = await getManifest();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (manifest) {
         const manifestAbs: Record<string, LogPreview> = {};
         Object.entries(manifest).forEach(([key, preview]) => {
@@ -199,6 +200,7 @@ function staticHttpApiForLog(logInfo: {
       }
 
       const manifest = await getManifest();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (manifest) {
         const keys = Object.keys(manifest);
         const result: LogPreview[] = [];

--- a/apps/inspect/src/client/api/view-server/api-view-server.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.ts
@@ -549,6 +549,7 @@ export function viewServerApi(
 
   const get_user_info = async (): Promise<UserInfo> => {
     const result = await requestApi.fetchString("GET", "/user-info");
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return (result.parsed as UserInfo) ?? {};
   };
 

--- a/apps/inspect/src/client/database/utils.ts
+++ b/apps/inspect/src/client/database/utils.ts
@@ -5,7 +5,7 @@ export function toLogOverview(header: EvalHeader): LogPreview {
 
   // Get the first metric from the first score's metrics
   let primary_metric = undefined;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const firstScore = results?.scores?.[0];
   if (firstScore) {
     // Get the first metric from the score's metrics object

--- a/apps/inspect/src/client/database/utils.ts
+++ b/apps/inspect/src/client/database/utils.ts
@@ -5,9 +5,11 @@ export function toLogOverview(header: EvalHeader): LogPreview {
 
   // Get the first metric from the first score's metrics
   let primary_metric = undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const firstScore = results?.scores?.[0];
   if (firstScore) {
     // Get the first metric from the score's metrics object
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const metricsValues = Object.values(firstScore.metrics || {});
     if (metricsValues.length > 0) {
       primary_metric = metricsValues[0];

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -92,9 +92,9 @@ export const headerFromLogStart = (start: LogStart): EvalHeader => ({
   status: "started",
   eval: start.eval,
   plan: start.plan,
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   tags: start.eval?.tags ?? [],
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   metadata: start.eval?.metadata ?? {},
 });
 

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -92,7 +92,9 @@ export const headerFromLogStart = (start: LogStart): EvalHeader => ({
   status: "started",
   eval: start.eval,
   plan: start.plan,
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   tags: start.eval?.tags ?? [],
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   metadata: start.eval?.metadata ?? {},
 });
 

--- a/apps/inspect/src/client/remote/zstd-worker.ts
+++ b/apps/inspect/src/client/remote/zstd-worker.ts
@@ -147,6 +147,7 @@ function getZstdWorker(): Promise<Worker> {
     // Wait for init confirmation before resolving
     const initHandler = (event: MessageEvent) => {
       const message = event.data as ZstdInitMessage;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (message.type === "init_complete") {
         zstdWorker!.removeEventListener("message", initHandler);
         if (message.success) {

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
 import { arrayToString } from "@tsmono/util";
 
@@ -50,7 +51,7 @@ export const deriveLogFields = (header: LogHeader): LogDerived => {
   }
 
   let duration: number | undefined;
-  if (header.stats?.started_at && header.stats?.completed_at) {
+  if (header.stats?.started_at && header.stats.completed_at) {
     const start = new Date(header.stats.started_at).getTime();
     const end = new Date(header.stats.completed_at).getTime();
     if (start && end && end > start) {

--- a/apps/inspect/src/client/utils/type-utils.ts
+++ b/apps/inspect/src/client/utils/type-utils.ts
@@ -128,7 +128,7 @@ export const toLogPreview = (header: EvalHeader | LogDetails): LogPreview => {
 const primaryMetric = (
   evalResults?: EvalResults | null
 ): EvalMetric | undefined => {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const firstScore = evalResults?.scores?.[0];
   if (firstScore) {
     const metrics = Object.values(firstScore.metrics);

--- a/apps/inspect/src/client/utils/type-utils.ts
+++ b/apps/inspect/src/client/utils/type-utils.ts
@@ -128,6 +128,7 @@ export const toLogPreview = (header: EvalHeader | LogDetails): LogPreview => {
 const primaryMetric = (
   evalResults?: EvalResults | null
 ): EvalMetric | undefined => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const firstScore = evalResults?.scores?.[0];
   if (firstScore) {
     const metrics = Object.values(firstScore.metrics);

--- a/apps/inspect/src/log_data/sampleData.ts
+++ b/apps/inspect/src/log_data/sampleData.ts
@@ -46,7 +46,7 @@ const settledSampleData = (sample: EvalSample): EvalSampleData => ({
   error: undefined,
   running: kNoRunningEvents,
   eventsCleared:
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     sample.events.length === 0 && (sample.messages?.length ?? 0) > 0,
   backfilling: false,
 });

--- a/apps/inspect/src/log_data/sampleData.ts
+++ b/apps/inspect/src/log_data/sampleData.ts
@@ -46,6 +46,7 @@ const settledSampleData = (sample: EvalSample): EvalSampleData => ({
   error: undefined,
   running: kNoRunningEvents,
   eventsCleared:
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     sample.events.length === 0 && (sample.messages?.length ?? 0) > 0,
   backfilling: false,
 });
@@ -186,6 +187,7 @@ export const deriveSampleData = ({
   const loading = chunked.loading || query.loading;
   return {
     sample: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     status: loading ? "loading" : query.error ? "error" : "ok",
     error: loading ? undefined : query.error,
     running: kNoRunningEvents,

--- a/apps/inspect/src/log_data/scoreSchema.ts
+++ b/apps/inspect/src/log_data/scoreSchema.ts
@@ -58,6 +58,7 @@ export function computeScorerMap(logs: Log[], scopeDir?: string): ScorerMap {
     }
     if (log.header?.results?.scores) {
       for (const evalScore of log.header.results.scores) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (evalScore.metrics) {
           for (const [metricName, metric] of Object.entries(
             evalScore.metrics

--- a/apps/inspect/src/scoring/metrics.ts
+++ b/apps/inspect/src/scoring/metrics.ts
@@ -18,8 +18,10 @@ export const metricDisplayName = (metric: MetricSummary): string => {
 };
 
 export const firstMetric = (results: EvalResults) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const scores = results.scores || [];
-  const firstScore = scores.length > 0 ? results.scores?.[0] : undefined;
+  const firstScore = scores.length > 0 ? results.scores[0] : undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (firstScore === undefined || firstScore.metrics === undefined) {
     return undefined;
   }

--- a/apps/inspect/src/state/appSlice.ts
+++ b/apps/inspect/src/state/appSlice.ts
@@ -383,6 +383,7 @@ export const initializeAppSlice = (
 ) => {
   set((state) => {
     state.capabilities = capabilities;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!state.app) {
       state.app = initialState;
     }

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -150,6 +150,7 @@ export const useEvalScorePanelSort = (): ScorePanelSortState | undefined => {
     if (!stored) return undefined;
     return {
       column: stored.column ?? null,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       dir: stored.dir ?? "asc",
     };
   }, [stored]);
@@ -304,6 +305,7 @@ export const useEvalDescriptor = () => {
   const scores = useScores();
   const sampleSummaries = useSelectedSampleSummariesData();
   return useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return scores ? createEvalDescriptor(scores, sampleSummaries) : null;
   }, [scores, sampleSummaries]);
 };

--- a/apps/inspect/src/state/logSlice.ts
+++ b/apps/inspect/src/state/logSlice.ts
@@ -159,6 +159,7 @@ export const initalializeLogSlice = (
   set: (fn: (state: StoreState) => void) => void
 ) => {
   set((state) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!state.log) {
       state.log = initialState;
     }

--- a/apps/inspect/src/state/logsSlice.ts
+++ b/apps/inspect/src/state/logsSlice.ts
@@ -177,6 +177,7 @@ export const initializeLogsSlice = <T extends LogsSlice>(
   set: (fn: (state: T) => void) => void
 ) => {
   set((state) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!state.logs) {
       state.logs = initialState;
     }

--- a/apps/inspect/src/state/sampleSlice.ts
+++ b/apps/inspect/src/state/sampleSlice.ts
@@ -177,6 +177,7 @@ export const initializeSampleSlice = (
   set: (fn: (state: StoreState) => void) => void
 ) => {
   set((state) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!state.sample) {
       state.sample = initialState;
     }

--- a/apps/inspect/src/utils/attachments.ts
+++ b/apps/inspect/src/utils/attachments.ts
@@ -21,6 +21,7 @@ export const resolveAttachments = <T>(
     });
 
     // Only return the new array if something actually changed
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return hasChanged ? (resolvedArray as unknown as T) : value;
   }
 

--- a/apps/scout/src/api/api-scout-server.ts
+++ b/apps/scout/src/api/api-scout-server.ts
@@ -188,6 +188,7 @@ export const apiScoutServer = (
         "POST",
         `/transcripts/${encodeBase64Url(transcriptsDir)}/distinct`,
         {},
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         JSON.stringify({ column, filter: filter ?? null })
       );
       return asyncJsonParse<ScalarValue[]>(result.raw);
@@ -280,6 +281,7 @@ export const apiScoutServer = (
             parsed.input_data
           ),
         },
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         scanEvents: parsed.scan_events ?? [],
       };
     },

--- a/apps/scout/src/api/request.ts
+++ b/apps/scout/src/api/request.ts
@@ -88,7 +88,7 @@ export function serverRequestApi(
     const baseHeaders = request?.enableBrowserCache
       ? {
           Accept: "application/json",
-          ...request?.headers,
+          ...request.headers,
         }
       : {
           Accept: "application/json",

--- a/apps/scout/src/app/components/DataframeView.tsx
+++ b/apps/scout/src/app/components/DataframeView.tsx
@@ -68,7 +68,7 @@ export const DataframeView: FC<DataframeViewProps> = ({
             if (!col) {
               return undefined;
             }
-            const sampleValue = col?.at(0) as unknown;
+            const sampleValue = col.at(0) as unknown;
 
             // Create value formatter based on truncation options and data type
             const valueFormatter = options
@@ -96,7 +96,7 @@ export const DataframeView: FC<DataframeViewProps> = ({
               maxWidth: 800,
               cellDataType:
                 typeof sampleValue === "boolean" ? false : undefined,
-              hide: !columnNames?.includes(name) || false,
+              hide: !columnNames.includes(name) || false,
               valueFormatter,
               wrapText: wrapText,
               autoHeight: wrapText,
@@ -112,7 +112,7 @@ export const DataframeView: FC<DataframeViewProps> = ({
             headerName: "",
             valueGetter: (params) => {
               return params.node?.rowIndex !== undefined &&
-                params.node?.rowIndex !== null
+                params.node.rowIndex !== null
                 ? params.node.rowIndex + 1
                 : "";
             },
@@ -131,6 +131,7 @@ export const DataframeView: FC<DataframeViewProps> = ({
             },
             onCellClicked: (params) => {
               if (params.data && onRowDoubleClicked) {
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 if (params.rowIndex !== null && params.rowIndex !== undefined) {
                   setSelectedDataframeRow(params.rowIndex);
                 }
@@ -162,6 +163,7 @@ export const DataframeView: FC<DataframeViewProps> = ({
   useEffect(() => {
     if (gridRef.current?.api && gridState && !gridState.filter) {
       const currentFilterModel = gridRef.current.api.getFilterModel();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (currentFilterModel && Object.keys(currentFilterModel).length > 0) {
         gridRef.current.api.setFilterModel(null);
       }

--- a/apps/scout/src/app/components/EditableText.tsx
+++ b/apps/scout/src/app/components/EditableText.tsx
@@ -98,7 +98,7 @@ export const EditableText: FC<EditableTextProps> = ({
 
   const commitChanges = useCallback(() => {
     if (spanRef.current) {
-      const newValue = spanRef.current.textContent?.trim() || "";
+      const newValue = spanRef.current.textContent.trim() || "";
       if (newValue !== "" && newValue !== initialValueRef.current) {
         onValueChanged(newValue);
       } else if (newValue === "") {

--- a/apps/scout/src/app/components/TranscriptsNavbar.tsx
+++ b/apps/scout/src/app/components/TranscriptsNavbar.tsx
@@ -73,7 +73,7 @@ export const TranscriptsNavbar: FC<TranscriptsNavbarProps> = ({
 
   const editable = false;
   const filterText =
-    filter && !filter?.startsWith("(")
+    filter && !filter.startsWith("(")
       ? `(${filter})`
       : filter
         ? filter
@@ -100,6 +100,7 @@ export const TranscriptsNavbar: FC<TranscriptsNavbarProps> = ({
           }
           onPathChanged={setTranscriptsDir}
           placeholder={
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             editable
               ? "Select Transcripts Folder"
               : "No transcripts directory configured."

--- a/apps/scout/src/app/components/columnSizing/strategies.ts
+++ b/apps/scout/src/app/components/columnSizing/strategies.ts
@@ -22,5 +22,6 @@ export const sizingStrategies: Record<ColumnSizingStrategyKey, SizingStrategy> =
 export function getSizingStrategy(
   key: ColumnSizingStrategyKey
 ): SizingStrategy {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return sizingStrategies[key] ?? sizingStrategies.default;
 }

--- a/apps/scout/src/app/components/dataGrid/DataGrid.tsx
+++ b/apps/scout/src/app/components/dataGrid/DataGrid.tsx
@@ -209,6 +209,7 @@ export function DataGrid<
 
   // Compute effective column order
   const effectiveColumnOrder = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (columnOrder && columnOrder.length > 0) {
       return columnOrder;
     }

--- a/apps/scout/src/app/hooks/useSelectedScanner.ts
+++ b/apps/scout/src/app/hooks/useSelectedScanner.ts
@@ -26,6 +26,7 @@ export const useSelectedScanner = (): AsyncData<string> => {
 };
 
 const _get_default_scanner = (s: Status): string => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const result = s.summary.scanners
     ? Object.keys(s.summary.scanners)[0]
     : undefined;

--- a/apps/scout/src/app/hooks/useWindowMessaging.ts
+++ b/apps/scout/src/app/hooks/useWindowMessaging.ts
@@ -124,6 +124,7 @@ export const useWindowMessaging = (): void => {
       navigate,
       setSingleFileMode,
       setSelectedScanner,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       scansDir: scansDir ?? "",
     };
   }, [navigate, setSingleFileMode, setSelectedScanner, scansDir]);

--- a/apps/scout/src/app/project/ProjectPanel.tsx
+++ b/apps/scout/src/app/project/ProjectPanel.tsx
@@ -78,6 +78,7 @@ export const ProjectPanel: FC<ProjectPanelProps> = ({ config }) => {
   // We store the ID since React may recreate the DOM element
   const handleSaveMouseDown = useCallback(() => {
     const el = document.activeElement as HTMLElement;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (el && el !== document.body && el.id) {
       focusedFieldIdRef.current = el.id;
     } else {
@@ -112,6 +113,7 @@ export const ProjectPanel: FC<ProjectPanelProps> = ({ config }) => {
         if (!mutation.isPending) {
           // Capture focused element ID for restoration after save
           const el = document.activeElement as HTMLElement;
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (el && el !== document.body && el.id) {
             focusedFieldIdRef.current = el.id;
           } else {

--- a/apps/scout/src/app/project/SettingsContent.tsx
+++ b/apps/scout/src/app/project/SettingsContent.tsx
@@ -158,6 +158,7 @@ export const SettingsContent: FC<SettingsContentProps> = ({
   // Tags field - use local state to allow typing commas/spaces freely
   // but also update config on input so Ctrl+S saves correctly
   const [tagsText, setTagsText] = useState(() =>
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     Array.isArray(config.tags) ? config.tags.join(", ") : (config.tags ?? "")
   );
 
@@ -165,7 +166,8 @@ export const SettingsContent: FC<SettingsContentProps> = ({
   useEffect(() => {
     const configValue = Array.isArray(config.tags)
       ? config.tags.join(", ")
-      : (config.tags ?? "");
+      : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        (config.tags ?? "");
     // Only sync if the parsed values differ (avoids cursor jump while typing)
     const currentParsed = tagsText
       .split(",")

--- a/apps/scout/src/app/project/configUtils.ts
+++ b/apps/scout/src/app/project/configUtils.ts
@@ -213,6 +213,7 @@ export function initializeEditedConfig(
 ): Partial<ProjectConfigInput> {
   return {
     transcripts: serverConfig.transcripts ?? null,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     filter: serverConfig.filter ?? null,
     scans: serverConfig.scans ?? null,
     max_transcripts: serverConfig.max_transcripts ?? null,

--- a/apps/scout/src/app/runScan/ActiveScanView.tsx
+++ b/apps/scout/src/app/runScan/ActiveScanView.tsx
@@ -79,7 +79,7 @@ const ActiveScanCard: FC<{ info: ActiveScanInfo }> = ({ info }) => {
 
   // Check if any scanner has validations or metrics (use scanner_names for iteration)
   const hasValidations = info.scanner_names.some(
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     (name) => (summary.scanners[name]?.validation?.entries?.length ?? 0) > 0
   );
   const hasMetrics = info.scanner_names.some(

--- a/apps/scout/src/app/runScan/ActiveScanView.tsx
+++ b/apps/scout/src/app/runScan/ActiveScanView.tsx
@@ -79,6 +79,7 @@ const ActiveScanCard: FC<{ info: ActiveScanInfo }> = ({ info }) => {
 
   // Check if any scanner has validations or metrics (use scanner_names for iteration)
   const hasValidations = info.scanner_names.some(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     (name) => (summary.scanners[name]?.validation?.entries?.length ?? 0) > 0
   );
   const hasMetrics = info.scanner_names.some(
@@ -91,6 +92,7 @@ const ActiveScanCard: FC<{ info: ActiveScanInfo }> = ({ info }) => {
     const scanner = summary.scanners[name];
     const totalTokens = scanner
       ? Object.values(scanner.model_usage).reduce<number>(
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           (sum, usage) => sum + (usage.total_tokens ?? 0),
           0
         )
@@ -301,6 +303,7 @@ export const ActiveScanView: FC<Props> = ({ scanId }) => {
           text="Scan not found"
         />
       )}
+      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
       {scanInfo && !error && <ActiveScanCard info={scanInfo} />}
     </div>
   );

--- a/apps/scout/src/app/scan/ScanPanelBody.tsx
+++ b/apps/scout/src/app/scan/ScanPanelBody.tsx
@@ -101,11 +101,13 @@ export const ScanPanelBody: React.FC<{ selectedScan: Status }> = ({
 
   // Figure out whether grouping should be shown
   const groupOptions: Array<ResultGroup> = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!visibleScannerResults || visibleScannerResults.length === 0) {
       return [];
     }
 
     const hasLabel = visibleScannerResults.some(
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       (summary) => summary.label !== undefined && summary.label !== null
     );
 

--- a/apps/scout/src/app/scan/info/ScanInfo.tsx
+++ b/apps/scout/src/app/scan/info/ScanInfo.tsx
@@ -43,14 +43,16 @@ const ScanInfoCard: FC<ScanInfoCardProps> = ({ selectedScan, className }) => {
     record["Source File"] = selectedScan.spec.scan_file;
   }
   if (selectedScan.spec.revision?.origin) {
-    record["Origin"] = selectedScan.spec.revision?.origin;
+    record["Origin"] = selectedScan.spec.revision.origin;
   }
   if (selectedScan.spec.revision?.commit) {
-    record["Commit"] = selectedScan.spec.revision?.commit;
+    record["Commit"] = selectedScan.spec.revision.commit;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (selectedScan.spec.packages) {
     record["Packages"] = selectedScan.spec.packages;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (selectedScan.spec.options) {
     record["Options"] = selectedScan.spec.options;
   }

--- a/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
+++ b/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { FC, Fragment, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router";

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeCSVButtons.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeCSVButtons.tsx
@@ -37,6 +37,7 @@ export const ScannerDataframeCopyCSVButton: FC = () => {
     if (!gridApi) return;
 
     // Check clipboard API availability (not available in non-secure contexts)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!navigator.clipboard) {
       console.error("Clipboard API not available (requires HTTPS)");
       setStatus("error");

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
@@ -98,11 +98,9 @@ const useDataframeColumns = () => {
   const filterColumn = useCallback(
     (column: string, show: boolean) => {
       if (show && !filteredColumns.includes(column)) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        setFilteredColumns([...(filteredColumns || []), column]);
+        setFilteredColumns([...filteredColumns, column]);
       } else if (!show) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        setFilteredColumns(filteredColumns.filter((c) => c !== column) || []);
+        setFilteredColumns(filteredColumns.filter((c) => c !== column));
       }
     },
     [filteredColumns, setFilteredColumns]
@@ -182,8 +180,7 @@ const useDataframeColumns = () => {
     setAllFilter,
     setNoneFilter,
     filterColumn,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    filtered: filteredColumns || [],
+    filtered: filteredColumns,
     arrangedColumns,
   };
 };

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
@@ -82,10 +82,10 @@ const useDataframeColumns = () => {
     (state) => state.setDataframeFilterColumns
   );
   const isDefaultFilter =
-    filteredColumns?.length === defaultColumns.length &&
+    filteredColumns.length === defaultColumns.length &&
     filteredColumns.every((col) => defaultColumns.includes(col));
-  const isAllFilter = filteredColumns?.length === allColumns.length;
-  const isNoneFilter = filteredColumns?.length === 0;
+  const isAllFilter = filteredColumns.length === allColumns.length;
+  const isNoneFilter = filteredColumns.length === 0;
   const setDefaultFilter = () => {
     setFilteredColumns(defaultColumns);
   };
@@ -97,10 +97,12 @@ const useDataframeColumns = () => {
   };
   const filterColumn = useCallback(
     (column: string, show: boolean) => {
-      if (show && !filteredColumns?.includes(column)) {
+      if (show && !filteredColumns.includes(column)) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         setFilteredColumns([...(filteredColumns || []), column]);
       } else if (!show) {
-        setFilteredColumns(filteredColumns?.filter((c) => c !== column) || []);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        setFilteredColumns(filteredColumns.filter((c) => c !== column) || []);
       }
     },
     [filteredColumns, setFilteredColumns]
@@ -180,6 +182,7 @@ const useDataframeColumns = () => {
     setAllFilter,
     setNoneFilter,
     filterColumn,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     filtered: filteredColumns || [],
     arrangedColumns,
   };

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.tsx
@@ -55,7 +55,7 @@ const ColumnHeader: FC<{
       const nextSortDirection =
         sort?.direction === undefined
           ? "asc"
-          : sort?.direction === "asc"
+          : sort.direction === "asc"
             ? "desc"
             : undefined;
 
@@ -105,7 +105,7 @@ const ColumnHeader: FC<{
       {sort && (
         <i
           className={clsx(
-            sort?.direction === "asc"
+            sort.direction === "asc"
               ? ApplicationIcons.arrows.up
               : ApplicationIcons.arrows.down
           )}

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -47,6 +47,7 @@ interface ResultGroup {
 const isResultGroup = (
   entry: ResultGroup | ScanResultSummary
 ): entry is ResultGroup => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return "type" in entry && entry.type === "group";
 };
 
@@ -487,6 +488,7 @@ const optimalColumnLayout = (
         return Math.max(max, len);
       } else {
         const valStr =
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           s.value !== undefined && s.value !== null
             ? valueAsString(s.value)
             : "";
@@ -499,6 +501,7 @@ const optimalColumnLayout = (
   }
 
   const hasValidations = scannerSummaries.some(
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     (s) => s.validationResult !== undefined && s.validationResult !== null
   );
   if (hasValidations) {

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
@@ -42,6 +42,7 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
   );
 
   // Generate the route to the scan result using the current scan path and the entry's uuid
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const isNavigable = summary.identifier !== undefined && !!scansDir;
   const scanResultUrl = isNavigable
     ? scanResultRoute(scansDir, scanPath, summary.identifier, searchParams)

--- a/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultHeader.tsx
@@ -49,6 +49,7 @@ export const ScannerResultHeader: FC<ScannerResultHeaderProps> = ({
   if (collapsed) {
     if (!inputData || !isTranscriptInput(inputData) || !resultData) return null;
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const sourceUri = resultData.transcriptSourceUri ?? "";
     let resolvedSourceUrl = sourceUri;
     if (resolvedSourceUrl && resolvedSourceUrl.startsWith("/")) {
@@ -162,6 +163,7 @@ const transcriptHeadings = (
   if (!resultData) return [];
 
   // Source info
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const sourceUri = resultData.transcriptSourceUri ?? "";
   let resolvedSourceUrl = sourceUri;
   if (resolvedSourceUrl && resolvedSourceUrl.startsWith("/")) {
@@ -277,6 +279,7 @@ const messageHeadings = (
     headings.push({ label: "Model", value: message.model });
     headings.push({
       label: "Tool Calls",
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       value: ((message.tool_calls as []) || []).length,
     });
   } else {

--- a/apps/scout/src/app/scannerResult/ScannerResultNav.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultNav.tsx
@@ -21,7 +21,7 @@ export const ScannerResultNav: FC = () => {
     >
       <span className="text-size-smallest">
         {result
-          ? printIdentifier(resultIdentifier(result), result?.label)
+          ? printIdentifier(resultIdentifier(result), result.label)
           : undefined}
       </span>
     </NextPreviousNav>

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -252,7 +252,8 @@ export const ScannerResultPanel: FC = () => {
 
   const hasError =
     selectedResult?.scanError !== undefined &&
-    selectedResult?.scanError !== null;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    selectedResult.scanError !== null;
 
   const highlightLabeled = useStore((state) => state.highlightLabeled);
   const setHighlightLabeled = useStore((state) => state.setHighlightLabeled);
@@ -285,7 +286,7 @@ export const ScannerResultPanel: FC = () => {
     if (
       selectedTab === kTabIdInput &&
       selectedResult?.inputType === "transcript" &&
-      selectedResult?.messageReferences.length > 0
+      selectedResult.messageReferences.length > 0
     ) {
       toolButtons.push(
         <ToolButton
@@ -376,6 +377,7 @@ export const ScannerResultPanel: FC = () => {
           id={kTabIdResult}
           selected={
             selectedTab === kTabIdResult ||
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             (!hasError && selectedTab === undefined)
           }
           title="Result"
@@ -385,6 +387,7 @@ export const ScannerResultPanel: FC = () => {
           }}
           className={styles.fullHeight}
         >
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
           {resultData && inputData && (
             <ResultPanel resultData={resultData} inputData={inputData} />
           )}

--- a/apps/scout/src/app/scannerResult/info/InfoPanel.tsx
+++ b/apps/scout/src/app/scannerResult/info/InfoPanel.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { FC } from "react";
 
@@ -37,8 +38,8 @@ export const InfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
           </CardBody>
         </Card>
 
-        {resultData?.scanModelUsage &&
-          Object.keys(resultData?.scanModelUsage).length > 0 && (
+        {resultData.scanModelUsage &&
+          Object.keys(resultData.scanModelUsage).length > 0 && (
             <Card>
               <CardHeader label="Model Usage" type="modern" />
               <CardBody>
@@ -46,14 +47,14 @@ export const InfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
               </CardBody>
             </Card>
           )}
-        {resultData?.scanMetadata &&
+        {resultData.scanMetadata &&
           Object.keys(resultData.scanMetadata).length > 0 && (
             <Card>
               <CardHeader label="Metadata" type="modern" />
               <CardBody>
                 <RecordTree
-                  id={`scan-metadata-${resultData?.identifier}`}
-                  record={resultData?.scanMetadata || {}}
+                  id={`scan-metadata-${resultData.identifier}`}
+                  record={resultData.scanMetadata || {}}
                   copyButton={true}
                 />
               </CardBody>
@@ -70,7 +71,7 @@ export const ScannerInfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
       <div className={clsx(styles.scanInfo)}>
         <LabeledValue label="Name">{resultData?.scannerName}</LabeledValue>
         {resultData?.scannerFile && resultData.scannerFile !== null && (
-          <LabeledValue label="File">{resultData?.scannerFile}</LabeledValue>
+          <LabeledValue label="File">{resultData.scannerFile}</LabeledValue>
         )}
         {(resultData?.scanTotalTokens || 0) > 0 && (
           <LabeledValue label="Tokens">
@@ -82,15 +83,15 @@ export const ScannerInfoPanel: FC<InfoPanelProps> = ({ resultData }) => {
       </div>
       {resultData?.scanTags && resultData.scanTags.length > 0 && (
         <LabeledValue label="Tags">
-          {(resultData?.scanTags || []).join(", ")}
+          {(resultData.scanTags || []).join(", ")}
         </LabeledValue>
       )}
       {resultData?.scannerParams &&
         Object.keys(resultData.scannerParams).length > 0 && (
           <LabeledValue label="Params">
             <RecordTree
-              id={`scanner-params-${resultData?.identifier}`}
-              record={resultData?.scannerParams}
+              id={`scanner-params-${resultData.identifier}`}
+              record={resultData.scannerParams}
             />
           </LabeledValue>
         )}

--- a/apps/scout/src/app/scannerResult/metadata/MetadataPanel.tsx
+++ b/apps/scout/src/app/scannerResult/metadata/MetadataPanel.tsx
@@ -18,8 +18,7 @@ interface MetadataPanelProps {
 }
 
 export const MetadataPanel: FC<MetadataPanelProps> = ({ resultData }) => {
-  const hasMetadata =
-    resultData && Object.keys(resultData?.metadata).length > 0;
+  const hasMetadata = resultData && Object.keys(resultData.metadata).length > 0;
   return (
     resultData && (
       <div className={clsx(styles.container, "text-size-base")}>
@@ -30,6 +29,7 @@ export const MetadataPanel: FC<MetadataPanelProps> = ({ resultData }) => {
             <CardBody>
               <RecordTree
                 id={`result-metadata-${resultData.identifier}`}
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 record={resultData.metadata || {}}
                 copyButton={true}
               />

--- a/apps/scout/src/app/scannerResult/result/ResultBody.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultBody.tsx
@@ -117,6 +117,7 @@ const InputRenderer: FC<InputRendererProps> = ({
   onHeadroomResetAnchor,
 }) => {
   if (isTranscriptInput(inputData)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (inputData.input.messages && inputData.input.messages.length > 0) {
       const labels = resultData?.messageReferences.reduce((acc, ref) => {
         if (ref.cite) {
@@ -127,6 +128,7 @@ const InputRenderer: FC<InputRendererProps> = ({
 
       return (
         <ChatViewVirtualList
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           messages={inputData.input.messages || []}
           id={"scan-input-virtual-list"}
           display={{ indented: true }}
@@ -136,6 +138,7 @@ const InputRenderer: FC<InputRendererProps> = ({
           labels={{ highlight: highlightLabeled, messageLabels: labels }}
         />
       );
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (inputData.input.events && inputData.input.events.length > 0) {
       return (
         <TimelineEventsView

--- a/apps/scout/src/app/scannerResult/useScannerResultPrevNext.ts
+++ b/apps/scout/src/app/scannerResult/useScannerResultPrevNext.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { useMemo } from "react";
 import { useSearchParams } from "react-router";
 

--- a/apps/scout/src/app/scans/ScansGrid.tsx
+++ b/apps/scout/src/app/scans/ScansGrid.tsx
@@ -131,6 +131,7 @@ export const ScansGrid: FC<ScansGridProps> = ({
 
   // Compute effective column order
   const effectiveColumnOrder = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (columnOrder && columnOrder.length > 0) {
       return columnOrder;
     }

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -192,6 +192,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
     "outlineCollapsed",
     { defaultValue: !defaultOutlineExpanded }
   );
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const userOutlineCollapsed = outlineCollapsed ?? !defaultOutlineExpanded;
 
   const selectedOutlineId = useStore((state) => state.transcriptOutlineId);

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import {
   FC,

--- a/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
+++ b/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
@@ -142,6 +142,7 @@ export const TranscriptEventPanel: FC = () => {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (loading && !transcript) {
     return (
       <>
@@ -155,6 +156,7 @@ export const TranscriptEventPanel: FC = () => {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (transcript && nav.slice.length === 0) {
     return (
       <>
@@ -173,6 +175,7 @@ export const TranscriptEventPanel: FC = () => {
         header={header}
         className={styles.focusRoot}
         error={
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
           transcript?.error
             ? { label: "Transcript error", message: transcript.error }
             : undefined

--- a/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
+++ b/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
@@ -175,7 +175,7 @@ export const TranscriptEventPanel: FC = () => {
         header={header}
         className={styles.focusRoot}
         error={
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
           transcript?.error
             ? { label: "Transcript error", message: transcript.error }
             : undefined

--- a/apps/scout/src/app/transcripts/TranscriptsGrid.tsx
+++ b/apps/scout/src/app/transcripts/TranscriptsGrid.tsx
@@ -75,6 +75,7 @@ export const TranscriptsGrid: FC<TranscriptGridProps> = ({
     (state) => state.transcriptsTableState.rowSelection
   );
   const columnFilters =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     useStore((state) => state.transcriptsTableState.columnFilters) ?? {};
   const focusedRowId = useStore(
     (state) => state.transcriptsTableState.focusedRowId
@@ -129,6 +130,7 @@ export const TranscriptsGrid: FC<TranscriptGridProps> = ({
 
   // Compute effective column order: use explicit order if set, otherwise derive from DEFAULT_COLUMN_ORDER
   const effectiveColumnOrder = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (columnOrder && columnOrder.length > 0) {
       return columnOrder;
     }

--- a/apps/scout/src/app/transcripts/columns.tsx
+++ b/apps/scout/src/app/transcripts/columns.tsx
@@ -131,6 +131,7 @@ function createColumn<K extends keyof TranscriptInfo>(config: {
       if (config.cell) {
         return config.cell(value);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (value === undefined || value === null) {
         return "-";
       }

--- a/apps/scout/src/app/utils/arrow.ts
+++ b/apps/scout/src/app/utils/arrow.ts
@@ -92,6 +92,7 @@ export async function expandResultsetRows(
 
       // If the row has an empty result set, just leave it
       // intact
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!results || results.length === 0) {
         const expandedRow = { ...row };
         expandedRow.value = null;

--- a/apps/scout/src/app/utils/arrowHelpers.ts
+++ b/apps/scout/src/app/utils/arrowHelpers.ts
@@ -68,6 +68,7 @@ export const parseScanResultData = async (
     transcript_agent_args_raw
       ? parseJson(transcript_agent_args_raw)
       : Promise.resolve(undefined),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     transcript_score_raw !== null && transcript_score_raw !== undefined
       ? parseJsonValue(transcript_score_raw)
       : Promise.resolve(undefined),
@@ -171,6 +172,7 @@ export const parseScanResultData = async (
     scannerName,
     scannerParams: scannerParams as Record<string, JsonValue>,
     transcriptId,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     transcriptMetadata: transcriptMetadata ?? {},
     transcriptSourceId,
     transcriptSourceUri,
@@ -243,6 +245,7 @@ export const parseScanResultSummaries = async (
         transcriptTaskId: r.transcript_task_id as string | number | undefined,
         transcriptTaskRepeat: r.transcript_task_repeat as number | undefined,
         transcriptModel: r.transcript_model as string | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         transcriptMetadata: transcriptMetadata ?? {},
         transcriptSourceId: r.transcript_source_id as string,
         scanError: r.scan_error as string,

--- a/apps/scout/src/app/utils/refs.tsx
+++ b/apps/scout/src/app/utils/refs.tsx
@@ -185,6 +185,7 @@ const referenceTable = (
       {}
     );
   } else if (isTranscriptInput(inputData)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const eventRefs = (inputData.input.events || []).reduce<
       Record<string, () => ReactNode>
     >((acc, event) => {
@@ -196,6 +197,7 @@ const referenceTable = (
       return acc;
     }, {});
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const messageRefs = (inputData.input.messages || []).reduce<
       Record<string, () => ReactNode>
     >((acc, msg) => {

--- a/apps/scout/src/app/utils/results.ts
+++ b/apps/scout/src/app/utils/results.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import {
   isArrayValue,
   isBooleanValue,

--- a/apps/scout/src/app/utils/useTranscriptsDir.ts
+++ b/apps/scout/src/app/utils/useTranscriptsDir.ts
@@ -32,7 +32,7 @@ export function useTranscriptsDir(
       ? "route"
       : userTranscriptsDir
         ? "user"
-        : config.transcripts && config.transcripts?.source === "cli"
+        : config.transcripts && config.transcripts.source === "cli"
           ? "cli"
           : "project";
 

--- a/apps/scout/src/app/validation/ValidationPanel.tsx
+++ b/apps/scout/src/app/validation/ValidationPanel.tsx
@@ -215,7 +215,7 @@ export const ValidationPanel: FC = () => {
   }
 
   // Check for empty state (no validation sets available)
-  const hasNoValidationSets = !setsError && validationSets?.length === 0;
+  const hasNoValidationSets = !setsError && validationSets.length === 0;
 
   if (hasNoValidationSets) {
     return (
@@ -260,6 +260,7 @@ export const ValidationPanel: FC = () => {
           </div>
         ) : (
           <ValidationSetSelector
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             validationSets={validationSets ?? []}
             selectedUri={selectedUri}
             onSelect={handleSelectSet}
@@ -341,7 +342,8 @@ export const ValidationPanel: FC = () => {
               <div className={styles.error}>
                 Error loading cases: {casesError.message}
               </div>
-            ) : cases ? (
+            ) : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            cases ? (
               <ValidationCasesList
                 cases={cases}
                 transcriptsDir={transcriptsDir}
@@ -357,6 +359,7 @@ export const ValidationPanel: FC = () => {
           </>
         )}
 
+        {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
         {!selectedUri && !setsLoading && (
           <div className={styles.emptyState}>
             Select a validation set to view its cases.

--- a/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
@@ -156,6 +156,7 @@ export const ValidationCaseEditor: FC<ValidationCaseEditorProps> = ({
       {!error && (
         <>
           <LoadingBar loading={loading} />
+          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
           {showPanel && setsData && (
             <ValidationCaseEditorComponent
               key={validatedSetUri}
@@ -393,7 +394,7 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
       const newUri = `${config.project_dir}/${filename}`;
 
       // Check for duplicates
-      if (validationSets?.includes(newUri)) {
+      if (validationSets.includes(newUri)) {
         setCreateError("A validation set with this name already exists");
         return;
       }
@@ -437,7 +438,7 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
 
   const isEditable =
     caseData?.target === undefined ||
-    caseData?.target === null ||
+    caseData.target === null ||
     (!Array.isArray(caseData.target) && typeof caseData.target !== "object");
 
   const hasCaseData =
@@ -475,6 +476,7 @@ const ValidationCaseEditorComponent: FC<ValidationCaseEditorComponentProps> = ({
           <SecondaryDisplayValue label="ID" value={transcriptId} />
           <Field label="Validation Set">
             <ValidationSetSelector
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               validationSets={validationSets || []}
               selectedUri={editorValidationSetUri}
               onSelect={handleValidationSetSelect}

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
@@ -367,7 +367,7 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
             const trimmedName = newSetName.trim();
             const extensionError = getExtensionError(trimmedName);
             const displayError = validationError || extensionError;
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
             const displayDir = appConfig?.project_dir?.startsWith("file://")
               ? appConfig.project_dir.slice(7)
               : appConfig?.project_dir;

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
@@ -367,8 +367,9 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
             const trimmedName = newSetName.trim();
             const extensionError = getExtensionError(trimmedName);
             const displayError = validationError || extensionError;
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
             const displayDir = appConfig?.project_dir?.startsWith("file://")
-              ? appConfig?.project_dir.slice(7)
+              ? appConfig.project_dir.slice(7)
               : appConfig?.project_dir;
 
             // Show hint only if no error and we have a name and projectDir

--- a/apps/scout/src/debugging/navigationDebugging.tsx
+++ b/apps/scout/src/debugging/navigationDebugging.tsx
@@ -14,6 +14,7 @@ const NAVIGATION_LOGGING_ENABLED = false;
 const timestamp = () => new Date().toISOString().slice(11, 23);
 
 export const navigationLog = (description: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (NAVIGATION_LOGGING_ENABLED) {
     console.log(`[${timestamp()}] ${description}`);
   }

--- a/packages/inspect-common/src/utils/effectiveConfig.ts
+++ b/packages/inspect-common/src/utils/effectiveConfig.ts
@@ -195,7 +195,7 @@ const changesFor = (
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can carry undefined previous despite JsonValue
           change.previous !== undefined,
         scope: update.scope,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (see malformedUpdates tests)
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (#555; see malformedUpdates tests)
         inherited: update.provenance?.metadata?.["inherited"] === true,
         provenance: update.provenance,
       });
@@ -246,7 +246,7 @@ export const concurrencyChanges = (
         cleared: change.cleared,
         limitLifted: false,
         scope: update.scope,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (see malformedUpdates tests)
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (#555; see malformedUpdates tests)
         inherited: update.provenance?.metadata?.["inherited"] === true,
         provenance: update.provenance,
       });

--- a/packages/inspect-common/src/utils/effectiveConfig.ts
+++ b/packages/inspect-common/src/utils/effectiveConfig.ts
@@ -192,9 +192,10 @@ const changesFor = (
           !change.cleared &&
           change.value === null &&
           change.previous !== null &&
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can carry undefined previous despite JsonValue
           change.previous !== undefined,
         scope: update.scope,
-        // provenance?. — the cast doesn't guarantee it exists either.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (see malformedUpdates tests)
         inherited: update.provenance?.metadata?.["inherited"] === true,
         provenance: update.provenance,
       });
@@ -245,6 +246,7 @@ export const concurrencyChanges = (
         cleared: change.cleared,
         limitLifted: false,
         scope: update.scope,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: crafted logs can omit provenance despite the type (see malformedUpdates tests)
         inherited: update.provenance?.metadata?.["inherited"] === true,
         provenance: update.provenance,
       });

--- a/packages/inspect-common/src/utils/modelFallbacks.ts
+++ b/packages/inspect-common/src/utils/modelFallbacks.ts
@@ -5,6 +5,7 @@ import type { ModelFallback } from "../types";
  */
 export const totalModelFallbacks = (
   fallbacks?: ModelFallback[] | null
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 ): number => (fallbacks ?? []).reduce((sum, f) => sum + (f.count ?? 1), 0);
 
 /**
@@ -15,5 +16,6 @@ export const modelFallbackLines = (
 ): string[] =>
   (fallbacks ?? []).map(
     (f) =>
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       `${f.model} → ${f.fallback_model}${(f.count ?? 1) > 1 ? ` (×${f.count})` : ""}`
   );

--- a/packages/inspect-components/src/chat/ChatMessage.tsx
+++ b/packages/inspect-components/src/chat/ChatMessage.tsx
@@ -72,6 +72,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
     message.role === "system" ||
     message.role === "user" ||
     message.role === "assistant" ||
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     message.role === "tool";
   const hideRole = unlabeledRoles?.includes(message.role) ?? false;
 
@@ -83,6 +84,7 @@ export const ChatMessage: FC<ChatMessageProps> = memo(function ChatMessage({
   if (
     displayMode === "rendered" &&
     isNonSubagentTool &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     message.role === "tool" &&
     message.function
   ) {

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -122,6 +122,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
     resolvedMessage.message.tool_calls &&
     resolvedMessage.message.tool_calls.length
   ) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const toolMessages = resolvedMessage.toolMessages || [];
     let idx = 0;
     for (const tool_call of resolvedMessage.message.tool_calls) {

--- a/packages/inspect-components/src/chat/MessageContent.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.tsx
@@ -102,6 +102,7 @@ export const MessageContent: FC<MessageContentProps> = ({
           references
         );
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (content) {
           const renderer = messageRenderers[content.type];
           if (renderer) {

--- a/packages/inspect-components/src/chat/messageSearchText.ts
+++ b/packages/inspect-components/src/chat/messageSearchText.ts
@@ -21,6 +21,7 @@ export const messageSearchText = (resolved: ResolvedMessage): string[] => {
       if (toolCall.function) {
         texts.push(toolCall.function);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (toolCall.arguments) {
         texts.push(JSON.stringify(toolCall.arguments));
       }

--- a/packages/inspect-components/src/chat/messagesToStr.ts
+++ b/packages/inspect-components/src/chat/messagesToStr.ts
@@ -54,6 +54,7 @@ const messageToStr = (
       const funcName = tool.function;
       const args = tool.arguments;
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (typeof args === "object" && args !== null) {
         const argsText = Object.entries(args)
           .map(([k, v]) => `${k}: ${String(v)}`)

--- a/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
+++ b/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
@@ -230,6 +230,7 @@ const maybeCodeExecution = (
   }
   try {
     const parsed = JSON.parse(content.result) as Record<string, unknown>;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (typeof parsed !== "object" || parsed === null) {
       return undefined;
     }
@@ -273,6 +274,7 @@ const resolveArgs = (content: ContentToolUse): Record<string, unknown> => {
     return {};
   } else if (typeof content.arguments === "object") {
     return content.arguments;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (content.arguments) {
     return { arguments: content.arguments };
   } else {
@@ -297,6 +299,7 @@ const argsSummary = (args: Record<string, unknown>): string => {
 };
 
 const hasResultContent = (result: ContentToolUse["result"]): boolean => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (result === null || result === undefined) return false;
   if (typeof result === "string") return result.trim().length > 0;
   return true;

--- a/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
+++ b/packages/inspect-components/src/chat/tools/ClientToolCall.tsx
@@ -161,6 +161,7 @@ const fullArgs = (functionCall: string, tool: string): string | undefined => {
 
 /** Whether the tool output has anything worth an output well. */
 const hasOutputContent = (output: ToolCallViewProps["output"]): boolean => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (output === undefined || output === null) return false;
   if (typeof output === "string") return output.trim().length > 0;
   if (typeof output === "number" || typeof output === "boolean") return true;

--- a/packages/inspect-components/src/chat/tools/ToolOutput.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolOutput.tsx
@@ -65,6 +65,7 @@ export const ToolOutput: FC<ToolOutputProps> = ({
         if (out.reasoning) {
           outputs.push(<ToolTextOutput text={out.reasoning} key={key} />);
         }
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       } else if (out.type === "data" && out.data) {
         outputs.push(
           <ToolTextOutput text={JSON.stringify(out.data)} key={key} />

--- a/packages/inspect-components/src/chat/tools/tool.ts
+++ b/packages/inspect-components/src/chat/tools/tool.ts
@@ -700,6 +700,7 @@ const extractInput = (
   };
 
   // No args
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!args) {
     return {
       args: [],

--- a/packages/inspect-components/src/config/ConfigChangedChip.tsx
+++ b/packages/inspect-components/src/config/ConfigChangedChip.tsx
@@ -212,6 +212,7 @@ export const ConfigValueCell: FC<ConfigValueCellProps> = ({
 }) => {
   const showPrior =
     !change.cleared &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     change.previous !== undefined &&
     change.previous !== change.value;
 

--- a/packages/inspect-components/src/content/MetaDataGrid.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.tsx
@@ -171,11 +171,13 @@ export const MetaDataGrid: FC<MetadataGridProps> = ({
 const entryRecords = (
   entries: { name: string; value: unknown }[] | Record<string, unknown>
 ): { name: string; value: unknown }[] => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!entries) {
     return [];
   }
 
   if (!Array.isArray(entries)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return Object.entries(entries || {}).map(([key, value]) => {
       return { name: key, value };
     });

--- a/packages/inspect-components/src/content/RecordTree.tsx
+++ b/packages/inspect-components/src/content/RecordTree.tsx
@@ -294,6 +294,7 @@ export const toTreeItems = (
   currentDepth = 0,
   currentPath: string[] = []
 ): MetadataItem[] => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!record) {
     return [];
   }
@@ -358,6 +359,7 @@ const processNodeRecursive = (
     processChildren = true;
     childCount = value.length;
     displayValue = `Array(${value.length})`;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (typeof value === "object" && value !== null) {
     processChildren = true;
     childCount = Object.keys(value).length;
@@ -411,6 +413,7 @@ const processNodeRecursive = (
           );
         });
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (typeof value === "object" && value !== null) {
       // Process object properties
       Object.entries(value as Record<string, unknown>).forEach(

--- a/packages/inspect-components/src/content/copyText.ts
+++ b/packages/inspect-components/src/content/copyText.ts
@@ -25,6 +25,7 @@ export const copyValueText = (value: unknown): string => {
   // Circular structures (or exotic objects JSON can't represent) have no
   // sensible text form — copy an empty string rather than "[object Object]".
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return JSON.stringify(value, null, 2) ?? "";
   } catch {
     return "";

--- a/packages/inspect-components/src/transcript-search/SearchPanel.tsx
+++ b/packages/inspect-components/src/transcript-search/SearchPanel.tsx
@@ -731,6 +731,7 @@ const SearchResult: FC<{
   const markdownRefs = useMemo((): MarkdownReference[] => {
     const seen = new Set<string>();
     const refs: MarkdownReference[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     for (const ref of result.references ?? []) {
       if (ref.cite && !seen.has(ref.cite)) {
         seen.add(ref.cite);
@@ -739,7 +740,8 @@ const SearchResult: FC<{
             ? scope === "events"
               ? getEventMessageUrl(ref.id)
               : getMessageUrl(ref.id)
-            : ref.type === "event"
+            : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              ref.type === "event"
               ? getEventUrl(ref.id)
               : undefined;
         refs.push({

--- a/packages/inspect-components/src/transcript-search/referenceLabels.ts
+++ b/packages/inspect-components/src/transcript-search/referenceLabels.ts
@@ -26,6 +26,7 @@ export const deriveSearchReferenceLabels = (
     if (!ref.cite) continue;
     if (ref.type === "message") {
       messageLabels[ref.id] = ref.cite;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (ref.type === "event") {
       eventLabels[ref.id] = ref.cite;
     }

--- a/packages/inspect-components/src/transcript/BranchPoint.tsx
+++ b/packages/inspect-components/src/transcript/BranchPoint.tsx
@@ -79,6 +79,7 @@ const Segment: FC<SegmentProps> = ({
 }) => {
   const interactive = !!onSelect && !isCurrent;
   const handleClick = (e: MouseEvent<HTMLButtonElement>): void => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (interactive && onSelect) {
       onSelect(branch, e.currentTarget);
     }

--- a/packages/inspect-components/src/transcript/GoToTurnBar.tsx
+++ b/packages/inspect-components/src/transcript/GoToTurnBar.tsx
@@ -91,6 +91,7 @@ export const GoToTurnBar = forwardRef<GoToTurnBarHandle, GoToTurnBarProps>(
         // Several transcripts can be mounted at once (e.g. one in a modal over
         // another) — only the visible bar may claim the shortcut.
         const dock = dockRef.current;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- checkVisibility is missing in jsdom and pre-17.4 Safari despite lib.dom
         if (!dock?.isConnected || dock.checkVisibility?.() === false) return;
         // Use the shared editable check against activeElement so it pierces
         // shadow DOM (vscode-elements inputs) and covers <select> — matching

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { FC, useMemo, useRef, useState } from "react";
 
@@ -63,6 +64,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   const isCancelled = isCancelError(event.error);
   const isFailed = !!event.error && !isCancelled;
 
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const totalUsage = event.output?.usage?.total_tokens;
   const callTime = event.output?.time;
 
@@ -78,6 +80,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   // Stop reason / refusal detail for the (primary) generated choice. `category`
   // and `explanation` are only present on a refusal/content-filter stop. Skip the
   // panel for a plain "stop" with no details — otherwise it shows on every call.
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const firstChoice = event.output?.choices?.[0];
   const stopDetails = firstChoice?.stop_details;
   const showStopReason =
@@ -140,6 +143,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       ? `${panelTitle} · Cancelled${formatFailureTime(event)}`
       : formatTitle(panelTitle, totalUsage, callTime);
 
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const fallback = event.output?.fallback;
   const fallbackBadge = fallback ? (
     <span className={styles.fallbackBadge}>

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -64,7 +64,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   const isCancelled = isCancelError(event.error);
   const isFailed = !!event.error && !isCancelled;
 
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const totalUsage = event.output?.usage?.total_tokens;
   const callTime = event.output?.time;
 
@@ -80,7 +80,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   // Stop reason / refusal detail for the (primary) generated choice. `category`
   // and `explanation` are only present on a refusal/content-filter stop. Skip the
   // panel for a plain "stop" with no details — otherwise it shows on every call.
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const firstChoice = event.output?.choices?.[0];
   const stopDetails = firstChoice?.stop_details;
   const showStopReason =
@@ -143,7 +143,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       ? `${panelTitle} · Cancelled${formatFailureTime(event)}`
       : formatTitle(panelTitle, totalUsage, callTime);
 
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const fallback = event.output?.fallback;
   const fallbackBadge = fallback ? (
     <span className={styles.fallbackBadge}>

--- a/packages/inspect-components/src/transcript/ScoreEditEventView.tsx
+++ b/packages/inspect-components/src/transcript/ScoreEditEventView.tsx
@@ -115,10 +115,12 @@ export const ScoreEditEventView: FC<ScoreEditEventViewProps> = ({
           ""
         )}
 
+        {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
         {event.edit.metadata && event.edit.metadata !== kUnchangedSentinel ? (
           <div data-name="Metadata">
             <RecordTree
               id={`${eventNode.id}-score-metadata`}
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               record={event.edit.metadata || {}}
               className={styles.metadataTree}
               defaultExpandLevel={0}

--- a/packages/inspect-components/src/transcript/SpanEventView.tsx
+++ b/packages/inspect-components/src/transcript/SpanEventView.tsx
@@ -96,6 +96,7 @@ const spanDescriptor = (
     return { ...rootStepDescriptor };
   } else if (event.type === "scorer") {
     return { ...rootStepDescriptor };
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (event.event === "span_begin") {
     if (event.span_id === kSandboxSignalName) {
       return { ...rootStepDescriptor, name: "Sandbox Events" };

--- a/packages/inspect-components/src/transcript/StepEventView.tsx
+++ b/packages/inspect-components/src/transcript/StepEventView.tsx
@@ -91,6 +91,7 @@ const stepDescriptor = (
     return { ...rootStepDescriptor };
   } else if (event.type === "scorer") {
     return { ...rootStepDescriptor };
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (event.event === "step") {
     if (event.name === kSandboxSignalName) {
       return { ...rootStepDescriptor, name: "Sandbox Events" };

--- a/packages/inspect-components/src/transcript/SubtaskEventView.tsx
+++ b/packages/inspect-components/src/transcript/SubtaskEventView.tsx
@@ -81,6 +81,7 @@ const SubtaskSummary: FC<SubtaskSummaryProps> = ({ input, result }) => {
       <div className={clsx("text-style-label", "text-size-small")}>Input</div>
       <div className={clsx("text-size-large", styles.subtaskLabel)}></div>
       <div className={clsx("text-style-label", "text-size-small")}>Output</div>
+      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
       {input ? <Rendered values={input} /> : undefined}
       <div className={clsx("text-size-title-secondary", styles.subtaskLabel)}>
         <i className={kArrowRightIcon} />

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -93,7 +93,7 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
     const directLabel = event.message_id
       ? messageLabels[event.message_id]
       : undefined;
-    const label = directLabel ?? context?.toolLabels?.[event.id];
+    const label = directLabel ?? context.toolLabels?.[event.id];
     return { messageLabels: label ? { [event.id]: label } : {} };
   }, [context?.messageLabels, context?.toolLabels, event.id, event.message_id]);
 
@@ -115,6 +115,7 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
       input={input}
       description={description}
       contentType={contentType}
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       output={event.result ?? ""}
       selfAnnotation={context?.selfAnnotation}
       inputScreenshot={context?.inputScreenshot}

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
@@ -111,6 +111,7 @@ export interface TranscriptViewNodesHandle {
 // =============================================================================
 
 const escapeAttr = (id: string): string =>
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   typeof CSS !== "undefined" && CSS.escape
     ? CSS.escape(id)
     : id.replace(/"/g, '\\"');

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -476,7 +476,7 @@ export const EventPanel: FC<EventPanelProps> = ({
             : undefined
         )}
       >
-        {filteredArrChildren?.map((child, index) => {
+        {filteredArrChildren.map((child, index) => {
           const id = pillId(index);
           const isSelected = id === selectedNav;
 
@@ -489,6 +489,7 @@ export const EventPanel: FC<EventPanelProps> = ({
             <div
               key={`children-${id}-${index}`}
               id={id}
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               className={clsx("tab-pane", "show", isSelected ? "active" : "")}
             >
               {child}

--- a/packages/inspect-components/src/transcript/event/StopReasonBadge.tsx
+++ b/packages/inspect-components/src/transcript/event/StopReasonBadge.tsx
@@ -62,6 +62,7 @@ export const StopReasonBadge: FC<StopReasonBadgeProps> = ({
   reason,
   details,
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const toneClass = TONE_CLASS[STOP_TONE[reason] ?? "gray"];
   const entries = detailEntries(details);
 

--- a/packages/inspect-components/src/transcript/event/attemptDuration.ts
+++ b/packages/inspect-components/src/transcript/event/attemptDuration.ts
@@ -9,7 +9,7 @@ import type { ModelEvent } from "@tsmono/inspect-common/types";
  * dependable duration can be derived.
  */
 export function attemptDurationSec(event: ModelEvent): number | null {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   const explicit = event.output?.time ?? event.working_time;
   if (typeof explicit === "number" && !Number.isNaN(explicit)) {
     return explicit;

--- a/packages/inspect-components/src/transcript/event/attemptDuration.ts
+++ b/packages/inspect-components/src/transcript/event/attemptDuration.ts
@@ -9,6 +9,7 @@ import type { ModelEvent } from "@tsmono/inspect-common/types";
  * dependable duration can be derived.
  */
 export function attemptDurationSec(event: ModelEvent): number | null {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   const explicit = event.output?.time ?? event.working_time;
   if (typeof explicit === "number" && !Number.isNaN(explicit)) {
     return explicit;

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -66,7 +66,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
         fields.push(["model", modelEvent.model]);
       }
       // Extract text from model output
-      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
+      // intentional ?. — log data isn't validated at the wire (#555); old files may omit type-required fields
       if (modelEvent.output?.choices) {
         for (const choice of modelEvent.output.choices) {
           for (const text of extractContentText(choice.message.content)) {
@@ -137,7 +137,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "error": {
       const errorEvent = event;
-      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
+      // intentional ?. — log data isn't validated at the wire (#555); old files may omit type-required fields
       if (errorEvent.error?.message) {
         fields.push(["message", errorEvent.error.message]);
       }
@@ -149,7 +149,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "logger": {
       const loggerEvent = event;
-      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
+      // intentional ?. — log data isn't validated at the wire (#555); old files may omit type-required fields
       if (loggerEvent.message?.message) {
         fields.push(["message", loggerEvent.message.message]);
       }

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import type { Content } from "@tsmono/inspect-common/types";
 
 import type { EventType } from "./types";
@@ -65,6 +66,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
         fields.push(["model", modelEvent.model]);
       }
       // Extract text from model output
+      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
       if (modelEvent.output?.choices) {
         for (const choice of modelEvent.output.choices) {
           for (const text of extractContentText(choice.message.content)) {
@@ -135,6 +137,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "error": {
       const errorEvent = event;
+      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
       if (errorEvent.error?.message) {
         fields.push(["message", errorEvent.error.message]);
       }
@@ -146,6 +149,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "logger": {
       const loggerEvent = event;
+      // intentional ?. — log data isn't validated at the wire; old files may omit type-required fields
       if (loggerEvent.message?.message) {
         fields.push(["message", loggerEvent.message.message]);
       }

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.ts
@@ -50,6 +50,7 @@ export function useTranscriptCollapse(
     }
     if (bulkCollapse === "expand") {
       onSetTranscriptCollapsed({});
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (bulkCollapse === "collapse") {
       const allCollapsibleIds = collectAllCollapsibleIds(eventNodes);
       onSetTranscriptCollapsed(allCollapsibleIds);
@@ -63,6 +64,7 @@ export function useTranscriptCollapse(
   const onCollapseTranscript = useCallback(
     (nodeId: string, collapsed: boolean) => {
       if (!onCollapseTranscriptRaw || !onSetTranscriptCollapsed) return;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!collapseState?.transcript) {
         // First toggle — seed defaults then apply the toggle
         onSetTranscriptCollapsed({
@@ -87,6 +89,7 @@ export function useTranscriptCollapse(
   const onExpandNodes = useCallback(
     (nodeIds: string[]) => {
       if (!onSetTranscriptCollapsed) return;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const next = { ...(collapseState?.transcript ?? defaultCollapsedIds) };
       for (const id of nodeIds) next[id] = false;
       onSetTranscriptCollapsed(next);

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.ts
@@ -65,6 +65,7 @@ export function useTranscriptKeyboardNavigation({
       const container = scrollRef?.current;
       if (
         container &&
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: checkVisibility is absent in jsdom and older browsers
         (!container.isConnected || container.checkVisibility?.() === false)
       ) {
         return;

--- a/packages/inspect-components/src/transcript/resolveMessageToEvent.ts
+++ b/packages/inspect-components/src/transcript/resolveMessageToEvent.ts
@@ -296,8 +296,10 @@ function matchEvent(
     if (!uuid) return matches;
 
     // Priority 1: ModelEvent output
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
     if (event.output?.choices) {
       for (const choice of event.output.choices) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
         if (choice.message?.id === messageId) {
           matches.push({
             priority: PRIORITY_MODEL_OUTPUT,
@@ -311,6 +313,7 @@ function matchEvent(
     // Priority 2: Agent card result via bridge flow
     // Priority 3.5: Tool call bridge — tool-role message whose tool_call_id
     // matches a sibling ToolEvent's id. Redirects to the ToolEvent.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (event.input) {
       for (const msg of event.input) {
         if (msg.role === "tool" && msg.id === messageId) {
@@ -344,6 +347,7 @@ function matchEvent(
     }
 
     // Priority 4: ModelEvent input
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (event.input) {
       for (const msg of event.input) {
         if (msg.id === messageId) {

--- a/packages/inspect-components/src/transcript/resolveMessageToEvent.ts
+++ b/packages/inspect-components/src/transcript/resolveMessageToEvent.ts
@@ -296,10 +296,10 @@ function matchEvent(
     if (!uuid) return matches;
 
     // Priority 1: ModelEvent output
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
     if (event.output?.choices) {
       for (const choice of event.output.choices) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
         if (choice.message?.id === messageId) {
           matches.push({
             priority: PRIORITY_MODEL_OUTPUT,

--- a/packages/inspect-components/src/transcript/state/StateEventRenderers.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventRenderers.tsx
@@ -128,6 +128,7 @@ const human_baseline_session: ChangeType = {
 
     // Collect raw parts keyed by timestamp, then keep only entries with required fields
     const partial = new Map<string, Partial<SessionLog>>();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (rawSessions) {
       for (const key of Object.keys(rawSessions)) {
         const value = rawSessions[key] as string;
@@ -215,6 +216,7 @@ const renderTools = (
 
   // Show either all tools or just the specific tools
   const tools = resolvedState.tools as [];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (tools.length > 0) {
     if (toolIndexes.length === 0) {
       toolsInfo["Tools"] = (

--- a/packages/inspect-components/src/transcript/state/StateEventView.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventView.tsx
@@ -127,6 +127,7 @@ const generatePreview = (
         switch (op) {
           case "add":
             if (
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               changeType.signature.add &&
               changeType.signature.add.length > 0
             ) {
@@ -139,6 +140,7 @@ const generatePreview = (
             break;
           case "remove":
             if (
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               changeType.signature.remove &&
               changeType.signature.remove.length > 0
             ) {
@@ -151,6 +153,7 @@ const generatePreview = (
             break;
           case "replace":
             if (
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               changeType.signature.replace &&
               changeType.signature.replace.length > 0
             ) {

--- a/packages/inspect-components/src/transcript/timeline/contentItems.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/contentItems.test.ts
@@ -188,6 +188,7 @@ describe("buildContentItems", () => {
       const agentNames = items
         .filter((i) => i.type === "agent_card")
         .map((i) => {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (i.type !== "agent_card") throw new Error("unreachable");
           return i.agentNode.name;
         });
@@ -237,6 +238,7 @@ describe("buildContentItems", () => {
       expect(agentCards.length).toBe(4); // 4 utility spans
 
       const utilityCards = agentCards.filter(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         (i) => i.type === "agent_card" && i.agentNode.utility
       );
       expect(utilityCards).toHaveLength(4);
@@ -260,6 +262,7 @@ describe("buildContentItems", () => {
       const agentNames = items
         .filter((i) => i.type === "agent_card")
         .map((i) => {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (i.type !== "agent_card") throw new Error("unreachable");
           return i.agentNode.name;
         });

--- a/packages/inspect-components/src/transcript/timeline/contentItems.ts
+++ b/packages/inspect-components/src/transcript/timeline/contentItems.ts
@@ -148,7 +148,7 @@ function findEventByMessageId(items: ContentItem[], messageId: string): number {
     if (!item || item.type !== "event") continue;
     const event = item.eventNode.event;
     if (event.event === "model") {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
       const outMsg = event.output?.choices?.[0]?.message;
       if (outMsg && "id" in outMsg && outMsg.id === messageId) {
         return i;

--- a/packages/inspect-components/src/transcript/timeline/contentItems.ts
+++ b/packages/inspect-components/src/transcript/timeline/contentItems.ts
@@ -148,6 +148,7 @@ function findEventByMessageId(items: ContentItem[], messageId: string): number {
     if (!item || item.type !== "event") continue;
     const event = item.eventNode.event;
     if (event.event === "model") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
       const outMsg = event.output?.choices?.[0]?.message;
       if (outMsg && "id" in outMsg && outMsg.id === messageId) {
         return i;
@@ -165,6 +166,7 @@ function findEventByMessageId(items: ContentItem[], messageId: string): number {
     const item = items[i];
     if (!item || item.type !== "event") continue;
     const event = item.eventNode.event;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (event.event === "model" && event.input) {
       const input = event.input as Array<Record<string, unknown>>;
       for (const msg of input) {

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -503,7 +503,7 @@ export function stripSuffix(e: Event, suffix: string, trajId: string): Event {
  */
 function getEventTokens(event: Event): number {
   if (event.event === "model") {
-    // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+    // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
     const usage = event.output?.usage;
     if (usage) {
       const inputTokens = usage.input_tokens ?? 0;
@@ -1316,7 +1316,7 @@ function getSystemPromptForEvent(event: ModelEvent): string | null {
  * Check whether a ModelEvent's output contains tool calls.
  */
 function hasToolCalls(event: ModelEvent): boolean {
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   const choices = event.output?.choices;
   if (choices && choices.length > 0) {
     const msg = choices[0]!.message;
@@ -1412,7 +1412,7 @@ function wrapUtilityEvents(agent: TimelineSpan): void {
 }
 
 function isWarmupCall(event: ModelEvent): boolean {
-  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
+  // intentional ?. — data isn't validated at the wire (#555); old files may omit type-required fields
   if (event.config?.max_tokens == null || event.config.max_tokens > 1) {
     return false;
   }

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /**
  * Transcript nodes: hierarchical structure for visualization and scanning.
  *
@@ -502,6 +503,7 @@ export function stripSuffix(e: Event, suffix: string, trajId: string): Event {
  */
 function getEventTokens(event: Event): number {
   if (event.event === "model") {
+    // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
     const usage = event.output?.usage;
     if (usage) {
       const inputTokens = usage.input_tokens ?? 0;
@@ -1314,6 +1316,7 @@ function getSystemPromptForEvent(event: ModelEvent): string | null {
  * Check whether a ModelEvent's output contains tool calls.
  */
 function hasToolCalls(event: ModelEvent): boolean {
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   const choices = event.output?.choices;
   if (choices && choices.length > 0) {
     const msg = choices[0]!.message;
@@ -1409,6 +1412,7 @@ function wrapUtilityEvents(agent: TimelineSpan): void {
 }
 
 function isWarmupCall(event: ModelEvent): boolean {
+  // intentional ?. — data isn't validated at the wire; old files may omit type-required fields
   if (event.config?.max_tokens == null || event.config.max_tokens > 1) {
     return false;
   }

--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /**
  * Fixture-driven tests for buildTimeline().
  *

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -201,7 +201,7 @@ export function useTranscriptTimeline(
           priorSelected: timelineProps?.selected ?? null,
         },
       ]);
-      timelineProps?.onSelect?.(null);
+      timelineProps?.onSelect(null);
     },
     [baseTimeline.root, timelineProps]
   );
@@ -209,7 +209,7 @@ export function useTranscriptTimeline(
     const top = viewStack.at(-1);
     if (!top) return;
     setViewStack((s) => s.slice(0, -1));
-    timelineProps?.onSelect?.(top.priorSelected);
+    timelineProps?.onSelect(top.priorSelected);
   }, [viewStack, timelineProps]);
 
   const state = useTimeline(timeline, timelineOptions, timelineProps);
@@ -349,6 +349,7 @@ export function useTranscriptTimeline(
     keys.set(rowKey, 100);
 
     let childKey = rowKey;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (true) {
       const parentKey = getParentKeyFromBranch(childKey);
       if (!parentKey) break;
@@ -372,6 +373,7 @@ export function useTranscriptTimeline(
     (timeline.root.content.some(
       (item) =>
         item.type === "span" ||
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         (item.type === "event" && item.event.event === "span_begin")
     ) ||
       timeline.root.branches.length > 0);
@@ -494,6 +496,7 @@ function computeBranchMappings(
   // Nearest ancestor row whose logical start has been computed.
   const nearestAncestor = (key: string): SwimlaneRow | undefined => {
     let k = key;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (true) {
       const i = k.lastIndexOf("/");
       if (i < 0) return root;

--- a/packages/inspect-components/src/transcript/timeline/markers.ts
+++ b/packages/inspect-components/src/transcript/timeline/markers.ts
@@ -146,6 +146,7 @@ function collectEventMarkers(
   for (const item of node.content) {
     if (item.type === "event") {
       addEventMarker(item, markers);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (item.type === "span" && shouldDescend(depth, currentLevel)) {
       collectEventMarkers(item, depth, currentLevel + 1, markers);
     }

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -49,6 +49,7 @@ interface PendingFailed {
 function toolChoiceEqual(a: ToolChoice, b: ToolChoice): boolean {
   if (a === b) return true;
   if (typeof a === "string" || typeof b === "string") return a === b;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
   return a?.name === b?.name;
 }
 

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.ts
@@ -49,7 +49,7 @@ interface PendingFailed {
 function toolChoiceEqual(a: ToolChoice, b: ToolChoice): boolean {
   if (a === b) return true;
   if (typeof a === "string" || typeof b === "string") return a === b;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
   return a?.name === b?.name;
 }
 

--- a/packages/inspect-components/src/transcript/timeline/swimlaneLayout.ts
+++ b/packages/inspect-components/src/transcript/timeline/swimlaneLayout.ts
@@ -265,6 +265,7 @@ function computeBarFromMapping(
 export function spanHasEvents(span: TimelineSpan): boolean {
   for (const item of span.content) {
     if (item.type === "event") return true;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (item.type === "span" && spanHasEvents(item)) return true;
   }
   return false;

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.ts
@@ -457,6 +457,7 @@ function collectFromContent(
       // already shown on the AgentCard, so don't duplicate them inline.
       if (item.event.event === "model" && pendingToolCallIds.size > 0) {
         const modelEvent = item.event;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (modelEvent.input && Array.isArray(modelEvent.input)) {
           const filteredInput = (
             modelEvent.input as Array<Record<string, unknown>>
@@ -674,6 +675,7 @@ function buildPath(rows: SwimlaneRow[], selectedKey: string): PathSegment[] {
   const byKey = new Map(rows.map((r) => [r.key, r]));
   const keys: string[] = [selectedKey];
   let k = selectedKey;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
     const parent = getParentKeyFromBranch(k);
     if (!parent || !byKey.has(parent)) break;

--- a/packages/inspect-components/src/transcript/transform/fixups.ts
+++ b/packages/inspect-components/src/transcript/transform/fixups.ts
@@ -45,7 +45,7 @@ const processPendingEvents = (events: Event[], filter: boolean): Event[] => {
           lastIndex >= 0 &&
           event.uuid != null &&
           acc[lastIndex]?.pending &&
-          acc[lastIndex]?.uuid === event.uuid
+          acc[lastIndex].uuid === event.uuid
         ) {
           acc[lastIndex] = event;
         } else {

--- a/packages/inspect-components/src/transcript/transform/labels.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.ts
@@ -26,6 +26,7 @@ export const buildToolLabels = (
         : undefined;
       if (label) toolLabels[event.id] = label;
     } else if (event.event === "model") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       for (const message of event.input ?? []) {
         if (message.role !== "tool" || !message.id) continue;
         const label = messageLabels[message.id];
@@ -55,10 +56,13 @@ export const scopeMessageLabels = (
   const present = new Set<string>();
   for (const event of events) {
     if (event.event === "model") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       for (const message of event.input ?? []) {
         if (message.id) present.add(message.id);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
       for (const choice of event.output?.choices ?? []) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
         if (choice.message?.id) present.add(choice.message.id);
       }
     } else if (event.event === "tool" && event.message_id) {

--- a/packages/inspect-components/src/transcript/transform/labels.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.ts
@@ -60,9 +60,9 @@ export const scopeMessageLabels = (
       for (const message of event.input ?? []) {
         if (message.id) present.add(message.id);
       }
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
       for (const choice of event.output?.choices ?? []) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire; old files may omit type-required fields
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: data isn't validated at the wire (#555); old files may omit type-required fields
         if (choice.message?.id) present.add(choice.message.id);
       }
     } else if (event.event === "tool" && event.message_id) {

--- a/packages/inspect-components/src/transcript/transform/transform.ts
+++ b/packages/inspect-components/src/transcript/transform/transform.ts
@@ -52,6 +52,7 @@ export const transformTree = (roots: EventNode[]): EventNode[] => {
     }
 
     // Return all processed nodes
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return currentNodes && currentNodes.length === 1 && currentNodes[0]
       ? currentNodes[0]
       : currentNodes;
@@ -65,6 +66,7 @@ export const transformTree = (roots: EventNode[]): EventNode[] => {
   for (const transformer of treeNodeTransformers) {
     if (transformer.flush) {
       const flushResults = transformer.flush();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (flushResults && flushResults.length > 0) {
         flushedNodes.push(...flushResults);
       }
@@ -101,7 +103,7 @@ const transformers = () => {
         node.event["type"] === TYPE_SOLVER &&
         node.children.length === 2 &&
         node.children[0]?.event.event === SPAN_BEGIN &&
-        node.children[0]?.event.type === TYPE_AGENT &&
+        node.children[0].event.type === TYPE_AGENT &&
         node.children[1]?.event.event === STATE,
 
       process: (node) => skipFirstChildNode(node),
@@ -113,7 +115,7 @@ const transformers = () => {
         node.event["type"] === TYPE_SOLVER &&
         node.children.length === 3 &&
         node.children[0]?.event.event === SPAN_BEGIN &&
-        node.children[0]?.event.type === TYPE_AGENT &&
+        node.children[0].event.type === TYPE_AGENT &&
         node.children[1]?.event.event === STATE &&
         node.children[2]?.event.event === STORE,
       process: (node) => skipFirstChildNode(node),
@@ -132,16 +134,16 @@ const transformers = () => {
         if (node.children.length === 1) {
           return (
             node.children[0]?.event.event === TOOL &&
-            !!node.children[0]?.event.agent
+            !!node.children[0].event.agent
           );
         } else {
           return (
             node.children.length === 2 &&
             node.children[0]?.event.event === TOOL &&
             node.children[1]?.event.event === STORE &&
-            node.children[0]?.children.length === 2 &&
-            node.children[0]?.children[0]?.event.event === SPAN_BEGIN &&
-            node.children[0]?.children[0]?.event.type === TYPE_AGENT
+            node.children[0].children.length === 2 &&
+            node.children[0].children[0]?.event.event === SPAN_BEGIN &&
+            node.children[0].children[0].event.type === TYPE_AGENT
           );
         }
       },

--- a/packages/inspect-components/src/transcript/transform/treeify.ts
+++ b/packages/inspect-components/src/transcript/transform/treeify.ts
@@ -244,6 +244,7 @@ const injectScorersSpan = (events: Event[]): Event[] => {
     if (
       event.event === SPAN_BEGIN &&
       event.type === TYPE_SCORER &&
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       !hasCollectedScorers
     ) {
       collecting = event.span_id ?? null;
@@ -276,6 +277,7 @@ export const filterEmptySpans = (
   eventNodes: EventNode<EventType>[]
 ): EventNode<EventType>[] => {
   return eventNodes.filter((node) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (node.children && node.children.length > 0) {
       node.children = filterEmptySpans(node.children);
     }
@@ -289,6 +291,7 @@ export const filterEmptySpans = (
     }
     return (
       (node.event.event !== "span_begin" && node.event.event !== "step") ||
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       (node.children && node.children.length > 0)
     );
   });

--- a/packages/inspect-components/src/transcript/turnNavigation.ts
+++ b/packages/inspect-components/src/transcript/turnNavigation.ts
@@ -115,9 +115,11 @@ export function anchorIndexForEvent(
 function agentBoundaryName(node: EventNode): string | undefined {
   const event = node.event;
   if (event.event === "span_begin" && event.type === "agent") {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return event.name ?? "agent";
   }
   if (event.event === "subtask") {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return event.name ?? "subtask";
   }
   return undefined;
@@ -180,7 +182,7 @@ export function focusedTurnNodes(
   if (!target) return [];
   const end = flat.indexOf(slice[slice.length - 1]!) + 1;
   const isLastTurn =
-    target?.event.event === "model" &&
+    target.event.event === "model" &&
     !flat.slice(end).some((n) => n.event.event === "model");
   const trailing = isLastTurn
     ? flat.slice(end).filter((n) => kSampleTerminalEvents.has(n.event.event))

--- a/packages/inspect-components/src/usage/ModelUsagePanel.tsx
+++ b/packages/inspect-components/src/usage/ModelUsagePanel.tsx
@@ -129,6 +129,7 @@ export const ModelUsagePanel: FC<ModelUsageProps> = ({
   timing,
   className,
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!usage) return null;
 
   const categories = buildCategories(usage);

--- a/packages/inspect-components/src/usage/configsForUsage.ts
+++ b/packages/inspect-components/src/usage/configsForUsage.ts
@@ -50,6 +50,7 @@ export const buildConfigsByRole = (
   if (!evalSpec?.model_roles) return undefined;
   const acc: DictMap = {};
   for (const [role, rc] of Object.entries(evalSpec.model_roles)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (rc.config) acc[role] = stripNullish(rc.config);
   }
   return finalize(acc);
@@ -75,6 +76,7 @@ export const buildArgsByRole = (evalSpec?: EvalSpec): DictMap | undefined => {
   if (!evalSpec?.model_roles) return undefined;
   const acc: DictMap = {};
   for (const [role, rc] of Object.entries(evalSpec.model_roles)) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (rc.args) acc[role] = stripNullish(rc.args);
   }
   return finalize(acc);

--- a/packages/react/src/components/AnsiDisplay.tsx
+++ b/packages/react/src/components/AnsiDisplay.tsx
@@ -153,6 +153,7 @@ const computeCSSProperties = (outputRun: ANSIOutputRun) => {
 
 const computeStyles = (styles: ANSIStyle[]) => {
   let cssProperties = {};
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (styles) {
     styles.forEach((style) => {
       switch (style) {

--- a/packages/react/src/components/AutocompleteInput.tsx
+++ b/packages/react/src/components/AutocompleteInput.tsx
@@ -276,10 +276,11 @@ export const AutocompleteInput: FC<AutocompleteInputProps> = ({
   // Scroll highlighted item into view
   useEffect(() => {
     if (listRef.current && showDropdown && highlightedIndex >= 0) {
-      const highlighted = listRef.current.children[
-        highlightedIndex
-      ] as HTMLElement;
-      highlighted.scrollIntoView({ block: "nearest" });
+      // item() is honestly typed `Element | null`, covering an out-of-bounds
+      // index if the highlight/suggestions invariant ever breaks
+      listRef.current.children
+        .item(highlightedIndex)
+        ?.scrollIntoView({ block: "nearest" });
     }
   }, [highlightedIndex, showDropdown]);
 

--- a/packages/react/src/components/AutocompleteInput.tsx
+++ b/packages/react/src/components/AutocompleteInput.tsx
@@ -279,7 +279,7 @@ export const AutocompleteInput: FC<AutocompleteInputProps> = ({
       const highlighted = listRef.current.children[
         highlightedIndex
       ] as HTMLElement;
-      highlighted?.scrollIntoView({ block: "nearest" });
+      highlighted.scrollIntoView({ block: "nearest" });
     }
   }, [highlightedIndex, showDropdown]);
 

--- a/packages/react/src/components/ExpandablePanel.tsx
+++ b/packages/react/src/components/ExpandablePanel.tsx
@@ -89,6 +89,7 @@ export const ExpandablePanel: FC<ExpandablePanelProps> = memo(
         setContainsFindTarget(false);
         return;
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const text = (root.textContent ?? "").toLowerCase();
       setContainsFindTarget(text.includes(findTarget.term.toLowerCase()));
     });

--- a/packages/react/src/components/FindBand.tsx
+++ b/packages/react/src/components/FindBand.tsx
@@ -204,6 +204,7 @@ export const FindBand: FC<FindBandProps> = ({ onClose, debounceMs = 100 }) => {
         }
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: activeElement can be null; the cast hides it
       focusedElement?.focus();
     },
     [setFindTarget, extendedFindTerm, countAllMatches, getMatchCountersVersion]
@@ -223,6 +224,7 @@ export const FindBand: FC<FindBandProps> = ({ onClose, debounceMs = 100 }) => {
       if (scrollTimeoutRef.current !== null) {
         window.clearTimeout(scrollTimeoutRef.current);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (focusTimeout !== null) {
         window.clearTimeout(focusTimeout);
       }

--- a/packages/react/src/components/MarkdownDiv.tsx
+++ b/packages/react/src/components/MarkdownDiv.tsx
@@ -164,10 +164,12 @@ export class MarkdownRenderQueue {
 
         try {
           const result = await task();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (!cancelled) {
             resolve(result);
           }
         } catch (error) {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (!cancelled) {
             reject(error instanceof Error ? error : new Error(String(error)));
           }

--- a/packages/react/src/components/Modal.tsx
+++ b/packages/react/src/components/Modal.tsx
@@ -117,6 +117,7 @@ export const Modal: FC<ModalProps> = ({
     }, 0);
     return () => {
       window.clearTimeout(timer);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: activeElement cast hides null/non-HTMLElement; .focus may be absent
       previouslyFocused?.focus?.();
     };
   }, [show]);

--- a/packages/react/src/components/NavPills.tsx
+++ b/packages/react/src/components/NavPills.tsx
@@ -16,7 +16,7 @@ interface NavPillsProps {
 }
 
 export const NavPills: FC<NavPillsProps> = ({ id, children }) => {
-  const defaultNav = children ? children?.[0]?.props["title"] : "";
+  const defaultNav = children ? children[0]?.props["title"] : "";
   const [activeItem, setActiveItem] = useProperty(id, "active", {
     defaultValue: defaultNav,
   });
@@ -29,7 +29,7 @@ export const NavPills: FC<NavPillsProps> = ({ id, children }) => {
   const navPills = children.map((nav, idx) => {
     const title =
       typeof nav === "object"
-        ? nav["props"]?.title || `Tab ${idx}`
+        ? nav["props"].title || `Tab ${idx}`
         : `Tab ${idx}`;
     return (
       <NavPill
@@ -47,7 +47,7 @@ export const NavPills: FC<NavPillsProps> = ({ id, children }) => {
       <div
         key={`nav-pill-container-${idx}`}
         className={
-          child["props"]?.title === activeItem ? styles.visible : styles.hidden
+          child["props"].title === activeItem ? styles.visible : styles.hidden
         }
       >
         {child}

--- a/packages/react/src/components/NavPills.tsx
+++ b/packages/react/src/components/NavPills.tsx
@@ -29,7 +29,8 @@ export const NavPills: FC<NavPillsProps> = ({ id, children }) => {
   const navPills = children.map((nav, idx) => {
     const title =
       typeof nav === "object"
-        ? nav["props"].title || `Tab ${idx}`
+        ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: conditional/non-element children can reach here at runtime despite the declared type
+          nav["props"]?.title || `Tab ${idx}`
         : `Tab ${idx}`;
     return (
       <NavPill
@@ -47,7 +48,8 @@ export const NavPills: FC<NavPillsProps> = ({ id, children }) => {
       <div
         key={`nav-pill-container-${idx}`}
         className={
-          child["props"].title === activeItem ? styles.visible : styles.hidden
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: conditional/non-element children can reach here at runtime despite the declared type
+          child["props"]?.title === activeItem ? styles.visible : styles.hidden
         }
       >
         {child}

--- a/packages/react/src/components/PopOver.tsx
+++ b/packages/react/src/components/PopOver.tsx
@@ -155,6 +155,7 @@ export const PopOver: React.FC<PopOverProps> = ({
     }
 
     // Add event listeners to the positionEl (the trigger element)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (positionEl && isOpen) {
       positionEl.addEventListener("mousemove", handleMouseMove);
       positionEl.addEventListener("mouseleave", handleMouseLeave);
@@ -245,7 +246,7 @@ export const PopOver: React.FC<PopOverProps> = ({
       options: { padding: 8 },
       fn({ state, name, options }) {
         const padding =
-          typeof options?.padding === "number" ? options.padding : 8;
+          typeof options.padding === "number" ? options.padding : 8;
         state.modifiersData[name] = {
           width: Math.max(0, window.innerWidth - 2 * padding),
           height: Math.max(0, window.innerHeight - 2 * padding),
@@ -466,6 +467,7 @@ export const PopOver: React.FC<PopOverProps> = ({
 
   // Define arrow data-* attribute based on placement
   const getArrowDataPlacement = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!state || !state.placement) return placement;
     return state.placement;
   };

--- a/packages/react/src/components/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl.tsx
@@ -39,6 +39,7 @@ export const SegmentedControl: FC<SegmentedControlProps> = ({
     [onSegmentChange]
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const selectedId = selectedIdProp ?? segments[0]?.id ?? "";
 
   return (

--- a/packages/react/src/hooks/useBreadcrumbTruncation.test.tsx
+++ b/packages/react/src/hooks/useBreadcrumbTruncation.test.tsx
@@ -19,8 +19,7 @@ describe("useBreadcrumbTruncation", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverStub);
     vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(
       function (this: HTMLElement) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        return (this.textContent.length ?? 0) * 10;
+        return this.textContent.length * 10;
       }
     );
   });

--- a/packages/react/src/hooks/useBreadcrumbTruncation.test.tsx
+++ b/packages/react/src/hooks/useBreadcrumbTruncation.test.tsx
@@ -19,7 +19,8 @@ describe("useBreadcrumbTruncation", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverStub);
     vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(
       function (this: HTMLElement) {
-        return (this.textContent?.length ?? 0) * 10;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        return (this.textContent.length ?? 0) * 10;
       }
     );
   });

--- a/packages/react/src/hooks/useListKeyboardNavigation.ts
+++ b/packages/react/src/hooks/useListKeyboardNavigation.ts
@@ -37,6 +37,7 @@ export function useListKeyboardNavigation({
       const container = scrollRef?.current;
       if (
         container &&
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: checkVisibility is absent in jsdom and older browsers
         (!container.isConnected || container.checkVisibility?.() === false)
       ) {
         return;

--- a/packages/react/src/hooks/usePrismHighlight.ts
+++ b/packages/react/src/hooks/usePrismHighlight.ts
@@ -47,7 +47,7 @@ export const usePrismHighlight = (
           return Array.from(mutation.addedNodes).some((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
               const el = node as HTMLElement;
-              return el.querySelector?.("pre code") || el.matches?.("pre code");
+              return el.querySelector("pre code") || el.matches("pre code");
             }
             return false;
           });

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -108,6 +108,7 @@ export function useStatefulScrollPosition<
       }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (element.addEventListener) {
       element.addEventListener("scroll", handleScroll);
     } else {
@@ -118,6 +119,7 @@ export function useStatefulScrollPosition<
       if (pollTimer !== undefined) {
         clearTimeout(pollTimer);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (element.removeEventListener) {
         element.removeEventListener("scroll", handleScroll);
       } else {

--- a/packages/react/src/virtual/use-virtual-list-state.ts
+++ b/packages/react/src/virtual/use-virtual-list-state.ts
@@ -23,6 +23,7 @@ export function useVirtualListState(
   const getRestoreSnapshot = useCallback(():
     VirtualListStateSnapshot | undefined => {
     if (!stored) return undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (stored.version !== CURRENT_VERSION) return undefined;
     return stored;
   }, [stored]);

--- a/packages/scout-components/src/scanner-result-detail/ScannerResultDetailView.tsx
+++ b/packages/scout-components/src/scanner-result-detail/ScannerResultDetailView.tsx
@@ -211,6 +211,7 @@ function renderField(
     case "validation":
       if (
         data.validationResult === undefined ||
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         data.validationResult === null
       ) {
         return null;

--- a/packages/scout-components/src/scanner-result-detail/ValidationResult.tsx
+++ b/packages/scout-components/src/scanner-result-detail/ValidationResult.tsx
@@ -21,6 +21,7 @@ export const ValidationResult: FC<ValidationResultProps> = ({
         targetValue={valueStr(resolveTargetValue(target, label))}
       />
     );
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (result !== null && typeof result === "object") {
     const entries = Object.entries(result);
 

--- a/packages/scout-components/src/scanner-result-detail/Value.tsx
+++ b/packages/scout-components/src/scanner-result-detail/Value.tsx
@@ -58,6 +58,7 @@ export const Value: FC<ValueProps> = ({
         options={options}
       />
     );
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   } else if (isNumberValue(input) && input.value !== null) {
     return formatPrettyDecimal(input.value);
   } else if (isBooleanValue(input)) {

--- a/packages/scout-components/src/sentinels/viewerConfig.ts
+++ b/packages/scout-components/src/sentinels/viewerConfig.ts
@@ -134,6 +134,7 @@ function scannerResultViewEntries(
 ): Array<{ pattern: string; view: ScannerResultView }> {
   if (!viewer) return [];
   const raw = viewer.scanner_result_view;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!raw) return [];
   // Bare `ScannerResultView` shorthand for `{"*": view}`.
   if (isScannerResultView(raw)) return [{ pattern: "*", view: raw }];
@@ -235,6 +236,7 @@ function coerceField(
     if (!kBuiltinNames.has(entry.name)) return null;
     return entry;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (entry.kind === "metadata") return entry;
   return null;
 }

--- a/packages/theme/src/bootstrap.ts
+++ b/packages/theme/src/bootstrap.ts
@@ -228,6 +228,7 @@ let mediaListenerInstalled = false;
 let bodyClassObserverInstalled = false;
 
 const hostIsDarkFromBody = (): boolean | null => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof document === "undefined" || !document.body) return null;
   const cls = document.body.classList;
   // VS Code high contrast: `vscode-high-contrast` is the HC-dark theme,
@@ -248,6 +249,7 @@ const installBodyClassObserver = (): void => {
   if (
     bodyClassObserverInstalled ||
     typeof MutationObserver === "undefined" ||
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     !document.body
   ) {
     return;
@@ -306,6 +308,7 @@ export const createApplyTheme = (options: ApplyThemeOptions): (() => void) => {
       if (result.hostIsDark !== null) {
         setDocumentBaseScheme(result.hostIsDark);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (result.kind === "apply") {
       // data-* attributes belong on <html> (CSS gates `:root[data-bs-theme]`);
       // the vscode-* class belongs on <body> (CSS gates `body[class^=...]`).
@@ -327,6 +330,7 @@ export const createApplyTheme = (options: ApplyThemeOptions): (() => void) => {
       // Adding `vscode-light` would activate the bridge in light mode and
       // silently re-skin every `--bs-*` token.
       if (result.toggleBodyClass) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: document.body is null while parsing <head>
         document.body?.classList.toggle("vscode-dark", result.isDark);
       }
     }

--- a/packages/util/src/arrow.ts
+++ b/packages/util/src/arrow.ts
@@ -142,7 +142,7 @@ function castColumns(table: ColumnTable): ColumnTable {
     derivations.scan_error_refusal = escape(
       (d: { scan_error_refusal: string }) => {
         if (typeof d.scan_error_refusal === "string") {
-          return d.scan_error_refusal?.toLowerCase() === "true";
+          return d.scan_error_refusal.toLowerCase() === "true";
         }
 
         return !!d.scan_error_refusal;

--- a/packages/util/src/browser.ts
+++ b/packages/util/src/browser.ts
@@ -4,8 +4,10 @@
 export const clearDocumentSelection = () => {
   const sel = window.getSelection();
   if (sel) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (sel.removeAllRanges) {
       sel.removeAllRanges();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (sel.empty) {
       sel.empty();
     }

--- a/packages/util/src/jsonrpc.ts
+++ b/packages/util/src/jsonrpc.ts
@@ -190,6 +190,7 @@ function isJsonRpcMessage(message: unknown): message is JsonRpcMessage {
 }
 
 function isJsonRpcRequest(message: JsonRpcMessage): message is JsonRpcRequest {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return (message as JsonRpcRequest).method !== undefined;
 }
 

--- a/packages/util/src/sync.ts
+++ b/packages/util/src/sync.ts
@@ -28,6 +28,7 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
     // the call to func could have a side effect of mutating timeout if it makes
     // a call to throttled below
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!timeout) {
       args = null;
     }
@@ -90,6 +91,7 @@ export function debounce<T extends (...args: any[]) => unknown>(
         // that the call to func could have a side effect of mutating timeout if
         // it makes a call to debounced below
 
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!timeout) {
           args = null!;
         }

--- a/packages/zustand-devtools/src/entries.ts
+++ b/packages/zustand-devtools/src/entries.ts
@@ -119,6 +119,7 @@ export const toClipboardJson = (value: unknown): string => {
   };
   try {
     return (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       JSON.stringify(value, (_key, v: unknown) => replace(v), 2) ?? "undefined"
     );
   } catch (error) {

--- a/tooling/eslint-config/base.js
+++ b/tooling/eslint-config/base.js
@@ -14,6 +14,7 @@ export default tseslint.config(
     },
     rules: {
       "import-x/no-duplicates": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
       // Disallow `void` as an escape hatch for floating promises — prefixing a
       // hanging promise with `void` silently drops errors. Mark genuine cases
       // with an eslint-disable-next-line comment so the issue stays visible.


### PR DESCRIPTION
Enable `@typescript-eslint/no-unnecessary-condition` (error) in the shared ESLint base config so new code gets the rule immediately.

Existing violations are baselined, not fixed:
- **`?.` collapses (107 sites)**: applied the rule&#39;s own suggestion fixes only where non-nullishness is guaranteed at runtime (a dominating guard in the same flow, locally constructed values, spec-guaranteed DOM behavior). Every one of the 179 candidate sites was audited.
- **`?.` kept (72 sites)**: where the guard is intentional defense — data isn&#39;t validated at the wire (old eval logs / journal files / API responses / persisted webview state may omit type-required fields), browser APIs that may be absent (`checkVisibility`, `activeElement`), or internal return types that lie via `@ts-expect-error`. Each carries a suppression plus an `intentional` comment saying why.
- **everything else suppressed**: file-level `eslint-disable` for files with &gt;3 violations, `eslint-disable-next-line` otherwise.

No behavior changes intended, with one deliberate exception: in `filters.ts` `sampleFilterItems`, the `!descriptor` fallback now runs before the `descriptor.filterable` read. Previously a missing score descriptor threw a TypeError before reaching the fallback (dead code); it now produces the placeholder item as intended, and `SampleFilterItem.scoreType` is typed `string | undefined` to match. lint / typecheck / test / format:check green across all packages.