### PR TITLE
Extract OutlineSidebar/useSwimlaneHeader and group TranscriptLayout props

### DIFF
--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.tsx
@@ -184,7 +184,7 @@ const RetryEventsView: FC<{
         scrollRef={scrollRef}
         listId={listId}
         embedded
-        showSwimlanes={false}
+        timeline={{ showSwimlanes: false }}
         collapseState={collapseState}
         bulkCollapse={bulkCollapse}
         eventNodeContext={{ inlineExpansionUX: true }}

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
@@ -91,7 +91,7 @@ vi.mock("@tsmono/inspect-components/transcript", async (importOriginal) => {
         {outlineUrl && props.outline?.renderLink
           ? props.outline.renderLink(outlineUrl, <span>outline link</span>)
           : null}
-        <button onClick={() => props.onMarkerNavigate?.("event-1")}>
+        <button onClick={() => props.timeline?.onMarkerNavigate?.("event-1")}>
           marker
         </button>
       </div>

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -353,18 +353,21 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
       backfilling={backfilling}
       scrollRef={scrollRef}
       offsetTop={offsetTop}
-      timelineSelection={timelineSelection}
-      activeTimeline={activeTimeline}
-      serverTimelines={serverTimelines}
-      showSwimlanes="auto"
-      onMarkerNavigate={onMarkerNavigate}
-      headroomHidden={headroomHidden}
-      onHeadroomResetAnchor={onHeadroomResetAnchor}
-      onHeadroomSetHidden={setHeadroomHidden}
+      timeline={{
+        selection: timelineSelection,
+        active: activeTimeline,
+        serverTimelines,
+        showSwimlanes: "auto",
+        onMarkerNavigate,
+      }}
+      headroom={{
+        hidden: headroomHidden,
+        onSetHidden: setHeadroomHidden,
+        onResetAnchor: onHeadroomResetAnchor,
+      }}
       eventNodeContext={eventNodeContext}
       listId={id}
-      initialEventId={initialEventId}
-      initialMessageId={initialMessageId}
+      deepLink={{ eventId: initialEventId, messageId: initialMessageId }}
       getEventUrl={getFullEventUrl}
       // Only surface the copy-link button where a shared absolute URL is
       // meaningful — not in VS Code webviews or localhost. Matches the message
@@ -388,16 +391,17 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
         selectedId: selectedOutlineId,
         setSelectedId: setSelectedOutlineId,
       }}
-      emptyText={
-        backfilling && isDefaultFilter
-          ? "Loading events"
-          : running && isDefaultFilter
-            ? "Sample is starting"
-            : filteredEventTypes.length > 0
-              ? "The currently applied filter hides all events."
-              : undefined
-      }
-      emptyBusy={(running || backfilling) && isDefaultFilter}
+      empty={{
+        text:
+          backfilling && isDefaultFilter
+            ? "Loading events"
+            : running && isDefaultFilter
+              ? "Sample is starting"
+              : filteredEventTypes.length > 0
+                ? "The currently applied filter hides all events."
+                : undefined,
+        busy: (running || backfilling) && isDefaultFilter,
+      }}
     />
   );
 });

