### PR TITLE
Regenerate schema: Add `CompactionEvent.role`

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -997,6 +997,8 @@ export interface components {
             } | null;
             /** Pending */
             pending?: boolean | null;
+            /** Role */
+            role?: string | null;
             /** Source */
             source?: string | null;
             /** Span Id */


### PR DESCRIPTION
Regenerates `packages/inspect-common/src/types/generated.ts` to add the new optional `role?: string | null` field on `CompactionEvent`.

This is the ts-mono half of the type-generation pipeline (Python → `inspect-openapi.json` → `generated.ts`) for inspect_ai PR [UKGovernmentBEIS/inspect_ai#4417](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4417), which adds `CompactionEvent.role` so crash-recovery message reconstruction attributes a compaction to its own conversation's role.

Generated by running `python src/inspect_ai/_view/schema.py` against upstream inspect_ai `main` + the `CompactionEvent.role` field, on top of ts-mono `main`. The only change is the added `role` field — no other schema drift.

Draft until the inspect_ai PR is finalized; merge here first, then the inspect_ai PR bumps its submodule pointer to this commit so `check-schema-and-types` and `submodule-on-main` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)