### PR TITLE
fix(viewer): show the Action tab first for annotated browser actions

### DIFF
--- a/packages/inspect-components/src/chat/tools/ToolCallView.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.tsx
@@ -238,8 +238,8 @@ export const ToolCallView: FC<ToolCallViewProps> = ({
   if (actionElement) {
     outputContent = hasContent ? (
       <NavPills id={`${id}-browser-action`}>
-        <div title="Result">{outputSection}</div>
         <div title="Action">{actionElement}</div>
+        <div title="Result">{outputSection}</div>
       </NavPills>
     ) : (
       actionElement


### PR DESCRIPTION
Tiny followup to #423 

The UI shows a list of these actions taking place, so we'll put the Action tab first and have it selected by default.

<img width="1004" height="1087" alt="Screenshot 2026-07-16 at 1 38 51 PM" src="https://github.com/user-attachments/assets/c42b50c2-4c46-4995-868a-9912788c8fe8" />
