### PR TITLE
Regenerate scout types: add reasoning_mode to GenerateConfig

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1607,6 +1607,8 @@ export interface components {
             reasoning_effort?: ("none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") | null;
             /** Reasoning History */
             reasoning_history?: ("none" | "all" | "last" | "auto") | null;
+            /** Reasoning Mode */
+            reasoning_mode?: ("standard" | "pro") | null;
             /** Reasoning Summary */
             reasoning_summary?: ("none" | "concise" | "detailed" | "auto") | null;
             /** Reasoning Tokens */
@@ -1692,6 +1694,8 @@ export interface components {
             reasoning_effort?: ("none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max") | null;
             /** Reasoning History */
             reasoning_history?: ("none" | "all" | "last" | "auto") | null;
+            /** Reasoning Mode */
+            reasoning_mode?: ("standard" | "pro") | null;
             /** Reasoning Summary */
             reasoning_summary?: ("none" | "concise" | "detailed" | "auto") | null;
             /** Reasoning Tokens */


### PR DESCRIPTION
inspect_ai@main added a `reasoning_mode` (`"standard" | "pro"`) field to `GenerateConfig`, which changed inspect_scout's exported `openapi.json`. This regenerates `apps/scout/src/types/generated.ts` (via `pnpm --filter scout types:generate`) to match.

Companion to the inspect_scout branch `claude/answer-type-errors-schema-tx1ibp`, which updates the committed `openapi.json`. Once this merges to main, the inspect_scout submodule pointer will be bumped to the merged commit so its `check-schema-and-types` CI job passes.

`pnpm --filter scout typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEmdhb9t9GyvYJBVcUdstv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEmdhb9t9GyvYJBVcUdstv)_