### PR TITLE
Extract deep-link, collapse, and outline view-model hooks from TranscriptLayout

### DIFF
--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -40,8 +40,10 @@ import { useElementHeight, useScrubberProgress } from "@tsmono/react/hooks";
 import { useDeepLinkResolution } from "./hooks/useDeepLinkResolution";
 import { useEventNodeData } from "./hooks/useEventNodeData";
 import { useListPositionManager } from "./hooks/useListPositionManager";
+import { useOutlineAutoHide } from "./hooks/useOutlineAutoHide";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
 import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
+import { useTranscriptCollapse } from "./hooks/useTranscriptCollapse";
 import { TranscriptOutline } from "./outline/TranscriptOutline";
 import { useTranscriptSearchSource } from "./search";
 import { AgentCardView, TimelineSwimLanes } from "./timeline/components";
@@ -62,7 +64,6 @@ import {
   TranscriptViewNodes,
   type TranscriptViewNodesHandle,
 } from "./TranscriptViewNodes";
-import { collectAllCollapsibleIds } from "./transform/collapse";
 import {
   EventNode,
   type EventNodeContext,
@@ -455,94 +456,25 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   }, [effectiveInitialEventId, onHeadroomResetAnchor]);
 
   // ---------------------------------------------------------------------------
-  // Bulk collapse/expand
+  // Collapse state & outline auto-hide
   // ---------------------------------------------------------------------------
 
-  const onSetTranscriptCollapsed = collapseState?.onSetTranscriptCollapsed;
-  useEffect(() => {
-    if (events.length <= 0 || !bulkCollapse || !onSetTranscriptCollapsed) {
-      return;
-    }
-    if (bulkCollapse === "expand") {
-      onSetTranscriptCollapsed({});
-    } else if (bulkCollapse === "collapse") {
-      const allCollapsibleIds = collectAllCollapsibleIds(eventNodes);
-      onSetTranscriptCollapsed(allCollapsibleIds);
-    }
-  }, [eventNodes, bulkCollapse, onSetTranscriptCollapsed, events.length]);
+  const { onCollapseTranscript, onExpandNodes } = useTranscriptCollapse({
+    eventNodes,
+    defaultCollapsedIds,
+    collapseState,
+    bulkCollapse,
+    eventCount: events.length,
+  });
 
-  // Lazy-seed: when the user toggles an individual node for the first time
-  // (store scope is empty), seed the store with defaults before applying the
-  // toggle so that all other nodes retain their default collapsed state.
-  const onCollapseTranscriptRaw = collapseState?.onCollapseTranscript;
-  const onCollapseTranscript = useCallback(
-    (nodeId: string, collapsed: boolean) => {
-      if (!onCollapseTranscriptRaw || !onSetTranscriptCollapsed) return;
-      if (!collapseState?.transcript) {
-        // First toggle — seed defaults then apply the toggle
-        onSetTranscriptCollapsed({
-          ...defaultCollapsedIds,
-          [nodeId]: collapsed,
-        });
-      } else {
-        onCollapseTranscriptRaw(nodeId, collapsed);
-      }
-    },
-    [
-      onCollapseTranscriptRaw,
-      onSetTranscriptCollapsed,
-      collapseState?.transcript,
-      defaultCollapsedIds,
-    ]
-  );
-
-  // Bulk-expand for deep links into collapsed regions. One batched update —
-  // sequential onCollapseTranscript calls would each re-seed defaults and
-  // clobber the previous call's expansion while the store is unseeded.
-  const onExpandNodes = useCallback(
-    (nodeIds: string[]) => {
-      if (!onSetTranscriptCollapsed) return;
-      const next = { ...(collapseState?.transcript ?? defaultCollapsedIds) };
-      for (const id of nodeIds) next[id] = false;
-      onSetTranscriptCollapsed(next);
-    },
-    [onSetTranscriptCollapsed, collapseState?.transcript, defaultCollapsedIds]
-  );
-
-  // ---------------------------------------------------------------------------
-  // Outline auto-hide
-  // ---------------------------------------------------------------------------
-  //
-  // Track whether the outline component reports displayable nodes. When the
-  // outline is collapsed (unmounted), it can't report, so we optimistically
-  // fall back to eventNodes.length > 0 to keep the toggle enabled.
-  //
-  // Auto-hide the outline when content has no nodes (e.g. utility agent)
-  // without touching the user's persistent preference. When the user navigates
-  // back to an agent with outline content, the preference is still intact.
-
-  const [reportedHasNodes, setReportedHasNodes] = useState(true);
-
-  // Reset to optimistic when eventNodes change (e.g. agent selection changes).
-  // Uses "adjust state during render" pattern to avoid an extra effect cycle.
-  const [prevEventNodes, setPrevEventNodes] = useState(eventNodes);
-  if (prevEventNodes !== eventNodes) {
-    setPrevEventNodes(eventNodes);
-    if (!reportedHasNodes) {
-      setReportedHasNodes(true);
-    }
-  }
+  const { isOutlineCollapsed, outlineHasNodes, onOutlineHasNodesChange } =
+    useOutlineAutoHide({
+      eventNodes,
+      hasOutline: !!outline,
+      outlineCollapsed: outline?.collapsed,
+    });
 
   const hasMatchingEvents = eventNodes.length > 0;
-  const autoHidden = outline ? !reportedHasNodes && !outline.collapsed : false;
-  const isOutlineCollapsed = !outline || outline.collapsed || autoHidden;
-
-  const outlineHasNodes = isOutlineCollapsed
-    ? hasMatchingEvents
-    : reportedHasNodes;
-  const handleOutlineHasNodesChange = useCallback((hasNodes: boolean) => {
-    setReportedHasNodes(hasNodes);
-  }, []);
 
   // ---------------------------------------------------------------------------
   // Agent card rendering
@@ -804,7 +736,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                           getEventUrl={getEventUrl}
                           renderLink={outline.renderLink}
                           onNavigateToEvent={outline.onNavigateToEvent}
