### PR TITLE
Extract transcript data derivation into view-model hooks

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -71,11 +71,11 @@ import {
   TimelineSelectContext,
 } from "./TimelineSelectContext";
 import styles from "./TranscriptLayout.module.css";
-import { collectAllCollapsibleIds } from "./transform/collapse";
 import {
   TranscriptViewNodes,
   type TranscriptViewNodesHandle,
 } from "./TranscriptViewNodes";
+import { collectAllCollapsibleIds } from "./transform/collapse";
 import {
   EventNode,
   type EventNodeContext,

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -42,8 +42,10 @@ import {
   findTimelineIndexForMessage,
   timelineContainsEvent,
 } from "./findTimelineForDeepLink";
+import { useEventNodeData } from "./hooks/useEventNodeData";
 import { useListPositionManager } from "./hooks/useListPositionManager";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
+import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
 import { TranscriptOutline } from "./outline/TranscriptOutline";
 import {
   resolveEventInBranches,
@@ -53,12 +55,8 @@ import {
 } from "./resolveMessageToEvent";
 import { useTranscriptSearchSource } from "./search";
 import { AgentCardView, TimelineSwimLanes } from "./timeline/components";
-import { spanHasBranches, type TimelineSpan } from "./timeline/core";
+import { type TimelineSpan } from "./timeline/core";
 import {
-  useEventNodes,
-  useTimelineConfig,
-  useTimelinesArray,
-  useTranscriptTimeline,
   type TimelineOptions,
   type UseActiveTimelineProps,
   type UseTimelineProps,
@@ -73,14 +71,13 @@ import {
   TimelineSelectContext,
 } from "./TimelineSelectContext";
 import styles from "./TranscriptLayout.module.css";
+import { collectAllCollapsibleIds } from "./transform/collapse";
 import {
   TranscriptViewNodes,
   type TranscriptViewNodesHandle,
 } from "./TranscriptViewNodes";
 import {
   EventNode,
-  kCollapsibleEventTypes,
-  kContentCollapsibleEventTypes,
   type EventNodeContext,
   type TranscriptCollapseState,
 } from "./types";
@@ -204,89 +201,6 @@ export interface TranscriptLayoutProps {
 }
 
 // =============================================================================
-// Helpers
-// =============================================================================
-
-const collectAllCollapsibleIds = (
-  nodes: EventNode[]
-): Record<string, boolean> => {
-  const result: Record<string, boolean> = {};
-  const traverse = (nodeList: EventNode[]) => {
-    for (const node of nodeList) {
-      if (
-        kCollapsibleEventTypes.includes(node.event.event) ||
-        kContentCollapsibleEventTypes.includes(node.event.event)
-      ) {
-        result[node.id] = true;
-      }
-      if (node.children.length > 0) {
-        traverse(node.children);
-      }
-    }
-  };
-  traverse(nodes);
-  return result;
-};
-
-const buildToolLabels = (
-  events: Event[],
-  messageLabels: Record<string, string> | undefined
-): Record<string, string> | undefined => {
-  if (!messageLabels) return undefined;
-
-  const toolLabels: Record<string, string> = {};
-  for (const event of events) {
-    if (event.event === "tool") {
-      const label = event.message_id
-        ? messageLabels[event.message_id]
-        : undefined;
-      if (label) toolLabels[event.id] = label;
-    } else if (event.event === "model") {
-      for (const message of event.input ?? []) {
-        if (message.role !== "tool" || !message.id) continue;
-        const label = messageLabels[message.id];
-        if (label && message.tool_call_id) {
-          toolLabels[message.tool_call_id] = label;
-        }
-      }
-    }
-  }
-
-  return Object.keys(toolLabels).length > 0 ? toolLabels : undefined;
-};
-
-// Restrict the message-label map to messages actually present in `events`.
-// The map is shared across the whole sample, but timelines (e.g. auditor vs
-// target) show different events — without this an unlabeled timeline would
-// reserve label-column space just because another timeline is labeled.
-const scopeMessageLabels = (
-  events: Event[],
-  messageLabels: Record<string, string> | undefined
-): Record<string, string> | undefined => {
-  if (!messageLabels) return undefined;
-
-  const present = new Set<string>();
-  for (const event of events) {
-    if (event.event === "model") {
-      for (const message of event.input ?? []) {
-        if (message.id) present.add(message.id);
-      }
-      for (const choice of event.output?.choices ?? []) {
-        if (choice.message?.id) present.add(choice.message.id);
-      }
-    } else if (event.event === "tool" && event.message_id) {
-      present.add(event.message_id);
-    }
-  }
-
-  const scoped: Record<string, string> = {};
-  for (const [id, label] of Object.entries(messageLabels)) {
-    if (present.has(id)) scoped[id] = label;
-  }
-  return Object.keys(scoped).length > 0 ? scoped : undefined;
-};
-
-// =============================================================================
 // Component
 // =============================================================================
 
@@ -327,146 +241,50 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   className,
 }) => {
   // ---------------------------------------------------------------------------
-  // Timeline-pipeline events
-  // ---------------------------------------------------------------------------
-
-  // Apply the user's event-type filter to the timeline pipeline so hidden
-  // types don't leave behind empty swimlane rows (e.g. an "init" span whose
-  // only content was a filtered `sample_init`). `anchor` events are always
-  // preserved — they're structural references used by `convertServerTimeline`
-  // to position fork navigators, not display content.
-  const eventsForTimeline = useMemo(() => {
-    if (!hiddenEventTypes || hiddenEventTypes.length === 0) return events;
-    return events.filter(
-      (e) => e.event === "anchor" || !hiddenEventTypes.includes(e.event)
-    );
-  }, [events, hiddenEventTypes]);
-
-  // ---------------------------------------------------------------------------
-  // Timeline config (persistent user preferences)
-  // ---------------------------------------------------------------------------
-
-  // Detect whether any timeline in this sample contains branches so the
-  // config hook can default `showBranches` on (when the user has not
-  // explicitly toggled it). `useTimelinesArray` is memoized, so the redundant
-  // call inside `useTranscriptTimeline` below reuses the same result.
-  const timelinesForBranchDetection = useTimelinesArray(
-    eventsForTimeline,
-    serverTimelines
-  );
-  const branchesPresent = useMemo(
-    () => timelinesForBranchDetection.some((tl) => spanHasBranches(tl.root)),
-    [timelinesForBranchDetection]
-  );
-
-  const timelineConfig = useTimelineConfig({ branchesPresent });
-  const resolvedMarkerConfig =
-    markerConfigOverride ?? timelineConfig.markerConfig;
-  const resolvedAgentConfig = agentConfigOverride ?? timelineConfig.agentConfig;
-
-  // ---------------------------------------------------------------------------
-  // Timeline pipeline
+  // Timeline pipeline + event nodes
   // ---------------------------------------------------------------------------
 
   const {
-    timeline: timelineData,
-    state: timelineState,
-    layouts: timelineLayouts,
-    rootTimeMapping,
-    selectedEvents,
-    sourceSpans,
-    minimapSelection,
-    hasTimeline,
-    hasAgentTimeline,
-    timelines,
-    activeTimelineIndex,
-    setActiveTimeline,
-    regionCounts,
-    branchScrollTarget,
-    highlightedKeys,
-    selectedRowName,
-    viewStack,
-    pushView,
-    popView,
-  } = useTranscriptTimeline({
-    events: eventsForTimeline,
-    markerConfig: resolvedMarkerConfig,
-    timelineOptions: resolvedAgentConfig,
+    timeline: {
+      timeline: timelineData,
+      state: timelineState,
+      layouts: timelineLayouts,
+      rootTimeMapping,
+      minimapSelection,
+      timelines,
+      activeTimelineIndex,
+      setActiveTimeline,
+      regionCounts,
+      branchScrollTarget,
+      highlightedKeys,
+      selectedRowName,
+      viewStack,
+      pushView,
+      popView,
+    },
+    timelineConfig,
+    showSwimlanes,
+    swimlanesDefaultCollapsed,
+    nodeFeed,
+    searchableEvents,
+  } = useTimelinePipeline({
+    events,
+    hiddenEventTypes,
     serverTimelines,
-    timelineProps: timelineSelection,
-    activeTimelineProps: activeTimeline,
+    markerConfig: markerConfigOverride,
+    agentConfig: agentConfigOverride,
+    showSwimlanes: showSwimlanesOption,
+    timelineSelection,
+    activeTimeline,
   });
 
-  // ---------------------------------------------------------------------------
-  // Swimlane visibility
-  // ---------------------------------------------------------------------------
-
-  const showSwimlanes = useMemo(() => {
-    if (showSwimlanesOption === "auto") {
-      return hasTimeline || regionCounts.size > 0 || timelines.length > 1;
-    }
-    return showSwimlanesOption;
-  }, [showSwimlanesOption, hasTimeline, regionCounts, timelines.length]);
-
-  const swimlanesDefaultCollapsed = useMemo(() => {
-    if (
-      showSwimlanesOption === "auto" &&
-      !hasTimeline &&
-      regionCounts.size === 0
-    ) {
-      return true;
-    }
-    if (hasTimeline) {
-      // Expand by default only when there's agent sub-structure to drill into.
-      // A bare main + scoring (or init) timeline has nothing to expand, so
-      // default it collapsed.
-      return hasAgentTimeline ? false : true;
-    }
-    return undefined;
-  }, [showSwimlanesOption, hasTimeline, hasAgentTimeline, regionCounts]);
-
-  // ---------------------------------------------------------------------------
-  // Event nodes
-  // ---------------------------------------------------------------------------
-
-  const rawEventsForNodes = showSwimlanes ? selectedEvents : events;
-  const eventsForNodes = useMemo(
-    () =>
-      hiddenEventTypes && hiddenEventTypes.length > 0
-        ? rawEventsForNodes.filter((e) => !hiddenEventTypes.includes(e.event))
-        : rawEventsForNodes,
-    [rawEventsForNodes, hiddenEventTypes]
-  );
-  const { eventNodes, defaultCollapsedIds, retryAttempts } = useEventNodes(
-    eventsForNodes,
-    running,
-    showSwimlanes ? sourceSpans : undefined
-  );
-
-  const mergedEventNodeContext = useMemo<Partial<EventNodeContext>>(() => {
-    const messageLabels = scopeMessageLabels(
-      eventsForNodes,
-      eventNodeContext?.messageLabels
-    );
-    const toolLabels = buildToolLabels(eventsForNodes, messageLabels);
-    return {
-      ...eventNodeContext,
-      messageLabels,
-      retryAttempts,
-      ...(toolLabels ? { toolLabels } : {}),
-    };
-  }, [eventsForNodes, eventNodeContext, retryAttempts]);
+  const {
+    eventNodes,
+    defaultCollapsedIds,
+    eventNodeContext: mergedEventNodeContext,
+  } = useEventNodeData(nodeFeed, running, eventNodeContext);
 
   const nullViewNodesRef = useRef<TranscriptViewNodesHandle | null>(null);
-
-  // Honor the same event-type filter the renderer uses. State/store events
-  // carry huge JSON payloads but aren't surfaced in the transcript tree;
-  // matching their fields would inflate the counter with unreachable results.
-  const searchableEvents = useMemo(() => {
-    if (!hiddenEventTypes || hiddenEventTypes.length === 0) return events;
-    const hidden = new Set(hiddenEventTypes);
-    return events.filter((e) => !hidden.has(e.event));
-  }, [events, hiddenEventTypes]);
 
   useTranscriptSearchSource({
     id: listId,
@@ -746,7 +564,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   // selected. The event-id analogue of the message side-effect above.
   const resolvedEventSpan = useMemo(() => {
     if (!initialEventId || !showSwimlanes) return undefined;
-    const present = eventsForNodes.some(
+    const present = nodeFeed.events.some(
       (e) => (e as { uuid?: string | null }).uuid === initialEventId
     );
     if (present) return undefined;
@@ -754,7 +572,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
       resolveEventToSpan(initialEventId, timelineData.root) ??
       resolveEventInBranches(initialEventId, timelineData.root)
     );
-  }, [initialEventId, showSwimlanes, eventsForNodes, timelineData.root]);
+  }, [initialEventId, showSwimlanes, nodeFeed.events, timelineData.root]);
 
   const prevEventIdRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -85,4 +85,23 @@ describe("useEventNodeData", () => {
     // Caller extras pass through the merge.
     expect(context.inlineExpansionUX).toBe(true);
   });
+
+  it("preserves derived identities when feed and context are unchanged", () => {
+    const extraContext = {
+      inlineExpansionUX: true,
+      messageLabels: { m1: "A", m2: "B" },
+    };
+    const { result, rerender } = renderHook(() =>
+      useEventNodeData(feed, false, extraContext)
+    );
+    const firstEventNodes = result.current.eventNodes;
+    const firstDefaultCollapsedIds = result.current.defaultCollapsedIds;
+    const firstEventNodeContext = result.current.eventNodeContext;
+
+    rerender();
+
+    expect(result.current.eventNodes).toBe(firstEventNodes);
+    expect(result.current.defaultCollapsedIds).toBe(firstDefaultCollapsedIds);
+    expect(result.current.eventNodeContext).toBe(firstEventNodeContext);
+  });
 });

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { useEventNodeData } from "./useEventNodeData";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeModelEvent(uuid: string, messageId: string): Event {
+  return {
+    event: "model",
+    uuid,
+    model: "test-model",
+    input: [{ id: messageId, role: "user", content: "hi" }],
+    output: {
+      choices: [
+        {
+          message: { role: "assistant", content: "response" },
+          stop_reason: "stop",
+        },
+      ],
+      completion: "response",
+      model: "test-model",
+    },
+    config: {},
+    tools: [],
+    tool_choice: "auto",
+    timestamp: "2024-01-01T00:00:00Z",
+    working_start: 0,
+    working_time: 1,
+    error: null,
+    pending: false,
+    span_id: null,
+  } as unknown as Event;
+}
+
+function makeToolEvent(id: string, messageId: string): Event {
+  return {
+    event: "tool",
+    id,
+    uuid: `uuid-${id}`,
+    message_id: messageId,
+    function: "search",
+    arguments: {},
+    result: "ok",
+    error: null,
+    agent: null,
+    failed: null,
+    timestamp: "2024-01-01T00:00:01Z",
+    working_start: 1,
+    pending: false,
+    span_id: null,
+    events: [],
+  } as unknown as Event;
+}
+
+// =============================================================================
+// useEventNodeData
+// =============================================================================
+
+describe("useEventNodeData", () => {
+  const events = [
+    makeModelEvent("e1", "m1"),
+    makeToolEvent("t1", "m2"),
+  ];
+  const feed = { events, sourceSpans: undefined };
+
+  it("builds event nodes from the feed", () => {
+    const { result } = renderHook(() => useEventNodeData(feed, false));
+    expect(result.current.eventNodes.length).toBeGreaterThan(0);
+    expect(result.current.eventNodeContext.retryAttempts).toBeInstanceOf(Map);
+  });
+
+  it("scopes message labels and derives tool labels", () => {
+    const { result } = renderHook(() =>
+      useEventNodeData(feed, false, {
+        inlineExpansionUX: true,
+        messageLabels: { m1: "A", m2: "B", absent: "C" },
+      })
+    );
+    const context = result.current.eventNodeContext;
+    expect(context.messageLabels).toEqual({ m1: "A", m2: "B" });
+    expect(context.toolLabels).toEqual({ t1: "B" });
+    // Caller extras pass through the merge.
+    expect(context.inlineExpansionUX).toBe(true);
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -63,10 +63,7 @@ function makeToolEvent(id: string, messageId: string): Event {
 // =============================================================================
 
 describe("useEventNodeData", () => {
-  const events = [
-    makeModelEvent("e1", "m1"),
-    makeToolEvent("t1", "m2"),
-  ];
+  const events = [makeModelEvent("e1", "m1"), makeToolEvent("t1", "m2")];
   const feed = { events, sourceSpans: undefined };
 
   it("builds event nodes from the feed", () => {

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.ts
@@ -1,0 +1,50 @@
+/**
+ * View-model hook producing the EventNode tree and its render context from an
+ * EventNodeFeed (see useTimelinePipeline).
+ */
+
+import { useMemo } from "react";
+
+import { useEventNodes } from "../timeline/hooks";
+import { buildToolLabels, scopeMessageLabels } from "../transform/labels";
+import type { EventNode, EventNodeContext } from "../types";
+
+import type { EventNodeFeed } from "./useTimelinePipeline";
+
+export interface EventNodeData {
+  /** The EventNode tree for the transcript list and outline. */
+  eventNodes: EventNode[];
+  /** Node IDs collapsed by default. */
+  defaultCollapsedIds: Record<string, true>;
+  /** Context for event views: the caller's extras merged with derived
+   *  labels and retry attempts. */
+  eventNodeContext: Partial<EventNodeContext>;
+}
+
+export const useEventNodeData = (
+  nodeFeed: EventNodeFeed,
+  running: boolean,
+  extraContext?: Partial<EventNodeContext>
+): EventNodeData => {
+  const { eventNodes, defaultCollapsedIds, retryAttempts } = useEventNodes(
+    nodeFeed.events,
+    running,
+    nodeFeed.sourceSpans
+  );
+
+  const eventNodeContext = useMemo<Partial<EventNodeContext>>(() => {
+    const messageLabels = scopeMessageLabels(
+      nodeFeed.events,
+      extraContext?.messageLabels
+    );
+    const toolLabels = buildToolLabels(nodeFeed.events, messageLabels);
+    return {
+      ...extraContext,
+      messageLabels,
+      retryAttempts,
+      ...(toolLabels ? { toolLabels } : {}),
+    };
+  }, [nodeFeed.events, extraContext, retryAttempts]);
+
+  return { eventNodes, defaultCollapsedIds, eventNodeContext };
+};

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { useCallback, useState, type PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+import {
+  ComponentStateProvider,
+  type ComponentStateHooks,
+} from "@tsmono/react/state";
+
+import { useTimelinePipeline } from "./useTimelinePipeline";
+
+// =============================================================================
+// Reactive in-memory ComponentStateProvider for testing
+// =============================================================================
+
+function InMemoryStateWrapper({ children }: PropsWithChildren) {
+  const [store, setStore] = useState(
+    () => new Map<string, Map<string, unknown>>()
+  );
+
+  const getPropertyBag = useCallback(
+    (id: string): Map<string, unknown> => {
+      let bag = store.get(id);
+      if (!bag) {
+        bag = new Map();
+        store.set(id, bag);
+      }
+      return bag;
+    },
+    [store]
+  );
+
+  const hooks: ComponentStateHooks = {
+    useValue: (id: string, prop: string, defaultValue?: unknown): unknown => {
+      const bag = getPropertyBag(id);
+      return bag.has(prop) ? bag.get(prop) : defaultValue;
+    },
+    useSetValue: () => (id: string, prop: string, value: unknown) => {
+      getPropertyBag(id).set(prop, value);
+      setStore((prev) => new Map(prev));
+    },
+    useRemoveValue: () => (id: string, prop: string) => {
+      getPropertyBag(id).delete(prop);
+      setStore((prev) => new Map(prev));
+    },
+    useEntries: (id: string): Record<string, unknown> | undefined => {
+      const bag = store.get(id);
+      if (!bag) return undefined;
+      return Object.fromEntries(bag);
+    },
+    useRemoveAll: () => (id: string) => {
+      store.delete(id);
+      setStore((prev) => new Map(prev));
+    },
+    useRemoveByPrefix: () => (id: string, prefix: string) => {
+      const bag = store.get(id);
+      if (!bag) return;
+      for (const key of [...bag.keys()]) {
+        if (key.startsWith(prefix)) bag.delete(key);
+      }
+      setStore((prev) => new Map(prev));
+    },
+  };
+
+  return (
+    <ComponentStateProvider hooks={hooks}>{children}</ComponentStateProvider>
+  );
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeModelEvent(uuid: string, startSec: number): Event {
+  return {
+    event: "model",
+    uuid,
+    model: "test-model",
+    input: [],
+    output: {
+      choices: [
+        {
+          message: { role: "assistant", content: "response" },
+          stop_reason: "stop",
+        },
+      ],
+      completion: "response",
+      model: "test-model",
+    },
+    config: {},
+    tools: [],
+    tool_choice: "auto",
+    timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
+    working_start: startSec,
+    working_time: 1,
+    error: null,
+    pending: false,
+    span_id: null,
+  } as unknown as Event;
+}
+
+function makeInfoEvent(uuid: string, startSec: number): Event {
+  return {
+    event: "info",
+    uuid,
+    source: "test",
+    data: "",
+    timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
+    working_start: startSec,
+    pending: false,
+    span_id: null,
+  } as unknown as Event;
+}
+
+// =============================================================================
+// useTimelinePipeline
+// =============================================================================
+
+describe("useTimelinePipeline", () => {
+  const flatEvents = [makeModelEvent("e1", 0), makeInfoEvent("e2", 1)];
+
+  it("hides swimlanes for a flat event stream and feeds all events", () => {
+    const { result } = renderHook(
+      () => useTimelinePipeline({ events: flatEvents }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    expect(result.current.showSwimlanes).toBe(false);
+    expect(result.current.swimlanesDefaultCollapsed).toBe(true);
+    // No filtering or selection: the feed and search set are the input array.
+    expect(result.current.nodeFeed.events).toBe(flatEvents);
+    expect(result.current.nodeFeed.sourceSpans).toBeUndefined();
+    expect(result.current.searchableEvents).toBe(flatEvents);
+  });
+
+  it("honors an explicit showSwimlanes override", () => {
+    const { result } = renderHook(
+      () => useTimelinePipeline({ events: flatEvents, showSwimlanes: true }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    expect(result.current.showSwimlanes).toBe(true);
+    // With swimlanes on the feed carries the (empty) source-span map.
+    expect(result.current.nodeFeed.sourceSpans).toBeInstanceOf(Map);
+  });
+
+  it("filters hidden event types from the node feed and search set", () => {
+    const { result } = renderHook(
+      () =>
+        useTimelinePipeline({
+          events: flatEvents,
+          hiddenEventTypes: ["info"],
+        }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    expect(result.current.nodeFeed.events.map((e) => e.event)).toEqual([
+      "model",
+    ]);
+    expect(result.current.searchableEvents.map((e) => e.event)).toEqual([
+      "model",
+    ]);
+  });
+
+  it("always returns the full timeline pipeline result", () => {
+    const { result } = renderHook(
+      () => useTimelinePipeline({ events: flatEvents }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    expect(result.current.timeline.timelines).toHaveLength(1);
+    // Identity is not preserved here: the timeline pipeline re-sorts via
+    // correctRetryTimestamps, so compare by value.
+    expect(result.current.timeline.selectedEvents).toEqual(flatEvents);
+    expect(result.current.timelineConfig.markerConfig).toBeDefined();
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.tsx
@@ -161,6 +161,27 @@ describe("useTimelinePipeline", () => {
     ]);
   });
 
+  it("preserves feed and search identities when inputs are unchanged", () => {
+    const hiddenEventTypes = ["info"];
+    const { result, rerender } = renderHook(
+      () =>
+        useTimelinePipeline({
+          events: flatEvents,
+          hiddenEventTypes,
+        }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    const firstNodeFeed = result.current.nodeFeed;
+    const firstFeedEvents = result.current.nodeFeed.events;
+    const firstSearchableEvents = result.current.searchableEvents;
+
+    rerender();
+
+    expect(result.current.nodeFeed).toBe(firstNodeFeed);
+    expect(result.current.nodeFeed.events).toBe(firstFeedEvents);
+    expect(result.current.searchableEvents).toBe(firstSearchableEvents);
+  });
+
   it("always returns the full timeline pipeline result", () => {
     const { result } = renderHook(
       () => useTimelinePipeline({ events: flatEvents }),

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
@@ -33,7 +33,7 @@ import { type MarkerConfig } from "../timeline/markers";
 
 /** The events (and optional agent spans) that feed the EventNode tree. */
 export interface EventNodeFeed {
-  /** Events scoped to the swimlane selection, with hidden types removed. */
+  /** Events for the node tree: scoped to the swimlane selection when swimlanes are shown, with hidden types removed. */
   events: Event[];
   /** Agent spans for card rendering; undefined when swimlanes are hidden. */
   sourceSpans: ReadonlyMap<string, TimelineSpan> | undefined;

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
@@ -1,0 +1,203 @@
+/**
+ * View-model hook for the transcript's timeline section.
+ *
+ * Encapsulates the dataflow from raw events + configuration to everything the
+ * swimlane UI and the event-node tree need: event-type filtering, branch
+ * detection, config resolution, the timeline pipeline itself, the swimlane
+ * visibility policy, and the choice of which events feed the node tree.
+ */
+
+import { useMemo } from "react";
+
+import type {
+  Event,
+  Timeline as ServerTimeline,
+} from "@tsmono/inspect-common/types";
+
+import { spanHasBranches, type TimelineSpan } from "../timeline/core";
+import {
+  useTimelineConfig,
+  useTimelinesArray,
+  useTranscriptTimeline,
+  type TimelineOptions,
+  type TranscriptTimelineResult,
+  type UseActiveTimelineProps,
+  type UseTimelineConfigResult,
+  type UseTimelineProps,
+} from "../timeline/hooks";
+import { type MarkerConfig } from "../timeline/markers";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** The events (and optional agent spans) that feed the EventNode tree. */
+export interface EventNodeFeed {
+  /** Events scoped to the swimlane selection, with hidden types removed. */
+  events: Event[];
+  /** Agent spans for card rendering; undefined when swimlanes are hidden. */
+  sourceSpans: ReadonlyMap<string, TimelineSpan> | undefined;
+}
+
+export interface UseTimelinePipelineOptions {
+  /** The flat event array for the sample. */
+  events: Event[];
+  /** Event types to hide from the rendered card list. Applied after timeline
+   *  construction so structural events (anchor/branch) still resolve. */
+  hiddenEventTypes?: readonly string[];
+  /** Server-provided timelines (used when available instead of building from events). */
+  serverTimelines?: ServerTimeline[];
+  /** Override the user's marker config preference. */
+  markerConfig?: MarkerConfig;
+  /** Override the user's agent/timeline options preference. */
+  agentConfig?: TimelineOptions;
+  /** Swimlane visibility: explicit, or "auto" from timeline structure. */
+  showSwimlanes?: boolean | "auto";
+  /** Props for timeline selection state. */
+  timelineSelection?: UseTimelineProps;
+  /** Props for active timeline state. */
+  activeTimeline?: UseActiveTimelineProps;
+}
+
+export interface TimelinePipelineResult {
+  /** Full timeline pipeline result (selection state, layouts, navigation). */
+  timeline: TranscriptTimelineResult;
+  /** Resolved timeline config (persistent user preferences). */
+  timelineConfig: UseTimelineConfigResult;
+  /** Whether the swimlane section should render. */
+  showSwimlanes: boolean;
+  /** Default collapsed state for the swimlane section (undefined = component default). */
+  swimlanesDefaultCollapsed: boolean | undefined;
+  /** Events + spans that feed the EventNode tree. */
+  nodeFeed: EventNodeFeed;
+  /** Events eligible for transcript search (hidden types removed, unscoped by selection). */
+  searchableEvents: Event[];
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useTimelinePipeline(
+  options: UseTimelinePipelineOptions
+): TimelinePipelineResult {
+  const {
+    events,
+    hiddenEventTypes,
+    serverTimelines,
+    markerConfig: markerConfigOverride,
+    agentConfig: agentConfigOverride,
+    showSwimlanes: showSwimlanesOption = "auto",
+    timelineSelection,
+    activeTimeline,
+  } = options;
+
+  // Apply the user's event-type filter to the timeline pipeline so hidden
+  // types don't leave behind empty swimlane rows (e.g. an "init" span whose
+  // only content was a filtered `sample_init`). `anchor` events are always
+  // preserved — they're structural references used by `convertServerTimeline`
+  // to position fork navigators, not display content.
+  const eventsForTimeline = useMemo(() => {
+    if (!hiddenEventTypes || hiddenEventTypes.length === 0) return events;
+    return events.filter(
+      (e) => e.event === "anchor" || !hiddenEventTypes.includes(e.event)
+    );
+  }, [events, hiddenEventTypes]);
+
+  // Detect whether any timeline in this sample contains branches so the
+  // config hook can default `showBranches` on (when the user has not
+  // explicitly toggled it). `useTimelinesArray` is memoized, so the redundant
+  // call inside `useTranscriptTimeline` below reuses the same result.
+  const timelinesForBranchDetection = useTimelinesArray(
+    eventsForTimeline,
+    serverTimelines
+  );
+  const branchesPresent = useMemo(
+    () => timelinesForBranchDetection.some((tl) => spanHasBranches(tl.root)),
+    [timelinesForBranchDetection]
+  );
+
+  const timelineConfig = useTimelineConfig({ branchesPresent });
+  const resolvedMarkerConfig =
+    markerConfigOverride ?? timelineConfig.markerConfig;
+  const resolvedAgentConfig = agentConfigOverride ?? timelineConfig.agentConfig;
+
+  const timeline = useTranscriptTimeline({
+    events: eventsForTimeline,
+    markerConfig: resolvedMarkerConfig,
+    timelineOptions: resolvedAgentConfig,
+    serverTimelines,
+    timelineProps: timelineSelection,
+    activeTimelineProps: activeTimeline,
+  });
+
+  const {
+    hasTimeline,
+    hasAgentTimeline,
+    regionCounts,
+    timelines,
+    selectedEvents,
+    sourceSpans,
+  } = timeline;
+
+  const showSwimlanes = useMemo(() => {
+    if (showSwimlanesOption === "auto") {
+      return hasTimeline || regionCounts.size > 0 || timelines.length > 1;
+    }
+    return showSwimlanesOption;
+  }, [showSwimlanesOption, hasTimeline, regionCounts, timelines.length]);
+
+  const swimlanesDefaultCollapsed = useMemo(() => {
+    if (
+      showSwimlanesOption === "auto" &&
+      !hasTimeline &&
+      regionCounts.size === 0
+    ) {
+      return true;
+    }
+    if (hasTimeline) {
+      // Expand by default only when there's agent sub-structure to drill into.
+      // A bare main + scoring (or init) timeline has nothing to expand, so
+      // default it collapsed.
+      return hasAgentTimeline ? false : true;
+    }
+    return undefined;
+  }, [showSwimlanesOption, hasTimeline, hasAgentTimeline, regionCounts]);
+
+  // With swimlanes on, the node tree shows only the selected row's events;
+  // otherwise it shows the full (unfiltered-by-selection) event stream.
+  const rawEventsForNodes = showSwimlanes ? selectedEvents : events;
+  const eventsForNodes = useMemo(
+    () =>
+      hiddenEventTypes && hiddenEventTypes.length > 0
+        ? rawEventsForNodes.filter((e) => !hiddenEventTypes.includes(e.event))
+        : rawEventsForNodes,
+    [rawEventsForNodes, hiddenEventTypes]
+  );
+
+  const nodeFeed = useMemo<EventNodeFeed>(
+    () => ({
+      events: eventsForNodes,
+      sourceSpans: showSwimlanes ? sourceSpans : undefined,
+    }),
+    [eventsForNodes, showSwimlanes, sourceSpans]
+  );
+
+  // Honor the same event-type filter the renderer uses. State/store events
+  // carry huge JSON payloads but aren't surfaced in the transcript tree;
+  // matching their fields would inflate the counter with unreachable results.
+  const searchableEvents = useMemo(() => {
+    if (!hiddenEventTypes || hiddenEventTypes.length === 0) return events;
+    const hidden = new Set(hiddenEventTypes);
+    return events.filter((e) => !hidden.has(e.event));
+  }, [events, hiddenEventTypes]);
+
+  return {
+    timeline,
+    timelineConfig,
+    showSwimlanes,
+    swimlanesDefaultCollapsed,
+    nodeFeed,
+    searchableEvents,
+  };
+}

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
@@ -5,7 +5,6 @@ import {
   RefObject,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
 } from "react";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
@@ -13,20 +12,11 @@ import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { useScrollTrack } from "@tsmono/react/hooks";
 
 import { useVirtuosoState } from "../../virtuoso/useVirtuosoState";
-import { kSandboxSignalName } from "../transform/fixups";
-import { flatTree } from "../transform/flatten";
 import { EventNode } from "../types";
 
 import { OutlineLoadingRow, OutlineRow } from "./OutlineRow";
 import styles from "./TranscriptOutline.module.css";
-import {
-  collapseScoring,
-  collapseTurns,
-  makeTurns,
-  noScorerChildren,
-  removeNodeVisitor,
-  removeStepSpanNameVisitor,
-} from "./tree-visitors";
+import { useOutlineNodes } from "./useOutlineNodes";
 import { useOutlineWidth } from "./useOutlineWidth";
 
 const kFramesToStabilize = 10;
@@ -174,25 +164,11 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
     [setSelectedOutlineId, beginProgrammaticScroll]
   );
 
-  const outlineNodeList = useMemo(() => {
-    const nodeList = flatTree(
-      eventNodes,
-      (collapsedEvents ? collapsedEvents : undefined) || defaultCollapsedIds,
-      [
-        removeNodeVisitor("logger"),
-        removeNodeVisitor("info"),
-        removeNodeVisitor("state"),
-        removeNodeVisitor("store"),
-        removeNodeVisitor("approval"),
-        removeNodeVisitor("input"),
-        removeNodeVisitor("sandbox"),
-        removeStepSpanNameVisitor(kSandboxSignalName),
-        noScorerChildren(),
-      ]
-    );
-
-    return collapseScoring(collapseTurns(makeTurns(nodeList)));
-  }, [eventNodes, collapsedEvents, defaultCollapsedIds]);
+  const { outlineNodeList, allNodesList } = useOutlineNodes(
+    eventNodes,
+    collapsedEvents,
+    defaultCollapsedIds
+  );
 
   const hasOutlineNodes = outlineNodeList.length > 0;
   useEffect(() => {
@@ -220,11 +196,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
       ancestor = ancestor.parentElement;
     }
   }, [outlineWidth]);
-
-  // All event nodes for scroll tracking
-  const allNodesList = useMemo(() => {
-    return flatTree(eventNodes, null);
-  }, [eventNodes]);
 
   const elementIds = allNodesList.map((node) => node.id);
   const findNearestOutlineAbove = useCallback(

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -1,8 +1,10 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { EventNode, type EventType } from "../types";
 
-import { buildOutlineNodeList } from "./useOutlineNodes";
+import { buildOutlineNodeList, useOutlineNodes } from "./useOutlineNodes";
 
 // =============================================================================
 // Fixtures
@@ -89,5 +91,29 @@ describe("buildOutlineNodeList", () => {
     expect(collapsed.map((n) => (n.event as { type?: string }).type)).toEqual([
       "agent",
     ]);
+  });
+});
+
+// =============================================================================
+// useOutlineNodes
+// =============================================================================
+
+describe("useOutlineNodes", () => {
+  it("preserves derived list identities when inputs are unchanged", () => {
+    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
+      modelNode(),
+    ]);
+    const eventNodes = [span];
+    const defaultCollapsedIds = {};
+    const { result, rerender } = renderHook(() =>
+      useOutlineNodes(eventNodes, undefined, defaultCollapsedIds)
+    );
+    const firstOutlineNodeList = result.current.outlineNodeList;
+    const firstAllNodesList = result.current.allNodesList;
+
+    rerender();
+
+    expect(result.current.outlineNodeList).toBe(firstOutlineNodeList);
+    expect(result.current.allNodesList).toBe(firstAllNodesList);
   });
 });

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { EventNode, type EventType } from "../types";
+
+import { buildOutlineNodeList } from "./useOutlineNodes";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+let nextId = 0;
+
+function node(
+  event: Partial<EventType> & { event: string },
+  children: EventNode[] = []
+): EventNode {
+  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
+  n.children = children;
+  return n;
+}
+
+function modelNode(): EventNode {
+  return node({
+    event: "model",
+    timestamp: "2024-01-01T00:00:00Z",
+    working_start: 0,
+    span_id: null,
+  });
+}
+
+// =============================================================================
+// buildOutlineNodeList
+// =============================================================================
+
+describe("buildOutlineNodeList", () => {
+  it("removes non-outline event types", () => {
+    const nodes = [
+      node({ event: "logger" }),
+      node({ event: "info" }),
+      node({ event: "state" }),
+      node({ event: "store" }),
+      node({ event: "error" }),
+    ];
+    const result = buildOutlineNodeList(nodes, {});
+    expect(result.map((n) => n.event.event)).toEqual(["error"]);
+  });
+
+  it("groups a model/tool run into a collapsed turns row", () => {
+    const nodes = [modelNode(), node({ event: "tool" })];
+    const result = buildOutlineNodeList(nodes, {});
+    expect(result).toHaveLength(1);
+    const turns = result[0]!;
+    expect(turns.event.event).toBe("span_begin");
+    expect((turns.event as { type?: string }).type).toBe("turns");
+    expect((turns.event as { name?: string }).name).toBe("1 turn");
+  });
+
+  it("counts consecutive turns", () => {
+    const nodes = [modelNode(), modelNode(), modelNode()];
+    const result = buildOutlineNodeList(nodes, {});
+    expect(result).toHaveLength(1);
+    expect((result[0]!.event as { name?: string }).name).toBe("3 turns");
+  });
+
+  it("collapses consecutive score events into a scoring row", () => {
+    const nodes = [
+      node({ event: "score" }),
+      node({ event: "score" }),
+      node({ event: "error" }),
+    ];
+    const result = buildOutlineNodeList(nodes, {});
+    expect(result.map((n) => (n.event as { name?: string }).name)).toEqual([
+      "scoring",
+      undefined,
+    ]);
+  });
+
+  it("does not descend into collapsed nodes", () => {
+    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
+      modelNode(),
+    ]);
+    const expanded = buildOutlineNodeList([span], {});
+    expect(expanded.map((n) => (n.event as { type?: string }).type)).toEqual([
+      "agent",
+      "turns",
+    ]);
+
+    const collapsed = buildOutlineNodeList([span], { [span.id]: true });
+    expect(collapsed.map((n) => (n.event as { type?: string }).type)).toEqual([
+      "agent",
+    ]);
+  });
+});

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
@@ -55,10 +55,7 @@ export const useOutlineNodes = (
 ): OutlineNodes => {
   const outlineNodeList = useMemo(
     () =>
-      buildOutlineNodeList(
-        eventNodes,
-        (collapsedEvents ? collapsedEvents : undefined) || defaultCollapsedIds
-      ),
+      buildOutlineNodeList(eventNodes, collapsedEvents ?? defaultCollapsedIds),
     [eventNodes, collapsedEvents, defaultCollapsedIds]
   );
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
@@ -1,0 +1,70 @@
+/**
+ * Derivation of the outline's row list from the transcript EventNode tree.
+ */
+
+import { useMemo } from "react";
+
+import { kSandboxSignalName } from "../transform/fixups";
+import { flatTree } from "../transform/flatten";
+import { EventNode } from "../types";
+
+import {
+  collapseScoring,
+  collapseTurns,
+  makeTurns,
+  noScorerChildren,
+  removeNodeVisitor,
+  removeStepSpanNameVisitor,
+} from "./tree-visitors";
+
+/**
+ * Build the outline's row list: flatten the tree with the outline's
+ * visibility visitors, then group model/tool runs into turns and collapse
+ * consecutive turns and scoring events.
+ */
+export const buildOutlineNodeList = (
+  eventNodes: EventNode[],
+  collapsedIds: Record<string, boolean>
+): EventNode[] => {
+  const nodeList = flatTree(eventNodes, collapsedIds, [
+    removeNodeVisitor("logger"),
+    removeNodeVisitor("info"),
+    removeNodeVisitor("state"),
+    removeNodeVisitor("store"),
+    removeNodeVisitor("approval"),
+    removeNodeVisitor("input"),
+    removeNodeVisitor("sandbox"),
+    removeStepSpanNameVisitor(kSandboxSignalName),
+    noScorerChildren(),
+  ]);
+
+  return collapseScoring(collapseTurns(makeTurns(nodeList)));
+};
+
+export interface OutlineNodes {
+  /** Rows displayed in the outline. */
+  outlineNodeList: EventNode[];
+  /** Full flattened node list (unfiltered), for scroll tracking. */
+  allNodesList: EventNode[];
+}
+
+export const useOutlineNodes = (
+  eventNodes: EventNode[],
+  collapsedEvents: Record<string, boolean> | undefined,
+  defaultCollapsedIds: Record<string, boolean>
+): OutlineNodes => {
+  const outlineNodeList = useMemo(
+    () =>
+      buildOutlineNodeList(
+        eventNodes,
+        (collapsedEvents ? collapsedEvents : undefined) || defaultCollapsedIds
+      ),
+    [eventNodes, collapsedEvents, defaultCollapsedIds]
+  );
+
+  const allNodesList = useMemo(() => {
+    return flatTree(eventNodes, null);
+  }, [eventNodes]);
+
+  return { outlineNodeList, allNodesList };
+};

--- a/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useEventNodes.ts
@@ -7,49 +7,16 @@
 
 import { useMemo } from "react";
 
-import type {
-  Event,
-  ModelEvent,
-  SpanBeginEvent,
-  StepEvent,
-  SubtaskEvent,
-  ToolEvent,
-} from "@tsmono/inspect-common/types";
+import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
 
-import { fixupEventStream, kSandboxSignalName } from "../../transform/fixups";
-import { treeifyEvents } from "../../transform/treeify";
-import { EventNode, kCollapsibleEventTypes } from "../../types";
-import type { EventType } from "../../types";
+import { computeDefaultCollapsedIds } from "../../transform/collapse";
+import { fixupEventStream } from "../../transform/fixups";
+import { filterEmptySpans, treeifyEvents } from "../../transform/treeify";
+import { EventNode } from "../../types";
 import type { TimelineSpan } from "../core";
 import { groupRetryAttempts } from "../retryGrouping";
 import { correctRetryTimestamps } from "../retryOrdering";
 import { attachSourceSpans } from "../timelineEventNodes";
-
-// =============================================================================
-// Collapse filters
-// =============================================================================
-
-const collapseFilters: Array<
-  (event: StepEvent | SpanBeginEvent | ToolEvent | SubtaskEvent) => boolean
-> = [
-  (event) => event.type === "solver" && event.name === "system_message",
-  (event) => {
-    if (event.event === "step" || event.event === "span_begin") {
-      return (
-        event.name === kSandboxSignalName ||
-        event.name === "init" ||
-        event.name === "sample_init"
-      );
-    }
-    return false;
-  },
-  (event) => event.event === "tool" && !event.agent && !event.failed,
-  (event) => event.event === "subtask",
-];
-
-// =============================================================================
-// Hook
-// =============================================================================
 
 export const useEventNodes = (
   events: Event[],
@@ -77,55 +44,14 @@ export const useEventNodes = (
     // Build the event tree
     const rawEventTree = treeifyEvents(resolvedEvents, 0);
 
-    // Attach source span references before filtering so filterEmpty
+    // Attach source span references before filtering so filterEmptySpans
     // can preserve agent card nodes (which have no children by design).
     if (sourceSpans && sourceSpans.size > 0) {
       attachSourceSpans(rawEventTree, sourceSpans);
     }
 
-    // Filter the tree to remove empty spans
-    const filterEmpty = (
-      eventNodes: EventNode<EventType>[]
-    ): EventNode<EventType>[] => {
-      return eventNodes.filter((node) => {
-        if (node.children && node.children.length > 0) {
-          node.children = filterEmpty(node.children);
-        }
-        // Preserve nodes with a sourceSpan (e.g. agent cards)
-        if (node.sourceSpan) return true;
-        if (
-          node.event.event === "span_begin" &&
-          (node.event.type === "fork_nav" || node.event.type === "empty_branch")
-        ) {
-          return true;
-        }
-        return (
-          (node.event.event !== "span_begin" && node.event.event !== "step") ||
-          (node.children && node.children.length > 0)
-        );
-      });
-    };
-    const eventTree = filterEmpty(rawEventTree);
-
-    // Compute default collapsed IDs
-    const defaultCollapsedIds: Record<string, true> = {};
-    const findCollapsibleEvents = (nodes: EventNode[]) => {
-      for (const node of nodes) {
-        if (
-          kCollapsibleEventTypes.includes(node.event.event) &&
-          collapseFilters.some((filter) =>
-            filter(
-              node.event as
-                StepEvent | SpanBeginEvent | ToolEvent | SubtaskEvent
-            )
-          )
-        ) {
-          defaultCollapsedIds[node.id] = true;
-        }
-        findCollapsibleEvents(node.children);
-      }
-    };
-    findCollapsibleEvents(eventTree);
+    const eventTree = filterEmptySpans(rawEventTree);
+    const defaultCollapsedIds = computeDefaultCollapsedIds(eventTree);
 
     return { eventTree, defaultCollapsedIds, retryAttempts };
   }, [events, running, sourceSpans]);

--- a/packages/inspect-components/src/transcript/transform/collapse.test.ts
+++ b/packages/inspect-components/src/transcript/transform/collapse.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { EventNode, type EventType } from "../types";
 
-import { collectAllCollapsibleIds, computeDefaultCollapsedIds } from "./collapse";
+import {
+  collectAllCollapsibleIds,
+  computeDefaultCollapsedIds,
+} from "./collapse";
 
 // =============================================================================
 // Fixtures
@@ -50,10 +53,9 @@ describe("computeDefaultCollapsedIds", () => {
 
   it("collapses subtasks and traverses children", () => {
     const subtask = node({ event: "subtask" });
-    const span = node(
-      { event: "span_begin", name: "agent", type: "agent" },
-      [subtask]
-    );
+    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
+      subtask,
+    ]);
     expect(computeDefaultCollapsedIds([span])).toEqual({
       [subtask.id]: true,
     });

--- a/packages/inspect-components/src/transcript/transform/collapse.test.ts
+++ b/packages/inspect-components/src/transcript/transform/collapse.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { EventNode, type EventType } from "../types";
+
+import { collectAllCollapsibleIds, computeDefaultCollapsedIds } from "./collapse";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+let nextId = 0;
+
+function node(
+  event: Partial<EventType> & { event: string },
+  children: EventNode[] = []
+): EventNode {
+  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
+  n.children = children;
+  return n;
+}
+
+// =============================================================================
+// computeDefaultCollapsedIds
+// =============================================================================
+
+describe("computeDefaultCollapsedIds", () => {
+  it("collapses successful non-agent tool events", () => {
+    const tool = node({ event: "tool", agent: null, failed: null });
+    expect(computeDefaultCollapsedIds([tool])).toEqual({ [tool.id]: true });
+  });
+
+  it("does not collapse agent or failed tool events", () => {
+    const agentTool = node({ event: "tool", agent: "handoff", failed: null });
+    const failedTool = node({ event: "tool", agent: null, failed: true });
+    expect(computeDefaultCollapsedIds([agentTool, failedTool])).toEqual({});
+  });
+
+  it("collapses init/sample_init spans and system_message solver steps", () => {
+    const init = node({ event: "span_begin", name: "init", type: null });
+    const sysMsg = node({
+      event: "step",
+      type: "solver",
+      name: "system_message",
+    });
+    expect(computeDefaultCollapsedIds([init, sysMsg])).toEqual({
+      [init.id]: true,
+      [sysMsg.id]: true,
+    });
+  });
+
+  it("collapses subtasks and traverses children", () => {
+    const subtask = node({ event: "subtask" });
+    const span = node(
+      { event: "span_begin", name: "agent", type: "agent" },
+      [subtask]
+    );
+    expect(computeDefaultCollapsedIds([span])).toEqual({
+      [subtask.id]: true,
+    });
+  });
+
+  it("ignores non-collapsible events", () => {
+    const model = node({ event: "model" });
+    const info = node({ event: "info" });
+    expect(computeDefaultCollapsedIds([model, info])).toEqual({});
+  });
+});
+
+// =============================================================================
+// collectAllCollapsibleIds
+// =============================================================================
+
+describe("collectAllCollapsibleIds", () => {
+  it("collects tree-collapsible and content-collapsible nodes recursively", () => {
+    const model = node({ event: "model" });
+    const state = node({ event: "state" });
+    const info = node({ event: "info" });
+    const tool = node({ event: "tool" }, [model]);
+    const span = node({ event: "span_begin", name: "s", type: null }, [
+      tool,
+      state,
+      info,
+    ]);
+
+    expect(collectAllCollapsibleIds([span])).toEqual({
+      [span.id]: true,
+      [tool.id]: true,
+      [model.id]: true,
+      [state.id]: true,
+    });
+  });
+});

--- a/packages/inspect-components/src/transcript/transform/collapse.ts
+++ b/packages/inspect-components/src/transcript/transform/collapse.ts
@@ -1,0 +1,90 @@
+/**
+ * Collapse policy for the transcript event tree: which nodes start collapsed
+ * by default, and which nodes are collapsible at all (for bulk collapse).
+ * Pure functions over EventNode trees; no React.
+ */
+
+import type {
+  SpanBeginEvent,
+  StepEvent,
+  SubtaskEvent,
+  ToolEvent,
+} from "@tsmono/inspect-common/types";
+
+import {
+  EventNode,
+  kCollapsibleEventTypes,
+  kContentCollapsibleEventTypes,
+} from "../types";
+
+import { kSandboxSignalName } from "./fixups";
+
+const collapseFilters: Array<
+  (event: StepEvent | SpanBeginEvent | ToolEvent | SubtaskEvent) => boolean
+> = [
+  (event) => event.type === "solver" && event.name === "system_message",
+  (event) => {
+    if (event.event === "step" || event.event === "span_begin") {
+      return (
+        event.name === kSandboxSignalName ||
+        event.name === "init" ||
+        event.name === "sample_init"
+      );
+    }
+    return false;
+  },
+  (event) => event.event === "tool" && !event.agent && !event.failed,
+  (event) => event.event === "subtask",
+];
+
+/**
+ * Compute the node IDs that start collapsed by default (system messages,
+ * init spans, successful non-agent tool calls, subtasks).
+ */
+export const computeDefaultCollapsedIds = (
+  eventNodes: EventNode[]
+): Record<string, true> => {
+  const defaultCollapsedIds: Record<string, true> = {};
+  const findCollapsibleEvents = (nodes: EventNode[]) => {
+    for (const node of nodes) {
+      if (
+        kCollapsibleEventTypes.includes(node.event.event) &&
+        collapseFilters.some((filter) =>
+          filter(
+            node.event as StepEvent | SpanBeginEvent | ToolEvent | SubtaskEvent
+          )
+        )
+      ) {
+        defaultCollapsedIds[node.id] = true;
+      }
+      findCollapsibleEvents(node.children);
+    }
+  };
+  findCollapsibleEvents(eventNodes);
+  return defaultCollapsedIds;
+};
+
+/**
+ * Collect every collapsible node ID in the tree (tree-collapsible and
+ * content-collapsible), for bulk collapse-all.
+ */
+export const collectAllCollapsibleIds = (
+  nodes: EventNode[]
+): Record<string, boolean> => {
+  const result: Record<string, boolean> = {};
+  const traverse = (nodeList: EventNode[]) => {
+    for (const node of nodeList) {
+      if (
+        kCollapsibleEventTypes.includes(node.event.event) ||
+        kContentCollapsibleEventTypes.includes(node.event.event)
+      ) {
+        result[node.id] = true;
+      }
+      if (node.children.length > 0) {
+        traverse(node.children);
+      }
+    }
+  };
+  traverse(nodes);
+  return result;
+};

--- a/packages/inspect-components/src/transcript/transform/labels.test.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { buildToolLabels, scopeMessageLabels } from "./labels";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+interface FixtureMessage {
+  id?: string;
+  role: string;
+  tool_call_id?: string;
+}
+
+function modelEvent(
+  input: FixtureMessage[],
+  choiceIds: string[] = []
+): Event {
+  return {
+    event: "model",
+    input,
+    output: {
+      choices: choiceIds.map((id) => ({
+        message: { id, role: "assistant", content: "" },
+      })),
+    },
+  } as unknown as Event;
+}
+
+function toolEvent(id: string, messageId: string | null): Event {
+  return { event: "tool", id, message_id: messageId } as unknown as Event;
+}
+
+// =============================================================================
+// scopeMessageLabels
+// =============================================================================
+
+describe("scopeMessageLabels", () => {
+  it("returns undefined when no labels are provided", () => {
+    expect(scopeMessageLabels([modelEvent([])], undefined)).toBeUndefined();
+  });
+
+  it("keeps labels for messages present in the events", () => {
+    const events = [
+      modelEvent([{ id: "m1", role: "user" }], ["m2"]),
+      toolEvent("t1", "m3"),
+    ];
+    const labels = { m1: "A", m2: "B", m3: "C", m4: "D" };
+    expect(scopeMessageLabels(events, labels)).toEqual({
+      m1: "A",
+      m2: "B",
+      m3: "C",
+    });
+  });
+
+  it("returns undefined when no labeled message is present", () => {
+    const events = [modelEvent([{ id: "m1", role: "user" }])];
+    expect(scopeMessageLabels(events, { other: "X" })).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// buildToolLabels
+// =============================================================================
+
+describe("buildToolLabels", () => {
+  it("returns undefined when no message labels are provided", () => {
+    expect(buildToolLabels([toolEvent("t1", "m1")], undefined)).toBeUndefined();
+  });
+
+  it("labels tool events via their message_id", () => {
+    const events = [toolEvent("t1", "m1"), toolEvent("t2", "unlabeled")];
+    expect(buildToolLabels(events, { m1: "A" })).toEqual({ t1: "A" });
+  });
+
+  it("labels tool calls via tool-role input messages on model events", () => {
+    const events = [
+      modelEvent([
+        { id: "m1", role: "tool", tool_call_id: "call1" },
+        { id: "m2", role: "user", tool_call_id: "call2" },
+      ]),
+    ];
+    // The user-role message must not produce a label even though m2 is labeled.
+    expect(buildToolLabels(events, { m1: "A", m2: "B" })).toEqual({
+      call1: "A",
+    });
+  });
+
+  it("returns undefined when nothing matches", () => {
+    const events = [toolEvent("t1", null)];
+    expect(buildToolLabels(events, { m1: "A" })).toBeUndefined();
+  });
+});

--- a/packages/inspect-components/src/transcript/transform/labels.test.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.test.ts
@@ -14,10 +14,7 @@ interface FixtureMessage {
   tool_call_id?: string;
 }
 
-function modelEvent(
-  input: FixtureMessage[],
-  choiceIds: string[] = []
-): Event {
+function modelEvent(input: FixtureMessage[], choiceIds: string[] = []): Event {
   return {
     event: "model",
     input,

--- a/packages/inspect-components/src/transcript/transform/labels.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.ts
@@ -1,0 +1,74 @@
+/**
+ * Derivation of gutter label maps (message labels, tool labels) from the
+ * event stream. Pure functions over Event[]; no React.
+ */
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+/**
+ * Derive tool-event labels from message labels.
+ *
+ * A tool event inherits the label of the tool message it produced — matched
+ * via `ToolEvent.message_id`, or via tool-role input messages on model
+ * events (keyed by `tool_call_id`).
+ */
+export const buildToolLabels = (
+  events: Event[],
+  messageLabels: Record<string, string> | undefined
+): Record<string, string> | undefined => {
+  if (!messageLabels) return undefined;
+
+  const toolLabels: Record<string, string> = {};
+  for (const event of events) {
+    if (event.event === "tool") {
+      const label = event.message_id
+        ? messageLabels[event.message_id]
+        : undefined;
+      if (label) toolLabels[event.id] = label;
+    } else if (event.event === "model") {
+      for (const message of event.input ?? []) {
+        if (message.role !== "tool" || !message.id) continue;
+        const label = messageLabels[message.id];
+        if (label && message.tool_call_id) {
+          toolLabels[message.tool_call_id] = label;
+        }
+      }
+    }
+  }
+
+  return Object.keys(toolLabels).length > 0 ? toolLabels : undefined;
+};
+
+/**
+ * Restrict the message-label map to messages actually present in `events`.
+ *
+ * The map is shared across the whole sample, but timelines (e.g. auditor vs
+ * target) show different events — without this an unlabeled timeline would
+ * reserve label-column space just because another timeline is labeled.
+ */
+export const scopeMessageLabels = (
+  events: Event[],
+  messageLabels: Record<string, string> | undefined
+): Record<string, string> | undefined => {
+  if (!messageLabels) return undefined;
+
+  const present = new Set<string>();
+  for (const event of events) {
+    if (event.event === "model") {
+      for (const message of event.input ?? []) {
+        if (message.id) present.add(message.id);
+      }
+      for (const choice of event.output?.choices ?? []) {
+        if (choice.message?.id) present.add(choice.message.id);
+      }
+    } else if (event.event === "tool" && event.message_id) {
+      present.add(event.message_id);
+    }
+  }
+
+  const scoped: Record<string, string> = {};
+  for (const [id, label] of Object.entries(messageLabels)) {
+    if (present.has(id)) scoped[id] = label;
+  }
+  return Object.keys(scoped).length > 0 ? scoped : undefined;
+};

--- a/packages/inspect-components/src/transcript/transform/treeify.test.ts
+++ b/packages/inspect-components/src/transcript/transform/treeify.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { EventNode, type EventType } from "../types";
+
+import { filterEmptySpans } from "./treeify";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+let nextId = 0;
+
+function node(
+  event: Partial<EventType> & { event: string },
+  children: EventNode[] = []
+): EventNode {
+  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
+  n.children = children;
+  return n;
+}
+
+// =============================================================================
+// filterEmptySpans
+// =============================================================================
+
+describe("filterEmptySpans", () => {
+  it("removes childless span and step nodes", () => {
+    const span = node({ event: "span_begin", name: "s", type: null });
+    const step = node({ event: "step", name: "s", type: null });
+    expect(filterEmptySpans([span, step])).toEqual([]);
+  });
+
+  it("keeps spans with children and leaf events", () => {
+    const model = node({ event: "model" });
+    const span = node({ event: "span_begin", name: "s", type: null }, [model]);
+    const info = node({ event: "info" });
+    expect(filterEmptySpans([span, info])).toEqual([span, info]);
+  });
+
+  it("removes spans whose only children are empty spans", () => {
+    const inner = node({ event: "span_begin", name: "inner", type: null });
+    const outer = node({ event: "span_begin", name: "outer", type: null }, [
+      inner,
+    ]);
+    expect(filterEmptySpans([outer])).toEqual([]);
+  });
+
+  it("keeps childless fork_nav and empty_branch spans", () => {
+    const forkNav = node({
+      event: "span_begin",
+      name: "f",
+      type: "fork_nav",
+    });
+    const emptyBranch = node({
+      event: "span_begin",
+      name: "b",
+      type: "empty_branch",
+    });
+    expect(filterEmptySpans([forkNav, emptyBranch])).toEqual([
+      forkNav,
+      emptyBranch,
+    ]);
+  });
+
+  it("keeps childless spans with an attached sourceSpan (agent cards)", () => {
+    const card = node({ event: "span_begin", name: "agent", type: "agent" });
+    card.sourceSpan = { spanType: "agent", name: "agent" };
+    expect(filterEmptySpans([card])).toEqual([card]);
+  });
+});

--- a/packages/inspect-components/src/transcript/transform/treeify.ts
+++ b/packages/inspect-components/src/transcript/transform/treeify.ts
@@ -265,3 +265,31 @@ const injectScorersSpan = (events: Event[]): Event[] => {
 
   return results;
 };
+
+/**
+ * Remove span/step nodes with no visible children (filtering recursively, in
+ * place on each node's `children`). Nodes with an attached `sourceSpan`
+ * (agent cards) and structural `fork_nav`/`empty_branch` spans are preserved
+ * even when childless.
+ */
+export const filterEmptySpans = (
+  eventNodes: EventNode<EventType>[]
+): EventNode<EventType>[] => {
+  return eventNodes.filter((node) => {
+    if (node.children && node.children.length > 0) {
+      node.children = filterEmptySpans(node.children);
+    }
+    // Preserve nodes with a sourceSpan (e.g. agent cards)
+    if (node.sourceSpan) return true;
+    if (
+      node.event.event === "span_begin" &&
+      (node.event.type === "fork_nav" || node.event.type === "empty_branch")
+    ) {
+      return true;
+    }
+    return (
+      (node.event.event !== "span_begin" && node.event.event !== "step") ||
+      (node.children && node.children.length > 0)
+    );
+  });
+};


### PR DESCRIPTION
Pure tactical refactoring, zero behavior change. `TranscriptLayout` and `TranscriptOutline` were doing heavy data derivation inline — filtering, branch detection, config resolution, node-feed selection, label scoping, outline row building — leaving the components ~half dataflow orchestration. This isolates that work into hooks and pure functions so the components render and the derivation is testable in isolation. First step of a larger cleanup; hook shapes are staging, not final.

- `useTimelinePipeline` — events + config → timeline pipeline result, swimlane policy, and the new `EventNodeFeed` concept (`{events, sourceSpans}`: which events feed the node tree, previously an inline `showSwimlanes ? selectedEvents : events` dance)
- `useEventNodeData` — feed → `eventNodes`, `defaultCollapsedIds`, merged `EventNodeContext`
- `useOutlineNodes` / pure `buildOutlineNodeList` — outline row derivation out of `TranscriptOutline`
- Pure functions moved to `transform/`: `labels.ts` (`scopeMessageLabels`, `buildToolLabels`), `collapse.ts` (`computeDefaultCollapsedIds`, `collectAllCollapsibleIds`), `filterEmptySpans` in `treeify.ts`

Every extraction is a verbatim move with identical memo dep arrays and input references, so output identities (which drive effects/resets downstream) are preserved by construction. `TranscriptTimelineResult`'s 20-field shape is deliberately frozen and passed through — regrouping it is a later pass, as are the deep-link resolution effects and collapse-state callbacks still in `TranscriptLayout`.

Adds 29 unit tests over the extracted derivation (labels, collapse policy, empty-span filtering, outline turn/scoring grouping, both hooks).
