### PR TITLE
Fold sidebar scroll refs into outline/rightRail prop groups

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -739,6 +739,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
       label: railLabel,
       panelWidth: railPanelWidth,
       onPanelWidthChange: setRailPanelWidth,
+      panelScrollRef: railPanelScrollRef,
     }),
     [railNode, railPanel, railLabel, railPanelWidth, setRailPanelWidth]
   );
@@ -820,7 +821,6 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                     initialEventId={sampleDetailNavigation.event}
                     initialMessageId={sampleDetailNavigation.message}
                     rightRail={hasRail ? transcriptRail : undefined}
-                    rightRailPanelScrollRef={railPanelScrollRef}
                   />
                 </div>
               )}

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -415,8 +415,6 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     (id: ActivityRailItemId) => setRightDock(rightDock === id ? "none" : id),
     [rightDock, setRightDock]
   );
-  const railPanelScrollRef = useRef<HTMLDivElement | null>(null);
-
   // Panel width is a global preference persisted across samples and reloads,
   // shared by the Transcript and Messages tabs.
   const railPanelWidth = useStore((state) => {
@@ -739,7 +737,6 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
       label: railLabel,
       panelWidth: railPanelWidth,
       onPanelWidthChange: setRailPanelWidth,
-      panelScrollRef: railPanelScrollRef,
     }),
     [railNode, railPanel, railLabel, railPanelWidth, setRailPanelWidth]
   );

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -59,7 +59,6 @@ interface TranscriptPanelProps {
 
   /** Always-visible right rail + optional panel (Search / Scans). */
   rightRail?: TranscriptLayoutRightRailProps;
-  rightRailPanelScrollRef?: RefObject<HTMLDivElement | null>;
 
   initialEventId?: string | null;
   initialMessageId?: string | null;
@@ -82,7 +81,6 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
     timelines: serverTimelines,
     eventNodeContext,
     rightRail,
-    rightRailPanelScrollRef,
   } = props;
 
   // ---------------------------------------------------------------------------
@@ -376,9 +374,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
       bulkCollapse={bulkCollapse}
       collapseState={collapseState}
       eventsListRef={eventsListRef}
-      outlineScrollRef={outlineScrollRef}
       rightRail={rightRail}
