### PR TITLE
Unify IndexedDB for Inspect

### DIFF
--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -233,7 +233,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // In the folder view, scope the Metrics list to logs under the current
   // directory so descending into a subfolder shows only that folder's metrics.
   // The flat tasks view shows columns across the whole set.
-  const scopePrefix = mode === "logs" ? currentDir : undefined;
+  const scopeDir = mode === "logs" ? currentDir : undefined;
 
   // Shared view-mode state for the scorer columns. The same useProperty
   // scope/key is read by LogListGrid so the grid and popover stay in sync,
@@ -254,7 +254,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
-  } = useLogListColumns(mode, scopePrefix, scoresViewMode);
+  } = useLogListColumns(mode, scopeDir, scoresViewMode);
 
   const listData = useLogListData({
     items: logItems,

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -72,7 +72,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const navigate = useNavigate();
 
   // Scope the column list to the current folder's logs in folder (logs) mode.
-  const scopePrefix = mode === "logs" ? currentPath : undefined;
+  const scopeDir = mode === "logs" ? currentPath : undefined;
   // Read the same shared view-mode property LogsPanel writes to, so the
   // grid's column set always matches the picker's current selection.
   const [scoresViewMode] = useProperty<ScoresViewMode>(
@@ -82,7 +82,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
   );
   const { columns, visibility } = useLogListColumns(
     mode,
-    scopePrefix,
+    scopeDir,
     scoresViewMode
   );
 

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -5,6 +5,7 @@ import type { FilterType } from "@tsmono/inspect-components/columnFilter";
 import { basename, formatNumber, formatPrettyDecimal } from "@tsmono/util";
 
 import { useLogDir } from "../../../../app_config";
+import { scopePrefix } from "../../../../client/database";
 import { kModelNone } from "../../../../constants";
 import {
   useLogListing,
@@ -66,11 +67,11 @@ export type ScoresViewMode = "by-metric" | "per-scorer";
 export const useLogListColumns = (
   mode: LogListMode = "logs",
   /**
-   * When set, scorer columns are computed only from logs whose name starts
-   * with this prefix. Used by the folder view so descending into a subfolder
+   * When set, scorer columns are computed only from logs under this
+   * directory. Used by the folder view so descending into a subfolder
    * recomputes the Metrics list to match the contents of that folder.
    */
-  scopePrefix?: string,
+  scopeDir?: string,
   /**
    * View mode for scorer columns:
    *   - "by-metric" (default): one synthetic column per unique metric name,
@@ -107,7 +108,7 @@ export const useLogListColumns = (
   // Settled schema only: column defs are decorative config — while the
   // listing loads there are simply no scorer columns yet, and listing errors
   // render in LogsPanel's error surface.
-  const scorerMap = useScoreSchema(logDir, scopePrefix).data ?? kNoScorerMap;
+  const scorerMap = useScoreSchema(logDir, scopeDir).data ?? kNoScorerMap;
 
   const allColumns = useMemo((): LogListColumn[] => {
     const baseColumns: LogListColumn[] = [
@@ -768,15 +769,14 @@ export const useLogListColumns = (
   // Auto-promote `sampleLimits` to default-visible when any in-scope log
   // has a sample that ended with a limit (an ingestion-derived header fact).
   const listingRows = useLogListing(logDir).data ?? kNoListingRows;
-  const hasSampleLimits = useMemo(
-    () =>
-      listingRows.some(
-        (row) =>
-          (!scopePrefix || row.name.startsWith(scopePrefix)) &&
-          (row.header?.sampleLimits.length ?? 0) > 0
-      ),
-    [listingRows, scopePrefix]
-  );
+  const hasSampleLimits = useMemo(() => {
+    const prefix = scopeDir ? scopePrefix(scopeDir) : undefined;
+    return listingRows.some(
+      (row) =>
+        (!prefix || row.name.startsWith(prefix)) &&
+        (row.header?.sampleLimits.length ?? 0) > 0
+    );
+  }, [listingRows, scopeDir]);
 
   // Default hidden columns per mode
   const defaultHiddenFields = useMemo(() => {

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -25,60 +25,16 @@ export type LogListItem = FileLogItem | FolderLogItem | PendingTaskItem;
 const rowForItem = (item: LogListItem): LogListingRow | undefined =>
   item.type === "file" ? item.log : undefined;
 
+// A projection, not a computation: every derived value is read off the row
+// (attached at ingestion by `detailTier`/`deriveLogFields`) so the grid can
+// never disagree with what the store holds.
 const buildLogListRow = (item: LogListItem): LogListRow => {
   const log = rowForItem(item);
   const details = log?.header;
+  const derived = log?.derived;
 
-  // Compute total tokens across all models
-  let totalTokens: number | undefined;
-  if (details?.stats?.model_usage) {
-    totalTokens = 0;
-    for (const usage of Object.values(details.stats.model_usage)) {
-      totalTokens += usage.total_tokens;
-    }
-  }
-
-  // Compute duration in seconds
-  let duration: number | undefined;
-  if (details?.stats?.started_at && details?.stats?.completed_at) {
-    const start = new Date(details.stats.started_at).getTime();
-    const end = new Date(details.stats.completed_at).getTime();
-    if (start && end && end > start) {
-      duration = (end - start) / 1000;
-    }
-  }
-
-  // Format task args. Prefer `task_args_passed` (the args the user
-  // actually supplied at the call site) over `task_args` (which
-  // would also include defaulted values).
   const taskArgsSource =
     details?.eval?.task_args_passed ?? details?.eval?.task_args;
-  let taskArgs: string | undefined;
-  if (taskArgsSource) {
-    const entries = Object.entries(taskArgsSource);
-    if (entries.length > 0) {
-      taskArgs = entries
-        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-        .join(", ");
-    }
-  }
-
-  // Percent of samples completed
-  let percentCompleted: number | undefined;
-  const total = details?.results?.total_samples;
-  const completed = details?.results?.completed_samples;
-  if (total && total > 0 && completed !== undefined) {
-    percentCompleted = (completed / total) * 100;
-  }
-
-  // Sample facts are derived at ingestion and carried on the header.
-  const sampleErrors = details?.sampleErrorCount;
-  // Distinct limit types across samples in this task, comma-joined (already
-  // sorted for stable text-filtering). Empty when no sample hit a limit.
-  const sampleLimits =
-    details !== undefined && details.sampleLimits.length > 0
-      ? details.sampleLimits.join(", ")
-      : undefined;
 
   const row: LogListRow = {
     id: item.id,
@@ -107,29 +63,23 @@ const buildLogListRow = (item: LogListItem): LogListRow => {
     totalSamples: details?.results?.total_samples,
     completedSamples: details?.results?.completed_samples,
     sandbox: details?.eval?.sandbox?.type,
-    totalTokens,
-    duration,
+    totalTokens: derived?.total_tokens,
+    duration: derived?.duration,
     taskFile: details?.eval?.task_file ?? undefined,
-    taskArgs,
+    taskArgs: derived?.task_args,
     taskArgsRaw: taskArgsSource ?? undefined,
     tags: details?.tags,
-    percentCompleted,
-    sampleErrors,
-    sampleLimits,
+    percentCompleted: derived?.percent_completed,
+    sampleErrors: details?.sampleErrorCount,
+    sampleLimits: derived?.sample_limits,
     errorMessage: details?.error?.message,
   };
 
-  // Add individual scorer columns from results. Key by (scorer, metric)
-  // so distinct scorers emitting the same metric name each get their own
-  // column. Reducer is omitted from the key: `reducer=null` (default,
-  // silently mean) and `reducer="mean"` (explicit) should land in the
-  // same column since the underlying computation is identical.
-  if (details?.results?.scores) {
-    for (const evalScore of details.results.scores) {
-      if (evalScore.metrics) {
-        for (const [metricName, metric] of Object.entries(evalScore.metrics)) {
-          row[`score_${evalScore.name}/${metricName}`] = metric.value;
-        }
+  // Individual scorer columns, keyed `score_<scorer>/<metric>`.
+  if (derived?.scores) {
+    for (const [scorerName, metrics] of Object.entries(derived.scores)) {
+      for (const [metricName, value] of Object.entries(metrics)) {
+        row[`score_${scorerName}/${metricName}`] = value;
       }
     }
   }

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -23,6 +23,7 @@ import {
 } from "@tsmono/react/components";
 
 import { EvalLogStatus } from "../../../@types/extraInspect.ts";
+import { totalSampleTokens } from "../../../client/utils/derive.ts";
 import { InlineSampleDisplay } from "../../../app/samples/InlineSampleDisplay.tsx";
 import { SampleList } from "../../../app/samples/list/SampleList.tsx";
 import { parseFilterSpecs } from "../../../app/samples/sample-tools/astToSpecs.ts";
@@ -433,12 +434,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({
   const items: SampleRow[] = useMemo(() => {
     if (!samplesDescriptor || !selectedLogFile) return [];
     return sampleSummaries.map((sample): SampleRow => {
-      const tokens = sample.model_usage
-        ? Object.values(sample.model_usage).reduce(
-            (sum, u) => sum + (u.total_tokens ?? 0),
-            0
-          )
-        : undefined;
+      const tokens = totalSampleTokens(sample.model_usage);
       return {
         logFile: selectedLogFile,
         sampleId: sample.id,

--- a/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/SamplesTab.tsx
@@ -23,7 +23,6 @@ import {
 } from "@tsmono/react/components";
 
 import { EvalLogStatus } from "../../../@types/extraInspect.ts";
-import { totalSampleTokens } from "../../../client/utils/derive.ts";
 import { InlineSampleDisplay } from "../../../app/samples/InlineSampleDisplay.tsx";
 import { SampleList } from "../../../app/samples/list/SampleList.tsx";
 import { parseFilterSpecs } from "../../../app/samples/sample-tools/astToSpecs.ts";
@@ -33,6 +32,7 @@ import {
   SampleTools,
   ScoreFilterTools,
 } from "../../../app/samples/SamplesTools.tsx";
+import { totalSampleTokens } from "../../../client/utils/derive.ts";
 import { kLogViewSamplesTabId } from "../../../constants.ts";
 import { selectSample } from "../../../state/actions.ts";
 import {

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -2,7 +2,6 @@ import type { SortingState } from "@tanstack/react-table";
 import clsx from "clsx";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
 
-import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
 import type {
   ColumnFilter,
   FilterSpec,
@@ -321,14 +320,11 @@ export const SamplesPanel: FC = () => {
       {}
     );
 
+    // A projection: sample-intrinsic derived values come off the listing row
+    // (attached at ingestion by `deriveSampleFields`); log-level context is
+    // the subsystem's read-time join.
     const allRows: SampleRow[] = scopedSamples.map(
-      ({ logFile, summary: sample, log }) => {
-        const tokens = sample.model_usage
-          ? Object.values(sample.model_usage).reduce(
-              (sum, u) => sum + (u.total_tokens ?? 0),
-              0
-            )
-          : undefined;
+      ({ logFile, summary: sample, derived, log }) => {
         const row: SampleRow = {
           logFile,
           sampleId: sample.id,
@@ -338,21 +334,19 @@ export const SamplesPanel: FC = () => {
           task: log.task || "",
           model: log.model || "",
           status: log.status,
-          input: inputString(sample.input).join("\n"),
-          target: Array.isArray(sample.target)
-            ? sample.target.join(", ")
-            : sample.target,
+          input: derived.input,
+          target: derived.target,
           error: sample.error,
           limit: sample.limit,
           retries: sample.retries,
-          fallbacks: totalModelFallbacks(sample.model_fallbacks) || undefined,
+          fallbacks: derived.fallbacks,
           completed: sample.completed,
-          tokens,
+          tokens: derived.tokens,
           duration: sample.total_time ?? undefined,
         };
-        if (sample.scores) {
-          for (const [scoreName, score] of Object.entries(sample.scores)) {
-            row[`${SCORE_FIELD_RAW_PREFIX}${scoreName}`] = score.value;
+        if (derived.scores) {
+          for (const [scoreName, value] of Object.entries(derived.scores)) {
+            row[`${SCORE_FIELD_RAW_PREFIX}${scoreName}`] = value;
           }
         }
         return row;

--- a/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
+++ b/apps/inspect/src/app/samples-panel/SamplesPanel.tsx
@@ -10,6 +10,7 @@ import type {
 import { ErrorPanel, ProgressBar } from "@tsmono/react/components";
 
 import { useLogDir } from "../../app_config";
+import { scopePrefix } from "../../client/database";
 import { ActivityBar } from "../../components/ActivityBar";
 import {
   LogListingRow,
@@ -137,7 +138,7 @@ export const SamplesPanel: FC = () => {
   const currentDirLogFiles = useMemo(() => {
     const files = [];
     for (const logFile of logFiles) {
-      const inCurrentDir = logFile.name.startsWith(currentDir);
+      const inCurrentDir = logFile.name.startsWith(scopePrefix(currentDir));
       const skipped = !showRetriedLogs && logFile.retried;
       if (inCurrentDir && !skipped) {
         files.push(logFile);

--- a/apps/inspect/src/app/samples/sample-tools/filters.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.ts
@@ -1,10 +1,12 @@
 import { compileExpression } from "filtrex";
 
 import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
+import { arrayToString } from "@tsmono/util";
 
 import { EvalSampleScore } from "../../../@types/extraInspect";
 import { FilterError, ScoreLabel } from "../../../app/types";
 import { SampleSummary } from "../../../client/api/types";
+import { totalSampleTokens } from "../../../client/utils/derive";
 import { kScoreTypeBoolean } from "../../../constants";
 import { SamplesDescriptor } from "../descriptor/samplesDescriptor";
 import { EvalDescriptor, ScoreDescriptor } from "../descriptor/types";
@@ -153,17 +155,6 @@ const getNestedPropertyValue = (obj: unknown, path: string): unknown => {
   return current;
 };
 
-const totalTokens = (sample: SampleSummary): number | null => {
-  if (!sample.model_usage) return null;
-  return Object.values(sample.model_usage).reduce(
-    (sum, u) => sum + (u.total_tokens ?? 0),
-    0
-  );
-};
-
-const targetString = (target: SampleSummary["target"]): string =>
-  Array.isArray(target) ? target.join(", ") : (target ?? "");
-
 export const sampleVariables = (
   sample: SampleSummary,
   samplesDescriptor: SamplesDescriptor | undefined
@@ -178,14 +169,14 @@ export const sampleVariables = (
     id: sample.id,
     uuid: sample.uuid ?? null,
     input: inputString(sample.input).join(" "),
-    target: targetString(sample.target),
+    target: arrayToString(sample.target ?? ""),
     answer:
       samplesDescriptor?.selectedScorerDescriptor(sample)?.answer() ?? null,
     error: sample.error ?? null,
     limit: sample.limit ?? null,
     retries: sample.retries ?? 0,
     fallbacks: totalModelFallbacks(sample.model_fallbacks),
-    tokens: totalTokens(sample),
+    tokens: totalSampleTokens(sample.model_usage) ?? null,
     duration: sample.total_time ?? null,
     metadata: sample.metadata,
   };

--- a/apps/inspect/src/app_config/appConfig.ts
+++ b/apps/inspect/src/app_config/appConfig.ts
@@ -119,14 +119,18 @@ export const loadResolvedAppConfig = async (
     bs.api.get_app_config(),
     resolveLogRoot(bs),
   ]);
-  if (!logRoot.log_dir) {
+  // Prefer the canonical URI form — the namespace file names live in — so
+  // prefix scoping (IndexedDB reads, samples scopes) holds. log_dir alone is
+  // a display form on local view servers (aliased/relative path).
+  const logDir = logRoot.log_dir_uri ?? logRoot.log_dir;
+  if (!logDir) {
     throw new Error("Log dir not resolved");
   }
   return {
     ...bs,
     inspect_version: versions.inspect_version,
     scout_version: versions.scout_version ?? null,
-    logDir: logRoot.log_dir,
+    logDir,
     absLogDir: logRoot.abs_log_dir,
   };
 };

--- a/apps/inspect/src/app_config/hooks.test.tsx
+++ b/apps/inspect/src/app_config/hooks.test.tsx
@@ -30,7 +30,6 @@ const notMocked = <T,>(): Promise<T> => Promise.reject(new Error("not mocked"));
 // get_app_config / get_log_root / get_log_dir are ever exercised.
 const baseApi = (): ClientAPI => ({
   get_log_dir: () => Promise.resolve(undefined),
-  get_log_dir_handle: () => "",
   get_logs: () => notMocked(),
   get_log_root: () => notMocked(),
   get_eval_set: () => Promise.resolve(undefined),

--- a/apps/inspect/src/client/api/client-api.ts
+++ b/apps/inspect/src/client/api/client-api.ts
@@ -541,14 +541,6 @@ export const clientApi = (
       return api.client_events();
     }),
     get_log_dir: middleware("get_log_dir", get_log_dir),
-    get_log_dir_handle: middleware(
-      "get_log_dir_handle",
-      (log_dir: string | undefined) => {
-        return api.get_log_dir_handle
-          ? api.get_log_dir_handle(log_dir)
-          : log_dir || "default_log_dir";
-      }
-    ),
     get_logs: middleware("get_log_files", get_logs),
     get_log_root: middleware("get_log_root", get_log_root),
     get_eval_set: middleware("get_eval_set", (dir?: string) => {

--- a/apps/inspect/src/client/api/static-http/api-static-http.test.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import staticHttpApi from "./api-static-http";
+
+// jsdom serves the "page" at http://localhost:3000/ — the base the canonical
+// namespace embeds for relative log dirs.
+describe("staticHttpApi identities", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              "task_abc123.eval": { task: "test-task", task_id: "task-1" },
+            }),
+            { status: 200 }
+          )
+        )
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("a relative log_dir yields origin-unique log_dir and names", async () => {
+    const api = staticHttpApi("logs");
+    const root = await api.get_log_root();
+
+    expect(root?.log_dir).toBe("http://localhost:3000/logs");
+    expect(root?.logs.map((log) => log.name)).toEqual([
+      "http://localhost:3000/logs/task_abc123.eval",
+    ]);
+  });
+
+  test("an absolute log_dir is already canonical", async () => {
+    const api = staticHttpApi("https://example.com/bucket/logs");
+    const root = await api.get_log_root();
+
+    expect(root?.log_dir).toBe("https://example.com/bucket/logs");
+    expect(root?.logs.map((log) => log.name)).toEqual([
+      "https://example.com/bucket/logs/task_abc123.eval",
+    ]);
+  });
+});

--- a/apps/inspect/src/client/api/static-http/api-static-http.ts
+++ b/apps/inspect/src/client/api/static-http/api-static-http.ts
@@ -1,6 +1,7 @@
 import { AppConfig, EvalSet } from "@tsmono/inspect-common/types";
 import { fetchRange } from "@tsmono/util";
 
+import { isUri } from "../../../utils/uri";
 import { fetchSize } from "../../remote/remoteZipFile";
 import { download_file } from "../shared/api-shared";
 import { Capabilities, LogPreview, LogRoot, LogViewAPI } from "../types";
@@ -12,6 +13,19 @@ import {
   fetchTextFile,
   joinURI,
 } from "./fetch";
+
+/** The canonical, origin-unique URL of a deployment's log dir. A relative
+ *  configured log_dir is page-relative for fetching, but page-relative
+ *  strings are not identities: two bundles at different paths on one origin
+ *  would collide in the shared per-origin IndexedDB. So everything the app
+ *  sees (log_dir, file names) is absolute. */
+const canonicalDirUrl = (log_dir: string): string => {
+  if (isUri(log_dir)) {
+    return log_dir;
+  }
+  const pageDir = `${window.location.origin}${window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"))}`;
+  return joinURI(pageDir, log_dir);
+};
 
 // Versions aren't reachable without a server; older bundles don't embed them.
 const kFallbackAppConfig: AppConfig = {
@@ -51,6 +65,8 @@ function staticHttpApiForLog(logInfo: {
   app_config?: AppConfig;
 }): LogViewAPI {
   const log_dir = logInfo.log_dir;
+  const canonical_log_dir =
+    log_dir === undefined ? undefined : canonicalDirUrl(log_dir);
   const abs_log_dir = logInfo.abs_log_dir;
   const app_config = logInfo.app_config ?? kFallbackAppConfig;
   let manifest: Record<string, LogPreview> | undefined = undefined;
@@ -81,29 +97,25 @@ function staticHttpApiForLog(logInfo: {
     },
     get_log_root: async (): Promise<LogRoot | undefined> => {
       // First check based upon the log dir
-      if (log_dir) {
+      if (log_dir && canonical_log_dir) {
         const manifest = await getManifest();
         if (manifest) {
           const logs = Object.entries(manifest).map(([key, preview]) => {
             return {
-              name: joinURI(log_dir, key),
+              name: joinURI(canonical_log_dir, key),
               task: preview.task,
               task_id: preview.task_id,
             };
           });
           return Promise.resolve({
             logs: logs,
-            log_dir,
+            log_dir: canonical_log_dir,
             abs_log_dir,
           });
         }
       }
 
       return undefined;
-    },
-    get_log_dir_handle: (log_dir: string | undefined): string => {
-      const currentDirUrl = `${window.location.origin}${window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"))}`;
-      return joinURI(currentDirUrl, log_dir || "default_log_dir");
     },
     get_eval_set: async (dir?: string) => {
       const dirSegments = [];
@@ -176,7 +188,7 @@ function staticHttpApiForLog(logInfo: {
       if (manifest) {
         const manifestAbs: Record<string, LogPreview> = {};
         Object.entries(manifest).forEach(([key, preview]) => {
-          manifestAbs[joinURI(log_dir || "", key)] = preview;
+          manifestAbs[joinURI(canonical_log_dir || "", key)] = preview;
         });
         const header = manifestAbs[log_file];
         if (header) {

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -461,6 +461,48 @@ export interface LogHeader extends EvalHeader {
 export type LogDepth = "listed" | "previewed" | "detailed";
 
 /**
+ * Listing columns derived from a details payload once at ingestion (see
+ * `deriveLogFields`) and stored on the row, so listing reads never compute —
+ * the same fields the log-list grid sorts/filters on, in query-ready form.
+ * Arrives at `detailed` depth; an mtime invalidation drops it with the rest
+ * of the row's content.
+ */
+export interface LogDerived {
+  /** Total tokens summed across all models. */
+  total_tokens?: number;
+  /** Wall-clock duration in seconds (stats.completed_at − stats.started_at). */
+  duration?: number;
+  /** Task args formatted as `k=v, ...` (prefers `task_args_passed`). */
+  task_args?: string;
+  /** Percent of samples completed (0–100). */
+  percent_completed?: number;
+  /** Distinct sample limit kinds, sorted and comma-joined. */
+  sample_limits?: string;
+  /** Score metric values keyed scorer → metric. */
+  scores?: Record<string, Record<string, number>>;
+}
+
+/**
+ * Sample listing columns derived from a summary once at ingestion (see
+ * `deriveSampleFields`) and stored beside it — the sample-intrinsic fields
+ * the samples grid sorts/filters on. Log-level context (task/model/status)
+ * is deliberately NOT denormalized here: it would go stale when the log row
+ * changes tier, so it stays a read-time join.
+ */
+export interface SampleDerived {
+  /** Total tokens summed across all models. */
+  tokens?: number;
+  /** Input as displayable/filterable text. */
+  input: string;
+  /** Target as displayable/filterable text. */
+  target: string;
+  /** Total model fallbacks (undefined when none). */
+  fallbacks?: number;
+  /** Raw score values keyed by score name. */
+  scores?: Record<string, unknown>;
+}
+
+/**
  * The Log entity row — identity plus header attributes at progressive
  * depth, plus retrieval facts. The one shape the store, the cache, and the
  * listing share (see design/migration/log-data-summaries-entity.md, phase
@@ -483,6 +525,7 @@ export interface Log extends LogHandle {
   primary_metric?: EvalMetric;
 
   header?: LogHeader;
+  derived?: LogDerived;
 
   // Retrieval (fetch) facts about the row — a domain separate from eval
   // status/error. Attempts gate backfill retries; the settled seq is the

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -547,6 +547,11 @@ export type LogFetchState = Pick<
 export interface LogRoot {
   logs: LogHandle[];
   log_dir?: string;
+  /** The dir in the same canonical URI namespace as file names (a local
+   *  view server aliases `log_dir` for display, e.g. `~/logs`, while names
+   *  are `file://` URIs). Prefix scoping needs this form; older servers
+   *  don't send it. */
+  log_dir_uri?: string;
   abs_log_dir?: string;
 }
 

--- a/apps/inspect/src/client/api/types.ts
+++ b/apps/inspect/src/client/api/types.ts
@@ -195,7 +195,6 @@ export interface LogViewAPI {
   get_eval_set: (dir?: string) => Promise<EvalSet | undefined>;
   get_flow: (dir?: string) => Promise<string | undefined>;
   get_log_dir?: () => Promise<string | undefined>;
-  get_log_dir_handle?: (log_dir: string | undefined) => string;
   get_logs?: (
     mtime: number,
     clientFileCount: number
@@ -298,8 +297,6 @@ export interface UserInfo {
 export interface ClientAPI {
   // Basic initialization
   get_log_dir: () => Promise<string | undefined>;
-
-  get_log_dir_handle: (log_dir: string | undefined) => string;
 
   // List of files
   get_logs: (

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -8,6 +8,7 @@
  * - sample_summaries: sample summaries split out of details payloads
  */
 
+import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { LogHandle } from "@tsmono/inspect-common";
@@ -19,6 +20,7 @@ import {
   SampleSummary,
 } from "../api/types";
 
+import { DB_NAME } from "./schema";
 import { createDatabaseService, DatabaseService } from "./service";
 
 // Helper function to create test LogSummary
@@ -111,18 +113,19 @@ describe("Database Service", () => {
   beforeEach(async () => {
     // Create a new database service for each test
     databaseService = createDatabaseService();
-    // Open database with test log directory
-    await databaseService.openDatabase("/test/logs");
+    await databaseService.openDatabase();
   });
 
   afterEach(async () => {
-    // Clean up after each test (only if database is still open)
+    // Clean up after each test (only if database is still open). The
+    // database name is a constant, so cross-test isolation comes from
+    // deleting it outright.
     try {
-      await databaseService.clearAllCaches();
       await databaseService.closeDatabase();
     } catch {
       // Database might already be closed in error handling tests
     }
+    await Dexie.delete(DB_NAME);
   });
 
   describe("Log Rows (identity tier)", () => {
@@ -146,7 +149,7 @@ describe("Database Service", () => {
       await databaseService.writeLogs(testLogRoot);
 
       // Retrieve cached files
-      const files = await databaseService.readLogs();
+      const files = await databaseService.readLogs({ prefix: "/test/logs" });
 
       expect(files).not.toBeNull();
       expect(files).toHaveLength(2);
@@ -169,7 +172,7 @@ describe("Database Service", () => {
         { name: "/test/logs/eval2.json", task: "additional-task" },
       ];
       await databaseService.writeLogs(updatedFiles);
-      const files = await databaseService.readLogs();
+      const files = await databaseService.readLogs({ prefix: "/test/logs" });
       expect(files).toHaveLength(2);
       expect(files?.find((f) => f.name === "/test/logs/eval1.json")?.task).toBe(
         "updated-task"
@@ -372,13 +375,14 @@ describe("Database Service", () => {
 
   describe("Cache Statistics and Management", () => {
     test("should return cache statistics", async () => {
-      const stats = await databaseService.getCacheStats();
+      const stats = await databaseService.getCacheStats({
+        prefix: "/test/logs",
+      });
 
       expect(stats.logFiles).toBe(0);
       expect(stats.logSummaries).toBe(0);
       expect(stats.logHeaders).toBe(0);
       expect(stats.sampleSummaries).toBe(0);
-      expect(stats.logHandle).toBe("/test/logs");
     });
 
     test("should clear all caches", async () => {
@@ -397,7 +401,9 @@ describe("Database Service", () => {
         }),
       });
 
-      const stats1 = await databaseService.getCacheStats();
+      const stats1 = await databaseService.getCacheStats({
+        prefix: "/test/logs",
+      });
       // One unified row, now at detailed depth: it counts as a log file, as
       // previewed-or-deeper (logSummaries) and as detailed (logHeaders).
       expect(stats1.logFiles).toBe(1);
@@ -406,9 +412,11 @@ describe("Database Service", () => {
       expect(stats1.sampleSummaries).toBe(1);
 
       // Clear all caches
-      await databaseService.clearAllCaches();
+      await databaseService.clearScope({ prefix: "/test/logs" });
 
-      const stats2 = await databaseService.getCacheStats();
+      const stats2 = await databaseService.getCacheStats({
+        prefix: "/test/logs",
+      });
       expect(stats2.logFiles).toBe(0);
       expect(stats2.logSummaries).toBe(0);
       expect(stats2.logHeaders).toBe(0);
@@ -424,7 +432,9 @@ describe("Database Service", () => {
         "/test/logs/detailed.json": createTestLogInfo(),
       });
 
-      const stats = await databaseService.getCacheStats();
+      const stats = await databaseService.getCacheStats({
+        prefix: "/test/logs",
+      });
       expect(stats.logFiles).toBe(3);
       expect(stats.logSummaries).toBe(2); // previewed + detailed
       expect(stats.logHeaders).toBe(1); // detailed only
@@ -448,7 +458,9 @@ describe("Database Service", () => {
         }),
       });
 
-      const stats = await databaseService.getCacheStats();
+      const stats = await databaseService.getCacheStats({
+        prefix: "/test/logs",
+      });
       expect(stats.sampleSummaries).toBe(5); // Total samples across both files
     });
   });
@@ -535,10 +547,63 @@ describe("Database Service", () => {
         "/test/logs/b.json": createTestFetchState(),
       });
 
-      await databaseService.clearAllCaches();
+      await databaseService.clearScope({ prefix: "/test/logs" });
 
-      const files = await databaseService.readLogs();
+      const files = await databaseService.readLogs({ prefix: "/test/logs" });
       expect(files).toHaveLength(0);
+    });
+  });
+
+  describe("Unified Database Scoping", () => {
+    test("reads and clears are isolated per scope", async () => {
+      await databaseService.writeLogs([
+        { name: "/logs/a.eval" },
+        { name: "/logs/important/b.eval" },
+        { name: "/other/c.eval" },
+      ]);
+
+      // A nested dir's rows are visible to both the parent and the nested
+      // scope — replicated once, shared.
+      expect(await databaseService.readLogs({ prefix: "/logs" })).toHaveLength(
+        2
+      );
+      expect(
+        await databaseService.readLogs({ prefix: "/logs/important" })
+      ).toHaveLength(1);
+
+      await databaseService.clearScope({ prefix: "/logs" });
+      expect(await databaseService.readLogs({ prefix: "/logs" })).toHaveLength(
+        0
+      );
+      expect(await databaseService.readLogs({ prefix: "/other" })).toHaveLength(
+        1
+      );
+    });
+
+    test("scope prefixes are boundary-safe", async () => {
+      await databaseService.writeLogs([
+        { name: "/logs/important/a.eval" },
+        { name: "/logs/important-2/b.eval" },
+      ]);
+
+      const files = await databaseService.readLogs({
+        prefix: "/logs/important",
+      });
+      expect(files?.map((f) => f.name)).toEqual(["/logs/important/a.eval"]);
+    });
+
+    test("sync scopes record activation and listing syncs", async () => {
+      await databaseService.touchSyncScope("/logs");
+      let stats = await databaseService.getSyncScope("/logs");
+      expect(stats?.last_accessed).toBeDefined();
+      expect(stats?.last_synced).toBeUndefined();
+
+      await databaseService.markScopeSynced("/logs");
+      stats = await databaseService.getSyncScope("/logs");
+      expect(stats?.last_synced).toBeDefined();
+
+      await databaseService.clearScope({ prefix: "/logs" });
+      expect(await databaseService.getSyncScope("/logs")).toBeUndefined();
     });
   });
 
@@ -585,7 +650,7 @@ describe("Database Service", () => {
       await databaseService.closeDatabase();
 
       // Should return null when database is closed (graceful error handling)
-      const result = await databaseService.readLogs();
+      const result = await databaseService.readLogs({ prefix: "/test/logs" });
       expect(result).toBeNull();
     });
   });

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -605,6 +605,23 @@ describe("Database Service", () => {
       await databaseService.clearScope({ prefix: "/logs" });
       expect(await databaseService.getSyncScope("/logs")).toBeUndefined();
     });
+
+    test("clearScope sweeps nested scopes' sync records with their rows", async () => {
+      await databaseService.markScopeSynced("/logs");
+      await databaseService.markScopeSynced("/logs/important");
+      await databaseService.markScopeSynced("/logs-other");
+
+      await databaseService.clearScope({ prefix: "/logs" });
+
+      expect(await databaseService.getSyncScope("/logs")).toBeUndefined();
+      expect(
+        await databaseService.getSyncScope("/logs/important")
+      ).toBeUndefined();
+      // Boundary-safe: a sibling '-suffix' scope survives.
+      expect(
+        (await databaseService.getSyncScope("/logs-other"))?.last_synced
+      ).toBeDefined();
+    });
   });
 
   describe("Depth Reset (invalidation)", () => {

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -619,6 +619,24 @@ describe("Database Service", () => {
       expect(await databaseService.getSyncScope("/logs")).toBeUndefined();
     });
 
+    test("clearAllData wipes every scope's rows and sync records", async () => {
+      await databaseService.writeLogs([
+        { name: "/logs/a.eval" },
+        { name: "/other/b.eval" },
+      ]);
+      await databaseService.markScopeSynced("/logs");
+
+      await databaseService.clearAllData();
+
+      expect(await databaseService.readLogs({ prefix: "/logs" })).toHaveLength(
+        0
+      );
+      expect(await databaseService.readLogs({ prefix: "/other" })).toHaveLength(
+        0
+      );
+      expect(await databaseService.getSyncScope("/logs")).toBeUndefined();
+    });
+
     test("clearScope sweeps nested scopes' sync records with their rows", async () => {
       await databaseService.markScopeSynced("/logs");
       await databaseService.markScopeSynced("/logs/important");

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -19,7 +19,6 @@ import {
   LogPreview,
   SampleSummary,
 } from "../api/types";
-
 import { prepareLogDetails } from "../utils/type-utils";
 
 import { DB_NAME } from "./schema";

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -20,6 +20,8 @@ import {
   SampleSummary,
 } from "../api/types";
 
+import { prepareLogDetails } from "../utils/type-utils";
+
 import { DB_NAME } from "./schema";
 import { createDatabaseService, DatabaseService } from "./service";
 
@@ -109,6 +111,18 @@ function createTestSampleSummary(
 
 describe("Database Service", () => {
   let databaseService: DatabaseService;
+
+  // The service ingests seam-prepared payloads; tests write raw LogDetails
+  // through the same normalization.
+  const writeLogDetails = (details: Record<string, LogDetails>) =>
+    databaseService.writeLogDetails(
+      Object.fromEntries(
+        Object.entries(details).map(([file, payload]) => [
+          file,
+          prepareLogDetails(payload),
+        ])
+      )
+    );
 
   beforeEach(async () => {
     // Create a new database service for each test
@@ -266,7 +280,7 @@ describe("Database Service", () => {
       });
 
       // Ingest the payload (split: detailed row tier + summary rows)
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": logInfo,
       });
 
@@ -303,7 +317,7 @@ describe("Database Service", () => {
         createTestSampleSummary({ id: 3, error: "timeout" }),
       ];
 
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: samples,
         }),
@@ -327,7 +341,7 @@ describe("Database Service", () => {
     });
 
     test("should read sample summaries across files by prefix", async () => {
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [
             createTestSampleSummary({ id: 1 }),
@@ -352,7 +366,7 @@ describe("Database Service", () => {
     });
 
     test("re-ingestion replaces a file's summary rows", async () => {
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [
             createTestSampleSummary({ id: 1 }),
@@ -360,7 +374,7 @@ describe("Database Service", () => {
           ],
         }),
       });
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [createTestSampleSummary({ id: 1 })],
         }),
@@ -395,7 +409,7 @@ describe("Database Service", () => {
         "/test/logs/eval1.json": createTestLogSummary(),
       });
 
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [createTestSampleSummary()],
         }),
@@ -428,7 +442,7 @@ describe("Database Service", () => {
       await databaseService.writeLogPreviews({
         "/test/logs/previewed.json": createTestLogSummary(),
       });
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/detailed.json": createTestLogInfo(),
       });
 
@@ -442,7 +456,7 @@ describe("Database Service", () => {
 
     test("should count sample summaries correctly", async () => {
       // Cache multiple log info with different number of samples
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [
             createTestSampleSummary({ id: 1 }),
@@ -629,7 +643,7 @@ describe("Database Service", () => {
       await databaseService.writeLogs([
         { name: "/test/logs/eval1.json", task: "task-1", mtime: 42 },
       ]);
-      await databaseService.writeLogDetails({
+      await writeLogDetails({
         "/test/logs/eval1.json": createTestLogInfo({
           sampleSummaries: [createTestSampleSummary()],
         }),

--- a/apps/inspect/src/client/database/index.ts
+++ b/apps/inspect/src/client/database/index.ts
@@ -1,6 +1,6 @@
-export { AppDatabase } from "./schema";
-export type { LogRecord, SampleSummaryRecord } from "./schema";
+export { AppDatabase, DB_NAME, scopePrefix } from "./schema";
+export type { LogRecord, SampleSummaryRecord, SyncScopeRecord } from "./schema";
 
 export { DatabaseManager } from "./manager";
 export { createDatabaseService, DatabaseService } from "./service";
-export type { SampleSummariesScope } from "./service";
+export type { LogScope, SampleSummariesScope } from "./service";

--- a/apps/inspect/src/client/database/manager.ts
+++ b/apps/inspect/src/client/database/manager.ts
@@ -35,8 +35,11 @@ export class DatabaseManager {
       await this.database.open();
       log.debug("Successfully opened database");
       // Pre-unification per-dir databases are dead weight; sweep them in the
-      // background.
-      void deleteLegacyDatabases().catch(() => {});
+      // background. Genuine fire-and-forget: it cannot reject (fully
+      // try/caught), and a legacy database held open by an older tab would
+      // block its delete until that tab closes.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      void deleteLegacyDatabases();
       return this.database;
     } catch (error) {
       log.error("Failed to open database:", error);

--- a/apps/inspect/src/client/database/manager.ts
+++ b/apps/inspect/src/client/database/manager.ts
@@ -2,60 +2,45 @@ import Dexie from "dexie";
 
 import { createLogger } from "@tsmono/util";
 
-import { AppDatabase } from "./schema";
+import { AppDatabase, DB_NAME, deleteLegacyDatabases } from "./schema";
 
 const log = createLogger("DatabaseManager");
 
 /**
- * Manages database instances for different log directories.
- * Each instance of this class manages a single database connection.
+ * Manages the (single, per-origin) database connection. Log dirs are query
+ * scopes over the unified database, not separate databases.
  */
 export class DatabaseManager {
   private database: AppDatabase | null = null;
-  private databaseHandle: string | null = null;
 
   /**
-   * Opens a database for the specified log directory.
-   * If already connected to this directory, returns the existing connection.
-   * If connected to a different directory, closes the current connection first.
+   * Open the database, returning the existing connection when already open.
    */
-  async openDatabase(databaseHandle: string): Promise<AppDatabase> {
-    if (this.databaseHandle === databaseHandle && this.database) {
+  async openDatabase(): Promise<AppDatabase> {
+    if (this.database) {
       return this.database;
-    }
-
-    log.debug(`Opening database for log directory: ${databaseHandle}`);
-
-    // Close current database if switching to a different directory
-    if (this.database && this.databaseHandle !== databaseHandle) {
-      await this.close();
     }
 
     // Check for version mismatch before opening
-    const needsRecreation =
-      await AppDatabase.checkVersionMismatch(databaseHandle);
+    const needsRecreation = await AppDatabase.checkVersionMismatch();
     if (needsRecreation) {
-      log.info(
-        `Recreating database due to version mismatch for: ${databaseHandle}`
-      );
-      const sanitizedDir = databaseHandle.replace(/[^a-zA-Z0-9_-]/g, "_");
-      const dbName = `InspectAI_${sanitizedDir}`;
-      await Dexie.delete(dbName);
-      log.debug(`Deleted old database: ${dbName}`);
+      log.info("Recreating database due to version mismatch");
+      await Dexie.delete(DB_NAME);
+      log.debug(`Deleted old database: ${DB_NAME}`);
     }
 
-    // Create and open new database
-    this.database = new AppDatabase(databaseHandle);
-    this.databaseHandle = databaseHandle;
+    this.database = new AppDatabase();
 
     try {
       await this.database.open();
-      log.debug(`Successfully opened database for: ${databaseHandle}`);
+      log.debug("Successfully opened database");
+      // Pre-unification per-dir databases are dead weight; sweep them in the
+      // background.
+      void deleteLegacyDatabases().catch(() => {});
       return this.database;
     } catch (error) {
-      log.error(`Failed to open database for ${databaseHandle}:`, error);
+      log.error("Failed to open database:", error);
       this.database = null;
-      this.databaseHandle = null;
       throw error;
     }
   }
@@ -69,22 +54,13 @@ export class DatabaseManager {
   }
 
   /**
-   * Get the current log directory.
-   * Returns null if no database is open.
-   */
-  getDatabaseHandle(): string | null {
-    return this.databaseHandle;
-  }
-
-  /**
    * Close the current database connection.
    */
   close(): Promise<void> {
     if (this.database) {
-      log.debug(`Closing database for: ${this.databaseHandle}`);
+      log.debug("Closing database");
       this.database.close();
       this.database = null;
-      this.databaseHandle = null;
     }
     return Promise.resolve();
   }
@@ -93,16 +69,6 @@ export class DatabaseManager {
    * Check if a database is currently open.
    */
   isOpen(): boolean {
-    return this.database !== null && this.databaseHandle !== null;
-  }
-
-  /**
-   * Get database info for debugging.
-   */
-  getInfo(): { databaseHandle: string | null; isOpen: boolean } {
-    return {
-      databaseHandle: this.databaseHandle,
-      isOpen: this.isOpen(),
-    };
+    return this.database !== null;
   }
 }

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -1,6 +1,7 @@
 import Dexie from "dexie";
 
 import { Log, SampleDerived, SampleSummary } from "../api/types";
+import { DERIVE_VERSION } from "../utils/derive";
 
 // Logs Table — THE Log entity row: identity + attribute columns at
 // progressive depth + retrieval facts (see
@@ -56,11 +57,14 @@ export interface SyncScopeRecord {
   last_accessed: string;
 }
 
-// Current database schema version. Bump on any schema change AND on any
-// behavior change in `deriveLogFields`/`deriveSampleFields` — stored rows
-// carry derived values and are only recomputed via the recreate-on-mismatch
-// wipe.
-export const DB_VERSION = 16;
+// The schema's shape version — bump on any table/index change.
+const SCHEMA_VERSION = 16;
+
+// The stored-data version: schema shape composed with derivation behavior,
+// so a derive.ts change can't ship without invalidating rows that carry
+// values from the old logic. DERIVE_VERSION lives beside the derivation
+// functions it versions.
+export const DB_VERSION = SCHEMA_VERSION * 100 + DERIVE_VERSION;
 
 // One database per origin (not per log dir): `file_path` is a full path/URI,
 // so rows from overlapping dirs (e.g. /logs and /logs/important) share

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -60,6 +60,22 @@ export interface SyncScopeRecord {
 // The schema's shape version — bump on any table/index change.
 const SCHEMA_VERSION = 13;
 
+// Runtime backstop for derive.ts's DeriveVersion type constraint: at 100 the
+// composition below aliases into the next schema version's namespace, and an
+// exact collision with a previously-deployed DB_VERSION would keep stale rows
+// without a wipe. Throwing at module load fails the whole app, loudly.
+if (
+  !Number.isInteger(DERIVE_VERSION) ||
+  DERIVE_VERSION < 0 ||
+  DERIVE_VERSION >= 100
+) {
+  throw new Error(
+    `DERIVE_VERSION must be an integer in [0, 100), got ${DERIVE_VERSION}: ` +
+      `it occupies the two low decimal digits of DB_VERSION, so values >= 100 ` +
+      `collide with other schema versions' namespaces`
+  );
+}
+
 // The stored-data version: schema shape composed with derivation behavior,
 // so a derive.ts change can't ship without invalidating rows that carry
 // values from the old logic. DERIVE_VERSION lives beside the derivation

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -58,7 +58,7 @@ export interface SyncScopeRecord {
 }
 
 // The schema's shape version — bump on any table/index change.
-const SCHEMA_VERSION = 16;
+const SCHEMA_VERSION = 13;
 
 // The stored-data version: schema shape composed with derivation behavior,
 // so a derive.ts change can't ship without invalidating rows that carry

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -41,18 +41,37 @@ export interface SampleSummaryRecord {
   cached_at: string;
 }
 
+// Sync Scopes Table - one row per log-dir prefix that has been replicated
+// into the (unified) database. Rows under a prefix are only reconciled/pruned
+// by that scope's listing syncs; the timestamps exist so future
+// eviction/cleanup policies can reason about scope staleness.
+export interface SyncScopeRecord {
+  /** The scope's directory prefix (a `file_path` prefix), as the app names
+   *  it — see `scopePrefix` for boundary-safe matching. */
+  prefix: string;
+  /** Last time a listing sync persisted under this scope. */
+  last_synced?: string;
+  /** Last time the app activated this scope. */
+  last_accessed: string;
+}
+
 // Current database schema version. Bump on any schema change AND on any
 // behavior change in `deriveLogFields`/`deriveSampleFields` — stored rows
 // carry derived values and are only recomputed via the recreate-on-mismatch
 // wipe.
-export const DB_VERSION = 13;
+export const DB_VERSION = 14;
 
-// Resolves a log dir into a database name
-function resolveDBName(databaseHandle: string): string {
-  const sanitizedDir = databaseHandle.replace(/[^a-zA-Z0-9_-]/g, "_");
-  const dbName = `InspectAI_${sanitizedDir}`;
-  return dbName;
-}
+// One database per origin (not per log dir): `file_path` is a full path/URI,
+// so rows from overlapping dirs (e.g. /logs and /logs/important) share
+// identity and replicate once. "Current log dir" is a query scope, not a
+// storage boundary. Pre-unification databases were named
+// `InspectAI_<sanitized dir>` — see `deleteLegacyDatabases`.
+export const DB_NAME = "InspectAI";
+
+/** The boundary-safe prefix for scoping `file_path` queries to a dir:
+ *  `/logs/important` must not match `/logs/important-2`. */
+export const scopePrefix = (dir: string): string =>
+  dir.endsWith("/") ? dir : `${dir}/`;
 
 export class AppDatabase extends Dexie {
   logs!: Dexie.Table<LogRecord, number>;
@@ -60,13 +79,14 @@ export class AppDatabase extends Dexie {
     SampleSummaryRecord,
     [string, string | number, number]
   >;
+  sync_scopes!: Dexie.Table<SyncScopeRecord, string>;
 
   /**
    * Check if an existing database needs to be recreated due to version mismatch.
    * Returns true if the database should be deleted and recreated.
    */
-  static async checkVersionMismatch(databaseHandle: string): Promise<boolean> {
-    const dbName = resolveDBName(databaseHandle);
+  static async checkVersionMismatch(): Promise<boolean> {
+    const dbName = DB_NAME;
 
     try {
       // Check if database exists and get its version
@@ -94,8 +114,8 @@ export class AppDatabase extends Dexie {
     }
   }
 
-  constructor(databaseHandle: string) {
-    super(resolveDBName(databaseHandle));
+  constructor() {
+    super(DB_NAME);
 
     this.version(DB_VERSION)
       .stores({
@@ -108,6 +128,9 @@ export class AppDatabase extends Dexie {
         // default listing sort.
         sample_summaries:
           "[file_path+id+epoch], file_path, summary.completed_at",
+
+        // Replicated log-dir scopes (see SyncScopeRecord).
+        sync_scopes: "prefix",
 
         // Superseded pre-v12 stores (their content lives on the logs row).
         log_previews: null,
@@ -122,8 +145,29 @@ export class AppDatabase extends Dexie {
       // the upgrade itself wipes every surviving table too.
       .upgrade((tx) =>
         Promise.all(
-          ["logs", "sample_summaries"].map((table) => tx.table(table).clear())
+          ["logs", "sample_summaries", "sync_scopes"].map((table) =>
+            tx.table(table).clear()
+          )
         )
       );
   }
 }
+
+/**
+ * Delete pre-unification per-dir databases (`InspectAI_<sanitized dir>`).
+ * Best-effort: `indexedDB.databases()` is not universally available and a
+ * database held open by another (older) tab may survive until it closes.
+ */
+export const deleteLegacyDatabases = async (): Promise<void> => {
+  try {
+    const databases = await indexedDB.databases();
+    await Promise.all(
+      databases
+        .map((info) => info.name)
+        .filter((name): name is string => !!name?.startsWith(`${DB_NAME}_`))
+        .map((name) => Dexie.delete(name).catch(() => {}))
+    );
+  } catch {
+    // Enumeration unavailable or failed — legacy databases linger, harmless.
+  }
+};

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -60,7 +60,7 @@ export interface SyncScopeRecord {
 // behavior change in `deriveLogFields`/`deriveSampleFields` — stored rows
 // carry derived values and are only recomputed via the recreate-on-mismatch
 // wipe.
-export const DB_VERSION = 15;
+export const DB_VERSION = 16;
 
 // One database per origin (not per log dir): `file_path` is a full path/URI,
 // so rows from overlapping dirs (e.g. /logs and /logs/important) share
@@ -121,8 +121,10 @@ export class AppDatabase extends Dexie {
     this.version(DB_VERSION)
       .stores({
         // The Log entity rows. depth is indexed for backfill discovery
-        // (missing previews/details); mtime for listing order.
-        logs: "++id, &file_path, mtime, task, task_id, depth, cached_at",
+        // (missing previews/details); mtime for listing order;
+        // [depth+file_path] serves scoped per-depth counts without
+        // materializing rows (see getCacheStats).
+        logs: "++id, &file_path, mtime, task, task_id, depth, cached_at, [depth+file_path]",
 
         // Sample summaries split out of details payloads. file_path serves
         // scope reads (equals / startsWith); summary.completed_at serves the

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -1,6 +1,6 @@
 import Dexie from "dexie";
 
-import { Log, SampleSummary } from "../api/types";
+import { Log, SampleDerived, SampleSummary } from "../api/types";
 
 // Logs Table — THE Log entity row: identity + attribute columns at
 // progressive depth + retrieval facts (see
@@ -36,12 +36,16 @@ export interface SampleSummaryRecord {
   epoch: number;
 
   summary: SampleSummary;
+  derived: SampleDerived;
 
   cached_at: string;
 }
 
-// Current database schema version
-export const DB_VERSION = 12;
+// Current database schema version. Bump on any schema change AND on any
+// behavior change in `deriveLogFields`/`deriveSampleFields` — stored rows
+// carry derived values and are only recomputed via the recreate-on-mismatch
+// wipe.
+export const DB_VERSION = 13;
 
 // Resolves a log dir into a database name
 function resolveDBName(databaseHandle: string): string {

--- a/apps/inspect/src/client/database/schema.ts
+++ b/apps/inspect/src/client/database/schema.ts
@@ -46,8 +46,9 @@ export interface SampleSummaryRecord {
 // by that scope's listing syncs; the timestamps exist so future
 // eviction/cleanup policies can reason about scope staleness.
 export interface SyncScopeRecord {
-  /** The scope's directory prefix (a `file_path` prefix), as the app names
-   *  it — see `scopePrefix` for boundary-safe matching. */
+  /** The scope's directory prefix (a `file_path` prefix), stored in
+   *  boundary-safe `scopePrefix` form so `clearScope` can sweep a scope and
+   *  everything nested under it with one prefix match. */
   prefix: string;
   /** Last time a listing sync persisted under this scope. */
   last_synced?: string;
@@ -59,7 +60,7 @@ export interface SyncScopeRecord {
 // behavior change in `deriveLogFields`/`deriveSampleFields` — stored rows
 // carry derived values and are only recomputed via the recreate-on-mismatch
 // wipe.
-export const DB_VERSION = 14;
+export const DB_VERSION = 15;
 
 // One database per origin (not per log dir): `file_path` is a full path/URI,
 // so rows from overlapping dirs (e.g. /logs and /logs/important) share

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -319,6 +319,26 @@ export class DatabaseService {
   }
 
   /**
+   * Wipe every table — the "Clear Local Database" escape hatch. Unlike
+   * `clearScope`, this reaches rows persisted under names outside any synced
+   * scope's namespace (see `namesInScope` in logsContent).
+   */
+  async clearAllData(): Promise<void> {
+    const db = this.getDb();
+    log.debug("Clearing all cached data");
+    await db.transaction(
+      "rw",
+      [db.logs, db.sample_summaries, db.sync_scopes],
+      () =>
+        Promise.all([
+          db.logs.clear(),
+          db.sample_summaries.clear(),
+          db.sync_scopes.clear(),
+        ])
+    );
+  }
+
+  /**
    * Clear all cached data under a scope: its log rows, their sample
    * summaries, and the scope's sync record. Other scopes' rows are untouched.
    */

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -16,6 +16,8 @@ import {
   fromLogRecord,
   LogRecord,
   SampleSummaryRecord,
+  scopePrefix,
+  SyncScopeRecord,
   toLogRecord,
 } from "./schema";
 
@@ -24,6 +26,11 @@ const log = createLogger("DatabaseService");
 /** Scope of a sample-summaries read: one log file, or every file under a
  *  path prefix. */
 export type SampleSummariesScope = { file: string } | { prefix: string };
+
+/** Scope of a log-rows read/clear: every file under a dir. The database is
+ *  unified across log dirs, so whole-table reads are never correct — every
+ *  listing-level operation names its scope. */
+export type LogScope = { prefix: string };
 
 const newRow = (handle: LogHandle): Log => ({
   ...handle,
@@ -61,10 +68,10 @@ export class DatabaseService {
   }
 
   /**
-   * Open a database for the specified log directory.
+   * Open the (unified) database.
    */
-  async openDatabase(databaseHandle: string): Promise<void> {
-    await this.manager.openDatabase(databaseHandle);
+  async openDatabase(): Promise<void> {
+    await this.manager.openDatabase();
   }
 
   /**
@@ -72,13 +79,6 @@ export class DatabaseService {
    */
   async closeDatabase(): Promise<void> {
     await this.manager.close();
-  }
-
-  /**
-   * Get the current log directory.
-   */
-  getDatabaseHandle(): string | null {
-    return this.manager.getDatabaseHandle();
   }
 
   // === LOG ROWS ===
@@ -92,7 +92,10 @@ export class DatabaseService {
     const db = this.getDb();
     const now = new Date().toISOString();
 
-    const existingRecords = await db.logs.toArray();
+    const existingRecords = await db.logs
+      .where("file_path")
+      .anyOf(handles.map((handle) => handle.name))
+      .toArray();
     const existingByPath = new Map(
       existingRecords.map((record) => [record.file_path, record])
     );
@@ -114,7 +117,7 @@ export class DatabaseService {
     await db.logs.bulkPut(records);
   }
 
-  async readLogs(): Promise<Log[] | null> {
+  async readLogs(scope: LogScope): Promise<Log[] | null> {
     try {
       if (!this.opened()) {
         log.debug("Database not open");
@@ -122,7 +125,10 @@ export class DatabaseService {
       }
 
       const db = this.getDb();
-      const records = await db.logs.toArray();
+      const records = await db.logs
+        .where("file_path")
+        .startsWith(scopePrefix(scope.prefix))
+        .toArray();
 
       // Sort by mtime (descending) if present, otherwise maintain insertion
       // order. Note: != null (not !==) catches both null and undefined.
@@ -261,7 +267,9 @@ export class DatabaseService {
     const collection =
       "file" in scope
         ? db.sample_summaries.where("file_path").equals(scope.file)
-        : db.sample_summaries.where("file_path").startsWith(scope.prefix);
+        : db.sample_summaries
+            .where("file_path")
+            .startsWith(scopePrefix(scope.prefix));
     return collection.toArray();
   }
 
@@ -319,33 +327,74 @@ export class DatabaseService {
   }
 
   /**
-   * Clear all cached data from all tables.
+   * Clear all cached data under a scope: its log rows, their sample
+   * summaries, and the scope's sync record. Other scopes' rows are untouched.
    */
-  async clearAllCaches(): Promise<void> {
+  async clearScope(scope: LogScope): Promise<void> {
     const db = this.getDb();
+    const prefix = scopePrefix(scope.prefix);
 
-    log.debug("Clearing all caches");
-    await Promise.all([db.logs.clear(), db.sample_summaries.clear()]);
+    log.debug(`Clearing caches under: ${prefix}`);
+    await Promise.all([
+      db.logs.where("file_path").startsWith(prefix).delete(),
+      db.sample_summaries.where("file_path").startsWith(prefix).delete(),
+      db.sync_scopes.delete(scope.prefix),
+    ]);
+  }
+
+  // === SYNC SCOPES ===
+
+  /** Record that a scope is active (creating its row on first contact). */
+  async touchSyncScope(prefix: string): Promise<void> {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    const existing = await db.sync_scopes.get(prefix);
+    await db.sync_scopes.put({ ...existing, prefix, last_accessed: now });
+  }
+
+  /** Read a scope's sync record (undefined when never activated). */
+  async getSyncScope(prefix: string): Promise<SyncScopeRecord | undefined> {
+    const db = this.getDb();
+    return db.sync_scopes.get(prefix);
+  }
+
+  /** Record that a listing sync persisted under a scope. */
+  async markScopeSynced(prefix: string): Promise<void> {
+    const db = this.getDb();
+    const now = new Date().toISOString();
+    const existing = await db.sync_scopes.get(prefix);
+    await db.sync_scopes.put({
+      prefix,
+      last_accessed: existing?.last_accessed ?? now,
+      last_synced: now,
+    });
   }
 
   /**
-   * Get cache statistics.
+   * Get cache statistics for a scope.
    */
-  async getCacheStats(): Promise<{
+  async getCacheStats(scope: LogScope): Promise<{
     logFiles: number;
     logSummaries: number;
     logHeaders: number;
     sampleSummaries: number;
-    logHandle: string | null;
   }> {
     const db = this.getDb();
+    const prefix = scopePrefix(scope.prefix);
 
+    // Depth breakdowns can't compose a second index with the file_path
+    // range — filter in JS (debug/advisory stats only).
+    const scoped = () => db.logs.where("file_path").startsWith(prefix);
     const [logFiles, logSummaries, logHeaders, sampleSummaries] =
       await Promise.all([
-        db.logs.count(),
-        db.logs.where("depth").anyOf(["previewed", "detailed"]).count(),
-        db.logs.where("depth").equals("detailed").count(),
-        db.sample_summaries.count(),
+        scoped().count(),
+        scoped()
+          .filter((record) => record.depth !== "listed")
+          .count(),
+        scoped()
+          .filter((record) => record.depth === "detailed")
+          .count(),
+        db.sample_summaries.where("file_path").startsWith(prefix).count(),
       ]);
 
     return {
@@ -353,7 +402,6 @@ export class DatabaseService {
       logSummaries,
       logHeaders,
       sampleSummaries,
-      logHandle: this.manager.getDatabaseHandle(),
     };
   }
 }

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -2,11 +2,7 @@ import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
 import { Log, LogFetchState, LogPreview } from "../api/types";
-import {
-  maxDepth,
-  PreparedLogDetails,
-  previewTier,
-} from "../utils/type-utils";
+import { maxDepth, PreparedLogDetails, previewTier } from "../utils/type-utils";
 
 import { DatabaseManager } from "./manager";
 import {
@@ -408,14 +404,12 @@ export class DatabaseService {
         .where("[depth+file_path]")
         .between([depth, prefix], [depth, prefix + "\uffff"])
         .count();
-    const [logFiles, previewed, detailed, sampleSummaries] = await Promise.all(
-      [
-        db.logs.where("file_path").startsWith(prefix).count(),
-        depthCount("previewed"),
-        depthCount("detailed"),
-        db.sample_summaries.where("file_path").startsWith(prefix).count(),
-      ]
-    );
+    const [logFiles, previewed, detailed, sampleSummaries] = await Promise.all([
+      db.logs.where("file_path").startsWith(prefix).count(),
+      depthCount("previewed"),
+      depthCount("detailed"),
+      db.sample_summaries.where("file_path").startsWith(prefix).count(),
+    ]);
 
     return {
       logFiles,

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -2,6 +2,7 @@ import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
 import { Log, LogDetails, LogFetchState, LogPreview } from "../api/types";
+import { deriveSampleFields } from "../utils/derive";
 import {
   detailTier,
   maxDepth,
@@ -245,6 +246,7 @@ export class DatabaseService {
             id: summary.id,
             epoch: summary.epoch,
             summary,
+            derived: deriveSampleFields(summary),
             cached_at: now,
           }))
         )

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -335,38 +335,60 @@ export class DatabaseService {
     const prefix = scopePrefix(scope.prefix);
 
     log.debug(`Clearing caches under: ${prefix}`);
-    await Promise.all([
-      db.logs.where("file_path").startsWith(prefix).delete(),
-      db.sample_summaries.where("file_path").startsWith(prefix).delete(),
-      db.sync_scopes.delete(scope.prefix),
-    ]);
+    // One transaction: a partial failure must not leave rows deleted while a
+    // sync record still claims the scope is replicated. The sync_scopes sweep
+    // is prefix-based so nested scopes' records go with their rows.
+    await db.transaction(
+      "rw",
+      [db.logs, db.sample_summaries, db.sync_scopes],
+      () =>
+        Promise.all([
+          db.logs.where("file_path").startsWith(prefix).delete(),
+          db.sample_summaries.where("file_path").startsWith(prefix).delete(),
+          db.sync_scopes.where("prefix").startsWith(prefix).delete(),
+        ])
+    );
   }
 
   // === SYNC SCOPES ===
+  // Keys are stored in boundary-safe `scopePrefix` form. The get-then-put
+  // upserts run in single transactions: the per-origin database is shared
+  // across tabs, and an unfenced read-modify-write can overwrite another
+  // tab's just-written timestamp.
 
   /** Record that a scope is active (creating its row on first contact). */
   async touchSyncScope(prefix: string): Promise<void> {
     const db = this.getDb();
+    const key = scopePrefix(prefix);
     const now = new Date().toISOString();
-    const existing = await db.sync_scopes.get(prefix);
-    await db.sync_scopes.put({ ...existing, prefix, last_accessed: now });
+    await db.transaction("rw", db.sync_scopes, async () => {
+      const existing = await db.sync_scopes.get(key);
+      await db.sync_scopes.put({
+        ...existing,
+        prefix: key,
+        last_accessed: now,
+      });
+    });
   }
 
   /** Read a scope's sync record (undefined when never activated). */
   async getSyncScope(prefix: string): Promise<SyncScopeRecord | undefined> {
     const db = this.getDb();
-    return db.sync_scopes.get(prefix);
+    return db.sync_scopes.get(scopePrefix(prefix));
   }
 
   /** Record that a listing sync persisted under a scope. */
   async markScopeSynced(prefix: string): Promise<void> {
     const db = this.getDb();
+    const key = scopePrefix(prefix);
     const now = new Date().toISOString();
-    const existing = await db.sync_scopes.get(prefix);
-    await db.sync_scopes.put({
-      prefix,
-      last_accessed: existing?.last_accessed ?? now,
-      last_synced: now,
+    await db.transaction("rw", db.sync_scopes, async () => {
+      const existing = await db.sync_scopes.get(key);
+      await db.sync_scopes.put({
+        prefix: key,
+        last_accessed: existing?.last_accessed ?? now,
+        last_synced: now,
+      });
     });
   }
 

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -404,25 +404,27 @@ export class DatabaseService {
     const db = this.getDb();
     const prefix = scopePrefix(scope.prefix);
 
-    // Depth breakdowns can't compose a second index with the file_path
-    // range — filter in JS (debug/advisory stats only).
-    const scoped = () => db.logs.where("file_path").startsWith(prefix);
-    const [logFiles, logSummaries, logHeaders, sampleSummaries] =
-      await Promise.all([
-        scoped().count(),
-        scoped()
-          .filter((record) => record.depth !== "listed")
-          .count(),
-        scoped()
-          .filter((record) => record.depth === "detailed")
-          .count(),
+    // Index-only counts: this runs throttled but repeatedly during active
+    // replication, and a cursor over the range would structured-clone every
+    // record (full header included) just to count it.
+    const depthCount = (depth: LogRecord["depth"]) =>
+      db.logs
+        .where("[depth+file_path]")
+        .between([depth, prefix], [depth, prefix + "\uffff"])
+        .count();
+    const [logFiles, previewed, detailed, sampleSummaries] = await Promise.all(
+      [
+        db.logs.where("file_path").startsWith(prefix).count(),
+        depthCount("previewed"),
+        depthCount("detailed"),
         db.sample_summaries.where("file_path").startsWith(prefix).count(),
-      ]);
+      ]
+    );
 
     return {
       logFiles,
-      logSummaries,
-      logHeaders,
+      logSummaries: previewed + detailed,
+      logHeaders: detailed,
       sampleSummaries,
     };
   }

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -1,13 +1,11 @@
 import { LogHandle } from "@tsmono/inspect-common";
 import { createLogger } from "@tsmono/util";
 
-import { Log, LogDetails, LogFetchState, LogPreview } from "../api/types";
-import { deriveSampleFields } from "../utils/derive";
+import { Log, LogFetchState, LogPreview } from "../api/types";
 import {
-  detailTier,
   maxDepth,
+  PreparedLogDetails,
   previewTier,
-  toLogHeader,
 } from "../utils/type-utils";
 
 import { DatabaseManager } from "./manager";
@@ -223,12 +221,15 @@ export class DatabaseService {
   // === DETAILED TIER ===
 
   /**
-   * Ingest details payloads: merge the detailed tier into each log row and
-   * replace the file's sample summary rows, in one transaction per call so a
-   * reader never sees a header whose summary rows are from an older
-   * ingestion.
+   * Ingest prepared details payloads (`prepareLogDetails` — the seam
+   * normalizes once for both stores): merge the detailed tier into each log
+   * row and replace the file's sample summary rows, in one transaction per
+   * call so a reader never sees a header whose summary rows are from an
+   * older ingestion.
    */
-  async writeLogDetails(details: Record<string, LogDetails>): Promise<void> {
+  async writeLogDetails(
+    details: Record<string, PreparedLogDetails>
+  ): Promise<void> {
     const db = this.getDb();
     const now = new Date().toISOString();
 
@@ -236,23 +237,18 @@ export class DatabaseService {
     log.debug(`Ingesting ${entries.length} log details (split)`);
     await db.transaction("rw", db.logs, db.sample_summaries, async () => {
       await this.mergeRows(
-        Object.fromEntries(
-          entries.map(([file, payload]) => [
-            file,
-            detailTier(toLogHeader(payload)),
-          ])
-        )
+        Object.fromEntries(entries.map(([file, { patch }]) => [file, patch]))
       );
       const files = entries.map(([filePath]) => filePath);
       await db.sample_summaries.where("file_path").anyOf(files).delete();
       await db.sample_summaries.bulkPut(
-        entries.flatMap(([filePath, payload]) =>
-          payload.sampleSummaries.map<SampleSummaryRecord>((summary) => ({
+        entries.flatMap(([filePath, { summaries }]) =>
+          summaries.map<SampleSummaryRecord>(({ summary, derived }) => ({
             file_path: filePath,
             id: summary.id,
             epoch: summary.epoch,
             summary,
-            derived: deriveSampleFields(summary),
+            derived,
             cached_at: now,
           }))
         )

--- a/apps/inspect/src/client/utils/derive.test.ts
+++ b/apps/inspect/src/client/utils/derive.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "vitest";
+
+import { LogHeader, SampleSummary } from "../api/types";
+
+import { deriveLogFields, deriveSampleFields } from "./derive";
+
+const makeHeader = (overrides: Partial<LogHeader> = {}): LogHeader => ({
+  version: 1,
+  status: "success",
+  eval: {
+    eval_id: "eval-1",
+    run_id: "run-1",
+    created: "2024-01-01T00:00:00Z",
+    task: "test-task",
+    task_id: "task-1",
+    task_args: {},
+    task_args_passed: {},
+    model: "gpt-4",
+  } as unknown as LogHeader["eval"],
+  results: null,
+  stats: undefined,
+  error: null,
+  sampleCount: 0,
+  sampleErrorCount: 0,
+  sampleLimits: [],
+  ...overrides,
+});
+
+const makeSummary = (
+  overrides: Partial<SampleSummary> = {}
+): SampleSummary => ({
+  id: 1,
+  epoch: 0,
+  input: "test input",
+  target: "test target",
+  scores: null,
+  completed: true,
+  ...overrides,
+});
+
+describe("deriveLogFields", () => {
+  test("sums total tokens across models", () => {
+    const header = makeHeader({
+      stats: {
+        started_at: "2024-01-01T00:00:00Z",
+        completed_at: "2024-01-01T01:00:00Z",
+        model_usage: {
+          "openai/gpt-4": {
+            input_tokens: 10,
+            output_tokens: 5,
+            total_tokens: 15,
+          },
+          "anthropic/claude": {
+            input_tokens: 20,
+            output_tokens: 10,
+            total_tokens: 30,
+          },
+        },
+      } as unknown as LogHeader["stats"],
+    });
+    const derived = deriveLogFields(header);
+    expect(derived.total_tokens).toBe(45);
+    expect(derived.duration).toBe(3600);
+  });
+
+  test("returns undefined fields for a header with no stats/results", () => {
+    const derived = deriveLogFields(makeHeader());
+    expect(derived.total_tokens).toBeUndefined();
+    expect(derived.duration).toBeUndefined();
+    expect(derived.task_args).toBeUndefined();
+    expect(derived.percent_completed).toBeUndefined();
+    expect(derived.sample_limits).toBeUndefined();
+    expect(derived.scores).toBeUndefined();
+  });
+
+  test("ignores a duration whose end precedes its start", () => {
+    const header = makeHeader({
+      stats: {
+        started_at: "2024-01-01T02:00:00Z",
+        completed_at: "2024-01-01T01:00:00Z",
+        model_usage: {},
+      } as unknown as LogHeader["stats"],
+    });
+    expect(deriveLogFields(header).duration).toBeUndefined();
+  });
+
+  test("formats task args, preferring task_args_passed", () => {
+    const header = makeHeader({
+      eval: {
+        task_args: { a: 1, b: "two", defaulted: true },
+        task_args_passed: { a: 1, b: "two" },
+      } as unknown as LogHeader["eval"],
+    });
+    expect(deriveLogFields(header).task_args).toBe('a=1, b="two"');
+  });
+
+  test("computes percent completed and joins sample limits", () => {
+    const header = makeHeader({
+      results: {
+        total_samples: 8,
+        completed_samples: 2,
+      } as unknown as LogHeader["results"],
+      sampleLimits: ["message", "time"],
+    });
+    const derived = deriveLogFields(header);
+    expect(derived.percent_completed).toBe(25);
+    expect(derived.sample_limits).toBe("message, time");
+  });
+
+  test("maps scores keyed scorer → metric", () => {
+    const header = makeHeader({
+      results: {
+        total_samples: 1,
+        completed_samples: 1,
+        scores: [
+          {
+            name: "grader",
+            metrics: {
+              accuracy: { name: "accuracy", value: 0.9 },
+              stderr: { name: "stderr", value: 0.01 },
+            },
+          },
+          {
+            name: "other",
+            metrics: { accuracy: { name: "accuracy", value: 0.5 } },
+          },
+        ],
+      } as unknown as LogHeader["results"],
+    });
+    expect(deriveLogFields(header).scores).toEqual({
+      grader: { accuracy: 0.9, stderr: 0.01 },
+      other: { accuracy: 0.5 },
+    });
+  });
+});
+
+describe("deriveSampleFields", () => {
+  test("derives text, tokens, fallbacks, and scores", () => {
+    const summary = makeSummary({
+      input: "what is 2+2?",
+      target: ["4", "four"],
+      model_usage: {
+        "openai/gpt-4": {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+        },
+      } as unknown as SampleSummary["model_usage"],
+      model_fallbacks: [
+        { model: "a", fallback_model: "b", count: 2 },
+      ] as unknown as SampleSummary["model_fallbacks"],
+      scores: {
+        accuracy: {
+          value: 1,
+          answer: null,
+          explanation: null,
+          metadata: {},
+          history: [],
+        },
+      },
+    });
+    const derived = deriveSampleFields(summary);
+    expect(derived.input).toBe("what is 2+2?");
+    expect(derived.target).toBe("4, four");
+    expect(derived.tokens).toBe(15);
+    expect(derived.fallbacks).toBe(2);
+    expect(derived.scores).toEqual({ accuracy: 1 });
+  });
+
+  test("handles a minimal summary", () => {
+    const derived = deriveSampleFields(makeSummary());
+    expect(derived.input).toBe("test input");
+    expect(derived.target).toBe("test target");
+    expect(derived.tokens).toBeUndefined();
+    expect(derived.fallbacks).toBeUndefined();
+    expect(derived.scores).toBeUndefined();
+  });
+});

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -19,13 +19,24 @@ import {
  * eventually the database query layer) sees.
  */
 
+type LessThan<
+  N extends number,
+  Acc extends number[] = [],
+> = Acc["length"] extends N ? Acc[number] : LessThan<N, [...Acc, Acc["length"]]>;
+
+/** The valid range for `DERIVE_VERSION`: `DB_VERSION` (schema.ts) packs it
+ *  into the two low decimal digits of `SCHEMA_VERSION * 100`, so a value of
+ *  100 would silently alias into the next schema version's namespace. */
+type DeriveVersion = LessThan<100>;
+
 /**
  * Version of the derivation behavior in this module, folded into the
  * database version (see `DB_VERSION` in schema.ts). Bump it on ANY behavior
  * change here: persisted rows carry values computed by the old logic and are
- * only recomputed via the recreate-on-mismatch wipe.
+ * only recomputed via the recreate-on-mismatch wipe. Must stay below 100
+ * (enforced by `DeriveVersion`; schema.ts asserts it again at runtime).
  */
-export const DERIVE_VERSION = 1;
+export const DERIVE_VERSION: number = 1 satisfies DeriveVersion;
 
 export const deriveLogFields = (header: LogHeader): LogDerived => {
   let total_tokens: number | undefined;

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -9,18 +9,23 @@ import {
 } from "../api/types";
 
 /**
- * Derivation of stored listing columns (`LogDerived` / `SampleDerived`).
+ * Derivation of stored listing columns (`LogDerived` / `SampleDerived` /
+ * the sample facts on `LogHeader`).
  *
- * These run once at ingestion — the write paths (`detailTier`, the details
- * sink) attach the result to the stored row, and the listing grids read the
- * stored values without computing. Grid columns must never re-derive these
- * fields at read time; that would let displayed values drift from what the
- * store (and eventually the database query layer) sees.
- *
- * Any behavior change here requires a `DB_VERSION` bump: persisted rows carry
- * values computed by the old logic and are only recomputed via the
- * recreate-on-mismatch wipe.
+ * These run once at ingestion — the write paths (`prepareLogDetails`) attach
+ * the result to the stored row, and the listing grids read the stored values
+ * without computing. Grid columns must never re-derive these fields at read
+ * time; that would let displayed values drift from what the store (and
+ * eventually the database query layer) sees.
  */
+
+/**
+ * Version of the derivation behavior in this module, folded into the
+ * database version (see `DB_VERSION` in schema.ts). Bump it on ANY behavior
+ * change here: persisted rows carry values computed by the old logic and are
+ * only recomputed via the recreate-on-mismatch wipe.
+ */
+export const DERIVE_VERSION = 1;
 
 export const deriveLogFields = (header: LogHeader): LogDerived => {
   let total_tokens: number | undefined;
@@ -86,6 +91,25 @@ export const deriveLogFields = (header: LogHeader): LogDerived => {
     percent_completed,
     sample_limits,
     scores,
+  };
+};
+
+/** The sample facts baked onto the stored `LogHeader` by `toLogHeader` —
+ *  persisted derivation like the fields above, so it lives under
+ *  `DERIVE_VERSION` with them. */
+export const deriveSampleFacts = (
+  summaries: SampleSummary[]
+): Pick<LogHeader, "sampleCount" | "sampleErrorCount" | "sampleLimits"> => {
+  const limits = new Set<string>();
+  let errorCount = 0;
+  for (const sample of summaries) {
+    if (sample.error) errorCount += 1;
+    if (sample.limit) limits.add(sample.limit);
+  }
+  return {
+    sampleCount: summaries.length,
+    sampleErrorCount: errorCount,
+    sampleLimits: [...limits].sort(),
   };
 };
 

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -22,7 +22,9 @@ import {
 type LessThan<
   N extends number,
   Acc extends number[] = [],
-> = Acc["length"] extends N ? Acc[number] : LessThan<N, [...Acc, Acc["length"]]>;
+> = Acc["length"] extends N
+  ? Acc[number]
+  : LessThan<N, [...Acc, Acc["length"]]>;
 
 /** The valid range for `DERIVE_VERSION`: `DB_VERSION` (schema.ts) packs it
  *  into the two low decimal digits of `SCHEMA_VERSION * 100`, so a value of

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -1,4 +1,5 @@
 import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
+import { arrayToString } from "@tsmono/util";
 
 import {
   LogDerived,
@@ -88,14 +89,20 @@ export const deriveLogFields = (header: LogHeader): LogDerived => {
   };
 };
 
-export const deriveSampleFields = (summary: SampleSummary): SampleDerived => {
-  const tokens = summary.model_usage
-    ? Object.values(summary.model_usage).reduce(
+/** A sample's total token spend across models (undefined before any usage).
+ *  The single home for this sum — the stored `derived.tokens` column and
+ *  read-time consumers (filter variables, sample rows) must agree. */
+export const totalSampleTokens = (
+  modelUsage: SampleSummary["model_usage"]
+): number | undefined =>
+  modelUsage
+    ? Object.values(modelUsage).reduce(
         (sum, u) => sum + (u.total_tokens ?? 0),
         0
       )
     : undefined;
 
+export const deriveSampleFields = (summary: SampleSummary): SampleDerived => {
   let scores: Record<string, unknown> | undefined;
   if (summary.scores) {
     scores = {};
@@ -107,12 +114,10 @@ export const deriveSampleFields = (summary: SampleSummary): SampleDerived => {
   // Tolerate partial summaries (e.g. a running log's provisional rows):
   // ingestion of a whole payload must not fail on one malformed sample.
   return {
-    tokens,
+    tokens: totalSampleTokens(summary.model_usage),
     input:
       summary.input !== undefined ? inputString(summary.input).join("\n") : "",
-    target: Array.isArray(summary.target)
-      ? summary.target.join(", ")
-      : (summary.target ?? ""),
+    target: arrayToString(summary.target ?? ""),
     fallbacks: totalModelFallbacks(summary.model_fallbacks) || undefined,
     scores,
   };

--- a/apps/inspect/src/client/utils/derive.ts
+++ b/apps/inspect/src/client/utils/derive.ts
@@ -1,0 +1,119 @@
+import { inputString, totalModelFallbacks } from "@tsmono/inspect-common/utils";
+
+import {
+  LogDerived,
+  LogHeader,
+  SampleDerived,
+  SampleSummary,
+} from "../api/types";
+
+/**
+ * Derivation of stored listing columns (`LogDerived` / `SampleDerived`).
+ *
+ * These run once at ingestion — the write paths (`detailTier`, the details
+ * sink) attach the result to the stored row, and the listing grids read the
+ * stored values without computing. Grid columns must never re-derive these
+ * fields at read time; that would let displayed values drift from what the
+ * store (and eventually the database query layer) sees.
+ *
+ * Any behavior change here requires a `DB_VERSION` bump: persisted rows carry
+ * values computed by the old logic and are only recomputed via the
+ * recreate-on-mismatch wipe.
+ */
+
+export const deriveLogFields = (header: LogHeader): LogDerived => {
+  let total_tokens: number | undefined;
+  if (header.stats?.model_usage) {
+    total_tokens = 0;
+    for (const usage of Object.values(header.stats.model_usage)) {
+      total_tokens += usage.total_tokens;
+    }
+  }
+
+  let duration: number | undefined;
+  if (header.stats?.started_at && header.stats?.completed_at) {
+    const start = new Date(header.stats.started_at).getTime();
+    const end = new Date(header.stats.completed_at).getTime();
+    if (start && end && end > start) {
+      duration = (end - start) / 1000;
+    }
+  }
+
+  // Prefer `task_args_passed` (the args the user actually supplied at the
+  // call site) over `task_args` (which would also include defaulted values).
+  const taskArgsSource = header.eval.task_args_passed ?? header.eval.task_args;
+  let task_args: string | undefined;
+  if (taskArgsSource) {
+    const entries = Object.entries(taskArgsSource);
+    if (entries.length > 0) {
+      task_args = entries
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join(", ");
+    }
+  }
+
+  let percent_completed: number | undefined;
+  const total = header.results?.total_samples;
+  const completed = header.results?.completed_samples;
+  if (total && total > 0 && completed !== undefined) {
+    percent_completed = (completed / total) * 100;
+  }
+
+  const sample_limits =
+    header.sampleLimits.length > 0 ? header.sampleLimits.join(", ") : undefined;
+
+  // Key by (scorer, metric) so distinct scorers emitting the same metric name
+  // each get their own entry. Reducer is omitted: `reducer=null` (default,
+  // silently mean) and `reducer="mean"` (explicit) land in the same slot
+  // since the underlying computation is identical.
+  let scores: Record<string, Record<string, number>> | undefined;
+  if (header.results?.scores) {
+    for (const evalScore of header.results.scores) {
+      if (evalScore.metrics) {
+        for (const [metricName, metric] of Object.entries(evalScore.metrics)) {
+          scores ??= {};
+          (scores[evalScore.name] ??= {})[metricName] = metric.value;
+        }
+      }
+    }
+  }
+
+  return {
+    total_tokens,
+    duration,
+    task_args,
+    percent_completed,
+    sample_limits,
+    scores,
+  };
+};
+
+export const deriveSampleFields = (summary: SampleSummary): SampleDerived => {
+  const tokens = summary.model_usage
+    ? Object.values(summary.model_usage).reduce(
+        (sum, u) => sum + (u.total_tokens ?? 0),
+        0
+      )
+    : undefined;
+
+  let scores: Record<string, unknown> | undefined;
+  if (summary.scores) {
+    scores = {};
+    for (const [scoreName, score] of Object.entries(summary.scores)) {
+      scores[scoreName] = score.value;
+    }
+  }
+
+  // Tolerate partial summaries (e.g. a running log's provisional rows):
+  // ingestion of a whole payload must not fail on one malformed sample.
+  return {
+    tokens,
+    input:
+      summary.input !== undefined ? inputString(summary.input).join("\n") : "",
+    target: Array.isArray(summary.target)
+      ? summary.target.join(", ")
+      : (summary.target ?? ""),
+    fallbacks: totalModelFallbacks(summary.model_fallbacks) || undefined,
+    scores,
+  };
+};

--- a/apps/inspect/src/client/utils/type-utils.ts
+++ b/apps/inspect/src/client/utils/type-utils.ts
@@ -9,6 +9,8 @@ import {
   LogPreview,
 } from "../api/types";
 
+import { deriveLogFields } from "./derive";
+
 const kDepthOrder: Record<LogDepth, number> = {
   listed: 0,
   previewed: 1,
@@ -40,13 +42,14 @@ export const previewTier = (
 });
 
 /** The detailed-tier attributes: the flat columns re-derived from the header
- *  plus the header itself. */
+ *  plus the header itself and the derived listing columns. */
 export const detailTier = (
   header: LogHeader
 ): Partial<Log> & { depth: LogDepth } => ({
   ...previewTier(toLogPreview(header)),
   depth: "detailed",
   header,
+  derived: deriveLogFields(header),
 });
 
 /** Split a details payload into its stored header form: everything but the

--- a/apps/inspect/src/client/utils/type-utils.ts
+++ b/apps/inspect/src/client/utils/type-utils.ts
@@ -7,9 +7,11 @@ import {
   LogDetails,
   LogHeader,
   LogPreview,
+  SampleDerived,
+  SampleSummary,
 } from "../api/types";
 
-import { deriveLogFields } from "./derive";
+import { deriveLogFields, deriveSampleFields } from "./derive";
 
 const kDepthOrder: Record<LogDepth, number> = {
   listed: 0,
@@ -67,6 +69,34 @@ export const toLogHeader = (details: LogDetails): LogHeader => {
     sampleCount: sampleSummaries.length,
     sampleErrorCount: errorCount,
     sampleLimits: [...limits].sort(),
+  };
+};
+
+export interface PreparedSampleSummary {
+  summary: SampleSummary;
+  derived: SampleDerived;
+}
+
+/** A details payload normalized once at ingestion: the header split out, its
+ *  detailed-tier row patch, and each summary paired with its derived columns.
+ *  Both stores (the query cache's pushes and the IndexedDB write) consume
+ *  this single computation, so they can't disagree — and `deriveSampleFields`
+ *  never runs twice for one payload. */
+export interface PreparedLogDetails {
+  header: LogHeader;
+  patch: Partial<Log> & { depth: LogDepth };
+  summaries: PreparedSampleSummary[];
+}
+
+export const prepareLogDetails = (details: LogDetails): PreparedLogDetails => {
+  const header = toLogHeader(details);
+  return {
+    header,
+    patch: detailTier(header),
+    summaries: details.sampleSummaries.map((summary) => ({
+      summary,
+      derived: deriveSampleFields(summary),
+    })),
   };
 };
 

--- a/apps/inspect/src/client/utils/type-utils.ts
+++ b/apps/inspect/src/client/utils/type-utils.ts
@@ -11,7 +11,11 @@ import {
   SampleSummary,
 } from "../api/types";
 
-import { deriveLogFields, deriveSampleFields } from "./derive";
+import {
+  deriveLogFields,
+  deriveSampleFacts,
+  deriveSampleFields,
+} from "./derive";
 
 const kDepthOrder: Record<LogDepth, number> = {
   listed: 0,
@@ -58,18 +62,7 @@ export const detailTier = (
  *  sample summaries, plus the sample facts derived from them. */
 export const toLogHeader = (details: LogDetails): LogHeader => {
   const { sampleSummaries, ...header } = details;
-  const limits = new Set<string>();
-  let errorCount = 0;
-  for (const sample of sampleSummaries) {
-    if (sample.error) errorCount += 1;
-    if (sample.limit) limits.add(sample.limit);
-  }
-  return {
-    ...header,
-    sampleCount: sampleSummaries.length,
-    sampleErrorCount: errorCount,
-    sampleLimits: [...limits].sort(),
-  };
+  return { ...header, ...deriveSampleFacts(sampleSummaries) };
 };
 
 export interface PreparedSampleSummary {

--- a/apps/inspect/src/log_data/fetchEngine.test.ts
+++ b/apps/inspect/src/log_data/fetchEngine.test.ts
@@ -828,7 +828,12 @@ describe("FetchEngine.applyListing epoch fencing", () => {
 
     // Dir switch: restart binds the next session's sink.
     const { sink, calls } = createFakeSink();
-    await engine.start({ api: fake.api, database: null, sink, logDir: "dir/logs" });
+    await engine.start({
+      api: fake.api,
+      database: null,
+      sink,
+      logDir: "dir/logs",
+    });
     const before = engine.listing();
 
     const result = await engine.applyListing({
@@ -1301,7 +1306,12 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     const db = createFakeDb([listedRow(handle("a.eval"))]);
     const { sink, calls } = createFakeSink(db);
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
+    await engine.start({
+      api: fake.api,
+      database: db,
+      sink,
+      logDir: "dir/logs",
+    });
 
     await expect(
       engine.ensure("a.eval", { depth: "detailed", priority: "user" })
@@ -1312,7 +1322,12 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     });
 
     engine.stop();
-    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
+    await engine.start({
+      api: fake.api,
+      database: db,
+      sink,
+      logDir: "dir/logs",
+    });
 
     expect(calls.fetchStates["a.eval"]).toMatchObject({
       details_fetch_error: "fetch failed: a.eval",
@@ -1478,7 +1493,12 @@ describe("FetchEngine details settle seq persistence (F3)", () => {
     const db = createFakeDb([listedRow(handle("a.eval"))]);
     const { sink, calls } = createFakeSink(db);
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
+    await engine.start({
+      api: fake.api,
+      database: db,
+      sink,
+      logDir: "dir/logs",
+    });
 
     await engine.ensure("a.eval", { depth: "detailed", priority: "user" });
 

--- a/apps/inspect/src/log_data/fetchEngine.test.ts
+++ b/apps/inspect/src/log_data/fetchEngine.test.ts
@@ -332,6 +332,7 @@ const createEngine = async (
     api: deps.api,
     database: deps.database ?? null,
     sink: deps.sink ?? sink,
+    logDir: deps.logDir ?? "dir/logs",
   });
   return { engine, sinkCalls: calls };
 };
@@ -827,7 +828,7 @@ describe("FetchEngine.applyListing epoch fencing", () => {
 
     // Dir switch: restart binds the next session's sink.
     const { sink, calls } = createFakeSink();
-    await engine.start({ api: fake.api, database: null, sink });
+    await engine.start({ api: fake.api, database: null, sink, logDir: "dir/logs" });
     const before = engine.listing();
 
     const result = await engine.applyListing({
@@ -858,7 +859,12 @@ describe("FetchEngine.applyListing epoch fencing", () => {
       },
     };
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fake.api, database: null, sink: gatedSink });
+    await engine.start({
+      api: fake.api,
+      database: null,
+      sink: gatedSink,
+      logDir: "dir/logs",
+    });
 
     const applied = engine.applyListing({
       listing: [handle("old-dir.eval", 1)],
@@ -869,7 +875,12 @@ describe("FetchEngine.applyListing epoch fencing", () => {
     });
 
     const { sink: secondSink, calls: secondCalls } = createFakeSink();
-    await engine.start({ api: fake.api, database: null, sink: secondSink });
+    await engine.start({
+      api: fake.api,
+      database: null,
+      sink: secondSink,
+      logDir: "dir/logs",
+    });
     gate.resolve();
 
     // The in-flight delete drains into the old session's sink; everything
@@ -895,7 +906,7 @@ describe("FetchEngine.applyListing epoch fencing", () => {
 
     // Dir switch while the server read is in flight.
     const { sink, calls } = createFakeSink();
-    await engine.start({ api, database: null, sink });
+    await engine.start({ api, database: null, sink, logDir: "dir/logs" });
     gate.resolve({
       files: [handle("old-dir.eval", 1)],
       response_type: "full",
@@ -1290,7 +1301,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     const db = createFakeDb([listedRow(handle("a.eval"))]);
     const { sink, calls } = createFakeSink(db);
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fake.api, database: db, sink });
+    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
 
     await expect(
       engine.ensure("a.eval", { depth: "detailed", priority: "user" })
@@ -1301,7 +1312,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     });
 
     engine.stop();
-    await engine.start({ api: fake.api, database: db, sink });
+    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
 
     expect(calls.fetchStates["a.eval"]).toMatchObject({
       details_fetch_error: "fetch failed: a.eval",
@@ -1467,7 +1478,7 @@ describe("FetchEngine details settle seq persistence (F3)", () => {
     const db = createFakeDb([listedRow(handle("a.eval"))]);
     const { sink, calls } = createFakeSink(db);
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fake.api, database: db, sink });
+    await engine.start({ api: fake.api, database: db, sink, logDir: "dir/logs" });
 
     await engine.ensure("a.eval", { depth: "detailed", priority: "user" });
 
@@ -1528,7 +1539,12 @@ describe("FetchEngine generation drops post-restart in-flight settles (F5)", () 
     const dbA = createFakeDb([listedRow(handle("a.eval"))]);
     const { sink: sinkA } = createFakeSink(dbA);
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
-    await engine.start({ api: fakeA.api, database: dbA, sink: sinkA });
+    await engine.start({
+      api: fakeA.api,
+      database: dbA,
+      sink: sinkA,
+      logDir: "dir/logs",
+    });
 
     const inFlight = engine.ensure("a.eval", {
       depth: "detailed",
@@ -1542,7 +1558,12 @@ describe("FetchEngine generation drops post-restart in-flight settles (F5)", () 
     const fakeB = createFakeApi();
     const dbB = createFakeDb([listedRow(handle("b.eval"))]);
     const { sink: sinkB, calls: callsB } = createFakeSink(dbB);
-    await engine.start({ api: fakeB.api, database: dbB, sink: sinkB });
+    await engine.start({
+      api: fakeB.api,
+      database: dbB,
+      sink: sinkB,
+      logDir: "dir/logs",
+    });
 
     await expect(inFlight).rejects.toThrow("Fetch engine stopped");
 
@@ -1722,7 +1743,12 @@ describe("FetchEngine batched flush trailing coalesce (F7)", () => {
       statsDelayMs: 0,
       concurrency: 1,
     });
-    await engine.start({ api: fake.api, database: null, sink: gatedSink });
+    await engine.start({
+      api: fake.api,
+      database: null,
+      sink: gatedSink,
+      logDir: "dir/logs",
+    });
 
     await engine.applyListing({
       listing: [handle("a.eval"), handle("b.eval")],
@@ -1773,7 +1799,12 @@ describe("FetchEngine batched flush trailing coalesce (F7)", () => {
       statsDelayMs: 0,
       concurrency: 1,
     });
-    await engine.start({ api: fake.api, database: null, sink: gatedSink });
+    await engine.start({
+      api: fake.api,
+      database: null,
+      sink: gatedSink,
+      logDir: "dir/logs",
+    });
 
     // a.eval's preview settles → its flush starts and blocks on the gate.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/apps/inspect/src/log_data/fetchEngine.ts
+++ b/apps/inspect/src/log_data/fetchEngine.ts
@@ -109,6 +109,9 @@ export interface FetchEngineDeps {
    *  sessions), in which case every read misses and writes are cache-only. */
   database: DatabaseService | null;
   sink: LogsContentSink;
+  /** The log dir this session replicates — the query scope for database
+   *  reads (the database itself is unified across dirs). */
+  logDir: string;
 }
 
 export interface DbStats {
@@ -617,7 +620,7 @@ export class FetchEngine {
     if (!deps.database) {
       return;
     }
-    const rows = await deps.database.readLogs();
+    const rows = await deps.database.readLogs({ prefix: deps.logDir });
     if (!rows) {
       return;
     }
@@ -1129,12 +1132,13 @@ export class FetchEngine {
   }
 
   private async updateDbStats(): Promise<void> {
-    const database = this._deps?.database;
-    if (!database?.opened()) {
+    const deps = this._deps;
+    const database = deps?.database;
+    if (deps === undefined || !database?.opened()) {
       return;
     }
     try {
-      const stats = await database.getCacheStats();
+      const stats = await database.getCacheStats({ prefix: deps.logDir });
       this.setStatus({
         dbStats: {
           logCount: stats.logFiles,

--- a/apps/inspect/src/log_data/logsContent.test.ts
+++ b/apps/inspect/src/log_data/logsContent.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the logsContent IndexedDB + cache seam (fake-indexeddb, like
+ * database.test.ts).
+ */
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { DB_NAME } from "../client/database/schema";
+import {
+  createDatabaseService,
+  DatabaseService,
+} from "../client/database/service";
+import { queryClient } from "../state/queryClient";
+
+import { writeListing } from "./logsContent";
+
+describe("writeListing", () => {
+  let db: DatabaseService;
+
+  beforeEach(async () => {
+    db = createDatabaseService();
+    await db.openDatabase();
+  });
+
+  afterEach(async () => {
+    queryClient.clear();
+    await db.closeDatabase();
+    await Dexie.delete(DB_NAME);
+  });
+
+  test("persists and reads back rows in the dir's namespace", async () => {
+    const rows = await writeListing(db, "file:///logs", [
+      { name: "file:///logs/a.eval" },
+    ]);
+
+    expect(rows.map((row) => row.name)).toEqual(["file:///logs/a.eval"]);
+    expect(await db.readLogs({ prefix: "file:///logs" })).toHaveLength(1);
+    expect((await db.getSyncScope("file:///logs"))?.last_synced).toBeDefined();
+  });
+
+  test("degrades to cache-only when names are outside the dir's namespace", async () => {
+    // An older view server: aliased-path log_dir, file:// URI names.
+    const rows = await writeListing(db, "~/logs", [
+      { name: "file:///home/me/logs/a.eval" },
+    ]);
+
+    // The listing still lands (cache) instead of being blanked by an empty
+    // scoped read-back...
+    expect(rows.map((row) => row.name)).toEqual([
+      "file:///home/me/logs/a.eval",
+    ]);
+    // ...and nothing was persisted where no scoped read could reach it.
+    expect(await db.readLogs({ prefix: "~/logs" })).toHaveLength(0);
+    expect(await db.getSyncScope("~/logs")).toBeUndefined();
+  });
+});

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -205,14 +205,24 @@ const clearCache = (logDir: string): void => {
  * persisting under such a scope would strand the rows where no scoped read,
  * clear, or seed can reach them, and the empty read-back would blank the
  * just-synced listing. Degrade to cache-only instead.
+ *
+ * Only listing persistence is gated: the keyed writes below (previews,
+ * details, fetch states) still persist out-of-namespace rows, which serve
+ * exact-path reads but which no listing sync governs and no scoped clear can
+ * remove. "Clear Local Database" (`clearAll`) wipes them along with
+ * everything else.
  */
+const warnedScopes = new Set<string>();
 const namesInScope = (logDir: string, handles: LogHandle[]): boolean => {
   const prefix = scopePrefix(logDir);
   const misnamed = handles.find((handle) => !handle.name.startsWith(prefix));
   if (misnamed !== undefined) {
-    log.warn(
-      `Listing names (e.g. ${misnamed.name}) are outside the log dir's namespace (${prefix}); skipping persistence for this scope.`
-    );
+    if (!warnedScopes.has(prefix)) {
+      warnedScopes.add(prefix);
+      log.warn(
+        `Listing names (e.g. ${misnamed.name}) are outside the log dir's namespace (${prefix}); skipping persistence for this scope.`
+      );
+    }
     return false;
   }
   return true;
@@ -360,7 +370,11 @@ export const clearAll = async (
 ): Promise<void> => {
   clearCache(logDir);
   if (db?.opened()) {
-    await db.clearScope({ prefix: logDir });
+    // The whole database, not just this scope: the button this backs says
+    // "Clear Local Database", and a scoped clear can't reach rows persisted
+    // under out-of-namespace names (see namesInScope). It's all a cache —
+    // other scopes re-sync on their next listing.
+    await db.clearAllData();
   }
 };
 

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -10,10 +10,9 @@ import {
 } from "../client/api/types";
 import { DatabaseService } from "../client/database";
 import {
-  detailTier,
   maxDepth,
+  prepareLogDetails,
   previewTier,
-  toLogHeader,
 } from "../client/utils/type-utils";
 import { queryClient } from "../state/queryClient";
 
@@ -251,35 +250,24 @@ export const writeDetails = async (
   logDir: string,
   details: Record<string, LogDetails>
 ): Promise<void> => {
-  const headers = Object.fromEntries(
-    Object.entries(details).map(([name, payload]) => [
-      name,
-      toLogHeader(payload),
-    ])
+  const prepared = Object.entries(details).map(
+    ([name, payload]) => [name, prepareLogDetails(payload)] as const
   );
   await Promise.all(
-    Object.entries(details).map(([name, payload]) => {
-      const header = headers[name];
-      return header === undefined
-        ? Promise.resolve()
-        : pushFileSamples(
-            logDir,
-            name,
-            toSamplesListingRows(name, header, payload.sampleSummaries)
-          );
-    })
+    prepared.map(([name, file]) =>
+      pushFileSamples(
+        logDir,
+        name,
+        toSamplesListingRows(name, file.header, file.summaries)
+      )
+    )
   );
   mergePatches(
     logDir,
-    Object.fromEntries(
-      Object.entries(headers).map(([name, header]) => [
-        name,
-        detailTier(header),
-      ])
-    )
+    Object.fromEntries(prepared.map(([name, file]) => [name, file.patch]))
   );
   if (db?.opened()) {
-    await db.writeLogDetails(details);
+    await db.writeLogDetails(Object.fromEntries(prepared));
     invalidateSamplesListings(logDir);
   }
 };

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -209,7 +209,8 @@ export const writeListing = async (
 ): Promise<Log[]> => {
   if (db?.opened()) {
     await db.writeLogs(handles);
-    const all = await db.readLogs();
+    await db.markScopeSynced(logDir);
+    const all = await db.readLogs({ prefix: logDir });
     if (all) {
       setRows(logDir, all);
       return all;
@@ -348,7 +349,7 @@ export const clearAll = async (
 ): Promise<void> => {
   clearCache(logDir);
   if (db?.opened()) {
-    await db.clearAllCaches();
+    await db.clearScope({ prefix: logDir });
   }
 };
 

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -1,6 +1,6 @@
 import { LogHandle } from "@tsmono/inspect-common/types";
 import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
-import { AsyncData } from "@tsmono/util";
+import { AsyncData, createLogger } from "@tsmono/util";
 
 import {
   Log,
@@ -8,7 +8,7 @@ import {
   LogFetchState,
   LogPreview,
 } from "../client/api/types";
-import { DatabaseService } from "../client/database";
+import { DatabaseService, scopePrefix } from "../client/database";
 import {
   maxDepth,
   prepareLogDetails,
@@ -38,6 +38,8 @@ import {
  * `set*`/`merge*`/`seed*` primitives) are allowed; the invariant is
  * one-directional (db ⟹ cache).
  */
+
+const log = createLogger("logsContent");
 
 const EMPTY_LOGS: Log[] = [];
 
@@ -196,6 +198,27 @@ const clearCache = (logDir: string): void => {
 // ---------------------------------------------------------------------------
 
 /**
+ * The store scopes every read by `file_path.startsWith(scopePrefix(logDir))`,
+ * so persistence requires the listing's names to live in `logDir`'s
+ * namespace. A server can violate that (e.g. an older view server hands out
+ * an aliased local path as log_dir while names are `file://` URIs) —
+ * persisting under such a scope would strand the rows where no scoped read,
+ * clear, or seed can reach them, and the empty read-back would blank the
+ * just-synced listing. Degrade to cache-only instead.
+ */
+const namesInScope = (logDir: string, handles: LogHandle[]): boolean => {
+  const prefix = scopePrefix(logDir);
+  const misnamed = handles.find((handle) => !handle.name.startsWith(prefix));
+  if (misnamed !== undefined) {
+    log.warn(
+      `Listing names (e.g. ${misnamed.name}) are outside the log dir's namespace (${prefix}); skipping persistence for this scope.`
+    );
+    return false;
+  }
+  return true;
+};
+
+/**
  * Persist the listing identity tier and cache the resulting full row list.
  * The db write is a merge-upsert (rows keep depth/content) and the cache
  * holds the full re-read, so the full list is read back and returned for the
@@ -206,7 +229,7 @@ export const writeListing = async (
   logDir: string,
   handles: LogHandle[]
 ): Promise<Log[]> => {
-  if (db?.opened()) {
+  if (db?.opened() && namesInScope(logDir, handles)) {
     await db.writeLogs(handles);
     await db.markScopeSynced(logDir);
     const all = await db.readLogs({ prefix: logDir });

--- a/apps/inspect/src/log_data/replicationControl.ts
+++ b/apps/inspect/src/log_data/replicationControl.ts
@@ -8,14 +8,16 @@ import { fetchEngine } from "./fetchEngine";
 import { syncListing } from "./listingSync";
 import { createLogsContentSink } from "./logsContent";
 
-// Open the per-dir IndexedDB for `logDir`. Returns the (already-constructed)
-// DatabaseService once its database is open, or undefined if unavailable.
+// Open the (unified) IndexedDB and mark `logDir`'s sync scope active.
+// Returns the (already-constructed) DatabaseService once its database is
+// open, or undefined if unavailable.
 export const openLogDirDatabase = async (
   logDir: string
 ): Promise<DatabaseService | undefined> => {
   const databaseService = getDatabaseService();
   try {
-    await databaseService.openDatabase(getApi().get_log_dir_handle(logDir));
+    await databaseService.openDatabase();
+    await databaseService.touchSyncScope(logDir);
     return databaseService;
   } catch (e) {
     console.log(e);
@@ -23,22 +25,19 @@ export const openLogDirDatabase = async (
   }
 };
 
-// Ensure the per-dir database is open and the fetch engine is running for
-// `logDir`, (re)activating if they aren't. Idempotent. This is the
-// composition root for the engine: the database, api, and per-dir cache sink
-// are wired here.
+// Ensure the database is open and the fetch engine is running for `logDir`,
+// (re)activating if they aren't. Idempotent. This is the composition root
+// for the engine: the database, api, and per-dir cache sink are wired here.
 const ensureActive = async (logDir: string): Promise<void> => {
-  const databaseHandle = getApi().get_log_dir_handle(logDir);
   const needsActivation =
     !fetchEngine.isStarted() ||
     engineDir !== logDir ||
-    getDatabaseService().getDatabaseHandle() !== databaseHandle;
+    !getDatabaseService().opened();
 
   if (needsActivation) {
-    // Bump the engine epoch before re-pointing the singleton database, so an
-    // in-flight listing sync for the old dir is fenced (see
-    // `ListingUpdate.epoch`) before its writes could land in the new dir's
-    // database.
+    // Bump the engine epoch before re-scoping, so an in-flight listing sync
+    // for the old dir is fenced (see `ListingUpdate.epoch`) before its
+    // writes could land in the new session.
     fetchEngine.stop();
     const opened = await openLogDirDatabase(logDir);
     if (!opened) {
@@ -48,6 +47,7 @@ const ensureActive = async (logDir: string): Promise<void> => {
       api: getApi(),
       database: opened,
       sink: createLogsContentSink(opened, logDir),
+      logDir,
     });
     engineDir = logDir;
   }
@@ -82,6 +82,7 @@ const ensureFetchEngine = (logDir: string): Promise<void> => {
           api: getApi(),
           database,
           sink: createLogsContentSink(database, logDir),
+          logDir,
         });
         engineDir = logDir;
       }

--- a/apps/inspect/src/log_data/runningSampleQuery.test.ts
+++ b/apps/inspect/src/log_data/runningSampleQuery.test.ts
@@ -10,6 +10,7 @@ import {
   SampleDataResponse,
   SampleSummary,
 } from "../client/api/types";
+import { deriveSampleFields } from "../client/utils/derive";
 import { queryClient } from "../state/queryClient";
 
 import { pendingSamplesKey } from "./pendingSamples";
@@ -67,7 +68,12 @@ const makeHandle = (logFile: string): SampleHandle => ({
 const seedLogDetails = (logFile: string, summaries: SampleSummary[]) => {
   queryClient.setQueryData<SamplesListingRow[]>(
     samplesListingKey({ logDir: LOG_DIR, scope: { file: logFile } }),
-    summaries.map((summary) => ({ logFile, summary, log: {} }))
+    summaries.map((summary) => ({
+      logFile,
+      summary,
+      derived: deriveSampleFields(summary),
+      log: {},
+    }))
   );
 };
 

--- a/apps/inspect/src/log_data/sampleSummaries.test.ts
+++ b/apps/inspect/src/log_data/sampleSummaries.test.ts
@@ -130,7 +130,6 @@ describe("useSampleSummaries during a running eval", () => {
     }) as unknown as LogDetails;
 
   const api = {
-    get_log_dir_handle: (dir: string) => `test-${dir}`,
     get_log_details: vi.fn(() => Promise.resolve(serverDetails)),
     get_log_info: vi.fn(() => Promise.resolve(serverInfo)),
     get_log_pending_samples: vi.fn(

--- a/apps/inspect/src/log_data/sampleSummaries.test.ts
+++ b/apps/inspect/src/log_data/sampleSummaries.test.ts
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
+import Dexie from "dexie";
 import { createElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -9,7 +10,11 @@ import {
   PendingSampleResponse,
   SampleSummary,
 } from "../client/api/types";
-import { createDatabaseService, DatabaseService } from "../client/database";
+import {
+  createDatabaseService,
+  DatabaseService,
+  DB_NAME,
+} from "../client/database";
 import { queryClient } from "../state/queryClient";
 
 import { fetchEngine } from "./fetchEngine";
@@ -154,12 +159,13 @@ describe("useSampleSummaries during a running eval", () => {
     db = createDatabaseService();
     holder.service = db;
     holder.api = api;
-    await db.openDatabase(`sample-summaries-test-${crypto.randomUUID()}`);
+    await db.openDatabase();
   });
 
   afterEach(async () => {
     fetchEngine.stop();
     await db.closeDatabase();
+    await Dexie.delete(DB_NAME);
     holder.service = null;
     holder.api = null;
     queryClient.clear();

--- a/apps/inspect/src/log_data/samplesListing.test.ts
+++ b/apps/inspect/src/log_data/samplesListing.test.ts
@@ -1,10 +1,15 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
+import Dexie from "dexie";
 import { createElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LogDetails, SampleSummary } from "../client/api/types";
-import { createDatabaseService, DatabaseService } from "../client/database";
+import {
+  createDatabaseService,
+  DatabaseService,
+  DB_NAME,
+} from "../client/database";
 import { queryClient } from "../state/queryClient";
 
 import { clearFile, createLogsContentSink, writeDetails } from "./logsContent";
@@ -65,11 +70,14 @@ let db: DatabaseService;
 beforeEach(async () => {
   db = createDatabaseService();
   holder.service = db;
-  await db.openDatabase(`samples-listing-test-${crypto.randomUUID()}`);
+  await db.openDatabase();
 });
 
 afterEach(async () => {
   await db.closeDatabase();
+  // The database name is a constant — cross-test isolation comes from
+  // deleting it outright.
+  await Dexie.delete(DB_NAME);
   holder.service = null;
   queryClient.clear();
 });
@@ -233,7 +241,7 @@ describe("useSamplesListing", () => {
     // (FetchEngine.start → sink.seedRows). A warm no-change boot performs no
     // writes after this, so seeding itself must refresh the listing.
     holder.service = db;
-    const rows = await db.readLogs();
+    const rows = await db.readLogs({ prefix: LOG_DIR });
     createLogsContentSink(db, LOG_DIR).seedRows(rows ?? []);
 
     await waitFor(() => expect(result.current.data).toHaveLength(2));

--- a/apps/inspect/src/log_data/samplesListing.ts
+++ b/apps/inspect/src/log_data/samplesListing.ts
@@ -4,8 +4,14 @@ import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
 import { AsyncData } from "@tsmono/util";
 
 import { EvalLogStatus } from "../@types/extraInspect";
-import { Log, LogHeader, SampleSummary } from "../client/api/types";
+import {
+  Log,
+  LogHeader,
+  SampleDerived,
+  SampleSummary,
+} from "../client/api/types";
 import { SampleSummariesScope } from "../client/database";
+import { deriveSampleFields } from "../client/utils/derive";
 import { queryClient } from "../state/queryClient";
 
 import { getDatabaseService } from "./databaseServiceInstance";
@@ -36,6 +42,7 @@ export interface SamplesListingLogContext {
 export interface SamplesListingRow {
   logFile: string;
   summary: SampleSummary;
+  derived: SampleDerived;
   log: SamplesListingLogContext;
 }
 
@@ -90,6 +97,7 @@ export const toSamplesListingRows = (
   summaries.map((summary) => ({
     logFile,
     summary,
+    derived: deriveSampleFields(summary),
     log: logContext(header),
   }));
 
@@ -128,6 +136,7 @@ const readSamplesListing = async (
     records.map((record) => ({
       logFile: record.file_path,
       summary: record.summary,
+      derived: record.derived,
       log: contexts.get(record.file_path) ?? {},
     })),
     params

--- a/apps/inspect/src/log_data/samplesListing.ts
+++ b/apps/inspect/src/log_data/samplesListing.ts
@@ -11,7 +11,7 @@ import {
   SampleSummary,
 } from "../client/api/types";
 import { SampleSummariesScope } from "../client/database";
-import { deriveSampleFields } from "../client/utils/derive";
+import { PreparedSampleSummary } from "../client/utils/type-utils";
 import { queryClient } from "../state/queryClient";
 
 import { getDatabaseService } from "./databaseServiceInstance";
@@ -87,17 +87,17 @@ const rowContext = (row: Log | undefined): SamplesListingLogContext =>
         status: row.status,
       };
 
-/** Assemble listing rows from an ingested payload's parts (the sink's push
+/** Assemble listing rows from a prepared payload's parts (the sink's push
  *  path — the db read below produces the same shape). */
 export const toSamplesListingRows = (
   logFile: string,
   header: LogHeader,
-  summaries: SampleSummary[]
+  summaries: PreparedSampleSummary[]
 ): SamplesListingRow[] =>
-  summaries.map((summary) => ({
+  summaries.map(({ summary, derived }) => ({
     logFile,
     summary,
-    derived: deriveSampleFields(summary),
+    derived,
     log: logContext(header),
   }));
 

--- a/apps/inspect/src/log_data/scoreSchema.test.ts
+++ b/apps/inspect/src/log_data/scoreSchema.test.ts
@@ -71,6 +71,21 @@ describe("computeScorerMap", () => {
     expect(Object.keys(map)).toEqual(["match/accuracy"]);
   });
 
+  it("does not match a sibling directory sharing the scope as a name prefix", () => {
+    const map = computeScorerMap(
+      fromMap({
+        "/dir/eval-set/a.eval": details([
+          { name: "match", metrics: { accuracy: 1 } },
+        ]),
+        "/dir/eval-set-2/b.eval": details([
+          { name: "other", metrics: { f1: 1 } },
+        ]),
+      }),
+      "/dir/eval-set"
+    );
+    expect(Object.keys(map)).toEqual(["match/accuracy"]);
+  });
+
   it("skips logs without score results", () => {
     const map = computeScorerMap(
       fromMap({

--- a/apps/inspect/src/log_data/scoreSchema.ts
+++ b/apps/inspect/src/log_data/scoreSchema.ts
@@ -5,6 +5,7 @@ import { AsyncData } from "@tsmono/util";
 
 import { useStableValue } from "../app/shared/useStableValue";
 import { Log } from "../client/api/types";
+import { scopePrefix } from "../client/database";
 
 import { useLogs } from "./logsContent";
 
@@ -44,14 +45,15 @@ export const scorerMetricKey = (
  * scorers emitting the same metric (e.g. two "accuracy"s) into one column.
  *
  * @param logs - The directory's Log rows
- * @param scopePrefix - When set, only logs whose name starts with this
- *   prefix contribute (folder view scoping)
+ * @param scopeDir - When set, only logs under this directory contribute
+ *   (folder view scoping)
  */
-export function computeScorerMap(logs: Log[], scopePrefix?: string): ScorerMap {
+export function computeScorerMap(logs: Log[], scopeDir?: string): ScorerMap {
   const info: ScorerMap = {};
+  const prefix = scopeDir ? scopePrefix(scopeDir) : undefined;
 
   for (const log of logs) {
-    if (scopePrefix && !log.name.startsWith(scopePrefix)) {
+    if (prefix && !log.name.startsWith(prefix)) {
       continue;
     }
     if (log.header?.results?.scores) {
@@ -115,16 +117,13 @@ const asyncScorerMapsEqual = (
 
 export const useScoreSchema = (
   logDir: string,
-  scopePrefix?: string
+  scopeDir?: string
 ): AsyncData<ScorerMap> => {
   const logs = useLogs(logDir);
   return useStableValue(
     useMapAsyncData(
       logs,
-      useCallback(
-        (rows: Log[]) => computeScorerMap(rows, scopePrefix),
-        [scopePrefix]
-      )
+      useCallback((rows: Log[]) => computeScorerMap(rows, scopeDir), [scopeDir])
     ),
     asyncScorerMapsEqual
   );


### PR DESCRIPTION
Previously IndexedDB was used to cache data from the server. Each log dir had its own IndexedDB instance. Many fields that are shown in the UI get derived from this raw data. This was fine since all of our sorting and querying was handled in JS.

We're moving in the direction of running queries against IndexedDB instead of doing full table reads, so in this PR, we start deriving those values prior to inserting the data into IndexedDB. Log files [have a better sense of identity now](https://github.com/UKGovernmentBEIS/inspect_ai/commit/0e3453962c4f771aae6623d5746f4331a3fe93ab), so we now have a single `InspectAI` DB regardless of your log dir. 

These rows are indexed by their full file paths. We now read all of them that start with the currently configured log dir:

```ts
      const records = await db.logs
        .where("file_path")
        .startsWith(scopePrefix(scope.prefix))
        .toArray();
```

For now, we continue filtering and sorting in memory. More to come.