### PR TITLE
fix(timeline): don't discard solver span that contains a single agent span child if it also contains other displayed events

### DIFF
--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -956,6 +956,19 @@ function unwrapSolverSpan(span: SpanNode): SpanNode {
     if (agentChildren.length !== 1) {
       break;
     }
+    // Only collapse the redundant solver→agent nesting when the solver carries
+    // no displayable events of its own. If it logged info/intermediate-score
+    // events, keep the solver span so those survive in the lane (state/store
+    // are structural bookkeeping and safe to drop). Non-span children are raw
+    // Events, so their type is `c.event` (a string), matching the existing
+    // `!isSpanNode(child) && child.event === "branch"` idiom in this file.
+    if (
+      span.children.some(
+        (c) => !isSpanNode(c) && c.event !== "state" && c.event !== "store"
+      )
+    ) {
+      break;
+    }
     span = agentChildren[0]!;
   }
   return span;

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -957,11 +957,10 @@ function unwrapSolverSpan(span: SpanNode): SpanNode {
       break;
     }
     // Only collapse the redundant solver→agent nesting when the solver carries
-    // no displayable events of its own. If it logged info/intermediate-score
-    // events, keep the solver span so those survive in the lane (state/store
-    // are structural bookkeeping and safe to drop). Non-span children are raw
-    // Events, so their type is `c.event` (a string), matching the existing
-    // `!isSpanNode(child) && child.event === "branch"` idiom in this file.
+    // no displayable events of its own. If it logged any other meaningful
+    // events, keep the solver span so those survive in the lane (when
+    // as_solver() runs an agent it emits state/store events, if these are the
+    // only other kind of events it's fine to drop them)
     if (
       span.children.some(
         (c) => !isSpanNode(c) && c.event !== "state" && c.event !== "store"

--- a/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
@@ -1,8 +1,8 @@
 /**
- * Regression tests for the timeline dropping solver-level info/intermediate
- * score events when a solver wraps an agent (e.g. react_with_gated_submit).
- * See the "solver child events" bug: unwrapSolverSpan used to descend into the
- * inner agent span and discard the solver's own event children.
+ * Regression tests for the timeline dropping solver-level events when a solver
+ * wraps an agent (e.g. as_solver): unwrapSolverSpan used to descend into the
+ * inner agent span and discard sibling events in the parent solver, even of
+ * types that were likely to be relevant (model, tool, score, info etc.).
  */
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
@@ -77,7 +77,12 @@ const scoreEvent = (span_id: string, sec: number, intermediate: boolean) =>
   }) as unknown as Event;
 
 const stateEvent = (span_id: string, sec: number) =>