--- a/apps/scout/src/app/scannerResult/transcript/TranscriptPanel.tsx
+++ b/apps/scout/src/app/scannerResult/transcript/TranscriptPanel.tsx
@@ -74,7 +74,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = ({
         events={events}
         scrollRef={scrollRef}
         listId={id}
-        showSwimlanes={false}
+        timeline={{ showSwimlanes: false }}
         collapseState={{
           transcript: collapsedEvents[kTranscriptCollapseScope],
           onCollapseTranscript,

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -229,19 +229,22 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
       events={events}
       scrollRef={scrollRef}
       offsetTop={offsetTop}
-      timelineSelection={timelineSelection}
-      activeTimeline={activeTimeline}
-      serverTimelines={serverTimelines}
-      markerConfig={markerConfig}
-      agentConfig={agentConfig}
-      showSwimlanes={timelineProp}
-      onMarkerNavigate={onMarkerNavigate}
-      onScrollToTop={scrollToTop}
-      headroomHidden={headroomHidden}
-      onHeadroomResetAnchor={onHeadroomResetAnchor}
+      timeline={{
+        selection: timelineSelection,
+        active: activeTimeline,
+        serverTimelines,
+        markerConfig,
+        agentConfig,
+        showSwimlanes: timelineProp,
+        onMarkerNavigate,
+        onScrollToTop: scrollToTop,
+      }}
+      headroom={{
+        hidden: headroomHidden,
+        onResetAnchor: onHeadroomResetAnchor,
+      }}
       listId={id}
-      initialEventId={initialEventId}
-      initialMessageId={initialMessageId}
+      deepLink={{ eventId: initialEventId, messageId: initialMessageId }}
       eventsListRef={eventsListRef}
       getEventUrl={getEventUrl}
       linkingEnabled={linkingEnabled}

--- a/packages/inspect-components/src/transcript/OutlineSidebar.tsx
+++ b/packages/inspect-components/src/transcript/OutlineSidebar.tsx
@@ -1,0 +1,182 @@
+/**
+ * The transcript's sticky outline sidebar: the expanded panel (header, close
+ * button, outline tree) or the collapsed show-outline toggle, pinned below
+ * the swimlanes via StickyScroll.
+ */
+
+import clsx from "clsx";
+import {
+  FC,
+  ReactNode,
+  RefObject,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+
+import { StickyScroll } from "@tsmono/react/components";
+
+import { TranscriptOutline } from "./outline/TranscriptOutline";
+import {
+  outlineCollapseState,
+  type OutlineCollapseState,
+} from "./outline/useOutlineCollapse";
+import styles from "./TranscriptLayout.module.css";
+import { EventNode, type TranscriptCollapseState } from "./types";
+
+export interface TranscriptLayoutOutlineProps {
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
+  toggleDisabled?: boolean;
+  toggleTitle?: string;
+  toggleIcon: string;
+  /** Header title shown next to the toggle icon when expanded. */
+  title?: string;
+  /** Name of the agent/subagent currently displayed. Shown as a header in the outline. */
+  name?: string;
+  renderLink?: (url: string, children: ReactNode) => ReactNode;
+  onNavigateToEvent?: (eventId: string) => void;
+  selectedId?: string | null;
+  setSelectedId?: (id: string) => void;
+}
+
+export interface OutlineSidebarProps {
+  outline: TranscriptLayoutOutlineProps;
+  /** Effective collapsed state (user intent + auto-hide). */
+  isCollapsed: boolean;
+  /** Whether the outline has displayable nodes (gates the show toggle). */
+  hasNodes: boolean;
+  onHasNodesChange: (hasNodes: boolean) => void;
+  eventNodes: EventNode[];
+  defaultCollapsedIds: Record<string, boolean>;
+  /** The main scroll container. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Optional external mirror of the sidebar's own scroll container (wheel
+   *  forwarding / headroom observers). */
+  outlineScrollRef?: RefObject<HTMLDivElement | null>;
+  running: boolean;
+  backfilling: boolean;
+  /** Resolved agent name header (outline.name or the selected row). */
+  agentName?: string;
+  /** Sticky offset below the swimlanes. */
+  offsetTop: number;
+  collapseState?: TranscriptCollapseState;
+  getEventUrl?: (eventId: string) => string | undefined;
+}
+
+export const OutlineSidebar: FC<OutlineSidebarProps> = ({
+  outline,
+  isCollapsed,
+  hasNodes,
+  onHasNodesChange,
+  eventNodes,
+  defaultCollapsedIds,
+  scrollRef,
+  outlineScrollRef,
+  running,
+  backfilling,
+  agentName,
+  offsetTop,
+  collapseState,
+  getEventUrl,
+}) => {
+  // Capture the outline's own scroll container (the StickyScroll div, which
+  // has overflow-y:auto) into state so the outline's Virtuoso can use it as
+  // its scroll parent. Resolving into state (rather than reading a ref during
+  // render) guarantees a re-render once the element mounts. Also mirror it
+  // into the optional external ref callers pass for wheel forwarding.
+  const [outlineScrollEl, setOutlineScrollEl] = useState<HTMLDivElement | null>(
+    null
+  );
+  const handleOutlineScrollRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      setOutlineScrollEl(el);
+      if (outlineScrollRef) {
+        outlineScrollRef.current = el;
+      }
+    },
+    [outlineScrollRef]
+  );
+
+  const collapse: OutlineCollapseState | undefined = useMemo(
+    () => outlineCollapseState(collapseState),
+    [collapseState]
+  );
+
+  return (
+    <>
+      <StickyScroll
+        ref={handleOutlineScrollRef}
+        scrollRef={scrollRef}
+        className={styles.outline}
+        offsetTop={offsetTop}
+      >
+        {!isCollapsed ? (
+          <>
+            {outline.title && (
+              <div className={styles.sidebarHeader}>
+                <span
+                  className={clsx(
+                    styles.sidebarHeaderTitle,
+                    "text-size-smaller"
+                  )}
+                >
+                  {outline.title}
+                </span>
+              </div>
+            )}
+            <div className={styles.sidebarHeaderCloseAnchor}>
+              <button
+                type="button"
+                className={styles.sidebarHeaderClose}
+                onClick={() => outline.onCollapsedChange(true)}
+                aria-label="Hide outline"
+                title={outline.toggleTitle ?? "Hide outline"}
+              >
+                <i className="bi bi-x" />
+              </button>
+            </div>
+            <TranscriptOutline
+              eventNodes={eventNodes}
+              defaultCollapsedIds={defaultCollapsedIds}
+              scrollRef={scrollRef}
+              outlineScrollEl={outlineScrollEl}
+              running={running}
+              backfilling={backfilling}
+              agentName={agentName}
+              scrollTrackOffset={offsetTop}
+              collapse={collapse}
+              selectedOutlineId={outline.selectedId}
+              setSelectedOutlineId={outline.setSelectedId}
+              getEventUrl={getEventUrl}
+              renderLink={outline.renderLink}
+              onNavigateToEvent={outline.onNavigateToEvent}
+              onHasNodesChange={onHasNodesChange}
+            />
+          </>
+        ) : (
+          <button
+            type="button"
+            className={styles.outlineToggle}
+            onClick={
+              hasNodes && !outline.toggleDisabled
+                ? () => outline.onCollapsedChange(false)
+                : undefined
+            }
+            aria-disabled={outline.toggleDisabled || !hasNodes}
+            title={
+              outline.toggleTitle ??
+              (!hasNodes
+                ? "No outline available for the current filter"
+                : undefined)
+            }
+            aria-label="Show outline"
+          >
+            <i className={outline.toggleIcon} />
+          </button>
+        )}
+      </StickyScroll>
+      <div className={styles.separator} />
+    </>
+  );
+};

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -20,10 +20,7 @@ import {
   ReactNode,
   RefObject,
   useCallback,
-  useEffect,
-  useMemo,
   useRef,
-  useState,
 } from "react";
 
 import type {
@@ -35,7 +32,7 @@ import {
   RailDock,
   StickyScroll,
 } from "@tsmono/react/components";
-import { useElementHeight, useScrubberProgress } from "@tsmono/react/hooks";
+import { useElementHeight } from "@tsmono/react/hooks";
 
 import { useDeepLinkResolution } from "./hooks/useDeepLinkResolution";
 import { useEventNodeData } from "./hooks/useEventNodeData";
@@ -44,9 +41,13 @@ import { useOutlineAutoHide } from "./hooks/useOutlineAutoHide";
 import { useSelectionActions } from "./hooks/useSelectionActions";
 import { useSidebarScrollCoupling } from "./hooks/useSidebarScrollCoupling";
 import { useStickySwimLaneHeight } from "./hooks/useStickySwimLaneHeight";
+import { useSwimlaneHeader } from "./hooks/useSwimlaneHeader";
 import { useTimelinePipeline } from "./hooks/useTimelinePipeline";
 import { useTranscriptCollapse } from "./hooks/useTranscriptCollapse";
-import { TranscriptOutline } from "./outline/TranscriptOutline";
+import {
+  OutlineSidebar,
+  type TranscriptLayoutOutlineProps,
+} from "./OutlineSidebar";
 import { useTranscriptSearchSource } from "./search";
 import { AgentCardView, TimelineSwimLanes } from "./timeline/components";
 import { type TimelineSpan } from "./timeline/core";
@@ -75,21 +76,7 @@ import {
 // Types
 // =============================================================================
 
-export interface TranscriptLayoutOutlineProps {
-  collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  toggleDisabled?: boolean;
-  toggleTitle?: string;
-  toggleIcon: string;
-  /** Header title shown next to the toggle icon when expanded. */
-  title?: string;
-  /** Name of the agent/subagent currently displayed. Shown as a header in the outline. */
-  name?: string;
-  renderLink?: (url: string, children: ReactNode) => ReactNode;
-  onNavigateToEvent?: (eventId: string) => void;
-  selectedId?: string | null;
-  setSelectedId?: (id: string) => void;
-}
+export { type TranscriptLayoutOutlineProps } from "./OutlineSidebar";
 
 export interface TranscriptLayoutRightRailProps {
   /** Always-visible rail content (the vertical activity bar). */
@@ -192,6 +179,12 @@ export interface TranscriptLayoutProps {
 // =============================================================================
 // Component
 // =============================================================================
+
+function renderAgentCard(node: EventNode, agentCardClassName?: string) {
+  const span = node.sourceSpan as TimelineSpan | undefined;
+  if (!span) return null;
+  return <AgentCardView span={span} className={agentCardClassName} />;
+}
 
 export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   events,
@@ -312,39 +305,18 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   );
 
   // ---------------------------------------------------------------------------
-  // Scrubber progress
+  // Swimlane header
   // ---------------------------------------------------------------------------
 
-  const [scrubberProgress, scrubTo] = useScrubberProgress(scrollRef);
-
-  const handleScrub = useCallback(
-    (progress: number) => {
-      onHeadroomResetAnchor?.(true);
-      scrubTo(progress);
-    },
-    [onHeadroomResetAnchor, scrubTo]
-  );
-
-  const swimlaneHeader = useMemo(
-    () => ({
-      onScrollToTop,
-      minimap,
-      scrubberProgress,
-      onScrub: handleScrub,
-      timelineConfig,
-      multiTimeline,
-      views,
-    }),
-    [
-      onScrollToTop,
-      minimap,
-      scrubberProgress,
-      handleScrub,
-      timelineConfig,
-      multiTimeline,
-      views,
-    ]
-  );
+  const swimlaneHeader = useSwimlaneHeader({
+    scrollRef,
+    onScrollToTop,
+    onHeadroomResetAnchor,
+    timelineConfig,
+    minimap,
+    multiTimeline,
+    views,
+  });
 
   // ---------------------------------------------------------------------------
   // Deep-link resolution
@@ -357,19 +329,8 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     spanSelectKeys,
     showSwimlanes,
     nodeFeedEvents: nodeFeed.events,
+    onHeadroomResetAnchor,
   });
-
-  // Suppress headroom (swimlane collapse/expand) during programmatic scrolls
-  // — fires for any change to the effective scroll target (URL `?event=`,
-  // resolved message, branch switch). The reset-anchor uses a debounced
-  // lock that stays active while the imperative scroll's retry loop keeps
-  // emitting scroll events, so the swimlane doesn't flicker open/closed
-  // during the multi-pass settling.
-  useEffect(() => {
-    if (effectiveInitialEventId) {
-      onHeadroomResetAnchor?.(true);
-    }
-  }, [effectiveInitialEventId, onHeadroomResetAnchor]);
 
   // ---------------------------------------------------------------------------
   // Collapse state & outline auto-hide
@@ -390,32 +351,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
       outlineCollapsed: outline?.collapsed,
     });
 
-  const outlineCollapse = useMemo(
-    () =>
-      collapseState
-        ? {
-            collapsed: collapseState.outline,
-            onCollapse: collapseState.onCollapseOutline,
-            onSetCollapsed: collapseState.onSetOutlineCollapsed,
-          }
-        : undefined,
-    [collapseState]
-  );
-
   const hasMatchingEvents = eventNodes.length > 0;
-
-  // ---------------------------------------------------------------------------
-  // Agent card rendering
-  // ---------------------------------------------------------------------------
-
-  const renderAgentCard = useCallback(
-    (node: EventNode, agentCardClassName?: string) => {
-      const span = node.sourceSpan as TimelineSpan | undefined;
-      if (!span) return null;
-      return <AgentCardView span={span} className={agentCardClassName} />;
-    },
-    []
-  );
 
   // ---------------------------------------------------------------------------
   // Headroom reset anchor
@@ -446,24 +382,6 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
       },
     ],
   });