-                          onHasNodesChange={handleOutlineHasNodesChange}
+                          onHasNodesChange={onOutlineHasNodesChange}
                         />
                       </>
                     ) : (
@@ -854,9 +786,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                   collapsedTranscript={collapseState?.transcript}
                   collapsedOutline={collapseState?.outline}
                   onCollapseTranscript={onCollapseTranscript}
-                  onExpandNodes={
-                    onSetTranscriptCollapsed ? onExpandNodes : undefined
-                  }
+                  onExpandNodes={onExpandNodes}
                   eventNodeContext={mergedEventNodeContext}
                 />
               ) : emptyText !== null ? (

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -37,22 +37,12 @@ import {
 } from "@tsmono/react/components";
 import { useElementHeight, useScrubberProgress } from "@tsmono/react/hooks";
 
-import {
-  findTimelineIndexForEvent,
-  findTimelineIndexForMessage,
-  timelineContainsEvent,
-} from "./findTimelineForDeepLink";
+import { useDeepLinkResolution } from "./hooks/useDeepLinkResolution";
 import { useEventNodeData } from "./hooks/useEventNodeData";
 import { useListPositionManager } from "./hooks/useListPositionManager";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
 import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
 import { TranscriptOutline } from "./outline/TranscriptOutline";
-import {
-  resolveEventInBranches,
-  resolveEventToSpan,
-  resolveMessageInBranches,
-  resolveMessageToEvent,
-} from "./resolveMessageToEvent";
 import { useTranscriptSearchSource } from "./search";
 import { AgentCardView, TimelineSwimLanes } from "./timeline/components";
 import { type TimelineSpan } from "./timeline/core";
@@ -62,10 +52,7 @@ import {
   type UseTimelineProps,
 } from "./timeline/hooks";
 import { type MarkerConfig } from "./timeline/markers";
-import {
-  buildSpanSelectKeys,
-  getSelectedSpans,
-} from "./timeline/timelineEventNodes";
+import { buildSpanSelectKeys } from "./timeline/timelineEventNodes";
 import {
   TimelineRowSelectContext,
   TimelineSelectContext,
@@ -245,23 +232,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   // ---------------------------------------------------------------------------
 
   const {
-    timeline: {
-      timeline: timelineData,
-      state: timelineState,
-      layouts: timelineLayouts,
-      rootTimeMapping,
-      minimapSelection,
-      timelines,
-      activeTimelineIndex,
-      setActiveTimeline,
-      regionCounts,
-      branchScrollTarget,
-      highlightedKeys,
-      selectedRowName,
-      viewStack,
-      pushView,
-      popView,
-    },
+    timeline: transcriptTimeline,
     timelineConfig,
     showSwimlanes,
     swimlanesDefaultCollapsed,
@@ -277,6 +248,23 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     timelineSelection,
     activeTimeline,
   });
+
+  const {
+    timeline: timelineData,
+    state: timelineState,
+    layouts: timelineLayouts,
+    rootTimeMapping,
+    minimapSelection,
+    timelines,
+    activeTimelineIndex,
+    setActiveTimeline,
+    regionCounts,
+    highlightedKeys,
+    selectedRowName,
+    viewStack,
+    pushView,
+    popView,
+  } = transcriptTimeline;
 
   const {
     eventNodes,
@@ -432,175 +420,17 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   );
 
   // ---------------------------------------------------------------------------
-  // Message ID → event resolution
+  // Deep-link resolution
   // ---------------------------------------------------------------------------
 
-  // Resolve message ID against the selected span first, then fall back to root.
-  const resolvedLocal = useMemo(() => {
-    if (initialEventId || !initialMessageId) return undefined;
-    const selectedSpans = getSelectedSpans(
-      timelineState.rows,
-      timelineState.selected
-    );
-    for (const span of selectedSpans) {
-      const result = resolveMessageToEvent(initialMessageId, span);
-      if (result && !result.agentSpanId) return result;
-    }
-    return undefined;
-  }, [
+  const { effectiveInitialEventId } = useDeepLinkResolution({
     initialEventId,
     initialMessageId,
-    timelineState.rows,
-    timelineState.selected,
-  ]);
-
-  const resolvedRoot = useMemo(() => {
-    if (initialEventId || !initialMessageId || resolvedLocal) return undefined;
-    // First try the main content tree (existing behavior).
-    const main = resolveMessageToEvent(initialMessageId, timelineData.root);
-    if (main) return main;
-    // Fall back to branches: walk every branch in the tree and return the
-    // first match in swimlane row order (latest fork first).
-    return resolveMessageInBranches(initialMessageId, timelineData.root);
-  }, [initialEventId, initialMessageId, resolvedLocal, timelineData.root]);
-
-  const resolved = resolvedLocal ?? resolvedRoot;
-
-  // Cross-timeline deep links: if the target lives in a different root
-  // timeline, find it so the effect below can switch to it. -1 = no switch.
-  const deepLinkTimelineIndex = useMemo(() => {
-    if (timelines.length <= 1) return -1;
-    if (initialEventId) {
-      const active = timelines[activeTimelineIndex];
-      if (!active || timelineContainsEvent(initialEventId, active)) return -1;
-      return findTimelineIndexForEvent(initialEventId, timelines);
-    }
-    if (initialMessageId && !resolvedLocal && !resolvedRoot) {
-      return findTimelineIndexForMessage(initialMessageId, timelines);
-    }
-    return -1;
-  }, [
-    initialEventId,
-    initialMessageId,
-    resolvedLocal,
-    resolvedRoot,
-    timelines,
-    activeTimelineIndex,
-  ]);
-
-  // Side-effect: switch swimlane selection when resolution comes from root
-  // (i.e. requires moving the user to a different row to see the resolved
-  // event). Calls `timelineState.select` with `{ preserveDeepLink: true }`
-  // so hosts know to keep the URL `?message=` / `?event=` params intact
-  // rather than clearing them as they would for a user row click — the
-  // imperative scroll about to fire still needs the deep-link target.
-  //
-  // Gated on `initialMessageId` actually changing — selection-only changes
-  // (user clicked a swimlane row) cause `resolvedRoot` to recompute against
-  // the still-stale URL message during the intermediate render before URL
-  // clearing is applied; firing the side effect there would override the
-  // user's just-expressed selection intent.
-  const prevMessageIdRef = useRef<string | null | undefined>(undefined);
-  useEffect(() => {
-    if (prevMessageIdRef.current === initialMessageId) return;
-    // A cross-timeline switch is pending: don't consume the message id yet —
-    // this effect must re-evaluate after the switch lands and resolution
-    // re-runs against the new root.
-    if (deepLinkTimelineIndex >= 0) return;
-    prevMessageIdRef.current = initialMessageId;
-    if (!resolvedRoot) return;
-    let targetKey: string | null = null;
-    if (resolvedRoot.branchRowKey) {
-      targetKey = resolvedRoot.branchRowKey;
-    } else if (resolvedRoot.agentSpanId) {
-      targetKey = spanSelectKeys.get(resolvedRoot.agentSpanId)?.key ?? null;
-    }
-    if (timelineState.selected === targetKey) return;
-    timelineState.select(targetKey, { preserveDeepLink: true });
-  }, [
-    initialMessageId,
-    deepLinkTimelineIndex,
-    resolvedRoot,
+    timeline: transcriptTimeline,
     spanSelectKeys,
-    timelineState,
-  ]);
-
-  // Fire the timeline switch once per deep-link change — a stale `?event=` /
-  // `?message=` param left in the URL must not snap the user back after they
-  // manually switch timelines away.
-  //
-  // Mark the key "consumed" only once we've actually switched. While the
-  // target isn't found yet (index -1 — e.g. timeline data still building or
-  // events still streaming), leave it unconsumed so a later data update with
-  // the same key can still trigger the switch. The snap-back guard still
-  // holds: after a switch, the target resolves in the now-active timeline,
-  // so `deepLinkTimelineIndex` drops to -1 and the consumed key blocks any
-  // re-switch even if the user navigates timelines manually.
-  const prevDeepLinkRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (timelines.length <= 1) return;
-    const key = initialEventId ?? initialMessageId ?? null;
-    if (key === null) {
-      prevDeepLinkRef.current = null;
-      return;
-    }
-    if (prevDeepLinkRef.current === key) return;
-    if (deepLinkTimelineIndex < 0) return;
-    prevDeepLinkRef.current = key;
-    if (deepLinkTimelineIndex === activeTimelineIndex) return;
-    setActiveTimeline(deepLinkTimelineIndex);
-  }, [
-    initialEventId,
-    initialMessageId,
-    deepLinkTimelineIndex,
-    activeTimelineIndex,
-    setActiveTimeline,
-    timelines.length,
-  ]);
-
-  // Event deep links targeting a non-visible swimlane lane: with swimlanes
-  // on, the event list only contains the selected rows' events, so a target
-  // in another agent lane (or branch) is unreachable until that row is
-  // selected. The event-id analogue of the message side-effect above.
-  const resolvedEventSpan = useMemo(() => {
-    if (!initialEventId || !showSwimlanes) return undefined;
-    const present = nodeFeed.events.some(
-      (e) => (e as { uuid?: string | null }).uuid === initialEventId
-    );
-    if (present) return undefined;
-    return (
-      resolveEventToSpan(initialEventId, timelineData.root) ??
-      resolveEventInBranches(initialEventId, timelineData.root)
-    );
-  }, [initialEventId, showSwimlanes, nodeFeed.events, timelineData.root]);
-
-  const prevEventIdRef = useRef<string | null | undefined>(undefined);
-  useEffect(() => {
-    if (prevEventIdRef.current === initialEventId) return;
-    // A cross-timeline switch is pending: re-evaluate after it lands.
-    if (deepLinkTimelineIndex >= 0) return;
-    prevEventIdRef.current = initialEventId;
-    if (!resolvedEventSpan) return;
-    let targetKey: string | null = null;
-    if (resolvedEventSpan.branchRowKey) {
-      targetKey = resolvedEventSpan.branchRowKey;
-    } else if (resolvedEventSpan.agentSpanId) {
-      targetKey =
-        spanSelectKeys.get(resolvedEventSpan.agentSpanId)?.key ?? null;
-    }
-    if (!targetKey) return;
-    if (timelineState.selected === targetKey) return;
-    timelineState.select(targetKey, { preserveDeepLink: true });
-  }, [
-    initialEventId,
-    deepLinkTimelineIndex,
-    resolvedEventSpan,
-    spanSelectKeys,
-    timelineState,
-  ]);
-
-  const effectiveInitialEventId =
-    initialEventId ?? resolved?.eventId ?? branchScrollTarget ?? null;
+    showSwimlanes,
+    nodeFeedEvents: nodeFeed.events,
+  });
 
   // Branch selections share one effectiveListId (no remount), so the prefix
   // above the clicked navigator is laid out identically — restoring scrollTop

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { useMemo } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  Event,
+  Timeline as ServerTimeline,
+  TimelineEvent as ServerTimelineEvent,
+  TimelineSpan as ServerTimelineSpan,
+} from "@tsmono/inspect-common/types";
+
+import { useTranscriptTimeline, type SelectOptions } from "../timeline/hooks";
+import { buildSpanSelectKeys } from "../timeline/timelineEventNodes";
+
+import { useDeepLinkResolution } from "./useDeepLinkResolution";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeModelEvent(
+  uuid: string,
+  startSec: number,
+  outputMessageId?: string
+): Event {
+  return {
+    event: "model",
+    uuid,
+    model: "test-model",
+    input: [],
+    output: {
+      choices: [
+        {
+          message: {
+            id: outputMessageId,
+            role: "assistant",
+            content: "response",
+          },
+          stop_reason: "stop",
+        },
+      ],
+      completion: "response",
+      model: "test-model",
+    },
+    config: {},
+    tools: [],
+    tool_choice: "auto",
+    timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
+    working_start: startSec,
+    working_time: 1,
+    error: null,
+    pending: false,
+    span_id: null,
+  } as unknown as Event;
+}
+
+function makeServerEvent(uuid: string): ServerTimelineEvent {
+  return { type: "event", event: uuid };
+}
+
+function makeServerSpan(
+  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
+): ServerTimelineSpan {
+  return {
+    type: "span",
+    span_type: null,
+    content: [],
+    branches: [],
+    branched_from: null,
+    description: null,
+    utility: false,
+    tool_invoked: false,
+    agent_result: null,
+    outline: null,
+    ...overrides,
+  };
+}
+
+/** Single timeline: evt-1 at root, evt-2 inside agent span "agent-a". */
+function makeAgentTimeline(): ServerTimeline {
+  return {
+    name: "default",
+    description: "Test timeline",
+    root: makeServerSpan({
+      id: "root",
+      name: "Transcript",
+      content: [
+        makeServerEvent("evt-1"),
+        makeServerSpan({
+          id: "agent-a",
+          name: "Agent A",
+          span_type: "agent",
+          content: [makeServerEvent("evt-2")],
+        }),
+      ],
+    }),
+  };
+}
+
+// =============================================================================
+// Harness — real timeline pipeline feeding the hook under test
+// =============================================================================
+
+interface HarnessProps {
+  events: Event[];
+  serverTimelines?: ServerTimeline[];
+  selected: string | null;
+  onSelect: (key: string | null, options?: SelectOptions) => void;
+  activeIndex?: number;
+  onActiveChange?: (index: number) => void;
+  initialEventId?: string | null;
+  initialMessageId?: string | null;
+  showSwimlanes?: boolean;
+  nodeFeedEvents?: Event[];
+}
+
+function useHarness(props: HarnessProps) {
+  const timeline = useTranscriptTimeline({
+    events: props.events,
+    serverTimelines: props.serverTimelines,
+    timelineProps: { selected: props.selected, onSelect: props.onSelect },
+    activeTimelineProps:
+      props.activeIndex !== undefined && props.onActiveChange
+        ? {
+            activeIndex: props.activeIndex,
+            onActiveChange: props.onActiveChange,
+          }
+        : undefined,
+  });
+  const spanSelectKeys = useMemo(
+    () => buildSpanSelectKeys(timeline.state.rows),
+    [timeline.state.rows]
+  );
+  const resolution = useDeepLinkResolution({
+    initialEventId: props.initialEventId,
+    initialMessageId: props.initialMessageId,
+    timeline,
+    spanSelectKeys,
+    showSwimlanes: props.showSwimlanes ?? true,
+    nodeFeedEvents: props.nodeFeedEvents ?? props.events,
+  });
+  return { resolution, timeline, spanSelectKeys };
+}
+
+function renderHarness(props: Partial<HarnessProps> & { events: Event[] }) {
+  const onSelect = vi.fn();
+  const onActiveChange = vi.fn();
+  const base: HarnessProps = {
+    selected: null,
+    onSelect,
+    ...props,
+    ...(props.activeIndex !== undefined ? { onActiveChange } : {}),
+  };
+  const view = renderHook((p: HarnessProps) => useHarness(p), {
+    initialProps: base,
+  });
+  return { ...view, base, onSelect, onActiveChange };
+}
+
+// =============================================================================
+// effectiveInitialEventId precedence
+// =============================================================================
+
+describe("useDeepLinkResolution → effectiveInitialEventId", () => {
+  it("prefers the explicit event id over a resolvable message id", () => {
+    const events = [makeModelEvent("evt-1", 0, "m1")];
+    const { result } = renderHarness({
+      events,
+      initialEventId: "evt-9",
+      initialMessageId: "m1",
+    });
+    expect(result.current.resolution.effectiveInitialEventId).toBe("evt-9");
+  });
+
+  it("resolves a message id to its event", () => {
+    const events = [makeModelEvent("evt-1", 0, "m1")];
+    const { result } = renderHarness({ events, initialMessageId: "m1" });
+    expect(result.current.resolution.effectiveInitialEventId).toBe("evt-1");
+  });
+
+  it("is null with no deep link", () => {
+    const events = [makeModelEvent("evt-1", 0)];
+    const { result } = renderHarness({ events });
+    expect(result.current.resolution.effectiveInitialEventId).toBeNull();
+  });
+});
+
+// =============================================================================
+// Message → row selection side effect
+// =============================================================================
+
+describe("useDeepLinkResolution → message row selection", () => {
+  const events = [
+    makeModelEvent("evt-1", 0, "m1"),
+    makeModelEvent("evt-2", 4, "m2"),
+  ];
+
+  it("selects the agent row containing the message, preserving the deep link", () => {
+    const { result, onSelect } = renderHarness({
+      events,
+      serverTimelines: [makeAgentTimeline()],
+      initialMessageId: "m2",
+    });
+    const agentKey = result.current.spanSelectKeys.get("agent-a")?.key;
+    expect(agentKey).toBeDefined();
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(agentKey, {
+      preserveDeepLink: true,
+    });
+  });
+
+  it("consumes the message id: selection-only changes do not re-fire", () => {
+    const { result, rerender, base, onSelect } = renderHarness({
+      events,
+      serverTimelines: [makeAgentTimeline()],
+      initialMessageId: "m2",
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    // Simulate the user clicking a different row while the (stale) message
+    // id is still in the URL: the consumed key must not override the click.
+    const rootKey = result.current.timeline.state.rows[0]!.key;
+    rerender({ ...base, selected: rootKey });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not select when the message resolves at the root level", () => {
+    const { onSelect } = renderHarness({ events, initialMessageId: "m1" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Cross-timeline switch
+// =============================================================================
+
+describe("useDeepLinkResolution → cross-timeline switch", () => {
+  const timelineA: ServerTimeline = {
+    name: "A",
+    description: "Timeline A",
+    root: makeServerSpan({
+      id: "root-a",
+      name: "A",
+      content: [makeServerEvent("evt-1")],
+    }),
+  };
+  const timelineB: ServerTimeline = {
+    name: "B",
+    description: "Timeline B",
+    root: makeServerSpan({
+      id: "root-b",
+      name: "B",
+      content: [makeServerEvent("evt-9")],
+    }),
+  };
+
+  it("switches to the timeline containing the target, once per key", () => {
+    const events = [makeModelEvent("evt-1", 0), makeModelEvent("evt-9", 4)];
+    const { rerender, base, onActiveChange } = renderHarness({
+      events,
+      serverTimelines: [timelineA, timelineB],
+      activeIndex: 0,
+      initialEventId: "evt-9",
+    });
+    expect(onActiveChange).toHaveBeenCalledTimes(1);
+    expect(onActiveChange).toHaveBeenCalledWith(1);
+
+    // The switch lands.
+    rerender({ ...base, activeIndex: 1 });
+    expect(onActiveChange).toHaveBeenCalledTimes(1);
+
+    // Snap-back guard: the user manually switches away while the stale
+    // ?event= param is still in the URL — the consumed key must not
+    // yank them back.
+    rerender({ ...base, activeIndex: 0 });
+    expect(onActiveChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves an unresolved key unconsumed until the target's data arrives", () => {
+    // evt-9 exists in no timeline yet (its event is still streaming in).
+    const events = [makeModelEvent("evt-1", 0)];
+    const { rerender, base, onActiveChange } = renderHarness({
+      events,
+      serverTimelines: [timelineA, timelineB],
+      activeIndex: 0,
+      initialEventId: "evt-9",
+    });
+    expect(onActiveChange).not.toHaveBeenCalled();
+
+    // The event arrives: the same key must still trigger the switch.
+    const eventsLater = [...events, makeModelEvent("evt-9", 4)];
+    rerender({ ...base, events: eventsLater, nodeFeedEvents: eventsLater });
+    expect(onActiveChange).toHaveBeenCalledTimes(1);
+    expect(onActiveChange).toHaveBeenCalledWith(1);
+  });
+});
+
+// =============================================================================
+// Event → row selection side effect
+// =============================================================================
+
+describe("useDeepLinkResolution → event row selection", () => {
+  const events = [makeModelEvent("evt-1", 0), makeModelEvent("evt-2", 4)];
+
+  it("selects the agent row when the target event is not in the node feed", () => {
+    const { result, onSelect } = renderHarness({
+      events,
+      serverTimelines: [makeAgentTimeline()],
+      initialEventId: "evt-2",
+      // Only the root-level event is visible (another row is selected).
+      nodeFeedEvents: [events[0]!],
+    });
+    const agentKey = result.current.spanSelectKeys.get("agent-a")?.key;
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(agentKey, {
+      preserveDeepLink: true,
+    });
+  });
+
+  it("does not select when the target is already visible", () => {
+    const { onSelect } = renderHarness({
+      events,
+      serverTimelines: [makeAgentTimeline()],
+      initialEventId: "evt-2",
+      nodeFeedEvents: events,
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not select when swimlanes are hidden", () => {
+    const { onSelect } = renderHarness({
+      events,
+      serverTimelines: [makeAgentTimeline()],
+      initialEventId: "evt-2",
+      showSwimlanes: false,
+      nodeFeedEvents: [events[0]!],
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.ts
@@ -1,0 +1,247 @@
+/**
+ * View-model hook for transcript deep links (`?event=` / `?message=`).
+ *
+ * Resolves the deep-link target against the timeline and drives the
+ * selection side effects needed to make it visible:
+ * - message ID → event resolution (selected span first, then root/branches)
+ * - cross-timeline switch when the target lives in another root timeline
+ * - swimlane row selection when the target is outside the visible rows
+ *
+ * Each side effect fires once per deep-link key change, guarded by refs —
+ * see the comments on each effect for the races those guards prevent.
+ */
+
+import { useEffect, useMemo, useRef } from "react";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import {
+  findTimelineIndexForEvent,
+  findTimelineIndexForMessage,
+  timelineContainsEvent,
+} from "../findTimelineForDeepLink";
+import {
+  resolveEventInBranches,
+  resolveEventToSpan,
+  resolveMessageInBranches,
+  resolveMessageToEvent,
+} from "../resolveMessageToEvent";
+import { type TranscriptTimelineResult } from "../timeline/hooks";
+import {
+  getSelectedSpans,
+  type SpanSelectKey,
+} from "../timeline/timelineEventNodes";
+
+export interface UseDeepLinkResolutionOptions {
+  /** Deep-link to a specific event. Takes priority over initialMessageId. */
+  initialEventId?: string | null;
+  /** Deep-link to a message ID, resolved to the best matching event. */
+  initialMessageId?: string | null;
+  /** Full timeline pipeline result (rows, selection, timelines, root). */
+  timeline: TranscriptTimelineResult;
+  /** Span ID → swimlane selection key lookup. */
+  spanSelectKeys: ReadonlyMap<string, SpanSelectKey>;
+  /** Whether swimlanes (and therefore row-scoped event lists) are active. */
+  showSwimlanes: boolean;
+  /** The events currently in the node feed (to detect visible targets). */
+  nodeFeedEvents: Event[];
+}
+
+export interface DeepLinkResolution {
+  /** The event to scroll to: the explicit event id, the resolved message
+   *  target, or the branch scroll target. Null when there is none. */
+  effectiveInitialEventId: string | null;
+}
+
+export function useDeepLinkResolution(
+  options: UseDeepLinkResolutionOptions
+): DeepLinkResolution {
+  const {
+    initialEventId,
+    initialMessageId,
+    timeline: {
+      timeline: timelineData,
+      state: timelineState,
+      timelines,
+      activeTimelineIndex,
+      setActiveTimeline,
+      branchScrollTarget,
+    },
+    spanSelectKeys,
+    showSwimlanes,
+    nodeFeedEvents,
+  } = options;
+
+  // ---------------------------------------------------------------------------
+  // Message ID → event resolution
+  // ---------------------------------------------------------------------------
+
+  // Resolve message ID against the selected span first, then fall back to root.
+  const resolvedLocal = useMemo(() => {
+    if (initialEventId || !initialMessageId) return undefined;
+    const selectedSpans = getSelectedSpans(
+      timelineState.rows,
+      timelineState.selected
+    );
+    for (const span of selectedSpans) {
+      const result = resolveMessageToEvent(initialMessageId, span);
+      if (result && !result.agentSpanId) return result;
+    }
+    return undefined;
+  }, [
+    initialEventId,
+    initialMessageId,
+    timelineState.rows,
+    timelineState.selected,
+  ]);
+
+  const resolvedRoot = useMemo(() => {
+    if (initialEventId || !initialMessageId || resolvedLocal) return undefined;
+    // First try the main content tree (existing behavior).
+    const main = resolveMessageToEvent(initialMessageId, timelineData.root);
+    if (main) return main;
+    // Fall back to branches: walk every branch in the tree and return the
+    // first match in swimlane row order (latest fork first).
+    return resolveMessageInBranches(initialMessageId, timelineData.root);
+  }, [initialEventId, initialMessageId, resolvedLocal, timelineData.root]);
+
+  const resolved = resolvedLocal ?? resolvedRoot;
+
+  // Cross-timeline deep links: if the target lives in a different root
+  // timeline, find it so the effect below can switch to it. -1 = no switch.
+  const deepLinkTimelineIndex = useMemo(() => {
+    if (timelines.length <= 1) return -1;
+    if (initialEventId) {
+      const active = timelines[activeTimelineIndex];
+      if (!active || timelineContainsEvent(initialEventId, active)) return -1;
+      return findTimelineIndexForEvent(initialEventId, timelines);
+    }
+    if (initialMessageId && !resolvedLocal && !resolvedRoot) {
+      return findTimelineIndexForMessage(initialMessageId, timelines);
+    }
+    return -1;
+  }, [
+    initialEventId,
+    initialMessageId,
+    resolvedLocal,
+    resolvedRoot,
+    timelines,
+    activeTimelineIndex,
+  ]);
+
+  // Side-effect: switch swimlane selection when resolution comes from root
+  // (i.e. requires moving the user to a different row to see the resolved
+  // event). Calls `timelineState.select` with `{ preserveDeepLink: true }`
+  // so hosts know to keep the URL `?message=` / `?event=` params intact
+  // rather than clearing them as they would for a user row click — the
+  // imperative scroll about to fire still needs the deep-link target.
+  //
+  // Gated on `initialMessageId` actually changing — selection-only changes
+  // (user clicked a swimlane row) cause `resolvedRoot` to recompute against
+  // the still-stale URL message during the intermediate render before URL
+  // clearing is applied; firing the side effect there would override the
+  // user's just-expressed selection intent.
+  const prevMessageIdRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (prevMessageIdRef.current === initialMessageId) return;
+    // A cross-timeline switch is pending: don't consume the message id yet —
+    // this effect must re-evaluate after the switch lands and resolution
+    // re-runs against the new root.
+    if (deepLinkTimelineIndex >= 0) return;
+    prevMessageIdRef.current = initialMessageId;
+    if (!resolvedRoot) return;
+    let targetKey: string | null = null;
+    if (resolvedRoot.branchRowKey) {
+      targetKey = resolvedRoot.branchRowKey;
+    } else if (resolvedRoot.agentSpanId) {
+      targetKey = spanSelectKeys.get(resolvedRoot.agentSpanId)?.key ?? null;
+    }
+    if (timelineState.selected === targetKey) return;
+    timelineState.select(targetKey, { preserveDeepLink: true });
+  }, [
+    initialMessageId,
+    deepLinkTimelineIndex,
+    resolvedRoot,
+    spanSelectKeys,
+    timelineState,
+  ]);
+
+  // Fire the timeline switch once per deep-link change — a stale `?event=` /
+  // `?message=` param left in the URL must not snap the user back after they
+  // manually switch timelines away.
+  //
+  // Mark the key "consumed" only once we've actually switched. While the
+  // target isn't found yet (index -1 — e.g. timeline data still building or
+  // events still streaming), leave it unconsumed so a later data update with
+  // the same key can still trigger the switch. The snap-back guard still
+  // holds: after a switch, the target resolves in the now-active timeline,
+  // so `deepLinkTimelineIndex` drops to -1 and the consumed key blocks any
+  // re-switch even if the user navigates timelines manually.
+  const prevDeepLinkRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (timelines.length <= 1) return;
+    const key = initialEventId ?? initialMessageId ?? null;
+    if (key === null) {
+      prevDeepLinkRef.current = null;
+      return;
+    }
+    if (prevDeepLinkRef.current === key) return;
+    if (deepLinkTimelineIndex < 0) return;
+    prevDeepLinkRef.current = key;
+    if (deepLinkTimelineIndex === activeTimelineIndex) return;
+    setActiveTimeline(deepLinkTimelineIndex);
+  }, [
+    initialEventId,
+    initialMessageId,
+    deepLinkTimelineIndex,
+    activeTimelineIndex,
+    setActiveTimeline,
+    timelines.length,
+  ]);
+
+  // Event deep links targeting a non-visible swimlane lane: with swimlanes
+  // on, the event list only contains the selected rows' events, so a target
+  // in another agent lane (or branch) is unreachable until that row is
+  // selected. The event-id analogue of the message side-effect above.
+  const resolvedEventSpan = useMemo(() => {
+    if (!initialEventId || !showSwimlanes) return undefined;
+    const present = nodeFeedEvents.some(
+      (e) => (e as { uuid?: string | null }).uuid === initialEventId
+    );
+    if (present) return undefined;
+    return (
+      resolveEventToSpan(initialEventId, timelineData.root) ??
+      resolveEventInBranches(initialEventId, timelineData.root)
+    );
+  }, [initialEventId, showSwimlanes, nodeFeedEvents, timelineData.root]);
+
+  const prevEventIdRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (prevEventIdRef.current === initialEventId) return;
+    // A cross-timeline switch is pending: re-evaluate after it lands.
+    if (deepLinkTimelineIndex >= 0) return;
+    prevEventIdRef.current = initialEventId;
+    if (!resolvedEventSpan) return;
+    let targetKey: string | null = null;
+    if (resolvedEventSpan.branchRowKey) {
+      targetKey = resolvedEventSpan.branchRowKey;
+    } else if (resolvedEventSpan.agentSpanId) {
+      targetKey =
+        spanSelectKeys.get(resolvedEventSpan.agentSpanId)?.key ?? null;
+    }
+    if (!targetKey) return;
+    if (timelineState.selected === targetKey) return;
+    timelineState.select(targetKey, { preserveDeepLink: true });
+  }, [
+    initialEventId,
+    deepLinkTimelineIndex,
+    resolvedEventSpan,
+    spanSelectKeys,
+    timelineState,
+  ]);
+
+  const effectiveInitialEventId =
+    initialEventId ?? resolved?.eventId ?? branchScrollTarget ?? null;
+
+  return { effectiveInitialEventId };
+}

--- a/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { eventNode } from "../testHelpers";
+
+import { useOutlineAutoHide } from "./useOutlineAutoHide";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const someNodes = [eventNode({ event: "model" })];
+
+function render(
+  options: Partial<Parameters<typeof useOutlineAutoHide>[0]> = {}
+) {
+  return renderHook(
+    (p: Parameters<typeof useOutlineAutoHide>[0]) => useOutlineAutoHide(p),
+    {
+      initialProps: {
+        eventNodes: someNodes,
+        hasOutline: true,
+        outlineCollapsed: false,
+        ...options,
+      },
+    }
+  );
+}
+
+// =============================================================================
+// useOutlineAutoHide
+// =============================================================================
+
+describe("useOutlineAutoHide", () => {
+  it("is collapsed without an outline", () => {
+    const { result } = render({
+      hasOutline: false,
+      outlineCollapsed: undefined,
+    });
+    expect(result.current.isOutlineCollapsed).toBe(true);
+    expect(result.current.outlineHasNodes).toBe(true);
+  });
+
+  it("honors the user's collapsed preference, falling back to event presence", () => {
+    const { result } = render({ outlineCollapsed: true, eventNodes: [] });
+    expect(result.current.isOutlineCollapsed).toBe(true);
+    // Collapsed outline can't report, so node presence comes from events.
+    expect(result.current.outlineHasNodes).toBe(false);
+  });
+
+  it("auto-hides when the outline reports no displayable nodes", () => {
+    const { result } = render();
+    expect(result.current.isOutlineCollapsed).toBe(false);
+
+    act(() => result.current.onOutlineHasNodesChange(false));
+
+    expect(result.current.isOutlineCollapsed).toBe(true);
+  });
+
+  it("resets to optimistic when the event nodes change", () => {
+    const { result, rerender } = render();
+    act(() => result.current.onOutlineHasNodesChange(false));
+    expect(result.current.isOutlineCollapsed).toBe(true);
+
+    // New agent selection → new node tree: show the outline again and let
+    // it re-report.
+    rerender({
+      eventNodes: [eventNode({ event: "model" })],
+      hasOutline: true,
+      outlineCollapsed: false,
+    });
+    expect(result.current.isOutlineCollapsed).toBe(false);
+    expect(result.current.outlineHasNodes).toBe(true);
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.ts
+++ b/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.ts
@@ -1,0 +1,66 @@
+/**
+ * View-model hook for outline auto-hide.
+ *
+ * Tracks whether the outline component reports displayable nodes. When the
+ * outline is collapsed (unmounted), it can't report, so we optimistically
+ * fall back to eventNodes.length > 0 to keep the toggle enabled.
+ *
+ * Auto-hides the outline when content has no nodes (e.g. utility agent)
+ * without touching the user's persistent preference. When the user navigates
+ * back to an agent with outline content, the preference is still intact.
+ */
+
+import { useCallback, useState } from "react";
+
+import type { EventNode } from "../types";
+
+export interface UseOutlineAutoHideOptions {
+  /** The EventNode tree the outline derives from. */
+  eventNodes: EventNode[];
+  /** Whether the layout has an outline configured at all. */
+  hasOutline: boolean;
+  /** The user's persistent collapsed preference (undefined without outline). */
+  outlineCollapsed: boolean | undefined;
+}
+
+export interface OutlineAutoHide {
+  /** Whether the outline column renders collapsed (preference or auto-hide). */
+  isOutlineCollapsed: boolean;
+  /** Whether the outline has (or is presumed to have) displayable nodes. */
+  outlineHasNodes: boolean;
+  /** Callback for the outline's onHasNodesChange report. */
+  onOutlineHasNodesChange: (hasNodes: boolean) => void;
+}
+
+export function useOutlineAutoHide(
+  options: UseOutlineAutoHideOptions
+): OutlineAutoHide {
+  const { eventNodes, hasOutline, outlineCollapsed } = options;
+
+  const [reportedHasNodes, setReportedHasNodes] = useState(true);
+
+  // Reset to optimistic when eventNodes change (e.g. agent selection changes).
+  // Uses "adjust state during render" pattern to avoid an extra effect cycle.
+  const [prevEventNodes, setPrevEventNodes] = useState(eventNodes);
+  if (prevEventNodes !== eventNodes) {
+    setPrevEventNodes(eventNodes);
+    if (!reportedHasNodes) {
+      setReportedHasNodes(true);
+    }
+  }
+
+  const hasMatchingEvents = eventNodes.length > 0;
+  const autoHidden = hasOutline
+    ? !reportedHasNodes && !outlineCollapsed
+    : false;
+  const isOutlineCollapsed = !hasOutline || !!outlineCollapsed || autoHidden;
+
+  const outlineHasNodes = isOutlineCollapsed
+    ? hasMatchingEvents
+    : reportedHasNodes;
+  const onOutlineHasNodesChange = useCallback((hasNodes: boolean) => {
+    setReportedHasNodes(hasNodes);
+  }, []);
+
+  return { isOutlineCollapsed, outlineHasNodes, onOutlineHasNodesChange };
+}

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -1,73 +1,12 @@
 // @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
-import { useCallback, useState, type PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
 
 import type { Event } from "@tsmono/inspect-common/types";
-import {
-  ComponentStateProvider,
-  type ComponentStateHooks,
-} from "@tsmono/react/state";
+
+import { InMemoryStateWrapper } from "../testHelpers";
 
 import { useTimelinePipeline } from "./useTimelinePipeline";
-
-// =============================================================================
-// Reactive in-memory ComponentStateProvider for testing
-// =============================================================================
-
-function InMemoryStateWrapper({ children }: PropsWithChildren) {
-  const [store, setStore] = useState(
-    () => new Map<string, Map<string, unknown>>()
-  );
-
-  const getPropertyBag = useCallback(
-    (id: string): Map<string, unknown> => {
-      let bag = store.get(id);
-      if (!bag) {
-        bag = new Map();
-        store.set(id, bag);
-      }
-      return bag;
-    },
-    [store]
-  );
-
-  const hooks: ComponentStateHooks = {
-    useValue: (id: string, prop: string, defaultValue?: unknown): unknown => {
-      const bag = getPropertyBag(id);
-      return bag.has(prop) ? bag.get(prop) : defaultValue;
-    },
-    useSetValue: () => (id: string, prop: string, value: unknown) => {
-      getPropertyBag(id).set(prop, value);
-      setStore((prev) => new Map(prev));
-    },
-    useRemoveValue: () => (id: string, prop: string) => {
-      getPropertyBag(id).delete(prop);
-      setStore((prev) => new Map(prev));
-    },
-    useEntries: (id: string): Record<string, unknown> | undefined => {
-      const bag = store.get(id);
-      if (!bag) return undefined;
-      return Object.fromEntries(bag);
-    },
-    useRemoveAll: () => (id: string) => {
-      store.delete(id);
-      setStore((prev) => new Map(prev));
-    },
-    useRemoveByPrefix: () => (id: string, prefix: string) => {
-      const bag = store.get(id);
-      if (!bag) return;
-      for (const key of [...bag.keys()]) {
-        if (key.startsWith(prefix)) bag.delete(key);
-      }
-      setStore((prev) => new Map(prev));
-    },
-  };
-
-  return (
-    <ComponentStateProvider hooks={hooks}>{children}</ComponentStateProvider>
-  );
-}
 
 // =============================================================================
 // Fixtures

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { eventNode } from "../testHelpers";
+import type { TranscriptCollapseState } from "../types";
+
+import { useTranscriptCollapse } from "./useTranscriptCollapse";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeCollapseState(overrides?: Partial<TranscriptCollapseState>) {
+  return {
+    onCollapseTranscript: vi.fn<(nodeId: string, collapsed: boolean) => void>(),
+    onSetTranscriptCollapsed: vi.fn<(ids: Record<string, boolean>) => void>(),
+    ...overrides,
+  };
+}
+
+const defaultCollapsedIds: Record<string, true> = { a: true, b: true };
+
+function render(
+  options: Partial<Parameters<typeof useTranscriptCollapse>[0]> = {}
+) {
+  return renderHook(
+    (p: Parameters<typeof useTranscriptCollapse>[0]) =>
+      useTranscriptCollapse(p),
+    {
+      initialProps: {
+        eventNodes: [],
+        defaultCollapsedIds,
+        eventCount: 1,
+        ...options,
+      },
+    }
+  );
+}
+
+// =============================================================================
+// Individual toggles
+// =============================================================================
+
+describe("useTranscriptCollapse → onCollapseTranscript", () => {
+  it("seeds defaults on the first toggle of an unseeded store", () => {
+    const collapseState = makeCollapseState();
+    const { result } = render({ collapseState });
+
+    result.current.onCollapseTranscript("c", true);
+
+    // One batched set: the defaults plus the toggle, so all other nodes
+    // retain their default collapsed state.
+    expect(collapseState.onSetTranscriptCollapsed).toHaveBeenCalledWith({
+      a: true,
+      b: true,
+      c: true,
+    });
+    expect(collapseState.onCollapseTranscript).not.toHaveBeenCalled();
+  });
+
+  it("passes through once the store is seeded", () => {
+    const collapseState = makeCollapseState({ transcript: { a: true } });
+    const { result } = render({ collapseState });
+
+    result.current.onCollapseTranscript("a", false);
+
+    expect(collapseState.onCollapseTranscript).toHaveBeenCalledWith("a", false);
+    expect(collapseState.onSetTranscriptCollapsed).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Batched expansion
+// =============================================================================
+
+describe("useTranscriptCollapse → onExpandNodes", () => {
+  it("expands in one batched update over the seeded state", () => {
+    const collapseState = makeCollapseState({
+      transcript: { a: true, b: true, c: true },
+    });
+    const { result } = render({ collapseState });
+
+    result.current.onExpandNodes?.(["a", "c"]);
+
+    expect(collapseState.onSetTranscriptCollapsed).toHaveBeenCalledWith({
+      a: false,
+      b: true,
+      c: false,
+    });
+  });
+
+  it("bases expansion on defaults while the store is unseeded", () => {
+    const collapseState = makeCollapseState();
+    const { result } = render({ collapseState });
+
+    result.current.onExpandNodes?.(["a"]);
+
+    expect(collapseState.onSetTranscriptCollapsed).toHaveBeenCalledWith({
+      a: false,
+      b: true,
+    });
+  });
+
+  it("is undefined when the store provides no bulk setter", () => {
+    const { result } = render({
+      collapseState: { onCollapseTranscript: vi.fn() },
+    });
+    expect(result.current.onExpandNodes).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Bulk collapse/expand
+// =============================================================================
+
+describe("useTranscriptCollapse → bulkCollapse", () => {
+  it("bulk-expands by clearing the store", () => {
+    const collapseState = makeCollapseState();
+    render({ collapseState, bulkCollapse: "expand" });
+    expect(collapseState.onSetTranscriptCollapsed).toHaveBeenCalledWith({});
+  });
+
+  it("bulk-collapses every collapsible node", () => {
+    const tool = eventNode({ event: "tool" });
+    const model = eventNode({ event: "model" });
+    const info = eventNode({ event: "info" });
+    const collapseState = makeCollapseState();
+    render({
+      collapseState,
+      bulkCollapse: "collapse",
+      eventNodes: [tool, model, info],
+    });
+    expect(collapseState.onSetTranscriptCollapsed).toHaveBeenCalledWith({
+      [tool.id]: true,
+      [model.id]: true,
+    });
+  });
+
+  it("does nothing without events", () => {
+    const collapseState = makeCollapseState();
+    render({ collapseState, bulkCollapse: "collapse", eventCount: 0 });
+    expect(collapseState.onSetTranscriptCollapsed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.ts
@@ -1,0 +1,101 @@
+/**
+ * View-model hook for transcript collapse state.
+ *
+ * Bridges the app store's collapse callbacks (TranscriptCollapseState) to the
+ * event list: bulk collapse/expand, lazy default seeding on the first
+ * individual toggle, and batched expansion for deep links.
+ */
+
+import { useCallback, useEffect } from "react";
+
+import { collectAllCollapsibleIds } from "../transform/collapse";
+import type { EventNode, TranscriptCollapseState } from "../types";
+
+export interface UseTranscriptCollapseOptions {
+  /** The EventNode tree (source of collapsible ids). */
+  eventNodes: EventNode[];
+  /** Node IDs collapsed by default. */
+  defaultCollapsedIds: Record<string, true>;
+  /** Collapse state and callbacks from the app store. */
+  collapseState?: TranscriptCollapseState;
+  /** Bulk collapse/expand of all collapsible events. Omit for no-op. */
+  bulkCollapse?: "collapse" | "expand";
+  /** Number of events in the sample (bulk collapse is a no-op when 0). */
+  eventCount: number;
+}
+
+export interface TranscriptCollapse {
+  /** Collapse/expand a single node, seeding defaults on the first toggle. */
+  onCollapseTranscript: (nodeId: string, collapsed: boolean) => void;
+  /** Batched expansion for deep links into collapsed regions. Undefined when
+   *  the store provides no bulk setter. */
+  onExpandNodes: ((nodeIds: string[]) => void) | undefined;
+}
+
+export function useTranscriptCollapse(
+  options: UseTranscriptCollapseOptions
+): TranscriptCollapse {
+  const {
+    eventNodes,
+    defaultCollapsedIds,
+    collapseState,
+    bulkCollapse,
+    eventCount,
+  } = options;
+
+  const onSetTranscriptCollapsed = collapseState?.onSetTranscriptCollapsed;
+  useEffect(() => {
+    if (eventCount <= 0 || !bulkCollapse || !onSetTranscriptCollapsed) {
+      return;
+    }
+    if (bulkCollapse === "expand") {
+      onSetTranscriptCollapsed({});
+    } else if (bulkCollapse === "collapse") {
+      const allCollapsibleIds = collectAllCollapsibleIds(eventNodes);
+      onSetTranscriptCollapsed(allCollapsibleIds);
+    }
+  }, [eventNodes, bulkCollapse, onSetTranscriptCollapsed, eventCount]);
+
+  // Lazy-seed: when the user toggles an individual node for the first time
+  // (store scope is empty), seed the store with defaults before applying the
+  // toggle so that all other nodes retain their default collapsed state.
+  const onCollapseTranscriptRaw = collapseState?.onCollapseTranscript;
+  const onCollapseTranscript = useCallback(
+    (nodeId: string, collapsed: boolean) => {
+      if (!onCollapseTranscriptRaw || !onSetTranscriptCollapsed) return;
+      if (!collapseState?.transcript) {
+        // First toggle — seed defaults then apply the toggle
+        onSetTranscriptCollapsed({
+          ...defaultCollapsedIds,
+          [nodeId]: collapsed,
+        });
+      } else {
+        onCollapseTranscriptRaw(nodeId, collapsed);
+      }
+    },
+    [
+      onCollapseTranscriptRaw,
+      onSetTranscriptCollapsed,
+      collapseState?.transcript,
+      defaultCollapsedIds,
+    ]
+  );
+
+  // Bulk-expand for deep links into collapsed regions. One batched update —
+  // sequential onCollapseTranscript calls would each re-seed defaults and
+  // clobber the previous call's expansion while the store is unseeded.
+  const onExpandNodes = useCallback(
+    (nodeIds: string[]) => {
+      if (!onSetTranscriptCollapsed) return;
+      const next = { ...(collapseState?.transcript ?? defaultCollapsedIds) };
+      for (const id of nodeIds) next[id] = false;
+      onSetTranscriptCollapsed(next);
+    },
+    [onSetTranscriptCollapsed, collapseState?.transcript, defaultCollapsedIds]
+  );
+
+  return {
+    onCollapseTranscript,
+    onExpandNodes: onSetTranscriptCollapsed ? onExpandNodes : undefined,
+  };
+}

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -2,7 +2,9 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { EventNode, type EventType } from "../types";
+import { eventNode } from "../testHelpers";
+import { kSandboxSignalName } from "../transform/fixups";
+import { EventNode } from "../types";
 
 import { buildOutlineNodeList, useOutlineNodes } from "./useOutlineNodes";
 
@@ -10,19 +12,8 @@ import { buildOutlineNodeList, useOutlineNodes } from "./useOutlineNodes";
 // Fixtures
 // =============================================================================
 
-let nextId = 0;
-
-function node(
-  event: Partial<EventType> & { event: string },
-  children: EventNode[] = []
-): EventNode {
-  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
-  n.children = children;
-  return n;
-}
-
 function modelNode(): EventNode {
-  return node({
+  return eventNode({
     event: "model",
     timestamp: "2024-01-01T00:00:00Z",
     working_start: 0,
@@ -35,20 +26,55 @@ function modelNode(): EventNode {
 // =============================================================================
 
 describe("buildOutlineNodeList", () => {
-  it("removes non-outline event types", () => {
+  it.each([
+    "logger",
+    "info",
+    "state",
+    "store",
+    "approval",
+    "input",
+    "sandbox",
+  ] as const)("removes %s events", (eventType) => {
     const nodes = [
-      node({ event: "logger" }),
-      node({ event: "info" }),
-      node({ event: "state" }),
-      node({ event: "store" }),
-      node({ event: "error" }),
+      eventNode({ event: eventType }),
+      eventNode({ event: "error" }),
     ];
-    const result = buildOutlineNodeList(nodes, {});
-    expect(result.map((n) => n.event.event)).toEqual(["error"]);
+    expect(buildOutlineNodeList(nodes, {}).map((n) => n.event.event)).toEqual([
+      "error",
+    ]);
+  });
+
+  it("removes step/span nodes named with the sandbox signal", () => {
+    const nodes = [
+      eventNode({ event: "span_begin", name: kSandboxSignalName, type: null }),
+      eventNode({ event: "error" }),
+    ];
+    expect(buildOutlineNodeList(nodes, {}).map((n) => n.event.event)).toEqual([
+      "error",
+    ]);
+  });
+
+  it("removes the children of scorer spans", () => {
+    const scoreChild = eventNode({ event: "score" }, [], 2);
+    const scorer = eventNode(
+      { event: "span_begin", name: "grader", type: "scorer" },
+      [scoreChild],
+      1
+    );
+    const scorers = eventNode(
+      { event: "span_begin", name: "scorers", type: "scorers" },
+      [scorer],
+      0
+    );
+    const result = buildOutlineNodeList([scorers], {});
+    expect(result.map((n) => (n.event as { type?: string }).type)).toEqual([
+      "scorers",
+      "scorer",
+    ]);
   });
 
   it("groups a model/tool run into a collapsed turns row", () => {
-    const nodes = [modelNode(), node({ event: "tool" })];
+    const nodes = [modelNode(), eventNode({ event: "tool" })];
     const result = buildOutlineNodeList(nodes, {});
     expect(result).toHaveLength(1);
     const turns = result[0]!;
@@ -66,9 +92,9 @@ describe("buildOutlineNodeList", () => {
 
   it("collapses consecutive score events into a scoring row", () => {
     const nodes = [
-      node({ event: "score" }),
-      node({ event: "score" }),
-      node({ event: "error" }),
+      eventNode({ event: "score" }),
+      eventNode({ event: "score" }),
+      eventNode({ event: "error" }),
     ];
     const result = buildOutlineNodeList(nodes, {});
     expect(result.map((n) => (n.event as { name?: string }).name)).toEqual([
@@ -78,9 +104,10 @@ describe("buildOutlineNodeList", () => {
   });
 
   it("does not descend into collapsed nodes", () => {
-    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
-      modelNode(),
-    ]);
+    const span = eventNode(
+      { event: "span_begin", name: "agent", type: "agent" },
+      [modelNode()]
+    );
     const expanded = buildOutlineNodeList([span], {});
     expect(expanded.map((n) => (n.event as { type?: string }).type)).toEqual([
       "agent",
@@ -100,9 +127,10 @@ describe("buildOutlineNodeList", () => {
 
 describe("useOutlineNodes", () => {
   it("preserves derived list identities when inputs are unchanged", () => {
-    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
-      modelNode(),
-    ]);
+    const span = eventNode(
+      { event: "span_begin", name: "agent", type: "agent" },
+      [modelNode()]
+    );
     const eventNodes = [span];
     const defaultCollapsedIds = {};
     const { result, rerender } = renderHook(() =>

--- a/packages/inspect-components/src/transcript/testHelpers.tsx
+++ b/packages/inspect-components/src/transcript/testHelpers.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared test utilities for transcript tests.
+ *
+ * Provides an EventNode fixture factory (transform/outline tests) and a
+ * reactive in-memory ComponentStateProvider wrapper for hooks that read
+ * persisted preferences (useTimelineConfig, useTimelinePipeline).
+ */
+
+import { useCallback, useState, type PropsWithChildren } from "react";
+
+import {
+  ComponentStateProvider,
+  type ComponentStateHooks,
+} from "@tsmono/react/state";
+
+import { EventNode, type EventType } from "./types";
+
+// =============================================================================
+// EventNode fixtures
+// =============================================================================
+
+let nextId = 0;
+
+/** Creates an EventNode with a unique id from a partial event fixture. */
+export function eventNode(
+  event: Partial<EventType> & { event: string },
+  children: EventNode[] = [],
+  depth = 0
+): EventNode {
+  const n = new EventNode(`n${nextId++}`, event as EventType, depth);
+  n.children = children;
+  return n;
+}
+
+// =============================================================================
+// Reactive in-memory ComponentStateProvider
+// =============================================================================
+
+/**
+ * Wrapper component with a reactive in-memory store that triggers re-renders
+ * when values change (mirroring real Zustand-backed behaviour).
+ *
+ * State is kept in a `useState` Map so reads during render are lint-safe
+ * (no ref reads during render).
+ */
+export function InMemoryStateWrapper({ children }: PropsWithChildren) {
+  const [store, setStore] = useState(
+    () => new Map<string, Map<string, unknown>>()
+  );
+
+  const getPropertyBag = useCallback(
+    (id: string): Map<string, unknown> => {
+      let bag = store.get(id);
+      if (!bag) {
+        bag = new Map();
+        store.set(id, bag);
+      }
+      return bag;
+    },
+    [store]
+  );
+
+  const hooks: ComponentStateHooks = {
+    useValue: (id: string, prop: string, defaultValue?: unknown): unknown => {
+      const bag = getPropertyBag(id);
+      return bag.has(prop) ? bag.get(prop) : defaultValue;
+    },
+    useSetValue: () => (id: string, prop: string, value: unknown) => {
+      getPropertyBag(id).set(prop, value);
+      setStore((prev) => new Map(prev));
+    },
+    useRemoveValue: () => (id: string, prop: string) => {
+      getPropertyBag(id).delete(prop);
+      setStore((prev) => new Map(prev));
+    },
+    useEntries: (id: string): Record<string, unknown> | undefined => {
+      const bag = store.get(id);
+      if (!bag) return undefined;
+      return Object.fromEntries(bag);
+    },
+    useRemoveAll: () => (id: string) => {
+      store.delete(id);
+      setStore((prev) => new Map(prev));
+    },
+    useRemoveByPrefix: () => (id: string, prefix: string) => {
+      const bag = store.get(id);
+      if (!bag) return;
+      for (const key of [...bag.keys()]) {
+        if (key.startsWith(prefix)) bag.delete(key);
+      }
+      setStore((prev) => new Map(prev));
+    },
+  };
+
+  return (
+    <ComponentStateProvider hooks={hooks}>{children}</ComponentStateProvider>
+  );
+}

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
@@ -1,81 +1,11 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
-import { useCallback, useState, type PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
 
-import {
-  ComponentStateProvider,
-  type ComponentStateHooks,
-} from "@tsmono/react/state";
-
+import { InMemoryStateWrapper } from "../../testHelpers";
 import { defaultMarkerConfig } from "../markers";
 
 import { useTimelineConfig } from "./useTimelineConfig";
-
-// =============================================================================
-// Reactive in-memory ComponentStateProvider for testing
-// =============================================================================
-
-/**
- * Creates a wrapper component with a reactive in-memory store that triggers
- * re-renders when values change (mirroring real Zustand-backed behaviour).
- *
- * State is kept in a `useState` Map so reads during render are lint-safe
- * (no ref reads during render).
- */
-function InMemoryStateWrapper({ children }: PropsWithChildren) {
-  const [store, setStore] = useState(
-    () => new Map<string, Map<string, unknown>>()
-  );
-
-  const getPropertyBag = useCallback(
-    (id: string): Map<string, unknown> => {
-      let bag = store.get(id);
-      if (!bag) {
-        bag = new Map();
-        store.set(id, bag);
-      }
-      return bag;
-    },
-    [store]
-  );
-
-  const hooks: ComponentStateHooks = {
-    useValue: (id: string, prop: string, defaultValue?: unknown): unknown => {
-      const bag = getPropertyBag(id);
-      return bag.has(prop) ? bag.get(prop) : defaultValue;
-    },
-    useSetValue: () => (id: string, prop: string, value: unknown) => {
-      getPropertyBag(id).set(prop, value);
-      setStore((prev) => new Map(prev));
-    },
-    useRemoveValue: () => (id: string, prop: string) => {
-      getPropertyBag(id).delete(prop);
-      setStore((prev) => new Map(prev));
-    },
-    useEntries: (id: string): Record<string, unknown> | undefined => {
-      const bag = store.get(id);
-      if (!bag) return undefined;
-      return Object.fromEntries(bag);
-    },
-    useRemoveAll: () => (id: string) => {
-      store.delete(id);
-      setStore((prev) => new Map(prev));
-    },
-    useRemoveByPrefix: () => (id: string, prefix: string) => {
-      const bag = store.get(id);
-      if (!bag) return;
-      for (const key of [...bag.keys()]) {
-        if (key.startsWith(prefix)) bag.delete(key);
-      }
-      setStore((prev) => new Map(prev));
-    },
-  };
-
-  return (
-    <ComponentStateProvider hooks={hooks}>{children}</ComponentStateProvider>
-  );
-}
 
 // =============================================================================
 // useTimelineConfig hook

--- a/packages/inspect-components/src/transcript/transform/collapse.test.ts
+++ b/packages/inspect-components/src/transcript/transform/collapse.test.ts
@@ -1,70 +1,93 @@
 import { describe, expect, it } from "vitest";
 
-import { EventNode, type EventType } from "../types";
+import { eventNode } from "../testHelpers";
 
 import {
   collectAllCollapsibleIds,
   computeDefaultCollapsedIds,
 } from "./collapse";
-
-// =============================================================================
-// Fixtures
-// =============================================================================
-
-let nextId = 0;
-
-function node(
-  event: Partial<EventType> & { event: string },
-  children: EventNode[] = []
-): EventNode {
-  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
-  n.children = children;
-  return n;
-}
+import { kSandboxSignalName } from "./fixups";
 
 // =============================================================================
 // computeDefaultCollapsedIds
 // =============================================================================
 
 describe("computeDefaultCollapsedIds", () => {
-  it("collapses successful non-agent tool events", () => {
-    const tool = node({ event: "tool", agent: null, failed: null });
-    expect(computeDefaultCollapsedIds([tool])).toEqual({ [tool.id]: true });
-  });
+  it.each([
+    {
+      desc: "successful non-agent tool",
+      event: { event: "tool", agent: null, failed: null },
+      collapsed: true,
+    },
+    {
+      desc: "agent tool",
+      event: { event: "tool", agent: "handoff", failed: null },
+      collapsed: false,
+    },
+    {
+      desc: "failed tool",
+      event: { event: "tool", agent: null, failed: true },
+      collapsed: false,
+    },
+    {
+      desc: "init span",
+      event: { event: "span_begin", name: "init", type: null },
+      collapsed: true,
+    },
+    {
+      desc: "sample_init span",
+      event: { event: "span_begin", name: "sample_init", type: null },
+      collapsed: true,
+    },
+    {
+      desc: "sandbox-signal span",
+      event: { event: "span_begin", name: kSandboxSignalName, type: null },
+      collapsed: true,
+    },
+    {
+      desc: "system_message solver step",
+      event: { event: "step", type: "solver", name: "system_message" },
+      collapsed: true,
+    },
+    {
+      desc: "subtask",
+      event: { event: "subtask" },
+      collapsed: true,
+    },
+    {
+      desc: "model event",
+      event: { event: "model" },
+      collapsed: false,
+    },
+    {
+      desc: "info event",
+      event: { event: "info" },
+      collapsed: false,
+    },
+    {
+      desc: "plain agent span",
+      event: { event: "span_begin", name: "agent", type: "agent" },
+      collapsed: false,
+    },
+  ] as const)(
+    "$desc → collapsed by default: $collapsed",
+    ({ event, collapsed }) => {
+      const node = eventNode(event);
+      expect(computeDefaultCollapsedIds([node])).toEqual(
+        collapsed ? { [node.id]: true } : {}
+      );
+    }
+  );
 
-  it("does not collapse agent or failed tool events", () => {
-    const agentTool = node({ event: "tool", agent: "handoff", failed: null });
-    const failedTool = node({ event: "tool", agent: null, failed: true });
-    expect(computeDefaultCollapsedIds([agentTool, failedTool])).toEqual({});
-  });
-
-  it("collapses init/sample_init spans and system_message solver steps", () => {
-    const init = node({ event: "span_begin", name: "init", type: null });
-    const sysMsg = node({
-      event: "step",
-      type: "solver",
-      name: "system_message",
-    });
-    expect(computeDefaultCollapsedIds([init, sysMsg])).toEqual({
-      [init.id]: true,
-      [sysMsg.id]: true,
-    });
-  });
-
-  it("collapses subtasks and traverses children", () => {
-    const subtask = node({ event: "subtask" });
-    const span = node({ event: "span_begin", name: "agent", type: "agent" }, [
-      subtask,
-    ]);
+  it("traverses children", () => {
+    const subtask = eventNode({ event: "subtask" });
+    const span = eventNode(
+      { event: "span_begin", name: "agent", type: "agent" },
+      [subtask]
+    );
     expect(computeDefaultCollapsedIds([span])).toEqual({
       [subtask.id]: true,
     });
-  });
-
-  it("ignores non-collapsible events", () => {
-    const model = node({ event: "model" });
-    const info = node({ event: "info" });
-    expect(computeDefaultCollapsedIds([model, info])).toEqual({});
   });
 });
 
@@ -74,11 +97,11 @@ describe("computeDefaultCollapsedIds", () => {
 
 describe("collectAllCollapsibleIds", () => {
   it("collects tree-collapsible and content-collapsible nodes recursively", () => {
-    const model = node({ event: "model" });
-    const state = node({ event: "state" });
-    const info = node({ event: "info" });
-    const tool = node({ event: "tool" }, [model]);
-    const span = node({ event: "span_begin", name: "s", type: null }, [
+    const model = eventNode({ event: "model" });
+    const state = eventNode({ event: "state" });
+    const info = eventNode({ event: "info" });
+    const tool = eventNode({ event: "tool" }, [model]);
+    const span = eventNode({ event: "span_begin", name: "s", type: null }, [
       tool,
       state,
       info,

--- a/packages/inspect-components/src/transcript/transform/labels.test.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.test.ts
@@ -39,16 +39,22 @@ describe("scopeMessageLabels", () => {
     expect(scopeMessageLabels([modelEvent([])], undefined)).toBeUndefined();
   });
 
-  it("keeps labels for messages present in the events", () => {
-    const events = [
-      modelEvent([{ id: "m1", role: "user" }], ["m2"]),
-      toolEvent("t1", "m3"),
-    ];
-    const labels = { m1: "A", m2: "B", m3: "C", m4: "D" };
-    expect(scopeMessageLabels(events, labels)).toEqual({
+  it.each([
+    {
+      desc: "model input message",
+      events: [modelEvent([{ id: "m1", role: "user" }])],
+    },
+    {
+      desc: "model output choice",
+      events: [modelEvent([], ["m1"])],
+    },
+    {
+      desc: "tool event message_id",
+      events: [toolEvent("t1", "m1")],
+    },
+  ])("keeps labels for a $desc, drops absent ones", ({ events }) => {
+    expect(scopeMessageLabels(events, { m1: "A", absent: "B" })).toEqual({
       m1: "A",
-      m2: "B",
-      m3: "C",
     });
   });
 

--- a/packages/inspect-components/src/transcript/transform/treeify.test.ts
+++ b/packages/inspect-components/src/transcript/transform/treeify.test.ts
@@ -1,69 +1,73 @@
 import { describe, expect, it } from "vitest";
 
-import { EventNode, type EventType } from "../types";
+import { eventNode } from "../testHelpers";
 
 import { filterEmptySpans } from "./treeify";
-
-// =============================================================================
-// Fixtures
-// =============================================================================
-
-let nextId = 0;
-
-function node(
-  event: Partial<EventType> & { event: string },
-  children: EventNode[] = []
-): EventNode {
-  const n = new EventNode(`n${nextId++}`, event as EventType, 0);
-  n.children = children;
-  return n;
-}
 
 // =============================================================================
 // filterEmptySpans
 // =============================================================================
 
 describe("filterEmptySpans", () => {
-  it("removes childless span and step nodes", () => {
-    const span = node({ event: "span_begin", name: "s", type: null });
-    const step = node({ event: "step", name: "s", type: null });
-    expect(filterEmptySpans([span, step])).toEqual([]);
+  it.each([
+    {
+      desc: "childless span",
+      event: { event: "span_begin", name: "s", type: null },
+      kept: false,
+    },
+    {
+      desc: "childless step",
+      event: { event: "step", name: "s", type: null },
+      kept: false,
+    },
+    {
+      desc: "childless fork_nav span",
+      event: { event: "span_begin", name: "f", type: "fork_nav" },
+      kept: true,
+    },
+    {
+      desc: "childless empty_branch span",
+      event: { event: "span_begin", name: "b", type: "empty_branch" },
+      kept: true,
+    },
+    {
+      desc: "model leaf",
+      event: { event: "model" },
+      kept: true,
+    },
+    {
+      desc: "info leaf",
+      event: { event: "info" },
+      kept: true,
+    },
+  ] as const)("$desc → kept: $kept", ({ event, kept }) => {
+    const node = eventNode(event);
+    expect(filterEmptySpans([node])).toEqual(kept ? [node] : []);
   });
 
-  it("keeps spans with children and leaf events", () => {
-    const model = node({ event: "model" });
-    const span = node({ event: "span_begin", name: "s", type: null }, [model]);
-    const info = node({ event: "info" });
-    expect(filterEmptySpans([span, info])).toEqual([span, info]);
+  it("keeps spans with children", () => {
+    const model = eventNode({ event: "model" });
+    const span = eventNode({ event: "span_begin", name: "s", type: null }, [
+      model,
+    ]);
+    expect(filterEmptySpans([span])).toEqual([span]);
   });
 
   it("removes spans whose only children are empty spans", () => {
-    const inner = node({ event: "span_begin", name: "inner", type: null });
-    const outer = node({ event: "span_begin", name: "outer", type: null }, [
-      inner,
-    ]);
+    const inner = eventNode({ event: "span_begin", name: "inner", type: null });
+    const outer = eventNode(
+      { event: "span_begin", name: "outer", type: null },
+      [inner]
+    );
     expect(filterEmptySpans([outer])).toEqual([]);
   });
 
-  it("keeps childless fork_nav and empty_branch spans", () => {
-    const forkNav = node({
-      event: "span_begin",
-      name: "f",
-      type: "fork_nav",
-    });
-    const emptyBranch = node({
-      event: "span_begin",
-      name: "b",
-      type: "empty_branch",
-    });
-    expect(filterEmptySpans([forkNav, emptyBranch])).toEqual([
-      forkNav,
-      emptyBranch,
-    ]);
-  });
-
   it("keeps childless spans with an attached sourceSpan (agent cards)", () => {
-    const card = node({ event: "span_begin", name: "agent", type: "agent" });
+    const card = eventNode({
+      event: "span_begin",
+      name: "agent",
+      type: "agent",
+    });
     card.sourceSpan = { spanType: "agent", name: "agent" };
     expect(filterEmptySpans([card])).toEqual([card]);
   });


### PR DESCRIPTION
Round 2 of the TranscriptLayout view-model extraction (follows #432). Zero behavior change: every extraction is a verbatim move with identical memo/effect dep arrays and input references. TranscriptLayout is down to ~800 lines (from 1243 before #432); what remains is component-layer concerns (scroll/sticky/wheel wiring, refs, JSX).

- `useDeepLinkResolution` — the ~180-line `?event=`/`?message=` block: message/event resolution memos, cross-timeline switch, and the three ref-guarded selection effects. The hook owns its consumption refs. 11 tests (via a harness composing the real `useTranscriptTimeline`) now cover the previously untestable guard semantics: once-per-key consumption ("a user's row click isn't overridden by the stale URL message"), the snap-back guard after a cross-timeline switch, and unresolved-keys-stay-unconsumed until streaming data arrives.
- `useTranscriptCollapse` — bulk collapse/expand, lazy default seeding on first toggle, batched deep-link expansion. 8 tests including the seed-then-clobber batching semantics.
- `useOutlineAutoHide` — reported-nodes tracking + auto-hide state machine. 4 tests.
- Test-quality pass on the #432 tests: shared `testHelpers.tsx` (`eventNode` fixture factory, `InMemoryStateWrapper` deduplicated out of two test files), policy-matrix `it.each` tables for collapse defaults / empty-span filtering / outline visitor removal / label scoping, plus previously missing coverage (`sample_init`, sandbox-signal spans, `approval`/`input`/`sandbox` outline removal, `noScorerChildren`). Both hook test files lost their JSX in the dedup and are renamed `.tsx` → `.ts`.