-      rightRailPanelScrollRef={rightRailPanelScrollRef}
       outline={{
         collapsed: outlineCollapsed,
         onCollapsedChange: setOutlineCollapsed,
@@ -390,6 +386,7 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
         onNavigateToEvent: onOutlineNavigate,
         selectedId: selectedOutlineId,
         setSelectedId: setSelectedOutlineId,
+        scrollRef: outlineScrollRef,
       }}
       empty={{
         text:

--- a/packages/inspect-components/src/transcript/OutlineSidebar.tsx
+++ b/packages/inspect-components/src/transcript/OutlineSidebar.tsx
@@ -38,6 +38,9 @@ export interface TranscriptLayoutOutlineProps {
   onNavigateToEvent?: (eventId: string) => void;
   selectedId?: string | null;
   setSelectedId?: (id: string) => void;
+  /** Optional ref to the outline's sticky scroll container. Useful when the
+   *  caller wants to observe its scroll events (e.g. headroom direction). */
+  scrollRef?: RefObject<HTMLDivElement | null>;
 }
 
 export interface OutlineSidebarProps {
@@ -51,9 +54,6 @@ export interface OutlineSidebarProps {
   defaultCollapsedIds: Record<string, boolean>;
   /** The main scroll container. */
   scrollRef: RefObject<HTMLDivElement | null>;
-  /** Optional external mirror of the sidebar's own scroll container (wheel
-   *  forwarding / headroom observers). */
-  outlineScrollRef?: RefObject<HTMLDivElement | null>;
   running: boolean;
   backfilling: boolean;
   /** Resolved agent name header (outline.name or the selected row). */
@@ -72,7 +72,6 @@ export const OutlineSidebar: FC<OutlineSidebarProps> = ({
   eventNodes,
   defaultCollapsedIds,
   scrollRef,
-  outlineScrollRef,
   running,
   backfilling,
   agentName,
@@ -88,14 +87,15 @@ export const OutlineSidebar: FC<OutlineSidebarProps> = ({
   const [outlineScrollEl, setOutlineScrollEl] = useState<HTMLDivElement | null>(
     null
   );
+  const { scrollRef: externalScrollRef } = outline;
   const handleOutlineScrollRef = useCallback(
     (el: HTMLDivElement | null) => {
       setOutlineScrollEl(el);
-      if (outlineScrollRef) {
-        outlineScrollRef.current = el;
+      if (externalScrollRef) {
+        externalScrollRef.current = el;
       }
     },
-    [outlineScrollRef]
+    [externalScrollRef]
   );
 
   const collapse: OutlineCollapseState | undefined = useMemo(

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -94,8 +94,6 @@ export interface TranscriptLayoutRightRailProps {
   panelMaxWidth?: number;
   /** aria-label root for the panel region. */
   label?: string;
-  /** Optional ref to the rail panel's sticky scroll container (wheel forwarding). */
-  panelScrollRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Timeline data, selection adapters, and swimlane behavior
@@ -395,6 +393,10 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     [onHeadroomResetAnchor]
   );
 
+  // The rail panel's scroll container is written by RailDock and read only by
+  // the wheel coupling below — no caller sees it, so the layout owns the ref.
+  const railPanelScrollRef = useRef<HTMLDivElement | null>(null);
+
   // The rail panel pins directly below the toolbar (offsetTop), alongside
   // the timeline; the outline pins below the swimlanes (effectiveOffsetTop).
   // Each needs its own sticky-detection threshold. The remount keys re-attach
@@ -409,7 +411,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
         remountKey: outline?.collapsed ?? null,
       },
       {
-        scrollRef: rightRail?.panelScrollRef,
+        scrollRef: railPanelScrollRef,
         stickyTop: offsetTop,
         remountKey: rightRail?.panel != null,
       },
@@ -530,7 +532,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
               scrollRef={scrollRef}
               scrollerHeight={scrollerHeight}
               offsetTop={offsetTop}
-              panelScrollRef={rightRail.panelScrollRef}
+              panelScrollRef={railPanelScrollRef}
               railWidth={rightRail.railWidth}
               panelWidth={rightRail.panelWidth}
               onPanelWidthChange={rightRail.onPanelWidthChange}

--- a/packages/inspect-components/src/transcript/TranscriptLayout.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptLayout.tsx
@@ -94,6 +94,8 @@ export interface TranscriptLayoutRightRailProps {
   panelMaxWidth?: number;
   /** aria-label root for the panel region. */
   label?: string;
+  /** Optional ref to the rail panel's sticky scroll container (wheel forwarding). */
+  panelScrollRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Timeline data, selection adapters, and swimlane behavior
@@ -186,15 +188,10 @@ export interface TranscriptLayoutProps {
   // --- Outline ---
   /** Outline panel configuration. When omitted, the outline column is hidden entirely. */
   outline?: TranscriptLayoutOutlineProps;
-  /** Optional ref to the outline's sticky scroll container. Useful when the
-   *  caller wants to observe its scroll events (e.g. headroom direction). */
-  outlineScrollRef?: RefObject<HTMLDivElement | null>;
 
   // --- Right rail ---
   /** Optional always-visible right rail + optional panel. */
   rightRail?: TranscriptLayoutRightRailProps;
-  /** Optional ref to the rail panel's sticky scroll container (wheel forwarding). */
-  rightRailPanelScrollRef?: RefObject<HTMLDivElement | null>;
 
   /** Extra context fields merged into every EventNodeContext entry. */
   eventNodeContext?: Partial<EventNodeContext>;
@@ -230,9 +227,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
   bulkCollapse,
   collapseState,
   outline,
-  outlineScrollRef,
   rightRail,
-  rightRailPanelScrollRef,
   eventNodeContext,
   className,
 }) => {
@@ -409,12 +404,12 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
     mainScrollRef: scrollRef,
     sidebars: [
       {
-        scrollRef: outlineScrollRef,
+        scrollRef: outline?.scrollRef,
         stickyTop: effectiveOffsetTop,
         remountKey: outline?.collapsed ?? null,
       },
       {
-        scrollRef: rightRailPanelScrollRef,
+        scrollRef: rightRail?.panelScrollRef,
         stickyTop: offsetTop,
         remountKey: rightRail?.panel != null,
       },
@@ -485,7 +480,6 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
                   eventNodes={eventNodes}
                   defaultCollapsedIds={defaultCollapsedIds}
                   scrollRef={scrollRef}
-                  outlineScrollRef={outlineScrollRef}
                   running={running}
                   backfilling={backfilling}
                   agentName={
@@ -536,7 +530,7 @@ export const TranscriptLayout: FC<TranscriptLayoutProps> = ({
               scrollRef={scrollRef}
               scrollerHeight={scrollerHeight}
               offsetTop={offsetTop}
-              panelScrollRef={rightRailPanelScrollRef}
+              panelScrollRef={rightRail.panelScrollRef}
               railWidth={rightRail.railWidth}
               panelWidth={rightRail.panelWidth}
               onPanelWidthChange={rightRail.onPanelWidthChange}


### PR DESCRIPTION
Follow-up to #441: folds the two remaining top-level wiring refs on `TranscriptLayout` into their feature groups, finishing the "every prop lives with its feature" contract.

- `outlineScrollRef` → `outline.scrollRef` (`TranscriptLayoutOutlineProps`)
- `rightRailPanelScrollRef` → `rightRail.panelScrollRef` (`TranscriptLayoutRightRailProps`)

`OutlineSidebar` drops its separate ref prop and reads `outline.scrollRef`; the layout's wheel-coupling and `RailDock` read the group fields. Inspect's `TranscriptPanel` API loses `rightRailPanelScrollRef` (SampleDisplay now sets `panelScrollRef` in its `transcriptRail` memo) and moves its local outline ref into the `outline` literal. Scout never used these refs — no changes.

Note on `react-hooks/refs`: extracting the ref in `OutlineSidebar` via property access (`const x = outline.scrollRef`) tainted the whole `outline` object in the compiler's alias analysis, flagging unrelated render reads like `outline.title`. Destructuring (`const { scrollRef: externalScrollRef } = outline`) scopes the ref inference to the one binding — no suppressions.

Render output unchanged; no new tests needed (pure prop plumbing, covered by existing suites — full typecheck/lint/test green).
