### PR TITLE
Align transcript component props with view-model groups; characterization tests

### DIFF
--- a/apps/inspect/e2e/timeline.spec.ts
+++ b/apps/inspect/e2e/timeline.spec.ts
@@ -263,23 +263,6 @@ test("clicking a swimlane row updates selection", async ({ page, network }) => {
 // Characterization: minimap
 // ---------------------------------------------------------------------------
 
-test("timeline header shows the minimap with a time/token toggle", async ({
-  page,
-  network,
-}) => {
-  await openTranscriptWithTimeline(page, network);
-
-  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
-  await expect(swimlane).toBeVisible();
-
-  // The minimap mode label defaults to "time"; clicking it switches the
-  // labels to token counts.
-  const timeLabel = swimlane.getByText("time", { exact: true });
-  await expect(timeLabel).toBeVisible();
-  await timeLabel.click();
-  await expect(swimlane.getByText("tokens", { exact: true })).toBeVisible();
-});
-
 test("scrubbing the minimap scrolls the event list", async ({
   page,
   network,
@@ -341,85 +324,4 @@ test("scrubbing the minimap scrolls the event list", async ({
   await expect(
     page.getByText("Step 28 of the long transcript").first()
   ).toBeVisible();
-});
-
-// ---------------------------------------------------------------------------
-// Characterization: multi-timeline selector
-// ---------------------------------------------------------------------------
-
-test("multiple timelines render a selector that switches the active timeline", async ({
-  page,
-  network,
-}) => {
-  const events: Events = [
-    createModelEvent({ uuid: "evt-root", startSec: 0, endSec: 5, tokens: 200 }),
-    createModelEvent({
-      uuid: "evt-explore",
-      startSec: 0,
-      endSec: 3,
-      tokens: 200,
-      content: "Exploring the code",
-    }),
-    createModelEvent({
-      uuid: "evt-build",
-      startSec: 6,
-      endSec: 12,
-      tokens: 400,
-      content: "Building the feature",
-    }),
-    createModelEvent({
-      uuid: "evt-audit",
-      startSec: 2,
-      endSec: 8,
-      tokens: 300,
-      content: "Auditing the run",
-    }),
-  ];
-  const auditorTimeline: Timeline = {
-    name: "auditor",
-    description: "Auditor timeline",
-    root: makeServerSpan({
-      id: "audit-root",
-      name: "Auditor",
-      content: [
-        makeServerSpan({
-          id: "audit-agent",
-          name: "Audit",
-          span_type: "agent",
-          content: [makeServerEvent("evt-audit")],
-        }),
-      ],
-    }),
-  };
-  await openTranscriptWithTimeline(page, network, {
-    events,
-    timelines: [
-      createSampleTimeline(["evt-root", "evt-explore", "evt-build"]),
-      auditorTimeline,
-    ],
-  });
-
-  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
-  await expect(swimlane).toBeVisible();
-  await expect(
-    swimlane.getByRole("row").filter({ hasText: "Explore" })
-  ).toBeVisible();
-
-  // The selector shows the active timeline's name and lists both on open.
-  const selector = swimlane.locator('button[aria-haspopup="listbox"]');
-  await expect(selector).toBeVisible();
-  await expect(selector).toContainText("default");
-  await selector.click();
-
-  const option = page.getByRole("option", { name: "auditor" });
-  await expect(option).toBeVisible();
-  await option.click();
-
-  // The swimlane now shows the auditor timeline's rows.
-  await expect(
-    swimlane.getByRole("row").filter({ hasText: "Audit" }).first()
-  ).toBeVisible();
-  await expect(
-    swimlane.getByRole("row").filter({ hasText: "Explore" })
-  ).toBeHidden();
 });

--- a/apps/inspect/e2e/timeline.spec.ts
+++ b/apps/inspect/e2e/timeline.spec.ts
@@ -132,6 +132,8 @@ async function openTranscriptWithTimeline(
   options?: {
     messages?: ChatMessage[];
     sampleId?: number | string;
+    events?: Events;
+    timelines?: Timeline[];
   }
 ) {
   const sampleId = options?.sampleId ?? 1;
@@ -140,7 +142,7 @@ async function openTranscriptWithTimeline(
     { role: "assistant", content: "Hi there", source: "generate" },
   ];
 
-  const events: Events = [
+  const events: Events = options?.events ?? [
     createModelEvent({ uuid: "evt-root", startSec: 0, endSec: 5, tokens: 200 }),
     createModelEvent({
       uuid: "evt-explore",
@@ -160,7 +162,7 @@ async function openTranscriptWithTimeline(
 
   const sample = createEvalSample({ id: sampleId, epoch: 1, messages });
   (sample as { events: Events }).events = events;
-  (sample as { timelines: Timeline[] }).timelines = [
+  (sample as { timelines: Timeline[] }).timelines = options?.timelines ?? [
     createSampleTimeline(["evt-root", "evt-explore", "evt-build"]),
   ];
 
@@ -255,4 +257,169 @@ test("clicking a swimlane row updates selection", async ({ page, network }) => {
 
   // The Explore agent's content should no longer be visible
   await expect(page.getByText("Exploring the code")).not.toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Characterization: minimap
+// ---------------------------------------------------------------------------
+
+test("timeline header shows the minimap with a time/token toggle", async ({
+  page,
+  network,
+}) => {
+  await openTranscriptWithTimeline(page, network);
+
+  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
+  await expect(swimlane).toBeVisible();
+
+  // The minimap mode label defaults to "time"; clicking it switches the
+  // labels to token counts.
+  const timeLabel = swimlane.getByText("time", { exact: true });
+  await expect(timeLabel).toBeVisible();
+  await timeLabel.click();
+  await expect(swimlane.getByText("tokens", { exact: true })).toBeVisible();
+});
+
+test("scrubbing the minimap scrolls the event list", async ({
+  page,
+  network,
+}) => {
+  // Enough events that the list overflows and scrubbing has somewhere to go.
+  const events: Events = Array.from({ length: 30 }, (_, i) =>
+    createModelEvent({
+      uuid: `evt-${i}`,
+      content: `Step ${i} of the long transcript`,
+      startSec: i * 2,
+      endSec: i * 2 + 1,
+      tokens: 100,
+    })
+  );
+  // A child agent span is required for the swimlane section (and thus the
+  // minimap) to render at all.
+  const timeline: Timeline = {
+    name: "default",
+    description: "Long timeline",
+    root: makeServerSpan({
+      id: "root",
+      name: "Transcript",
+      content: [
+        ...events.slice(0, 29).map((e) => makeServerEvent(e.uuid!)),
+        makeServerSpan({
+          id: "deep",
+          name: "Deep",
+          span_type: "agent",
+          content: [makeServerEvent(events[29]!.uuid!)],
+        }),
+      ],
+    }),
+  };
+  await openTranscriptWithTimeline(page, network, {
+    events,
+    timelines: [timeline],
+  });
+
+  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
+  await expect(swimlane).toBeVisible();
+
+  // Early content is on screen, late content is virtualized away.
+  await expect(
+    page.getByText("Step 0 of the long transcript").first()
+  ).toBeVisible();
+  await expect(
+    page.getByText("Step 28 of the long transcript")
+  ).not.toBeVisible();
+
+  // Click near the right edge of the minimap's selection region: onScrub
+  // receives ~1.0 and the main scroller jumps to the end of the list.
+  const region = swimlane.locator('[class*="selectionRegion"]');
+  await expect(region).toBeVisible();
+  const box = (await region.boundingBox())!;
+  await page.mouse.click(box.x + box.width - 2, box.y + box.height / 2);
+
+  // Step 29 lives inside the agent span (it renders as an agent card at
+  // root selection), so the last root-level event is the scroll target.
+  await expect(
+    page.getByText("Step 28 of the long transcript").first()
+  ).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Characterization: multi-timeline selector
+// ---------------------------------------------------------------------------
+
+test("multiple timelines render a selector that switches the active timeline", async ({
+  page,
+  network,
+}) => {
+  const events: Events = [
+    createModelEvent({ uuid: "evt-root", startSec: 0, endSec: 5, tokens: 200 }),
+    createModelEvent({
+      uuid: "evt-explore",
+      startSec: 0,
+      endSec: 3,
+      tokens: 200,
+      content: "Exploring the code",
+    }),
+    createModelEvent({
+      uuid: "evt-build",
+      startSec: 6,
+      endSec: 12,
+      tokens: 400,
+      content: "Building the feature",
+    }),
+    createModelEvent({
+      uuid: "evt-audit",
+      startSec: 2,
+      endSec: 8,
+      tokens: 300,
+      content: "Auditing the run",
+    }),
+  ];
+  const auditorTimeline: Timeline = {
+    name: "auditor",
+    description: "Auditor timeline",
+    root: makeServerSpan({
+      id: "audit-root",
+      name: "Auditor",
+      content: [
+        makeServerSpan({
+          id: "audit-agent",
+          name: "Audit",
+          span_type: "agent",
+          content: [makeServerEvent("evt-audit")],
+        }),
+      ],
+    }),
+  };
+  await openTranscriptWithTimeline(page, network, {
+    events,
+    timelines: [
+      createSampleTimeline(["evt-root", "evt-explore", "evt-build"]),
+      auditorTimeline,
+    ],
+  });
+
+  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
+  await expect(swimlane).toBeVisible();
+  await expect(
+    swimlane.getByRole("row").filter({ hasText: "Explore" })
+  ).toBeVisible();
+
+  // The selector shows the active timeline's name and lists both on open.
+  const selector = swimlane.locator('button[aria-haspopup="listbox"]');
+  await expect(selector).toBeVisible();
+  await expect(selector).toContainText("default");
+  await selector.click();
+
+  const option = page.getByRole("option", { name: "auditor" });
+  await expect(option).toBeVisible();
+  await option.click();
+
+  // The swimlane now shows the auditor timeline's rows.
+  await expect(
+    swimlane.getByRole("row").filter({ hasText: "Audit" }).first()
+  ).toBeVisible();
+  await expect(
+    swimlane.getByRole("row").filter({ hasText: "Explore" })
+  ).toBeHidden();
 });

--- a/apps/inspect/e2e/transcript-events.spec.ts
+++ b/apps/inspect/e2e/transcript-events.spec.ts
@@ -526,31 +526,4 @@ test.describe("outline collapse", () => {
     await phaseRow.locator('[class*="toggle"]').click();
     await expect(turnsRow).toBeVisible();
   });
-
-  test("default-collapsed spans start collapsed (seeded defaults)", async ({
-    page,
-    network,
-  }) => {
-    await openTranscript(page, network, spanEvents());
-
-    const outline = page.locator(".transcript-outline");
-    await expect(outline).toBeVisible();
-
-    // The init span is default-collapsed: chevron points right and its
-    // child content contributes no outline rows. The phase span next to it
-    // keeps its expanded default — collapsing one row must not disturb the
-    // seeded defaults of the others.
-    const initRow = outline
-      .locator('[class*="eventRow"]')
-      .filter({ hasText: "init" });
-    await expect(initRow).toBeVisible();
-    await expect(initRow.locator("i.bi-chevron-right")).toBeVisible();
-
-    const phaseRow = outline
-      .locator('[class*="eventRow"]')
-      .filter({ hasText: "phase one" });
-    await phaseRow.locator('[class*="toggle"]').click();
-    await expect(phaseRow.locator("i.bi-chevron-right")).toBeVisible();
-    await expect(initRow.locator("i.bi-chevron-right")).toBeVisible();
-  });
 });

--- a/apps/inspect/e2e/transcript-events.spec.ts
+++ b/apps/inspect/e2e/transcript-events.spec.ts
@@ -417,3 +417,140 @@ test.describe("transcript event rendering", () => {
     await expect(page.getByText("Second model call").first()).toBeVisible();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Characterization: outline collapse
+// ---------------------------------------------------------------------------
+
+function createSpanBegin(
+  id: string,
+  name: string,
+  type: string | null,
+  timestamp: string
+): Events[number] {
+  return {
+    event: "span_begin",
+    id,
+    name,
+    type,
+    parent_id: null,
+    span_id: null,
+    timestamp,
+    working_start: 0,
+    pending: null,
+    uuid: `span-${id}`,
+    metadata: null,
+  } as unknown as Events[number];
+}
+
+function createSpanEnd(id: string, timestamp: string): Events[number] {
+  return {
+    event: "span_end",
+    id,
+    span_id: null,
+    timestamp,
+    working_start: 0,
+    pending: null,
+    uuid: `span-end-${id}`,
+    metadata: null,
+  } as unknown as Events[number];
+}
+
+function inSpan(event: ModelEvent, spanId: string): Events[number] {
+  return { ...event, span_id: spanId } as unknown as Events[number];
+}
+
+test.describe("outline collapse", () => {
+  // A plain (non-agent) span keeps its children in the outline tree; agent
+  // spans render as childless card rows until their swimlane row is selected.
+  const spanEvents = (): Events => [
+    createSpanBegin("init-1", "init", null, "2025-01-15T09:59:00Z"),
+    inSpan(
+      createModelEvent({
+        uuid: "init-model",
+        content: "Setting things up",
+        startSec: 0,
+        endSec: 1,
+      }),
+      "init-1"
+    ),
+    createSpanEnd("init-1", "2025-01-15T09:59:30Z"),
+    createSpanBegin("phase-1", "phase one", null, "2025-01-15T10:00:00Z"),
+    inSpan(
+      createModelEvent({
+        uuid: "phase-model-1",
+        content: "Research step one",
+        startSec: 2,
+        endSec: 4,
+      }),
+      "phase-1"
+    ),
+    inSpan(
+      createModelEvent({
+        uuid: "phase-model-2",
+        content: "Research step two",
+        startSec: 5,
+        endSec: 7,
+      }),
+      "phase-1"
+    ),
+    createSpanEnd("phase-1", "2025-01-15T10:01:00Z"),
+  ];
+
+  test("span rows collapse and expand via their chevrons", async ({
+    page,
+    network,
+  }) => {
+    await openTranscript(page, network, spanEvents());
+
+    const outline = page.locator(".transcript-outline");
+    await expect(outline).toBeVisible();
+
+    // The phase span row is expanded by default: its grouped turns row shows.
+    const phaseRow = outline
+      .locator('[class*="eventRow"]')
+      .filter({ hasText: "phase one" });
+    await expect(phaseRow).toBeVisible();
+    const turnsRow = outline
+      .locator('[class*="eventRow"]')
+      .filter({ hasText: "2 turns" });
+    await expect(turnsRow).toBeVisible();
+    await expect(phaseRow.locator("i.bi-chevron-down")).toBeVisible();
+
+    // Collapse the phase row: the turns row disappears.
+    await phaseRow.locator('[class*="toggle"]').click();
+    await expect(turnsRow).toBeHidden();
+    await expect(phaseRow.locator("i.bi-chevron-right")).toBeVisible();
+
+    // Expand it again.
+    await phaseRow.locator('[class*="toggle"]').click();
+    await expect(turnsRow).toBeVisible();
+  });
+
+  test("default-collapsed spans start collapsed (seeded defaults)", async ({
+    page,
+    network,
+  }) => {
+    await openTranscript(page, network, spanEvents());
+
+    const outline = page.locator(".transcript-outline");
+    await expect(outline).toBeVisible();
+
+    // The init span is default-collapsed: chevron points right and its
+    // child content contributes no outline rows. The phase span next to it
+    // keeps its expanded default — collapsing one row must not disturb the
+    // seeded defaults of the others.
+    const initRow = outline
+      .locator('[class*="eventRow"]')
+      .filter({ hasText: "init" });
+    await expect(initRow).toBeVisible();
+    await expect(initRow.locator("i.bi-chevron-right")).toBeVisible();
+
+    const phaseRow = outline
+      .locator('[class*="eventRow"]')
+      .filter({ hasText: "phase one" });
+    await phaseRow.locator('[class*="toggle"]').click();
+    await expect(phaseRow.locator("i.bi-chevron-right")).toBeVisible();
+    await expect(initRow.locator("i.bi-chevron-right")).toBeVisible();
+  });
+});

--- a/apps/scout/e2e/timeline.spec.ts
+++ b/apps/scout/e2e/timeline.spec.ts
@@ -11,7 +11,11 @@ import type {
 
 import { expect, test } from "./fixtures/app";
 import {
+  createMessagesEventsResponse,
+  createModelEvent,
+  createTimeline,
   createTimelineScenario,
+  createTimelineSpan,
   createTranscriptInfo,
   createTranscriptsResponse,
 } from "./fixtures/test-data";
@@ -219,4 +223,190 @@ test("transcript without timeline data renders without swimlane rows", async ({
   const rowCount = await swimlane.getByRole("row").count();
   // At most the root row (or 0 if completely hidden)
   expect(rowCount).toBeLessThanOrEqual(1);
+});
+
+// ---------------------------------------------------------------------------
+// Characterization: punch-down view stack
+// ---------------------------------------------------------------------------
+
+// NOTE: punch-down only supports branches reachable through the root span's
+// branch tree whose fork anchor is a direct content event of the parent
+// (`spliceToTimeline`/`ancestorChain` walk `branches`, not `content`) — a
+// branch attached to a nested agent span crashes on punch-down. This
+// scenario therefore attaches the branch (and its anchor) to the root span.
+function createRootBranchScenario(): MessagesEventsResponse {
+  const rootEvt = createModelEvent({
+    uuid: "evt-root-1",
+    startSec: 0,
+    endSec: 2,
+    tokens: 100,
+    content: "Planning the work",
+    spanId: "transcript",
+  });
+  const evt1 = createModelEvent({
+    uuid: "evt-explore-1",
+    startSec: 2,
+    endSec: 5,
+    tokens: 200,
+    content: "Exploring the codebase",
+    spanId: "explore",
+  });
+  const evt2 = createModelEvent({
+    uuid: "evt-build-1",
+    startSec: 8,
+    endSec: 14,
+    tokens: 400,
+    content: "Building the feature",
+    spanId: "build",
+  });
+  // splice() cuts the parent's stream at the AnchorEvent matching the
+  // branch's branched_from — the fork point must be an anchor event in the
+  // parent's direct content.
+  const anchorEvt = {
+    event: "anchor",
+    anchor_id: "fork-1",
+    uuid: "evt-anchor-1",
+    timestamp: "2025-01-15T10:00:06Z",
+    working_start: 6,
+    span_id: "transcript",
+    metadata: null,
+    pending: null,
+    source: null,
+  } as unknown as MessagesEventsResponse["events"][number];
+  const branchEvt = createModelEvent({
+    uuid: "evt-branch-1",
+    startSec: 10,
+    endSec: 12,
+    tokens: 150,
+    content: "Branch attempt",
+    spanId: "branch-1",
+  });
+  // The branch carries an agent span in its event stream so the spliced
+  // standalone timeline has swimlane structure (otherwise the header — and
+  // with it the back button — would not render).
+  type ScoutEvent = MessagesEventsResponse["events"][number];
+  const branchSpanBegin = {
+    event: "span_begin",
+    id: "retry",
+    name: "Retry",
+    type: "agent",
+    parent_id: null,
+    span_id: "branch-1",
+    uuid: "evt-sb-retry",
+    timestamp: "2025-01-15T10:00:11Z",
+    working_start: 11,
+    metadata: null,
+    pending: null,
+  } as unknown as ScoutEvent;
+  const branchInnerEvt = {
+    ...createModelEvent({
+      uuid: "evt-retry-1",
+      startSec: 11,
+      endSec: 12,
+      tokens: 100,
+      content: "Retrying the approach",
+      spanId: "retry",
+    }),
+  } as unknown as ScoutEvent;
+  const branchSpanEnd = {
+    event: "span_end",
+    id: "retry",
+    span_id: "branch-1",
+    uuid: "evt-se-retry",
+    timestamp: "2025-01-15T10:00:12Z",
+    working_start: 12,
+    metadata: null,
+    pending: null,
+  } as unknown as ScoutEvent;
+
+  const rootSpan = createTimelineSpan({
+    id: "transcript",
+    name: "Transcript",
+    span_type: "agent",
+    content: [
+      { type: "event", event: "evt-root-1" },
+      { type: "event", event: "evt-anchor-1" },
+      createTimelineSpan({
+        id: "explore",
+        name: "Explore",
+        span_type: "agent",
+        content: [{ type: "event", event: "evt-explore-1" }],
+      }),
+      createTimelineSpan({
+        id: "build",
+        name: "Build",
+        span_type: "agent",
+        content: [{ type: "event", event: "evt-build-1" }],
+      }),
+    ],
+    branches: [
+      createTimelineSpan({
+        id: "branch-1",
+        name: "branch",
+        span_type: "branch",
+        branched_from: "fork-1",
+        content: [
+          { type: "event", event: "evt-branch-1" },
+          { type: "event", event: "evt-sb-retry" },
+          { type: "event", event: "evt-retry-1" },
+          { type: "event", event: "evt-se-retry" },
+        ],
+      }),
+    ],
+  });
+
+  return createMessagesEventsResponse({
+    messages: [{ role: "user", content: "Help me refactor this code" }],
+    events: [
+      rootEvt,
+      anchorEvt,
+      evt1,
+      evt2,
+      branchEvt,
+      branchSpanBegin,
+      branchInnerEvt,
+      branchSpanEnd,
+    ],
+    timelines: [createTimeline(rootSpan)],
+  });
+}
+
+test("punch-down opens a branch as a standalone timeline and back returns", async ({
+  page,
+  network,
+}) => {
+  setupTranscriptWithTimeline(network, createRootBranchScenario());
+  await page.goto(transcriptUrl());
+
+  const swimlane = page.getByRole("grid", { name: "Timeline swimlane" });
+  await expect(swimlane).toBeVisible();
+
+  // Reveal the branch row via the root row's branch marker.
+  const branchMarker = swimlane
+    .getByRole("button", { name: "Toggle branches" })
+    .first();
+  await branchMarker.click();
+  const branchRow = swimlane.getByRole("row").filter({ hasText: "Branch 1" });
+  await expect(branchRow).toBeVisible();
+
+  // Punch down into the branch (button appears on row hover).
+  await branchRow.hover();
+  await branchRow
+    .locator('button[title="Open as standalone timeline"]')
+    .click();
+
+  // Standalone view: the back button shows and the sibling agent rows are
+  // replaced by the branch's own view.
+  const backButton = page.locator('button[title="Back to branch overview"]');
+  await expect(backButton).toBeVisible();
+  await expect(
+    swimlane.getByRole("row").filter({ hasText: "Explore" })
+  ).toBeHidden();
+
+  // Pop back to the full timeline.
+  await backButton.click();
+  await expect(backButton).toBeHidden();
+  await expect(
+    swimlane.getByRole("row").filter({ hasText: "Explore" })
+  ).toBeVisible();
 });

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -42,6 +42,7 @@ import { useEventNodeData } from "./hooks/useEventNodeData";
 import { useListPositionManager } from "./hooks/useListPositionManager";
 import { useOutlineAutoHide } from "./hooks/useOutlineAutoHide";
 import { useSelectionActions } from "./hooks/useSelectionActions";
+import { useSidebarScrollCoupling } from "./hooks/useSidebarScrollCoupling";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
 import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
 import { useTranscriptCollapse } from "./hooks/useTranscriptCollapse";
@@ -425,109 +426,30 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     [onHeadroomResetAnchor]
   );
 
-  // When a sidebar toggles, the layout reflows but no scroll/resize event
-  // fires — so sticky-state observers (useStickyObserver, StickyScroll)
-  // keep stale state. Dispatch a synthetic scroll event after the DOM has
-  // settled to force them to re-measure.
+  // The rail panel pins directly below the toolbar (offsetTop), alongside
+  // the timeline; the outline pins below the swimlanes (effectiveOffsetTop).
+  // Each needs its own sticky-detection threshold. The remount keys re-attach
+  // listeners when collapse state changes (the scroll elements may have
+  // unmounted/remounted via the conditional render).
   const outlineCollapsedFlag = outline?.collapsed ?? null;
   const railPanelOpenFlag = rightRail?.panel != null;
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const timer = setTimeout(() => {
-      el.dispatchEvent(new Event("scroll"));
-    }, 0);
-    return () => clearTimeout(timer);
-  }, [outlineCollapsedFlag, railPanelOpenFlag, scrollRef]);
-
-  // Forward wheel events from the sidebars to the main scroll container
-  // only while the header above the tabs is still visible. Once the sidebar
-  // is stuck at its sticky top (header fully out), wheel events stop chaining
-  // so the main transcript doesn't scroll along with the sidebar.
-  const effectiveOffsetTopRef = useRef(effectiveOffsetTop);
-  useEffect(() => {
-    effectiveOffsetTopRef.current = effectiveOffsetTop;
-  }, [effectiveOffsetTop]);
-  const offsetTopRef = useRef(offsetTop);
-  useEffect(() => {
-    offsetTopRef.current = offsetTop;
-  }, [offsetTop]);
-
-  useEffect(() => {
-    const main = scrollRef.current;
-    const outlineEl = outlineScrollRef?.current ?? null;
-    const railPanelEl = rightRailPanelScrollRef?.current ?? null;
-    if (!main) return;
-
-    const makeHandler =
-      (sidebar: HTMLDivElement, stickyTopRef: { current: number }) =>
-      (e: WheelEvent) => {
-        const mainMaxTop = main.scrollHeight - main.clientHeight;
-        // Is the sidebar currently stuck at its sticky top? If so, the header
-        // above the tabs has already scrolled off — don't chain further main
-        // scrolling or the transcript itself would move with the sidebar.
-        const mainRect = main.getBoundingClientRect();
-        const sidebarRect = sidebar.getBoundingClientRect();
-        const sidebarTopInScroller = sidebarRect.top - mainRect.top;
-        const sidebarIsSticky =
-          sidebarTopInScroller <= stickyTopRef.current + 1;
-
-        if (!sidebarIsSticky) {
-          // Header still visible — forward all wheel input to the main
-          // scroller so that the header collapses/expands. Suppress the
-          // sidebar's default scroll for this step.
-          const canMain =
-            (e.deltaY > 0 && main.scrollTop < mainMaxTop - 0.5) ||
-            (e.deltaY < 0 && main.scrollTop > 0.5);
-          if (canMain) {
-            e.preventDefault();
-            main.scrollBy({ top: e.deltaY, behavior: "auto" });
-          }
-        } else if (
-          e.deltaY < 0 &&
-          sidebar.scrollTop <= 0 &&
-          main.scrollTop > 0
-        ) {
-          // Sidebar is sticky and already at its own top — wheeling up should
-          // bring the header back, so forward to main.
-          e.preventDefault();
-          main.scrollBy({ top: e.deltaY, behavior: "auto" });
-        }
-        // Otherwise let the sidebar's native wheel scroll proceed.
-      };
-
-    // The rail panel pins directly below the toolbar (offsetTop), alongside
-    // the timeline; the outline pins below the swimlanes (effectiveOffsetTop).
-    // Each needs its own sticky-detection threshold.
-    const targets: {
-      el: HTMLDivElement;
-      stickyTopRef: { current: number };
-    }[] = [];
-    if (outlineEl)
-      targets.push({ el: outlineEl, stickyTopRef: effectiveOffsetTopRef });
-    if (railPanelEl)
-      targets.push({ el: railPanelEl, stickyTopRef: offsetTopRef });
-
-    const entries = targets.map(({ el, stickyTopRef }) => {
-      const handler = makeHandler(el, stickyTopRef);
-      // passive: false so we can preventDefault when taking over the scroll.
-      el.addEventListener("wheel", handler, { passive: false });
-      return { el, handler };
-    });
-    return () => {
-      for (const { el, handler } of entries) {
-        el.removeEventListener("wheel", handler);
-      }
-    };
-  }, [
-    scrollRef,
-    outlineScrollRef,
-    rightRailPanelScrollRef,
-    // Re-attach when collapse state changes (the scroll elements may have
-    // unmounted/remounted via the conditional render).
-    outlineCollapsedFlag,
-    railPanelOpenFlag,
-  ]);
+  const sidebarTargets = useMemo(
+    () => [
+      { scrollRef: outlineScrollRef, remountKey: outlineCollapsedFlag },
+      { scrollRef: rightRailPanelScrollRef, remountKey: railPanelOpenFlag },
+    ],
+    [
+      outlineScrollRef,
+      rightRailPanelScrollRef,
+      outlineCollapsedFlag,
+      railPanelOpenFlag,
+    ]
+  );
+  useSidebarScrollCoupling({
+    mainScrollRef: scrollRef,
+    sidebars: sidebarTargets,
+    stickyTops: [effectiveOffsetTop, offsetTop],
+  });
 
   // Capture the outline's own scroll container (the StickyScroll div, which
   // has overflow-y:auto) into state so the outline's Virtuoso can use it as

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -251,16 +251,11 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   });
 
   const {
-    timeline: timelineData,
     state: timelineState,
     swimlanes: { layouts: timelineLayouts, regionCounts, highlightedKeys },
-    minimap: { mapping: rootTimeMapping, selection: minimapSelection },
-    multiTimeline: {
-      timelines,
-      activeIndex: activeTimelineIndex,
-      setActive: setActiveTimeline,
-    },
-    views: { stack: viewStack, push: pushView, pop: popView },
+    minimap,
+    multiTimeline,
+    views,
     selection: { rowName: selectedRowName },
   } = transcriptTimeline;
 
@@ -343,50 +338,23 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
 
   const swimlaneHeader = useMemo(
     () => ({
-      rootLabel: timelineData.root.name,
       onScrollToTop,
-      minimap: {
-        root: timelineData.root,
-        selection: minimapSelection,
-        mapping: rootTimeMapping,
-        scrubberProgress,
-        onScrub: handleScrub,
-      },
+      minimap,
+      scrubberProgress,
+      onScrub: handleScrub,
       timelineConfig,
-      timelineSelector:
-        timelines.length > 1
-          ? {
-              timelines,
-              activeIndex: activeTimelineIndex,
-              onSelect: setActiveTimeline,
-            }
-          : undefined,
-      viewStack,
-      onPopView: popView,
+      multiTimeline,
+      views,
     }),
     [
-      timelineData.root,
       onScrollToTop,
-      minimapSelection,
-      rootTimeMapping,
+      minimap,
       scrubberProgress,
       handleScrub,
       timelineConfig,
-      timelines,
-      activeTimelineIndex,
-      setActiveTimeline,
-      viewStack,
-      popView,
+      multiTimeline,
+      views,
     ]
-  );
-
-  const handlePunchDown = useCallback(
-    (rowKey: string, label: string) => {
-      const row = timelineState.rows.find((r) => r.key === rowKey);
-      const span = row?.spans[0];
-      if (span && "agent" in span) pushView(span.agent, label);
-    },
-    [timelineState.rows, pushView]
   );
 
   // ---------------------------------------------------------------------------
@@ -470,6 +438,18 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
       hasOutline: !!outline,
       outlineCollapsed: outline?.collapsed,
     });
+
+  const outlineCollapse = useMemo(
+    () =>
+      collapseState
+        ? {
+            collapsed: collapseState.outline,
+            onCollapse: collapseState.onCollapseOutline,
+            onSetCollapsed: collapseState.onSetOutlineCollapsed,
+          }
+        : undefined,
+    [collapseState]
+  );
 
   const hasMatchingEvents = eventNodes.length > 0;
 
@@ -651,7 +631,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                     defaultCollapsed={swimlanesDefaultCollapsed}
                     regionCounts={regionCounts}
                     highlightedKeys={highlightedKeys}
-                    onPunchDown={handlePunchDown}
+                    onPunchDown={views.pushByRowKey}
                   />
                 </div>
               </StickyScroll>
@@ -717,17 +697,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                             (showSwimlanes ? selectedRowName : undefined)
                           }
                           scrollTrackOffset={effectiveOffsetTop}
-                          getCollapsed={
-                            collapseState?.outline
-                              ? (nodeId: string) =>
-                                  collapseState.outline?.[nodeId] === true
-                              : undefined
-                          }
-                          setCollapsed={collapseState?.onCollapseOutline}
-                          collapsedEvents={collapseState?.outline}
-                          setCollapsedEvents={
-                            collapseState?.onSetOutlineCollapsed
-                          }
+                          collapse={outlineCollapse}
                           selectedOutlineId={outline.selectedId}
                           setSelectedOutlineId={outline.setSelectedId}
                           getEventUrl={getEventUrl}

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -431,24 +431,20 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   // Each needs its own sticky-detection threshold. The remount keys re-attach
   // listeners when collapse state changes (the scroll elements may have
   // unmounted/remounted via the conditional render).
-  const outlineCollapsedFlag = outline?.collapsed ?? null;
-  const railPanelOpenFlag = rightRail?.panel != null;
-  const sidebarTargets = useMemo(
-    () => [
-      { scrollRef: outlineScrollRef, remountKey: outlineCollapsedFlag },
-      { scrollRef: rightRailPanelScrollRef, remountKey: railPanelOpenFlag },
-    ],
-    [
-      outlineScrollRef,
-      rightRailPanelScrollRef,
-      outlineCollapsedFlag,
-      railPanelOpenFlag,
-    ]
-  );
   useSidebarScrollCoupling({
     mainScrollRef: scrollRef,
-    sidebars: sidebarTargets,
-    stickyTops: [effectiveOffsetTop, offsetTop],
+    sidebars: [
+      {
+        scrollRef: outlineScrollRef,
+        stickyTop: effectiveOffsetTop,
+        remountKey: outline?.collapsed ?? null,
+      },
+      {
+        scrollRef: rightRailPanelScrollRef,
+        stickyTop: offsetTop,
+        remountKey: rightRail?.panel != null,
+      },
+    ],
   });
 
   // Capture the outline's own scroll container (the StickyScroll div, which

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -41,6 +41,7 @@ import { useDeepLinkResolution } from "./hooks/useDeepLinkResolution";
 import { useEventNodeData } from "./hooks/useEventNodeData";
 import { useListPositionManager } from "./hooks/useListPositionManager";
 import { useOutlineAutoHide } from "./hooks/useOutlineAutoHide";
+import { useSelectionActions } from "./hooks/useSelectionActions";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
 import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
 import { useTranscriptCollapse } from "./hooks/useTranscriptCollapse";
@@ -54,7 +55,6 @@ import {
   type UseTimelineProps,
 } from "./timeline/hooks";
 import { type MarkerConfig } from "./timeline/markers";
-import { buildSpanSelectKeys } from "./timeline/timelineEventNodes";
 import {
   TimelineRowSelectContext,
   TimelineSelectContext,
@@ -292,29 +292,17 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   const effectiveOffsetTop = offsetTop + stickySwimLaneHeight;
 
   // ---------------------------------------------------------------------------
-  // Per-agent list position management
+  // Selection actions + per-agent list position management
   // ---------------------------------------------------------------------------
 
-  // Suppress the scroll-to-top on selection change when an active deep-link
-  // target is in URL. The URL-driven case is sync (the URL update lands
-  // before the row-click effects fire, so a top reset would clobber the
-  // about-to-fire imperative scroll). For pure swimlane row clicks (URL
-  // bare, only `branchScrollTarget` set), keeping the top reset is
-  // desirable — it clears the previous branch's deep scroll position
-  // before the imperative scroll lands on the new branch separator.
-  // The imperative scroll runs in rAF and re-scrolls to its target after
-  // the sync top reset.
-  // Scroll-anchor for inline fork-navigator clicks: the prefix above the
-  // clicked navigator is unchanged across the selection, so capturing and
-  // restoring scrollTop keeps the navigator at the same viewport position.
-  const [scrollAnchor, setScrollAnchor] = useState<{
-    scrollTop: number;
-  } | null>(null);
-  const hasScrollTarget = !!(
-    initialEventId ||
-    initialMessageId ||
-    scrollAnchor
-  );
+  const { spanSelectKeys, selectBySpanId, selectByRowKey, hasScrollTarget } =
+    useSelectionActions({
+      timelineState,
+      scrollRef,
+      initialEventId,
+      initialMessageId,
+    });
+
   const { effectiveListId } = useListPositionManager(
     listId,
     timelineState.selected,
@@ -358,34 +346,6 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   );
 
   // ---------------------------------------------------------------------------
-  // Span selection context (agent card clicks → swimlane selection)
-  // ---------------------------------------------------------------------------
-
-  const spanSelectKeys = useMemo(
-    () => buildSpanSelectKeys(timelineState.rows),
-    [timelineState.rows]
-  );
-
-  const selectBySpanId = useCallback(
-    (spanId: string) => {
-      const key = spanSelectKeys.get(spanId);
-      if (!key) return;
-      timelineState.select(key.key);
-    },
-    [spanSelectKeys, timelineState]
-  );
-
-  const selectByRowKey = useCallback(
-    (rowKey: string, anchorEl?: HTMLElement) => {
-      if (anchorEl && scrollRef.current) {
-        setScrollAnchor({ scrollTop: scrollRef.current.scrollTop });
-      }
-      timelineState.select(rowKey, { preserveScroll: true });
-    },
-    [timelineState, scrollRef]
-  );
-
-  // ---------------------------------------------------------------------------
   // Deep-link resolution
   // ---------------------------------------------------------------------------
 
@@ -397,16 +357,6 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     showSwimlanes,
     nodeFeedEvents: nodeFeed.events,
   });
-
-  // Branch selections share one effectiveListId (no remount), so the prefix
-  // above the clicked navigator is laid out identically — restoring scrollTop
-  // keeps it at the same viewport position.
-  useEffect(() => {
-    if (!scrollAnchor) return;
-    requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo({ top: scrollAnchor.scrollTop });
-    });
-  }, [scrollAnchor, scrollRef]);
 
   // Suppress headroom (swimlane collapse/expand) during programmatic scrolls
   // — fires for any change to the effective scroll target (URL `?event=`,

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.ts
@@ -5,10 +5,10 @@
 
 import { useMemo } from "react";
 
-import { useEventNodes } from "../timeline/hooks";
 import { buildToolLabels, scopeMessageLabels } from "../transform/labels";
 import type { EventNode, EventNodeContext } from "../types";
 
+import { useEventNodes } from "./useEventNodes";
 import type { EventNodeFeed } from "./useTimelinePipeline";
 
 export interface EventNodeData {

--- a/packages/inspect-components/src/transcript/hooks/useEventNodes.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodes.ts
@@ -9,14 +9,14 @@ import { useMemo } from "react";
 
 import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
 
-import { computeDefaultCollapsedIds } from "../../transform/collapse";
-import { fixupEventStream } from "../../transform/fixups";
-import { filterEmptySpans, treeifyEvents } from "../../transform/treeify";
-import { EventNode } from "../../types";
-import type { TimelineSpan } from "../core";
-import { groupRetryAttempts } from "../retryGrouping";
-import { correctRetryTimestamps } from "../retryOrdering";
-import { attachSourceSpans } from "../timelineEventNodes";
+import type { TimelineSpan } from "../timeline/core";
+import { groupRetryAttempts } from "../timeline/retryGrouping";
+import { correctRetryTimestamps } from "../timeline/retryOrdering";
+import { attachSourceSpans } from "../timeline/timelineEventNodes";
+import { computeDefaultCollapsedIds } from "../transform/collapse";
+import { fixupEventStream } from "../transform/fixups";
+import { filterEmptySpans, treeifyEvents } from "../transform/treeify";
+import { EventNode } from "../types";
 
 export const useEventNodes = (
   events: Event[],

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TimelineState } from "../timeline/hooks";
+import type { SwimlaneRow } from "../timeline/swimlaneRows";
+
+import { useSelectionActions } from "./useSelectionActions";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/** Minimal single-agent-span swimlane row (the shape buildSpanSelectKeys reads). */
+function agentRow(key: string, spanId: string): SwimlaneRow {
+  return {
+    key,
+    name: spanId,
+    depth: 1,
+    branch: false,
+    spans: [{ agent: { id: spanId } }],
+  } as unknown as SwimlaneRow;
+}
+
+function makeTimelineState(rows: SwimlaneRow[]) {
+  const select = vi.fn<TimelineState["select"]>();
+  const state = { rows, selected: null, select } as unknown as TimelineState;
+  return { state, select };
+}
+
+function makeScrollRef(scrollTop = 0) {
+  const scrollTo = vi.fn<(opts: { top: number }) => void>();
+  const ref = {
+    current: { scrollTop, scrollTo },
+  } as unknown as RefObject<HTMLDivElement>;
+  return { ref, scrollTo };
+}
+
+// =============================================================================
+// useSelectionActions
+// =============================================================================
+
+describe("useSelectionActions", () => {
+  let rafQueue: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    rafQueue = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback): number => {
+        rafQueue.push(callback);
+        return rafQueue.length;
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const flushFrames = () => {
+    const callbacks = rafQueue;
+    rafQueue = [];
+    for (const callback of callbacks) callback(performance.now());
+  };
+
+  it("selects the row rendering a span (agent card clicks)", () => {
+    const { state, select } = makeTimelineState([agentRow("root/a", "span-a")]);
+    const { ref } = makeScrollRef();
+    const { result } = renderHook(() =>
+      useSelectionActions({ timelineState: state, scrollRef: ref })
+    );
+
+    result.current.selectBySpanId("span-a");
+    expect(select).toHaveBeenCalledWith("root/a");
+
+    select.mockClear();
+    result.current.selectBySpanId("unknown");
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("selects by row key preserving scroll, without an anchor", () => {
+    const { state, select } = makeTimelineState([]);
+    const { ref } = makeScrollRef();
+    const { result } = renderHook(() =>
+      useSelectionActions({ timelineState: state, scrollRef: ref })
+    );
+
+    result.current.selectByRowKey("root/b");
+    expect(select).toHaveBeenCalledWith("root/b", { preserveScroll: true });
+    expect(result.current.hasScrollTarget).toBe(false);
+  });
+
+  it("anchors and restores the scroll position for navigator clicks", () => {
+    const { state } = makeTimelineState([]);
+    const { ref, scrollTo } = makeScrollRef(123);
+    const { result } = renderHook(() =>
+      useSelectionActions({ timelineState: state, scrollRef: ref })
+    );
+
+    act(() =>
+      result.current.selectByRowKey("root/b", document.createElement("div"))
+    );
+    expect(result.current.hasScrollTarget).toBe(true);
+
+    // The restore runs in rAF after the selection lands.
+    flushFrames();
+    expect(scrollTo).toHaveBeenCalledWith({ top: 123 });
+  });
+
+  it("reports a pending scroll target for deep links", () => {
+    const { state } = makeTimelineState([]);
+    const { ref } = makeScrollRef();
+    const { result } = renderHook(() =>
+      useSelectionActions({
+        timelineState: state,
+        scrollRef: ref,
+        initialMessageId: "m1",
+      })
+    );
+    expect(result.current.hasScrollTarget).toBe(true);
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
@@ -1,0 +1,105 @@
+/**
+ * View-model hook for user-driven swimlane selection: agent-card clicks
+ * (span id → row key) and inline fork-navigator clicks (which preserve the
+ * clicked element's viewport position via a scroll anchor), plus the
+ * pending-scroll-target signal that suppresses scroll-to-top on selection
+ * change.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type RefObject,
+} from "react";
+
+import { type TimelineState } from "../timeline/hooks";
+import {
+  buildSpanSelectKeys,
+  type SpanSelectKey,
+} from "../timeline/timelineEventNodes";
+
+export interface UseSelectionActionsOptions {
+  /** Timeline selection state (rows + select). */
+  timelineState: TimelineState;
+  /** The transcript's scroll container. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Deep-link props (a pending deep link is a pending scroll target). */
+  initialEventId?: string | null;
+  initialMessageId?: string | null;
+}
+
+export interface SelectionActions {
+  /** Span ID → swimlane selection key lookup (also feeds deep-link resolution). */
+  spanSelectKeys: ReadonlyMap<string, SpanSelectKey>;
+  /** Select the swimlane row rendering `spanId` (agent card clicks). */
+  selectBySpanId: (spanId: string) => void;
+  /** Select a row by key. With an anchor element (inline fork-navigator
+   *  clicks), the current scroll position is captured and restored after the
+   *  selection lands. */
+  selectByRowKey: (rowKey: string, anchorEl?: HTMLElement) => void;
+  /** True while a deep link or scroll anchor is pending. Suppresses the
+   *  scroll-to-top on selection change: the URL-driven case is sync (the URL
+   *  update lands before the row-click effects fire, so a top reset would
+   *  clobber the about-to-fire imperative scroll). For pure swimlane row
+   *  clicks the top reset is desirable — it clears the previous branch's
+   *  deep scroll position before the imperative scroll lands. */
+  hasScrollTarget: boolean;
+}
+
+export function useSelectionActions(
+  options: UseSelectionActionsOptions
+): SelectionActions {
+  const { timelineState, scrollRef, initialEventId, initialMessageId } =
+    options;
+
+  // Scroll-anchor for inline fork-navigator clicks: the prefix above the
+  // clicked navigator is unchanged across the selection, so capturing and
+  // restoring scrollTop keeps the navigator at the same viewport position.
+  const [scrollAnchor, setScrollAnchor] = useState<{
+    scrollTop: number;
+  } | null>(null);
+
+  const hasScrollTarget = !!(
+    initialEventId ||
+    initialMessageId ||
+    scrollAnchor
+  );
+
+  const spanSelectKeys = useMemo(
+    () => buildSpanSelectKeys(timelineState.rows),
+    [timelineState.rows]
+  );
+
+  const selectBySpanId = useCallback(
+    (spanId: string) => {
+      const key = spanSelectKeys.get(spanId);
+      if (!key) return;
+      timelineState.select(key.key);
+    },
+    [spanSelectKeys, timelineState]
+  );
+
+  const selectByRowKey = useCallback(
+    (rowKey: string, anchorEl?: HTMLElement) => {
+      if (anchorEl && scrollRef.current) {
+        setScrollAnchor({ scrollTop: scrollRef.current.scrollTop });
+      }
+      timelineState.select(rowKey, { preserveScroll: true });
+    },
+    [timelineState, scrollRef]
+  );
+
+  // Branch selections share one effectiveListId (no remount), so the prefix
+  // above the clicked navigator is laid out identically — restoring scrollTop
+  // keeps it at the same viewport position.
+  useEffect(() => {
+    if (!scrollAnchor) return;
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollAnchor.scrollTop });
+    });
+  }, [scrollAnchor, scrollRef]);
+
+  return { spanSelectKeys, selectBySpanId, selectByRowKey, hasScrollTarget };
+}

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
@@ -57,6 +57,11 @@ export function useSelectionActions(
   // Scroll-anchor for inline fork-navigator clicks: the prefix above the
   // clicked navigator is unchanged across the selection, so capturing and
   // restoring scrollTop keeps the navigator at the same viewport position.
+  //
+  // Known issue: the anchor is never cleared after its restore runs, so the
+  // first anchored click latches hasScrollTarget true and suppresses the
+  // scroll-to-top for all later plain row selections. Pre-existing behavior,
+  // tracked in https://github.com/meridianlabs-ai/ts-mono/issues/440.
   const [scrollAnchor, setScrollAnchor] = useState<{
     scrollTop: number;
   } | null>(null);

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
@@ -52,14 +52,15 @@ function renderCoupling(
   stickyTop: number
 ) {
   const sidebars: SidebarScrollTarget[] = [
-    { scrollRef: ref(sidebar), remountKey: null },
+    { scrollRef: ref(sidebar), stickyTop, remountKey: null },
   ];
+  // Stable across renders, like the component's scrollRef prop.
+  const mainScrollRef = ref(main);
   return renderHook(
     (p: { sidebars: SidebarScrollTarget[] }) =>
       useSidebarScrollCoupling({
-        mainScrollRef: ref(main),
+        mainScrollRef,
         sidebars: p.sidebars,
-        stickyTops: [stickyTop],
       }),
     { initialProps: { sidebars } }
   );
@@ -135,9 +136,39 @@ describe("useSidebarScrollCoupling", () => {
 
     // A remount-key change (sidebar toggled) re-measures again.
     view.rerender({
-      sidebars: [{ scrollRef: ref(sidebar), remountKey: "collapsed" }],
+      sidebars: [
+        { scrollRef: ref(sidebar), stickyTop: 40, remountKey: "collapsed" },
+      ],
     });
     vi.advanceTimersByTime(0);
     expect(onScroll).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies sticky-offset changes without re-attaching or re-measuring", () => {
+    const { el: main, scrollBy } = makeScroller({ scrollTop: 100 });
+    // Sidebar at 60: sticky under a 100 threshold, not sticky under 40.
+    const { el: sidebar } = makeScroller({ top: 60, scrollTop: 50 });
+    const onScroll = vi.fn();
+    main.addEventListener("scroll", onScroll);
+
+    const view = renderCoupling(main, sidebar, 40);
+    vi.advanceTimersByTime(0);
+    expect(onScroll).toHaveBeenCalledTimes(1);
+
+    // Not sticky under the initial threshold: wheel input forwards to main.
+    expect(wheel(sidebar, 10).defaultPrevented).toBe(true);
+    expect(scrollBy).toHaveBeenCalledTimes(1);
+
+    // Raise the threshold (same remount key): the fresh offset applies at
+    // wheel time — the sidebar now counts as sticky and stops chaining —
+    // and no extra synthetic re-measure fires.
+    view.rerender({
+      sidebars: [{ scrollRef: ref(sidebar), stickyTop: 100, remountKey: null }],
+    });
+    vi.advanceTimersByTime(0);
+    expect(onScroll).toHaveBeenCalledTimes(1);
+
+    expect(wheel(sidebar, 10).defaultPrevented).toBe(false);
+    expect(scrollBy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useSidebarScrollCoupling,
+  type SidebarScrollTarget,
+} from "./useSidebarScrollCoupling";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+interface ScrollerOptions {
+  top?: number;
+  scrollTop?: number;
+  scrollHeight?: number;
+  clientHeight?: number;
+}
+
+function makeScroller(options: ScrollerOptions = {}) {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () => ({ top: options.top ?? 0 }) as DOMRect;
+  Object.defineProperty(el, "scrollHeight", {
+    value: options.scrollHeight ?? 1000,
+    configurable: true,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    value: options.clientHeight ?? 200,
+    configurable: true,
+  });
+  el.scrollTop = options.scrollTop ?? 0;
+  const scrollBy = vi.fn<(opts: { top: number }) => void>();
+  (el as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy;
+  return { el, scrollBy };
+}
+
+function wheel(el: HTMLElement, deltaY: number): WheelEvent {
+  const event = new WheelEvent("wheel", { deltaY, cancelable: true });
+  el.dispatchEvent(event);
+  return event;
+}
+
+function ref<T>(current: T): RefObject<T> {
+  return { current };
+}
+
+function renderCoupling(
+  main: HTMLDivElement,
+  sidebar: HTMLDivElement,
+  stickyTop: number
+) {
+  const sidebars: SidebarScrollTarget[] = [
+    { scrollRef: ref(sidebar), remountKey: null },
+  ];
+  return renderHook(
+    (p: { sidebars: SidebarScrollTarget[] }) =>
+      useSidebarScrollCoupling({
+        mainScrollRef: ref(main),
+        sidebars: p.sidebars,
+        stickyTops: [stickyTop],
+      }),
+    { initialProps: { sidebars } }
+  );
+}
+
+// =============================================================================
+// useSidebarScrollCoupling
+// =============================================================================
+
+describe("useSidebarScrollCoupling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("forwards wheel input to the main scroller while the sidebar is not sticky", () => {
+    const { el: main, scrollBy } = makeScroller({ scrollTop: 0 });
+    // Sidebar sits well below its sticky top: header still visible.
+    const { el: sidebar } = makeScroller({ top: 100 });
+    renderCoupling(main, sidebar, 40);
+
+    const event = wheel(sidebar, 10);
+    expect(event.defaultPrevented).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: 10, behavior: "auto" });
+  });
+
+  it("does not forward at the main scroller's end", () => {
+    const { el: main, scrollBy } = makeScroller({
+      scrollTop: 800,
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    const { el: sidebar } = makeScroller({ top: 100 });
+    renderCoupling(main, sidebar, 40);
+
+    const event = wheel(sidebar, 10);
+    expect(event.defaultPrevented).toBe(false);
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it("stops chaining once the sidebar is stuck at its sticky top", () => {
+    const { el: main, scrollBy } = makeScroller({ scrollTop: 100 });
+    const { el: sidebar } = makeScroller({ top: 40, scrollTop: 50 });
+    renderCoupling(main, sidebar, 40);
+
+    const event = wheel(sidebar, 10);
+    expect(event.defaultPrevented).toBe(false);
+    expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it("forwards wheel-up from a stuck sidebar at its own top to reveal the header", () => {
+    const { el: main, scrollBy } = makeScroller({ scrollTop: 100 });
+    const { el: sidebar } = makeScroller({ top: 40, scrollTop: 0 });
+    renderCoupling(main, sidebar, 40);
+
+    const event = wheel(sidebar, -10);
+    expect(event.defaultPrevented).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: -10, behavior: "auto" });
+  });
+
+  it("dispatches a synthetic scroll when a sidebar mounts or unmounts", () => {
+    const { el: main } = makeScroller();
+    const { el: sidebar } = makeScroller({ top: 100 });
+    const onScroll = vi.fn();
+    main.addEventListener("scroll", onScroll);
+
+    const view = renderCoupling(main, sidebar, 40);
+    vi.advanceTimersByTime(0);
+    expect(onScroll).toHaveBeenCalledTimes(1);
+
+    // A remount-key change (sidebar toggled) re-measures again.
+    view.rerender({
+      sidebars: [{ scrollRef: ref(sidebar), remountKey: "collapsed" }],
+    });
+    vi.advanceTimersByTime(0);
+    expect(onScroll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.ts
@@ -1,0 +1,109 @@
+/**
+ * Couples sticky sidebars to the main scroll container.
+ *
+ * Forwards wheel events from a sidebar to the main scroller only while the
+ * header above the tabs is still visible. Once the sidebar is stuck at its
+ * sticky top (header fully out), wheel events stop chaining so the main
+ * content doesn't scroll along with the sidebar. Also dispatches a synthetic
+ * scroll event when a sidebar mounts/unmounts: the layout reflows but no
+ * scroll/resize event fires, so sticky-state observers (useStickyObserver,
+ * StickyScroll) would otherwise keep stale state.
+ *
+ * Nothing here is transcript-specific; candidate for @tsmono/react/hooks.
+ */
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface SidebarScrollTarget {
+  /** The sidebar's sticky scroll container. */
+  scrollRef?: RefObject<HTMLDivElement | null>;
+  /** Changes when the sidebar mounts/unmounts (conditional render), forcing
+   *  listener re-attachment and a sticky re-measure. */
+  remountKey: unknown;
+}
+
+export interface UseSidebarScrollCouplingOptions {
+  /** The main scroll container. */
+  mainScrollRef: RefObject<HTMLDivElement | null>;
+  /** Sidebars to couple. Memoize — identity changes drive re-attachment. */
+  sidebars: ReadonlyArray<SidebarScrollTarget>;
+  /** Per-sidebar sticky offsets in px (parallel to `sidebars`). Read at
+   *  wheel time through a ref, so offset changes don't re-attach listeners. */
+  stickyTops: ReadonlyArray<number>;
+}
+
+export function useSidebarScrollCoupling(
+  options: UseSidebarScrollCouplingOptions
+): void {
+  const { mainScrollRef, sidebars, stickyTops } = options;
+
+  const stickyTopsRef = useRef(stickyTops);
+  useEffect(() => {
+    stickyTopsRef.current = stickyTops;
+  }, [stickyTops]);
+
+  // Synthetic scroll on sidebar mount/unmount, after the DOM has settled.
+  useEffect(() => {
+    const el = mainScrollRef.current;
+    if (!el) return;
+    const timer = setTimeout(() => {
+      el.dispatchEvent(new Event("scroll"));
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [sidebars, mainScrollRef]);
+
+  useEffect(() => {
+    const main = mainScrollRef.current;
+    if (!main) return;
+
+    const makeHandler =
+      (sidebar: HTMLDivElement, index: number) => (e: WheelEvent) => {
+        const mainMaxTop = main.scrollHeight - main.clientHeight;
+        // Is the sidebar currently stuck at its sticky top? If so, the header
+        // above the tabs has already scrolled off — don't chain further main
+        // scrolling or the main content itself would move with the sidebar.
+        const mainRect = main.getBoundingClientRect();
+        const sidebarRect = sidebar.getBoundingClientRect();
+        const sidebarTopInScroller = sidebarRect.top - mainRect.top;
+        const stickyTop = stickyTopsRef.current[index] ?? 0;
+        const sidebarIsSticky = sidebarTopInScroller <= stickyTop + 1;
+
+        if (!sidebarIsSticky) {
+          // Header still visible — forward all wheel input to the main
+          // scroller so that the header collapses/expands. Suppress the
+          // sidebar's default scroll for this step.
+          const canMain =
+            (e.deltaY > 0 && main.scrollTop < mainMaxTop - 0.5) ||
+            (e.deltaY < 0 && main.scrollTop > 0.5);
+          if (canMain) {
+            e.preventDefault();
+            main.scrollBy({ top: e.deltaY, behavior: "auto" });
+          }
+        } else if (
+          e.deltaY < 0 &&
+          sidebar.scrollTop <= 0 &&
+          main.scrollTop > 0
+        ) {
+          // Sidebar is sticky and already at its own top — wheeling up should
+          // bring the header back, so forward to main.
+          e.preventDefault();
+          main.scrollBy({ top: e.deltaY, behavior: "auto" });
+        }
+        // Otherwise let the sidebar's native wheel scroll proceed.
+      };
+
+    const entries = sidebars.flatMap((target, index) => {
+      const el = target.scrollRef?.current;
+      if (!el) return [];
+      const handler = makeHandler(el, index);
+      // passive: false so we can preventDefault when taking over the scroll.
+      el.addEventListener("wheel", handler, { passive: false });
+      return [{ el, handler }];
+    });
+    return () => {
+      for (const { el, handler } of entries) {
+        el.removeEventListener("wheel", handler);
+      }
+    };
+  }, [mainScrollRef, sidebars]);
+}

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.ts
@@ -15,32 +15,40 @@
 import { useEffect, useRef, type RefObject } from "react";
 
 export interface SidebarScrollTarget {
-  /** The sidebar's sticky scroll container. */
+  /** The sidebar's sticky scroll container. Assumed stable across renders. */
   scrollRef?: RefObject<HTMLDivElement | null>;
-  /** Changes when the sidebar mounts/unmounts (conditional render), forcing
-   *  listener re-attachment and a sticky re-measure. */
-  remountKey: unknown;
+  /** Offset at which the sidebar sticks (px from the scroller top). Read at
+   *  wheel time, so changes take effect without re-attaching listeners. */
+  stickyTop: number;
+  /** Identity token that changes when the sidebar mounts/unmounts
+   *  (conditional render), forcing listener re-attachment and a sticky
+   *  re-measure. */
+  remountKey: string | number | boolean | null | undefined;
 }
 
 export interface UseSidebarScrollCouplingOptions {
   /** The main scroll container. */
   mainScrollRef: RefObject<HTMLDivElement | null>;
-  /** Sidebars to couple. Memoize — identity changes drive re-attachment. */
+  /** Sidebars to couple. Pass a fresh array each render — re-attachment is
+   *  driven by the remount keys, not array identity. */
   sidebars: ReadonlyArray<SidebarScrollTarget>;
-  /** Per-sidebar sticky offsets in px (parallel to `sidebars`). Read at
-   *  wheel time through a ref, so offset changes don't re-attach listeners. */
-  stickyTops: ReadonlyArray<number>;
 }
 
 export function useSidebarScrollCoupling(
   options: UseSidebarScrollCouplingOptions
 ): void {
-  const { mainScrollRef, sidebars, stickyTops } = options;
+  const { mainScrollRef, sidebars } = options;
 
-  const stickyTopsRef = useRef(stickyTops);
+  // Mirror the latest targets so wheel handlers read current sticky offsets.
+  // Declared before the effects below so the mirror updates first in a flush.
+  const sidebarsRef = useRef(sidebars);
   useEffect(() => {
-    stickyTopsRef.current = stickyTops;
-  }, [stickyTops]);
+    sidebarsRef.current = sidebars;
+  });
+
+  // Value-stable re-attachment signal: changes only when a sidebar's remount
+  // key does, never when offsets do.
+  const structureKey = sidebars.map((s) => String(s.remountKey)).join("|");
 
   // Synthetic scroll on sidebar mount/unmount, after the DOM has settled.
   useEffect(() => {
@@ -50,7 +58,7 @@ export function useSidebarScrollCoupling(
       el.dispatchEvent(new Event("scroll"));
     }, 0);
     return () => clearTimeout(timer);
-  }, [sidebars, mainScrollRef]);
+  }, [structureKey, mainScrollRef]);
 
   useEffect(() => {
     const main = mainScrollRef.current;
@@ -65,7 +73,7 @@ export function useSidebarScrollCoupling(
         const mainRect = main.getBoundingClientRect();
         const sidebarRect = sidebar.getBoundingClientRect();
         const sidebarTopInScroller = sidebarRect.top - mainRect.top;
-        const stickyTop = stickyTopsRef.current[index] ?? 0;
+        const stickyTop = sidebarsRef.current[index]?.stickyTop ?? 0;
         const sidebarIsSticky = sidebarTopInScroller <= stickyTop + 1;
 
         if (!sidebarIsSticky) {
@@ -92,7 +100,7 @@ export function useSidebarScrollCoupling(
         // Otherwise let the sidebar's native wheel scroll proceed.
       };
 
-    const entries = sidebars.flatMap((target, index) => {
+    const entries = sidebarsRef.current.flatMap((target, index) => {
       const el = target.scrollRef?.current;
       if (!el) return [];
       const handler = makeHandler(el, index);
@@ -105,5 +113,5 @@ export function useSidebarScrollCoupling(
         el.removeEventListener("wheel", handler);
       }
     };
-  }, [mainScrollRef, sidebars]);
+  }, [mainScrollRef, structureKey]);
 }

--- a/packages/inspect-components/src/transcript/index.ts
+++ b/packages/inspect-components/src/transcript/index.ts
@@ -168,6 +168,7 @@ export {
 } from "./outline/useOutlineWidth";
 
 // Timeline utilities
+export { useEventNodes } from "./hooks/useEventNodes";
 export * from "./timeline";
 
 // Search utilities

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { OutlineLoadingRow } from "./OutlineRow";
+import { eventNode } from "../testHelpers";
+
+import { OutlineLoadingRow, OutlineRow } from "./OutlineRow";
 import styles from "./OutlineRow.module.css";
 
 describe("OutlineLoadingRow", () => {
@@ -21,5 +23,66 @@ describe("OutlineLoadingRow", () => {
     const status = container.querySelector('[role="status"]');
     expect(status).not.toBeNull();
     expect(status!.getAttribute("aria-live")).toBe("polite");
+  });
+});
+
+// =============================================================================
+// Collapse chevron
+// =============================================================================
+
+describe("OutlineRow collapse chevron", () => {
+  afterEach(() => cleanup());
+
+  const parentNode = () =>
+    eventNode({ event: "span_begin", name: "phase one", type: null }, [
+      eventNode({ event: "model" }),
+    ]);
+
+  it("shows a down chevron on expanded rows and toggles to collapsed", () => {
+    const setCollapsed = vi.fn<(id: string, collapsed: boolean) => void>();
+    const node = parentNode();
+    const { container } = render(
+      <OutlineRow
+        node={node}
+        getCollapsed={() => false}
+        setCollapsed={setCollapsed}
+      />
+    );
+
+    expect(container.querySelector("i.bi-chevron-down")).not.toBeNull();
+    fireEvent.click(container.querySelector(`.${styles.toggle}`)!);
+    expect(setCollapsed).toHaveBeenCalledWith(node.id, true);
+  });
+
+  it("shows a right chevron on collapsed rows and toggles to expanded", () => {
+    const setCollapsed = vi.fn<(id: string, collapsed: boolean) => void>();
+    const node = parentNode();
+    const { container } = render(
+      <OutlineRow
+        node={node}
+        getCollapsed={() => true}
+        setCollapsed={setCollapsed}
+      />
+    );
+
+    expect(container.querySelector("i.bi-chevron-right")).not.toBeNull();
+    fireEvent.click(container.querySelector(`.${styles.toggle}`)!);
+    expect(setCollapsed).toHaveBeenCalledWith(node.id, false);
+  });
+
+  it("renders no chevron for leaf rows and ignores toggle clicks", () => {
+    const setCollapsed = vi.fn<(id: string, collapsed: boolean) => void>();
+    const { container } = render(
+      <OutlineRow
+        node={eventNode({ event: "model" })}
+        getCollapsed={() => false}
+        setCollapsed={setCollapsed}
+      />
+    );
+
+    expect(container.querySelector("i.bi-chevron-down")).toBeNull();
+    expect(container.querySelector("i.bi-chevron-right")).toBeNull();
+    fireEvent.click(container.querySelector(`.${styles.toggle}`)!);
+    expect(setCollapsed).not.toHaveBeenCalled();
   });
 });

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
@@ -49,8 +49,6 @@ interface TranscriptOutlineProps {
   agentName?: string;
   /** Reports whether the outline has displayable nodes after filtering. */
   onHasNodesChange?: (hasNodes: boolean) => void;
-  /** Reports the ideal width (in px) for the outline column. */
-  onWidthChange?: (width: number) => void;
   /** Called when user clicks an outline item but URL-based navigation is unavailable. */
   onNavigateToEvent?: (eventId: string) => void;
   /** Offset from the top of the scroll container where visible content begins. */
@@ -103,7 +101,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
   style,
   agentName,
   onHasNodesChange,
-  onWidthChange,
   onNavigateToEvent,
   scrollTrackOffset,
   getEventUrl,
@@ -141,9 +138,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
 
   // Measure the ideal width for the outline column from label text
   const outlineWidth = useOutlineWidth(outlineNodeList, undefined, agentName);
-  useEffect(() => {
-    onWidthChange?.(outlineWidth);
-  }, [outlineWidth, onWidthChange]);
 
   // Set --outline-width on the nearest grid ancestor so the column resizes
   // automatically without each app needing to wire up the CSS variable.

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.tsx
@@ -14,6 +14,10 @@ import { EventNode } from "../types";
 
 import { OutlineLoadingRow, OutlineRow } from "./OutlineRow";
 import styles from "./TranscriptOutline.module.css";
+import {
+  useOutlineCollapse,
+  type OutlineCollapseState,
+} from "./useOutlineCollapse";
 import { useOutlineNodes } from "./useOutlineNodes";
 import { useOutlineScrollSync } from "./useOutlineScrollSync";
 import { useOutlineWidth } from "./useOutlineWidth";
@@ -55,14 +59,8 @@ interface TranscriptOutlineProps {
   // --- Callback props replacing store hooks ---
   /** URL generator for deep linking to events. */
   getEventUrl?: (eventId: string) => string | undefined;
-  /** Get collapsed state for an outline node. */
-  getCollapsed?: (id: string) => boolean;
-  /** Set collapsed state for an outline node. */
-  setCollapsed?: (id: string, collapsed: boolean) => void;
-  /** Current collapsed events for the outline scope. */
-  collapsedEvents?: Record<string, boolean>;
-  /** Set multiple collapsed events at once (for initialization). */
-  setCollapsedEvents?: (collapsed: Record<string, boolean>) => void;
+  /** Collapse state and callbacks for the outline scope. */
+  collapse?: OutlineCollapseState;
   /** Currently selected outline node ID. */
   selectedOutlineId?: string | null;
   /** Set the selected outline node ID. */
@@ -109,10 +107,7 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
   onNavigateToEvent,
   scrollTrackOffset,
   getEventUrl,
-  getCollapsed,
-  setCollapsed,
-  collapsedEvents,
-  setCollapsedEvents,
+  collapse,
   selectedOutlineId,
   setSelectedOutlineId,
   renderLink,
@@ -121,10 +116,14 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
   const listHandle = useRef<VirtuosoHandle | null>(null);
   const { getRestoreState } = useVirtuosoState(listHandle, id);
 
+  const { collapsedIds, getCollapsed, setCollapsed } = useOutlineCollapse(
+    defaultCollapsedIds,
+    collapse
+  );
+
   const { outlineNodeList, allNodesList } = useOutlineNodes(
     eventNodes,
-    collapsedEvents,
-    defaultCollapsedIds
+    collapsedIds
   );
 
   const { onOutlineSelect } = useOutlineScrollSync({
@@ -161,13 +160,6 @@ export const TranscriptOutline: FC<TranscriptOutlineProps> = ({
       ancestor = ancestor.parentElement;
     }
   }, [outlineWidth]);
-
-  // Initialize collapsed events from defaults
-  useEffect(() => {
-    if (!collapsedEvents && Object.keys(defaultCollapsedIds).length > 0) {
-      setCollapsedEvents?.(defaultCollapsedIds);
-    }
-  }, [defaultCollapsedIds, collapsedEvents, setCollapsedEvents]);
 
   const renderRow = useCallback(
     (index: number, node: EventNode) => {

--- a/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useOutlineCollapse } from "./useOutlineCollapse";
+
+const defaults: Record<string, boolean> = { a: true, b: true };
+
+describe("useOutlineCollapse", () => {
+  it("seeds the store with defaults when unseeded", () => {
+    const onSetCollapsed = vi.fn<(ids: Record<string, boolean>) => void>();
+    renderHook(() => useOutlineCollapse(defaults, { onSetCollapsed }));
+    expect(onSetCollapsed).toHaveBeenCalledWith(defaults);
+  });
+
+  it("does not re-seed once the store has state", () => {
+    const onSetCollapsed = vi.fn<(ids: Record<string, boolean>) => void>();
+    renderHook(() =>
+      useOutlineCollapse(defaults, { collapsed: { a: false }, onSetCollapsed })
+    );
+    expect(onSetCollapsed).not.toHaveBeenCalled();
+  });
+
+  it("resolves collapsed ids from the store, falling back to defaults", () => {
+    const seeded = renderHook(() =>
+      useOutlineCollapse(defaults, { collapsed: { a: false } })
+    );
+    expect(seeded.result.current.collapsedIds).toEqual({ a: false });
+
+    const unseeded = renderHook(() => useOutlineCollapse(defaults, {}));
+    expect(unseeded.result.current.collapsedIds).toBe(defaults);
+  });
+
+  it("exposes a row accessor only once the store is seeded", () => {
+    const unseeded = renderHook(() => useOutlineCollapse(defaults, {}));
+    expect(unseeded.result.current.getCollapsed).toBeUndefined();
+
+    const seeded = renderHook(() =>
+      useOutlineCollapse(defaults, { collapsed: { a: true, b: false } })
+    );
+    expect(seeded.result.current.getCollapsed?.("a")).toBe(true);
+    expect(seeded.result.current.getCollapsed?.("b")).toBe(false);
+    expect(seeded.result.current.getCollapsed?.("missing")).toBe(false);
+  });
+
+  it("passes the single-row toggle through", () => {
+    const onCollapse = vi.fn<(id: string, collapsed: boolean) => void>();
+    const { result } = renderHook(() =>
+      useOutlineCollapse(defaults, { collapsed: {}, onCollapse })
+    );
+    result.current.setCollapsed?.("a", true);
+    expect(onCollapse).toHaveBeenCalledWith("a", true);
+  });
+});

--- a/packages/inspect-components/src/transcript/outline/useOutlineCollapse.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineCollapse.ts
@@ -1,0 +1,58 @@
+/**
+ * View-model hook for outline collapse state (the outline twin of
+ * useTranscriptCollapse).
+ *
+ * Bridges the app store's outline collapse scope to the outline component:
+ * resolves the collapsed-id map (store state falling back to defaults),
+ * derives the per-row accessors, and seeds the store with the defaults on
+ * first mount so individual toggles preserve the other rows' default state.
+ */
+
+import { useEffect, useMemo } from "react";
+
+export interface OutlineCollapseState {
+  /** Current collapsed node IDs for the outline scope. */
+  collapsed?: Record<string, boolean>;
+  /** Collapse/expand a single outline node. */
+  onCollapse?: (nodeId: string, collapsed: boolean) => void;
+  /** Bulk-set outline collapsed state (for initialization). */
+  onSetCollapsed?: (ids: Record<string, boolean>) => void;
+}
+
+export interface OutlineCollapse {
+  /** Collapsed-id map for outline row derivation (store state or defaults). */
+  collapsedIds: Record<string, boolean>;
+  /** Per-row collapsed accessor; undefined while the store is unseeded. */
+  getCollapsed: ((id: string) => boolean) | undefined;
+  /** Collapse/expand a single outline row. */
+  setCollapsed: ((id: string, collapsed: boolean) => void) | undefined;
+}
+
+export function useOutlineCollapse(
+  defaultCollapsedIds: Record<string, boolean>,
+  collapse?: OutlineCollapseState
+): OutlineCollapse {
+  const collapsedEvents = collapse?.collapsed;
+  const onSetCollapsed = collapse?.onSetCollapsed;
+
+  // Initialize collapsed events from defaults
+  useEffect(() => {
+    if (!collapsedEvents && Object.keys(defaultCollapsedIds).length > 0) {
+      onSetCollapsed?.(defaultCollapsedIds);
+    }
+  }, [defaultCollapsedIds, collapsedEvents, onSetCollapsed]);
+
+  const getCollapsed = useMemo(
+    () =>
+      collapsedEvents
+        ? (id: string) => collapsedEvents[id] === true
+        : undefined,
+    [collapsedEvents]
+  );
+
+  return {
+    collapsedIds: collapsedEvents ?? defaultCollapsedIds,
+    getCollapsed,
+    setCollapsed: collapse?.onCollapse,
+  };
+}

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -132,9 +132,9 @@ describe("useOutlineNodes", () => {
       [modelNode()]
     );
     const eventNodes = [span];
-    const defaultCollapsedIds = {};
+    const collapsedIds = {};
     const { result, rerender } = renderHook(() =>
-      useOutlineNodes(eventNodes, undefined, defaultCollapsedIds)
+      useOutlineNodes(eventNodes, collapsedIds)
     );
     const firstOutlineNodeList = result.current.outlineNodeList;
     const firstAllNodesList = result.current.allNodesList;

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.ts
@@ -50,13 +50,11 @@ export interface OutlineNodes {
 
 export const useOutlineNodes = (
   eventNodes: EventNode[],
-  collapsedEvents: Record<string, boolean> | undefined,
-  defaultCollapsedIds: Record<string, boolean>
+  collapsedIds: Record<string, boolean>
 ): OutlineNodes => {
   const outlineNodeList = useMemo(
-    () =>
-      buildOutlineNodeList(eventNodes, collapsedEvents ?? defaultCollapsedIds),
-    [eventNodes, collapsedEvents, defaultCollapsedIds]
+    () => buildOutlineNodeList(eventNodes, collapsedIds),
+    [eventNodes, collapsedIds]
   );
 
   const allNodesList = useMemo(() => {

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { InMemoryStateWrapper } from "../../testHelpers";
+import { makeSpan, ts } from "../testHelpers";
+
+import { TimelineMinimap } from "./TimelineMinimap";
+import styles from "./TimelineMinimap.module.css";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const root = makeSpan("root", 0, 100, 1000);
+const selection = { startTime: ts(20), endTime: ts(80), totalTokens: 600 };
+
+function renderMinimap(onScrub?: (progress: number) => void) {
+  return render(
+    <InMemoryStateWrapper>
+      <TimelineMinimap root={root} selection={selection} onScrub={onScrub} />
+    </InMemoryStateWrapper>
+  );
+}
+
+// =============================================================================
+// TimelineMinimap
+// =============================================================================
+
+describe("TimelineMinimap", () => {
+  afterEach(() => cleanup());
+
+  it("toggles between time and token mode", () => {
+    const { getByText } = renderMinimap();
+
+    // Time mode by default: "time" shown, "tokens" hidden (both are always
+    // rendered for stable width; jsdom doesn't apply stylesheets so we assert
+    // the hidden class).
+    const time = getByText("time");
+    const tokens = getByText("tokens");
+    expect(time.className).not.toContain(styles.hidden!);
+    expect(tokens.className).toContain(styles.hidden!);
+
+    fireEvent.click(time);
+
+    expect(getByText("time").className).toContain(styles.hidden!);
+    expect(getByText("tokens").className).not.toContain(styles.hidden!);
+  });
+
+  it("emits the pointer position as a 0-1 scrub fraction", () => {
+    const onScrub = vi.fn<(progress: number) => void>();
+    const { container } = renderMinimap(onScrub);
+
+    const region = container.querySelector<HTMLDivElement>(
+      `.${styles.selectionRegion}`
+    )!;
+    expect(region).not.toBeNull();
+    region.getBoundingClientRect = () => ({ left: 100, width: 200 }) as DOMRect;
+    region.setPointerCapture = () => {};
+
+    fireEvent.pointerDown(region, { clientX: 250, pointerId: 1 });
+    fireEvent.pointerUp(region, { clientX: 250, pointerId: 1 });
+    expect(onScrub).toHaveBeenCalledWith(0.75);
+  });
+
+  it("clamps scrub fractions to the region bounds", () => {
+    const onScrub = vi.fn<(progress: number) => void>();
+    const { container } = renderMinimap(onScrub);
+
+    const region = container.querySelector<HTMLDivElement>(
+      `.${styles.selectionRegion}`
+    )!;
+    region.getBoundingClientRect = () => ({ left: 100, width: 200 }) as DOMRect;
+    region.setPointerCapture = () => {};
+
+    fireEvent.pointerDown(region, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerUp(region, { clientX: 0, pointerId: 1 });
+    expect(onScrub).toHaveBeenCalledWith(0);
+
+    fireEvent.pointerDown(region, { clientX: 900, pointerId: 1 });
+    fireEvent.pointerUp(region, { clientX: 900, pointerId: 1 });
+    expect(onScrub).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { InMemoryStateWrapper } from "../../testHelpers";
+import type { Timeline } from "../core";
+import { makeSpan } from "../testHelpers";
+
+import {
+  TimelineSwimLanes,
+  type TimelineNavigation,
+} from "./TimelineSwimLanes";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeTimeline(name: string): Timeline {
+  return {
+    name,
+    description: `${name} timeline`,
+    root: makeSpan(name, 0, 100, 1000),
+  };
+}
+
+function renderSwimlanes(
+  timelines: Timeline[],
+  setActive: (i: number) => void
+) {
+  const node = makeSpan("Transcript", 0, 100, 1000);
+  const timeline: TimelineNavigation = {
+    node,
+    selected: null,
+    select: vi.fn(),
+    clearSelection: vi.fn(),
+  };
+  return render(
+    <InMemoryStateWrapper>
+      <TimelineSwimLanes
+        layouts={[]}
+        timeline={timeline}
+        header={{
+          multiTimeline: { timelines, activeIndex: 0, setActive },
+        }}
+      />
+    </InMemoryStateWrapper>
+  );
+}
+
+// =============================================================================
+// Multi-timeline selector (header)
+// =============================================================================
+
+describe("TimelineSwimLanes header — multi-timeline selector", () => {
+  afterEach(() => cleanup());
+
+  it("renders the selector and switches the active timeline", () => {
+    const setActive = vi.fn<(index: number) => void>();
+    renderSwimlanes(
+      [makeTimeline("default"), makeTimeline("auditor")],
+      setActive
+    );
+
+    const trigger = screen.getByRole("button", { name: /default/ });
+    expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
+    fireEvent.click(trigger);
+
+    const option = screen.getByRole("option", { name: "auditor" });
+    fireEvent.click(option);
+    expect(setActive).toHaveBeenCalledWith(1);
+  });
+
+  it("renders no selector for a single timeline", () => {
+    renderSwimlanes([makeTimeline("default")], vi.fn());
+    expect(
+      document.querySelector('button[aria-haspopup="listbox"]')
+    ).toBeNull();
+  });
+});

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
@@ -3,8 +3,14 @@ import { FC, useCallback, useMemo, useRef, useState } from "react";
 
 import { useCollapsibleIds, useProperty } from "@tsmono/react/hooks";
 
+import type { TimelineSpan } from "../core";
 import { type TimelineState } from "../hooks/useTimeline";
 import type { UseTimelineConfigResult } from "../hooks/useTimelineConfig";
+import type {
+  MultiTimelineNav,
+  TimelineMinimapData,
+  TimelineViewStack,
+} from "../hooks/useTranscriptTimeline";
 import {
   formatTokenCount,
   type PositionedMarker,
@@ -14,12 +20,9 @@ import {
 import { buildSelectionKey, parseSelection } from "../timelineEventNodes";
 
 import { useTimelineIcons } from "./TimelineIconsContext";
-import { TimelineMinimap, type TimelineMinimapProps } from "./TimelineMinimap";
+import { TimelineMinimap } from "./TimelineMinimap";
 import { TimelineOptionsPopover } from "./TimelineOptionsPopover";
-import {
-  TimelineSelector,
-  type TimelineSelectorProps,
-} from "./TimelineSelector";
+import { TimelineSelector } from "./TimelineSelector";
 import styles from "./TimelineSwimLanes.module.css";
 
 // =============================================================================
@@ -77,26 +80,26 @@ export function buildBreadcrumbs(
 /** Navigation subset of TimelineState needed by the swimlane component. */
 export type TimelineNavigation = Pick<
   TimelineState,
-  "selected" | "select" | "clearSelection"
+  "node" | "selected" | "select" | "clearSelection"
 >;
 
-/** Header configuration: root label + optional minimap. */
+/** Header configuration. The root label and minimap span come from the
+ *  swimlane's timeline state. */
 export interface TimelineHeaderProps {
-  rootLabel: string;
   /** Called on header click to scroll the view to the top. */
   onScrollToTop?: () => void;
-  /** Minimap props for the zoom indicator. */
-  minimap?: TimelineMinimapProps;
+  /** Minimap data (root time mapping + selection) for the zoom indicator. */
+  minimap?: TimelineMinimapData;
+  /** Scrubber position within the minimap (0–1), or null when idle. */
+  scrubberProgress?: number | null;
+  /** Called when the user scrubs the minimap. */
+  onScrub?: (progress: number) => void;
   /** Timeline config for the options popover. When provided, shows the options button. */
   timelineConfig?: UseTimelineConfigResult;
-  /** Timeline selector for switching between multiple timelines. */
-  timelineSelector?: TimelineSelectorProps;
-  /** Called when the branches toggle is clicked (handles selection cleanup). */
-  onToggleBranches?: () => void;
-  /** Punched-down view labels (root → current). Renders a back button + trail when non-empty. */
-  viewStack?: ReadonlyArray<{ label: string }>;
-  /** Pop the punched-down view stack. */
-  onPopView?: () => void;
+  /** Multi-timeline navigation. The selector renders when >1 timelines. */
+  multiTimeline?: MultiTimelineNav;
+  /** Punch-down view navigation. The back button renders when the stack is non-empty. */
+  views?: TimelineViewStack;
 }
 
 export interface TimelineSwimLanesProps {
@@ -408,6 +411,7 @@ export const TimelineSwimLanes: FC<TimelineSwimLanesProps> = ({
         {header && (
           <HeaderRow
             {...header}
+            node={timeline.node}
             breadcrumbs={breadcrumbs}
             onBreadcrumbSelect={onSelect}
             onToggleBranches={handleBranchToggle}
@@ -749,46 +753,55 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
 // =============================================================================
 
 interface HeaderRowProps extends TimelineHeaderProps {
+  /** The root timeline span (labels the header and feeds the minimap). */
+  node: TimelineSpan;
   breadcrumbs?: BreadcrumbSegment[];
   onBreadcrumbSelect?: (key: string) => void;
+  /** Called when the branches toggle is clicked (handles selection cleanup). */
+  onToggleBranches?: () => void;
 }
 
 const HeaderRow: FC<HeaderRowProps> = ({
-  rootLabel,
+  node,
   minimap,
+  scrubberProgress,
+  onScrub,
   onScrollToTop,
   breadcrumbs,
   onBreadcrumbSelect,
   timelineConfig,
-  timelineSelector,
+  multiTimeline,
   onToggleBranches,
-  viewStack,
-  onPopView,
+  views,
 }) => {
   const icons = useTimelineIcons();
   const hasBreadcrumbs = breadcrumbs && breadcrumbs.length > 1;
-  const rootDisplay = rootLabel === "solvers" ? "main" : rootLabel;
+  const rootDisplay = node.name === "solvers" ? "main" : node.name;
 
   const [optionsOpen, setOptionsOpen] = useState(false);
   const optionsButtonRef = useRef<HTMLButtonElement | null>(null);
 
   return (
     <div className={styles.breadcrumbRow}>
-      {timelineSelector && (
+      {multiTimeline && multiTimeline.timelines.length > 1 && (
         <>
-          <TimelineSelector {...timelineSelector} />
+          <TimelineSelector
+            timelines={multiTimeline.timelines}
+            activeIndex={multiTimeline.activeIndex}
+            onSelect={multiTimeline.setActive}
+          />
           <span className={styles.breadcrumbDivider}>/</span>
         </>
       )}
-      {viewStack && viewStack.length > 0 && (
+      {views && views.stack.length > 0 && (
         <>
           <button
             className={styles.viewStackBack}
-            onClick={onPopView}
+            onClick={views.pop}
             title="Back to branch overview"
           >
             <i className={icons.chevron.left} />
-            {viewStack.at(-1)!.label}
+            {views.stack.at(-1)!.label}
           </button>
           <span className={styles.breadcrumbDivider}>/</span>
         </>
@@ -833,7 +846,15 @@ const HeaderRow: FC<HeaderRowProps> = ({
           <i className={icons.threeDots} />
         </button>
       )}
-      {minimap && <TimelineMinimap {...minimap} />}
+      {minimap && (
+        <TimelineMinimap
+          root={node}
+          mapping={minimap.mapping}
+          selection={minimap.selection}
+          scrubberProgress={scrubberProgress}
+          onScrub={onScrub}
+        />
+      )}
       {timelineConfig && onToggleBranches && (
         <TimelineOptionsPopover
           isOpen={optionsOpen}

--- a/packages/inspect-components/src/transcript/timeline/hooks/index.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/index.ts
@@ -23,5 +23,4 @@ export {
   type TranscriptTimelineResult,
   type UseTranscriptTimelineOptions,
 } from "./useTranscriptTimeline";
-export { useEventNodes } from "./useEventNodes";
 export { useTimelinesArray } from "./useTimelinesArray";

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   Event,
@@ -288,5 +288,96 @@ describe("useTranscriptTimeline", () => {
     expect(result.current.timeline).toBeDefined();
     expect(result.current.multiTimeline.timelines).toHaveLength(1);
     expect(result.current.selection.events.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Punch-down views
+// =============================================================================
+
+function makeAnchorEvent(
+  uuid: string,
+  anchorId: string,
+  startSec: number
+): Event {
+  return {
+    event: "anchor",
+    uuid,
+    anchor_id: anchorId,
+    timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
+    working_start: startSec,
+    span_id: null,
+    pending: null,
+    metadata: null,
+    source: null,
+  } as unknown as Event;
+}
+
+describe("useTranscriptTimeline punch-down views", () => {
+  const events = [
+    makeModelEvent("evt-1", 0, 3),
+    makeAnchorEvent("evt-anchor", "fork-1", 4),
+    makeModelEvent("evt-branch", 5, 8),
+  ];
+  const branchTimeline: ServerTimeline = {
+    name: "default",
+    description: "Branch timeline",
+    root: makeServerSpan({
+      id: "root",
+      name: "Transcript",
+      content: [makeServerEvent("evt-1"), makeServerEvent("evt-anchor")],
+      branches: [
+        makeServerSpan({
+          id: "branch-1",
+          name: "branch",
+          span_type: "branch",
+          branched_from: "fork-1",
+          content: [makeServerEvent("evt-branch")],
+        }),
+      ],
+    }),
+  };
+
+  // Stable identity: an inline array would recreate the timelines on every
+  // render, resetting the view stack via the stack-base adjustment.
+  const serverTimelines = [branchTimeline];
+
+  function renderViews() {
+    const onSelect = vi.fn();
+    const view = renderHook(() =>
+      useTranscriptTimeline({
+        events,
+        serverTimelines,
+        timelineOptions: { showBranches: true },
+        timelineProps: { selected: null, onSelect },
+      })
+    );
+    return { ...view, onSelect };
+  }
+
+  it("pushes a branch row as a standalone spliced view and pops back", () => {
+    const { result, onSelect } = renderViews();
+
+    const branchRow = result.current.state.rows.find((r) => r.branch);
+    expect(branchRow).toBeDefined();
+    const rootBefore = result.current.timeline.root;
+
+    act(() => result.current.views.pushByRowKey(branchRow!.key, "Branch 1"));
+    expect(result.current.views.stack).toHaveLength(1);
+    expect(result.current.views.stack[0]!.label).toBe("Branch 1");
+    // The current timeline is now the spliced standalone branch.
+    expect(result.current.timeline.root).not.toBe(rootBefore);
+    // Push clears the selection for the new view.
+    expect(onSelect).toHaveBeenCalledWith(null);
+
+    act(() => result.current.views.pop());
+    expect(result.current.views.stack).toHaveLength(0);
+    expect(result.current.timeline.root).toBe(rootBefore);
+  });
+
+  it("ignores unknown row keys", () => {
+    const { result } = renderViews();
+    act(() => result.current.views.pushByRowKey("no-such-row", "x"));
+    expect(result.current.views.stack).toHaveLength(0);
   });
 });

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -92,6 +92,9 @@ export interface TimelineViewStack {
   stack: ReadonlyArray<{ label: string; timeline: Timeline }>;
   /** Drill into `branch` — splice it against the base timeline's root and push onto the view stack. */
   push: (branch: TimelineSpan, label: string) => void;
+  /** Drill into the branch on the swimlane row with `rowKey`. No-op when the
+   *  row doesn't hold a single agent span. */
+  pushByRowKey: (rowKey: string, label: string) => void;
   /** Pop the top of the view stack (back to the previous view). */
   pop: () => void;
 }
@@ -404,9 +407,23 @@ export function useTranscriptTimeline(
     [timelines, activeTimelineIndex, setActiveTimeline]
   );
 
+  const pushViewByRowKey = useCallback(
+    (rowKey: string, label: string) => {
+      const row = state.rows.find((r) => r.key === rowKey);
+      const span = row?.spans[0];
+      if (span && "agent" in span) pushView(span.agent, label);
+    },
+    [state.rows, pushView]
+  );
+
   const views = useMemo(
-    () => ({ stack: viewStack, push: pushView, pop: popView }),
-    [viewStack, pushView, popView]
+    () => ({
+      stack: viewStack,
+      push: pushView,
+      pushByRowKey: pushViewByRowKey,
+      pop: popView,
+    }),
+    [viewStack, pushView, pushViewByRowKey, popView]
   );
 
   const selection = useMemo(

--- a/packages/inspect-components/src/transcript/timeline/index.ts
+++ b/packages/inspect-components/src/transcript/timeline/index.ts
@@ -99,7 +99,6 @@ export {
   clearDeepLinkParams,
   findBranchesByBranchedFrom,
   useActiveTimeline,
-  useEventNodes,
   useTimeline,
   useTimelineConfig,
   useTimelinesArray,


### PR DESCRIPTION
Round 4 (final) of the transcript view-model work (follows #432, #434, #435): with the extraction complete, this round aligns the seams so component prop shapes match the VM groups, and closes out the remaining cleanups. TranscriptLayout is down to 660 lines (from 1243 before #432), all rendering + one-line hook wiring.

**Characterization tests first.** The prop reshapes are the first non-verbatim interface changes of this effort, and the surfaces they touch (minimap, multi-timeline selector, punch-down, outline collapse) had no coverage. Characterization tests pin them before the reshape; writing them surfaced two real pre-existing punch-down bugs, filed as #436 (branch on a nested span crashes the page) and #437 (flat branch strands the user with no back button) — not fixed here. To keep the e2e suite lean, tests that don't need a real browser were then demoted to component/hook level: only 3 e2e remain (minimap scrub → real scrolling/virtualization, outline collapse round trip through the app store, punch-down enter/pop), with the minimap toggle + scrub-fraction math, selector switching, outline chevrons, and `views.pushByRowKey`/`pop` covered by jsdom tests instead.

**Reshapes:**
- `TimelineHeaderProps` takes the VM groups directly (`minimap: TimelineMinimapData`, `multiTimeline: MultiTimelineNav`, `views: TimelineViewStack` + scrubber). `rootLabel`/minimap root derive from timeline state; the ">1 timelines" selector policy and internally-injected `onToggleBranches` move inside the component. TranscriptLayout's header memo drops from 12-dep reassembly to a pass-through. `views.pushByRowKey` replaces the layout's punch-down row lookup.
- TranscriptOutline's five overlapping collapse props become one `collapse?: OutlineCollapseState`, handled by `useOutlineCollapse` (the outline twin of `useTranscriptCollapse`; owns resolution + default seeding). `useOutlineNodes` takes pre-resolved ids.

**Cleanups:**
- `useSelectionActions` — span/row click selection, the fork-navigator scroll anchor + restore, and the pending-scroll-target signal.
- `useSidebarScrollCoupling` — the ~120-line wheel-forwarding/reflow blob; sticky offsets read via ref at wheel time so offset changes don't re-attach listeners. Generic DOM behavior, candidate for `@tsmono/react/hooks` later.
- `useEventNodes` moves from `timeline/hooks/` to `transcript/hooks/` (package export path unchanged; no app edits).
- TranscriptOutline's dead `onWidthChange` prop removed.

24 new unit/component tests + 3 e2e. Verified per commit: package unit suite, both apps' full e2e suites, monorepo typecheck + tests.