-  ({ event: "state", span_id, changes: [], timestamp: at(sec) }) as unknown as Event;
+  ({
+    event: "state",
+    span_id,
+    changes: [],
+    timestamp: at(sec),
+  }) as unknown as Event;
 
 // --- assertion helper: collect every leaf event type in the built tree ------
 function collectEventTypes(span: TimelineSpan): string[] {
@@ -137,7 +142,9 @@ describe("timeline solver child events", () => {
     // and agent SpanNodes (see core.ts), so a kept (non-collapsed) solver span
     // surfaces with spanType "agent", not "solver" — count "agent" spans to
     // detect the double-nesting instead.
-    expect(countSubSpansOfType(timeline.root, "agent")).toBeGreaterThanOrEqual(1);
+    expect(countSubSpansOfType(timeline.root, "agent")).toBeGreaterThanOrEqual(
+      1
+    );
   });
 
   it("B: still flattens solver→agent to a single lane when extras are only state/store", () => {

--- a/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression tests for the timeline dropping solver-level info/intermediate
+ * score events when a solver wraps an agent (e.g. react_with_gated_submit).
+ * See the "solver child events" bug: unwrapSolverSpan used to descend into the
+ * inner agent span and discard the solver's own event children.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { buildTimeline, TimelineSpan, type Timeline } from "./core";
+
+const BASE = new Date("2025-01-15T10:00:00Z").getTime();
+const at = (sec: number) => new Date(BASE + sec * 1000).toISOString();
+
+// --- raw event builders (inspect transcript schema) -------------------------
+// NOTE FOR IMPLEMENTER: field names (id / parent_id / span_id / type) follow
+// inspect's SpanBegin/SpanEnd/Event schema. If Step 5 fails to BUILD (rather
+// than failing on the assertion), reconcile these against buildTimeline's
+// solvers branch (~line 1717+ in core.ts) and @tsmono/inspect-common/types,
+// then re-run. The test must fail because info/score are ABSENT, not because
+// the fixture is malformed.
+const spanBegin = (
+  id: string,
+  parent_id: string | null,
+  name: string,
+  type: string | null,
+  sec: number
+) =>
+  ({
+    event: "span_begin",
+    id,
+    parent_id,
+    name,
+    type,
+    timestamp: at(sec),
+  }) as unknown as Event;
+
+const spanEnd = (id: string, sec: number) =>
+  ({ event: "span_end", id, timestamp: at(sec) }) as unknown as Event;
+
+const modelEvent = (span_id: string, sec: number) =>
+  ({
+    event: "model",
+    span_id,
+    model: "test-model",
+    timestamp: at(sec),
+    completed: at(sec + 1),
+    output: {
+      usage: {
+        input_tokens: 6,
+        output_tokens: 4,
+        total_tokens: 10,
+        input_tokens_cache_read: null,
+        input_tokens_cache_write: null,
+        reasoning_tokens: null,
+        total_cost: null,
+      },
+    },
+  }) as unknown as Event;
+
+const infoEvent = (span_id: string, sec: number) =>
+  ({
+    event: "info",
+    span_id,
+    data: "solver-level info",
+    timestamp: at(sec),
+  }) as unknown as Event;
+
+const scoreEvent = (span_id: string, sec: number, intermediate: boolean) =>
+  ({
+    event: "score",
+    span_id,
+    intermediate,
+    score: { value: 1, answer: null, explanation: null, metadata: null },
+    timestamp: at(sec),
+  }) as unknown as Event;
+
+const stateEvent = (span_id: string, sec: number) =>
+  ({ event: "state", span_id, changes: [], timestamp: at(sec) }) as unknown as Event;
+
+// --- assertion helper: collect every leaf event type in the built tree ------
+function collectEventTypes(span: TimelineSpan): string[] {
+  const out: string[] = [];
+  for (const c of span.content) {
+    if (c.type === "event") {
+      out.push(c.event.event);
+    } else {
+      out.push(...collectEventTypes(c));
+    }
+  }
+  for (const b of span.branches) {
+    out.push(...collectEventTypes(b));
+  }
+  return out;
+}
+
+// Count nested spans of a given spanType anywhere under `span`. Used to detect
+// whether the redundant solver wrapper was kept (double-nesting) or collapsed.
+// NOTE FOR IMPLEMENTER: if a kept solver span surfaces under a different
+// spanType label than "solver", adjust this string to match what
+// buildSpanFromAgentSpan assigns (grep `spanType` in core.ts).
+function countSubSpansOfType(span: TimelineSpan, spanType: string): number {
+  let n = 0;
+  for (const c of span.content) {
+    if (c.type !== "event") {
+      if (c.spanType === spanType) n += 1;
+      n += countSubSpansOfType(c, spanType);
+    }
+  }
+  return n;
+}
+
+describe("timeline solver child events", () => {
+  it("A: keeps solver-level info and intermediate score when the solver wraps an agent", () => {
+    const events: Event[] = [
+      spanBegin("solvers", null, "solvers", "solvers", 0),
+      spanBegin("solver", "solvers", "react_with_gated_submit", "solver", 1),
+      spanBegin("agent", "solver", "react", "agent", 2),
+      modelEvent("agent", 3),
+      spanEnd("agent", 4),
+      infoEvent("solver", 5),
+      scoreEvent("solver", 6, true),
+      stateEvent("solver", 7),
+      spanEnd("solver", 8),
+      spanEnd("solvers", 9),
+    ];
+
+    const timeline: Timeline = buildTimeline(events);
+    const types = collectEventTypes(timeline.root);
+
+    expect(types).toContain("info");
+    expect(types).toContain("score");
+    expect(types).toContain("model"); // the agent's model call is still present
+    // The solver wrapper is KEPT (not collapsed) so its events can render.
+    // NOTE: buildSpanFromAgentSpan hardcodes spanType="agent" for both solver
+    // and agent SpanNodes (see core.ts), so a kept (non-collapsed) solver span
+    // surfaces with spanType "agent", not "solver" — count "agent" spans to
+    // detect the double-nesting instead.
+    expect(countSubSpansOfType(timeline.root, "agent")).toBeGreaterThanOrEqual(1);
+  });
+
+  it("B: still flattens solver→agent to a single lane when extras are only state/store", () => {
+    const events: Event[] = [
+      spanBegin("solvers", null, "solvers", "solvers", 0),
+      spanBegin("solver", "solvers", "basic_solver", "solver", 1),
+      spanBegin("agent", "solver", "react", "agent", 2),
+      modelEvent("agent", 3),
+      spanEnd("agent", 4),
+      stateEvent("solver", 5),
+      spanEnd("solver", 6),
+      spanEnd("solvers", 7),
+    ];
+
+    const timeline: Timeline = buildTimeline(events);
+
+    // No double nesting: with only state/store extras the solver→agent wrapper
+    // is collapsed, so NO extra nested "agent"-spanType span is retained under
+    // root (the tempting wrong fix, `children.length !== 1`, would keep it and
+    // regress this).
+    expect(countSubSpansOfType(timeline.root, "agent")).toBe(0);
+    // Nothing lost: the agent's model call still renders.
+    expect(collectEventTypes(timeline.root)).toContain("model");
+  });
+});


### PR DESCRIPTION
`unwrapSolverSpan` removes a solver span that contains exactly one agent span and replaces it with the agent span to avoid unnecessary visual nesting for agents run using `as_solver()` (which wraps the agent's span in a solver span that is otherwise redundant). 

Unfortunately `unwrapSolverSpan` does not check if the parent solver span contains other events, which can happen if a solver runs an agent using `run()`. This means that `unwrapSolverSpan` discards any other child events emitted from the solver.

This PR adds a guard to the unwrap so it only collapses when the solver carries no displayable events (state/store are still skipped as `as_solver` creates these and they are redundant).