-
-  // Capture the outline's own scroll container (the StickyScroll div, which
-  // has overflow-y:auto) into state so the outline's Virtuoso can use it as
-  // its scroll parent. Resolving into state (rather than reading a ref during
-  // render) guarantees a re-render once the element mounts. Also mirror it
-  // into the optional external ref callers pass for wheel forwarding.
-  const [outlineScrollEl, setOutlineScrollEl] = useState<HTMLDivElement | null>(
-    null
-  );
-  const handleOutlineScrollRef = useCallback(
-    (el: HTMLDivElement | null) => {
-      setOutlineScrollEl(el);
-      if (outlineScrollRef) {
-        outlineScrollRef.current = el;
-      }
-    },
-    [outlineScrollRef]
-  );
 
   // Track the scroll container's visible height so sticky sidebars can cap
   // their max-height to the actually-visible area (100vh would include the
@@ -521,85 +439,25 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
               }
             >
               {outline && (
-                <>
-                  <StickyScroll
-                    ref={handleOutlineScrollRef}
-                    scrollRef={scrollRef}
-                    className={styles.outline}
-                    offsetTop={effectiveOffsetTop}
-                  >
-                    {!isOutlineCollapsed ? (
-                      <>
-                        {outline.title && (
-                          <div className={styles.sidebarHeader}>
-                            <span
-                              className={clsx(
-                                styles.sidebarHeaderTitle,
-                                "text-size-smaller"
-                              )}
-                            >
-                              {outline.title}
-                            </span>
-                          </div>
-                        )}
-                        <div className={styles.sidebarHeaderCloseAnchor}>
-                          <button
-                            type="button"
-                            className={styles.sidebarHeaderClose}
-                            onClick={() => outline.onCollapsedChange(true)}
-                            aria-label="Hide outline"
-                            title={outline.toggleTitle ?? "Hide outline"}
-                          >
-                            <i className="bi bi-x" />
-                          </button>
-                        </div>
-                        <TranscriptOutline
-                          eventNodes={eventNodes}
-                          defaultCollapsedIds={defaultCollapsedIds}
-                          scrollRef={scrollRef}
-                          outlineScrollEl={outlineScrollEl}
-                          running={running}
-                          backfilling={backfilling}
-                          agentName={
-                            outline.name ??
-                            (showSwimlanes ? selectedRowName : undefined)
-                          }
-                          scrollTrackOffset={effectiveOffsetTop}
-                          collapse={outlineCollapse}
-                          selectedOutlineId={outline.selectedId}
-                          setSelectedOutlineId={outline.setSelectedId}
-                          getEventUrl={getEventUrl}
-                          renderLink={outline.renderLink}
-                          onNavigateToEvent={outline.onNavigateToEvent}
-                          onHasNodesChange={onOutlineHasNodesChange}
-                        />
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        className={styles.outlineToggle}
-                        onClick={
-                          outlineHasNodes && !outline.toggleDisabled
-                            ? () => outline.onCollapsedChange(false)
-                            : undefined
-                        }
-                        aria-disabled={
-                          outline.toggleDisabled || !outlineHasNodes
-                        }
-                        title={
-                          outline.toggleTitle ??
-                          (!outlineHasNodes
-                            ? "No outline available for the current filter"
-                            : undefined)
-                        }
-                        aria-label="Show outline"
-                      >
-                        <i className={outline.toggleIcon} />
-                      </button>
-                    )}
-                  </StickyScroll>
-                  <div className={styles.separator} />
-                </>
+                <OutlineSidebar
+                  outline={outline}
+                  isCollapsed={isOutlineCollapsed}
+                  hasNodes={outlineHasNodes}
+                  onHasNodesChange={onOutlineHasNodesChange}
+                  eventNodes={eventNodes}
+                  defaultCollapsedIds={defaultCollapsedIds}
+                  scrollRef={scrollRef}
+                  outlineScrollRef={outlineScrollRef}
+                  running={running}
+                  backfilling={backfilling}
+                  agentName={
+                    outline.name ??
+                    (showSwimlanes ? selectedRowName : undefined)
+                  }
+                  offsetTop={effectiveOffsetTop}
+                  collapseState={collapseState}
+                  getEventUrl={getEventUrl}
+                />
               )}
               {hasMatchingEvents ? (
                 <TranscriptViewNodes

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -96,6 +96,53 @@ export interface TranscriptLayoutRightRailProps {
   label?: string;
 }
 
+/** Timeline data, selection adapters, and swimlane behavior
+ *  (consumed by useTimelinePipeline). */
+export interface TranscriptLayoutTimelineProps {
+  /** Row selection state adapter. */
+  selection?: UseTimelineProps;
+  /** Active-timeline adapter (multi-timeline logs). */
+  active?: UseActiveTimelineProps;
+  serverTimelines?: ServerTimeline[];
+  /** Marker config override (default: useTimelineConfig()). */
+  markerConfig?: MarkerConfig;
+  /** Agent timeline options override (default: useTimelineConfig()). */
+  agentConfig?: TimelineOptions;
+  /** Swimlane visibility. "auto" (the default) shows them when the timeline
+   *  has agent structure. */
+  showSwimlanes?: boolean | "auto";
+  onMarkerNavigate?: (eventId: string, selectedKey?: string) => void;
+  /** Called on swimlane header click to scroll the view to the top. */
+  onScrollToTop?: () => void;
+}
+
+/** Deep-link target resolved on mount (consumed by useDeepLinkResolution). */
+export interface TranscriptLayoutDeepLinkProps {
+  /** Deep-link to a specific event. Takes priority over messageId. */
+  eventId?: string | null;
+  /** Deep-link to a message ID, resolved to the best matching event.
+   *  Used for citation navigation — resolves against selected span first, then root. */
+  messageId?: string | null;
+}
+
+/** Adapter for the host's headroom (collapsing chrome above the transcript). */
+export interface TranscriptLayoutHeadroomProps {
+  hidden?: boolean;
+  /** Force the headroom into the given hidden state. Used by sources (e.g.
+   *  search) that drive scroll-direction-sensitive UI when their motion
+   *  doesn't match what the scroll-direction tracker would infer. */
+  onSetHidden?: (hidden: boolean) => void;
+  onResetAnchor?: (debounce?: boolean) => void;
+}
+
+/** Empty-state display when no events match the current filter. */
+export interface TranscriptLayoutEmptyProps {
+  /** Text shown when no events match. Pass null to disable the empty state. */
+  text?: string | null;
+  /** Render the empty state as an in-progress placeholder (animated, no icon). */
+  busy?: boolean;
+}
+
 export interface TranscriptLayoutProps {
   // --- Events ---
   events: Event[];
@@ -115,35 +162,18 @@ export interface TranscriptLayoutProps {
    *  rather than as the page's primary scroll region. */
   embedded?: boolean;
 
-  // --- Timeline selection adapters ---
-  timelineSelection?: UseTimelineProps;
-  activeTimeline?: UseActiveTimelineProps;
-  serverTimelines?: ServerTimeline[];
-
-  // --- Timeline config overrides (default: useTimelineConfig()) ---
-  markerConfig?: MarkerConfig;
-  agentConfig?: TimelineOptions;
-
-  // --- Swimlane control ---
-  showSwimlanes?: boolean | "auto";
-  onMarkerNavigate?: (eventId: string, selectedKey?: string) => void;
-  onScrollToTop?: () => void;
-
-  // --- Headroom ---
-  headroomHidden?: boolean;
-  /** Force the headroom into the given hidden state. Used by sources (e.g.
-   *  search) that drive scroll-direction-sensitive UI when their motion
-   *  doesn't match what the scroll-direction tracker would infer. */
-  onHeadroomSetHidden?: (hidden: boolean) => void;
-  onHeadroomResetAnchor?: (debounce?: boolean) => void;
+  // --- Feature groups ---
+  /** Timeline data, selection adapters, and swimlane behavior. */
+  timeline?: TranscriptLayoutTimelineProps;
+  /** Deep-link target resolved on mount. */
+  deepLink?: TranscriptLayoutDeepLinkProps;
+  /** Host headroom adapter. */
+  headroom?: TranscriptLayoutHeadroomProps;
+  /** Empty-state display. Omit for the default text. */
+  empty?: TranscriptLayoutEmptyProps;
 
   // --- Event list ---
   listId: string;
-  /** Deep-link to a specific event on mount. Takes priority over initialMessageId. */
-  initialEventId?: string | null;
-  /** Deep-link to a message ID, resolved to the best matching event.
-   *  Used for citation navigation — resolves against selected span first, then root. */
-  initialMessageId?: string | null;
   eventsListRef?: RefObject<TranscriptViewNodesHandle | null>;
   getEventUrl?: (eventId: string) => string | undefined;
   linkingEnabled?: boolean;
@@ -168,11 +198,6 @@ export interface TranscriptLayoutProps {
 
   /** Extra context fields merged into every EventNodeContext entry. */
   eventNodeContext?: Partial<EventNodeContext>;
-
-  /** Text shown when no events match the current filter. Pass null to disable empty state. */
-  emptyText?: string | null;
-  /** Render the empty state as an in-progress placeholder (animated, no icon). */
-  emptyBusy?: boolean;
   className?: string;
 }
 
@@ -194,20 +219,11 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   scrollRef,
   offsetTop = 0,
   embedded = false,
-  timelineSelection,
-  activeTimeline,
-  serverTimelines,
-  markerConfig: markerConfigOverride,
-  agentConfig: agentConfigOverride,
-  showSwimlanes: showSwimlanesOption = "auto",
-  onMarkerNavigate,
-  onScrollToTop,
-  headroomHidden,
-  onHeadroomResetAnchor,
-  onHeadroomSetHidden,
+  timeline,
+  deepLink,
+  headroom,
+  empty,
   listId,
-  initialEventId,
-  initialMessageId,
   eventsListRef,
   getEventUrl,
   linkingEnabled,
@@ -218,10 +234,32 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   rightRail,
   rightRailPanelScrollRef,
   eventNodeContext,
-  emptyText = "No events match the current filter",
-  emptyBusy,
   className,
 }) => {
+  // Group props destructure to locals immediately: the group objects are
+  // typically fresh literals at call sites, but the values inside keep the
+  // caller's identity — hooks below depend on the values, never the groups.
+  const {
+    selection: timelineSelection,
+    active: activeTimeline,
+    serverTimelines,
+    markerConfig: markerConfigOverride,
+    agentConfig: agentConfigOverride,
+    showSwimlanes: showSwimlanesOption = "auto",
+    onMarkerNavigate,
+    onScrollToTop,
+  } = timeline ?? {};
+  const { eventId: initialEventId, messageId: initialMessageId } =
+    deepLink ?? {};
+  const {
+    hidden: headroomHidden,
+    onSetHidden: onHeadroomSetHidden,
+    onResetAnchor: onHeadroomResetAnchor,
+  } = headroom ?? {};
+  const {
+    text: emptyText = "No events match the current filter",
+    busy: emptyBusy,
+  } = empty ?? {};
   // ---------------------------------------------------------------------------
   // Timeline pipeline + event nodes
   // ---------------------------------------------------------------------------

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -97,7 +97,7 @@ export interface TranscriptLayoutRightRailProps {
 }
 
 /** Timeline data, selection adapters, and swimlane behavior
- *  (consumed by useTimelinePipeline). */
+ *  (consumed by the timeline pipeline + swimlane header). */
 export interface TranscriptLayoutTimelineProps {
   /** Row selection state adapter. */
   selection?: UseTimelineProps;

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -113,6 +113,7 @@ interface HarnessProps {
   initialMessageId?: string | null;
   showSwimlanes?: boolean;
   nodeFeedEvents?: Event[];
+  onHeadroomResetAnchor?: (debounce?: boolean) => void;
 }
 
 function useHarness(props: HarnessProps) {
@@ -139,6 +140,7 @@ function useHarness(props: HarnessProps) {
     spanSelectKeys,
     showSwimlanes: props.showSwimlanes ?? true,
     nodeFeedEvents: props.nodeFeedEvents ?? props.events,
+    onHeadroomResetAnchor: props.onHeadroomResetAnchor,
   });
   return { resolution, timeline, spanSelectKeys };
 }
@@ -183,6 +185,31 @@ describe("useDeepLinkResolution → effectiveInitialEventId", () => {
     const events = [makeModelEvent("evt-1", 0)];
     const { result } = renderHarness({ events });
     expect(result.current.resolution.effectiveInitialEventId).toBeNull();
+  });
+});
+
+// =============================================================================
+// Headroom anchor reset
+// =============================================================================
+
+describe("useDeepLinkResolution → headroom anchor reset", () => {
+  it("fires the debounced reset when a scroll target is pending", () => {
+    const onHeadroomResetAnchor = vi.fn();
+    renderHarness({
+      events: [makeModelEvent("evt-1", 0)],
+      initialEventId: "evt-1",
+      onHeadroomResetAnchor,
+    });
+    expect(onHeadroomResetAnchor).toHaveBeenCalledWith(true);
+  });
+
+  it("does not fire without a scroll target", () => {
+    const onHeadroomResetAnchor = vi.fn();
+    renderHarness({
+      events: [makeModelEvent("evt-1", 0)],
+      onHeadroomResetAnchor,
+    });
+    expect(onHeadroomResetAnchor).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.ts
@@ -45,6 +45,9 @@ export interface UseDeepLinkResolutionOptions {
   showSwimlanes: boolean;
   /** The events currently in the node feed (to detect visible targets). */
   nodeFeedEvents: Event[];
+  /** Headroom anchor reset, fired (debounced) whenever the effective scroll
+   *  target changes — see the effect below for why. */
+  onHeadroomResetAnchor?: (debounce?: boolean) => void;
 }
 
 export interface DeepLinkResolution {
@@ -72,6 +75,7 @@ export function useDeepLinkResolution(
     spanSelectKeys,
     showSwimlanes,
     nodeFeedEvents,
+    onHeadroomResetAnchor,
   } = options;
 
   // ---------------------------------------------------------------------------
@@ -244,6 +248,18 @@ export function useDeepLinkResolution(
 
   const effectiveInitialEventId =
     initialEventId ?? resolved?.eventId ?? branchScrollTarget ?? null;
+
+  // Suppress headroom (swimlane collapse/expand) during programmatic scrolls
+  // — fires for any change to the effective scroll target (URL `?event=`,
+  // resolved message, branch switch). The reset-anchor uses a debounced
+  // lock that stays active while the imperative scroll's retry loop keeps
+  // emitting scroll events, so the swimlane doesn't flicker open/closed
+  // during the multi-pass settling.
+  useEffect(() => {
+    if (effectiveInitialEventId) {
+      onHeadroomResetAnchor?.(true);
+    }
+  }, [effectiveInitialEventId, onHeadroomResetAnchor]);
 
   return { effectiveInitialEventId };
 }

--- a/packages/inspect-components/src/transcript/hooks/useSwimlaneHeader.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSwimlaneHeader.ts
@@ -1,0 +1,80 @@
+/**
+ * View-model hook for the swimlane header row: owns the minimap scrubber
+ * wiring (progress tracking + headroom anchor reset on scrub) and assembles
+ * the memoized `TimelineHeaderProps` object for `TimelineSwimLanes`.
+ */
+
+import { useCallback, useMemo, type RefObject } from "react";
+
+import { useScrubberProgress } from "@tsmono/react/hooks";
+
+import { type TimelineHeaderProps } from "../timeline/components";
+import {
+  type MultiTimelineNav,
+  type TimelineMinimapData,
+  type TimelineViewStack,
+  type UseTimelineConfigResult,
+} from "../timeline/hooks";
+
+export interface UseSwimlaneHeaderOptions {
+  /** The transcript's scroll container (scrub target). */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Called on header click to scroll the view to the top. */
+  onScrollToTop?: () => void;
+  /** Headroom anchor reset, fired (debounced) on scrub so the swimlane
+   *  doesn't collapse/expand while the scrubber drives the scroll. */
+  onHeadroomResetAnchor?: (debounce?: boolean) => void;
+  /** Timeline config for the options popover. */
+  timelineConfig?: UseTimelineConfigResult;
+  /** Minimap data (root time mapping + selection). */
+  minimap?: TimelineMinimapData;
+  /** Multi-timeline navigation. */
+  multiTimeline?: MultiTimelineNav;
+  /** Punch-down view navigation. */
+  views?: TimelineViewStack;
+}
+
+export function useSwimlaneHeader(
+  options: UseSwimlaneHeaderOptions
+): TimelineHeaderProps {
+  const {
+    scrollRef,
+    onScrollToTop,
+    onHeadroomResetAnchor,
+    timelineConfig,
+    minimap,
+    multiTimeline,
+    views,
+  } = options;
+
+  const [scrubberProgress, scrubTo] = useScrubberProgress(scrollRef);
+
+  const handleScrub = useCallback(
+    (progress: number) => {
+      onHeadroomResetAnchor?.(true);
+      scrubTo(progress);
+    },
+    [onHeadroomResetAnchor, scrubTo]
+  );
+
+  return useMemo(
+    () => ({
+      onScrollToTop,
+      minimap,
+      scrubberProgress,
+      onScrub: handleScrub,
+      timelineConfig,
+      multiTimeline,
+      views,
+    }),
+    [
+      onScrollToTop,
+      minimap,
+      scrubberProgress,
+      handleScrub,
+      timelineConfig,
+      multiTimeline,
+      views,
+    ]
+  );
+}

--- a/packages/inspect-components/src/transcript/index.ts
+++ b/packages/inspect-components/src/transcript/index.ts
@@ -102,6 +102,10 @@ export {
   type TranscriptLayoutProps,
   type TranscriptLayoutOutlineProps,
   type TranscriptLayoutRightRailProps,
+  type TranscriptLayoutTimelineProps,
+  type TranscriptLayoutDeepLinkProps,
+  type TranscriptLayoutHeadroomProps,
+  type TranscriptLayoutEmptyProps,
 } from "./TranscriptLayout";
 
 // Icons

--- a/packages/inspect-components/src/transcript/outline/useOutlineCollapse.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineCollapse.ts
@@ -10,6 +10,8 @@
 
 import { useEffect, useMemo } from "react";
 
+import { type TranscriptCollapseState } from "../types";
+
 export interface OutlineCollapseState {
   /** Current collapsed node IDs for the outline scope. */
   collapsed?: Record<string, boolean>;
@@ -17,6 +19,19 @@ export interface OutlineCollapseState {
   onCollapse?: (nodeId: string, collapsed: boolean) => void;
   /** Bulk-set outline collapsed state (for initialization). */
   onSetCollapsed?: (ids: Record<string, boolean>) => void;
+}
+
+/** Project the transcript-level collapse store down to the outline scope. */
+export function outlineCollapseState(
+  collapseState: TranscriptCollapseState | undefined
+): OutlineCollapseState | undefined {
+  return collapseState
+    ? {
+        collapsed: collapseState.outline,
+        onCollapse: collapseState.onCollapseOutline,
+        onSetCollapsed: collapseState.onSetOutlineCollapsed,
+      }
+    : undefined;
 }
 
 export interface OutlineCollapse {

--- a/packages/inspect-components/src/transcript/timeline/components/index.ts
+++ b/packages/inspect-components/src/transcript/timeline/components/index.ts
@@ -12,5 +12,6 @@ export {
 } from "./TimelineSelector";
 export {
   TimelineSwimLanes,
+  type TimelineHeaderProps,
   type TimelineSwimLanesProps,
 } from "./TimelineSwimLanes";

--- a/packages/inspect-components/src/transcript/timeline/hooks/index.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/index.ts
@@ -20,6 +20,9 @@ export {
 } from "./useTimelineConfig";
 export {
   useTranscriptTimeline,
+  type MultiTimelineNav,
+  type TimelineMinimapData,
+  type TimelineViewStack,
   type TranscriptTimelineResult,
   type UseTranscriptTimelineOptions,
 } from "./useTranscriptTimeline";


### PR DESCRIPTION
Round 5 of the transcript refactoring: shrinks `TranscriptLayout.tsx`'s remaining cognitive load on two axes — the last inline logic/JSX blobs move behind components/hooks, and the ~30-scalar prop contract regroups into documented feature objects that map 1:1 to their consuming hooks. Render output is unchanged.

## Extractions (render-identical moves)

- **`OutlineSidebar`** (new component): the sticky outline sidebar fragment — expanded panel (title header, close button, `TranscriptOutline`) vs. collapsed toggle — plus the `outlineScrollEl` state + external-ref mirror it exists to serve. `TranscriptLayoutOutlineProps` moves with it (re-exported, public API unchanged). Side benefit: outline scroll-el mounting now re-renders only the sidebar, not the whole layout.
- **`useSwimlaneHeader`** (new hook): owns minimap scrubber wiring (`useScrubberProgress` + debounced headroom reset on scrub) and assembles the memoized `TimelineHeaderProps` object.
- **Headroom reset folded into `useDeepLinkResolution`**: the "suppress headroom during programmatic scrolls" effect belongs to the deep-link concern; it moves in via a new `onHeadroomResetAnchor` option (+2 unit tests pinning fire/no-fire).
- `renderAgentCard` hoisted to module scope (zero deps); the outline collapse projection becomes a pure `outlineCollapseState()` in `useOutlineCollapse.ts`.

## Prop grouping (breaking for direct `TranscriptLayout` consumers)

Four new group interfaces, each consumed by exactly one hook:

- `timeline: TranscriptLayoutTimelineProps` — selection/active adapters, `serverTimelines`, marker/agent config, `showSwimlanes`, `onMarkerNavigate`, `onScrollToTop` (→ `useTimelinePipeline`)
- `deepLink: TranscriptLayoutDeepLinkProps` — `eventId`/`messageId` (→ `useDeepLinkResolution`)
- `headroom: TranscriptLayoutHeadroomProps` — `hidden`/`onSetHidden`/`onResetAnchor`
- `empty: TranscriptLayoutEmptyProps` — `text`/`busy`

Group literals are fresh per render at call sites; the component destructures them to locals immediately, so hooks keep depending on the inner values (caller identity preserved) and memo/effect behavior is unchanged. All four app call sites updated (inspect `TranscriptPanel`/`RetryAttemptCard`, scout `TranscriptPanel`/`TimelineEventsView`).

Not done (possible follow-up): folding `outlineScrollRef`/`rightRailPanelScrollRef` into the `outline`/`rightRail` groups — it ripples into the wrapper components' own prop APIs.

## Testing

- 2 new unit tests (`useDeepLinkResolution` headroom reset); all existing suites pass unchanged (typecheck/lint/test across the monorepo, forced turbo run).
- Existing e2e + characterization tests from rounds 1–4 cover the moved seams (swimlane header, outline sidebar, deep-link effects).
