### PR TITLE
fix: skip auto-review on fork/Dependabot PRs (no OIDC token there)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,8 +22,17 @@ jobs:
   review:
     # Run on PR events, or on a PR comment containing @review. `@review` does
     # not collide with the dev agent's `@claude` trigger.
+    #
+    # Auto-review is skipped for PRs from forks and from Dependabot: GitHub
+    # withholds the OIDC id-token (and secrets) from `pull_request` runs in
+    # those contexts for security, so the reviewer's WIF auth can't mint a
+    # token and the job would only fail. The `permissions:` block can't override
+    # this. Those PRs are instead reviewed on demand via an `@review` comment,
+    # which runs as `issue_comment` in the base-repo context (full token access).
     if: >
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]') ||
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review'))
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main


### PR DESCRIPTION
## Problem

The `review` check fails on PRs from **forks** (e.g. #418) and from **Dependabot** (e.g. #416) with:

> `Requesting OIDC token… Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`

Root cause is **not** a permissions-block problem — `id-token: write` is already granted in both this caller and the shared reusable workflow. GitHub *deliberately* withholds the OIDC id-token (and secrets) from `pull_request` runs triggered by forks and Dependabot, for security. The `permissions:` block can't override that, so the reviewer's WIF auth can't mint a token and the job can only fail.

(Confirmed: same-repo human PRs get the token and pass; the `@review` **comment** path passes too, because `issue_comment` runs in the base-repo context.)

## Fix

Gate the `pull_request` auto-trigger to **same-repo, non-Dependabot** PRs. Fork/Dependabot PRs no longer spawn a doomed auto-review (the job simply doesn't run → no failing check); they're reviewed **on demand via an `@review` comment**, which runs as `issue_comment` in the base context and works.

```yaml
if: >
  (github.event_name == 'pull_request' &&
   github.event.pull_request.head.repo.full_name == github.repository &&
   github.actor != 'dependabot[bot]') ||
  (github.event.issue.pull_request != null &&
   contains(github.event.comment.body, '@review'))
```

Scope: this repo's caller only, for now. If we like it, the same guard can move into the shared `meridianlabs-ai/agents` reusable workflow so every repo benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)