### PR TITLE
Prepare for true pagination

### DIFF
--- a/apps/inspect/e2e/log-list-find.spec.ts
+++ b/apps/inspect/e2e/log-list-find.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E tests for the log-list find band (Cmd/Ctrl+F).
+ *
+ * Match membership is a data-level query against the listing source (see
+ * readLogsListingMatches) running under a type-ahead debounce, so these
+ * exercise the full path: shortcut → typed term → debounced match query →
+ * counter/selection, plus the "No results" gating that must not flash
+ * while a keystroke's query is still in flight.
+ */
+import type { Page } from "@playwright/test";
+import { http, HttpResponse } from "msw";
+
+import { expect, test } from "./fixtures/app";
+
+const LOG_DIR = "/home/test/logs";
+
+const LOG_FILES = [
+  {
+    name: `${LOG_DIR}/2025-01-15T10-00-00_task-alpha_abc123.eval`,
+    task: "task-alpha",
+    task_id: "task-alpha",
+  },
+  {
+    name: `${LOG_DIR}/2025-01-15T10-05-00_task-beta_def456.eval`,
+    task: "task-beta",
+    task_id: "task-beta",
+  },
+  {
+    name: `${LOG_DIR}/2025-01-15T10-10-00_task-gamma_ghi789.eval`,
+    task: "task-gamma",
+    task_id: "task-gamma",
+  },
+];
+
+const LOG_HEADERS = LOG_FILES.map((f, i) => ({
+  eval_id: `eval-${i}`,
+  run_id: `run-${i}`,
+  task: f.task,
+  task_id: f.task_id,
+  task_version: 1,
+  model: "claude-sonnet-4-5-20250929",
+  status: "success",
+  started_at: "2025-01-15T10:00:00Z",
+  completed_at: "2025-01-15T10:05:00Z",
+}));
+
+function setupHandlers(
+  network: Parameters<Parameters<typeof test>[2]>[0]["network"]
+) {
+  network.use(
+    http.get("*/api/log-dir", () => HttpResponse.json({ log_dir: LOG_DIR })),
+    http.get("*/api/logs", () =>
+      HttpResponse.json({ log_dir: LOG_DIR, files: LOG_FILES })
+    ),
+    http.get("*/api/log-files*", () =>
+      HttpResponse.json({ files: LOG_FILES, response_type: "full" })
+    ),
+    http.get("*/api/log-headers*", () => HttpResponse.json(LOG_HEADERS))
+  );
+}
+
+function findInput(page: Page) {
+  return page.getByPlaceholder("Find");
+}
+
+function matchStatus(page: Page) {
+  return page.locator(".findBand-match-count");
+}
+
+async function openFindBand(page: Page) {
+  await page.keyboard.press("ControlOrMeta+f");
+  await expect(findInput(page)).toBeVisible();
+  await expect(findInput(page)).toBeFocused();
+}
+
+async function waitForGrid(page: Page) {
+  await expect(page.getByRole("grid")).toBeVisible();
+  await expect(
+    page.getByRole("gridcell").filter({ hasText: "task-alpha" }).first()
+  ).toBeVisible();
+}
+
+test.describe("Log-list find band", () => {
+  test("finds a unique term and selects its row", async ({ page, network }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await openFindBand(page);
+    await findInput(page).fill("beta");
+
+    await expect(matchStatus(page)).toHaveText("1 of 1");
+    await expect(
+      page.getByRole("row").filter({ hasText: "task-beta" })
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("navigates between matches with the counter tracking", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await openFindBand(page);
+    await findInput(page).fill("task-");
+
+    await expect(matchStatus(page)).toHaveText("1 of 3");
+    await page.locator(".findBand button.next").click();
+    await expect(matchStatus(page)).toHaveText("2 of 3");
+    await page.locator(".findBand button.prev").click();
+    await expect(matchStatus(page)).toHaveText("1 of 3");
+  });
+
+  test("reports no results only after the match query settles", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await openFindBand(page);
+    await findInput(page).fill("no-such-log-anywhere");
+
+    await expect(matchStatus(page)).toHaveText("No results");
+
+    // Narrowing back to a matching term recovers from the no-results state.
+    await findInput(page).fill("gamma");
+    await expect(matchStatus(page)).toHaveText("1 of 1");
+  });
+
+  test("escape closes the band and clears the term", async ({
+    page,
+    network,
+  }) => {
+    setupHandlers(network);
+    await page.goto("/");
+    await waitForGrid(page);
+
+    await openFindBand(page);
+    await findInput(page).fill("beta");
+    await expect(matchStatus(page)).toHaveText("1 of 1");
+
+    await page.keyboard.press("Escape");
+    await expect(findInput(page)).toBeHidden();
+
+    // Reopening starts clean — no stale term or counter.
+    await openFindBand(page);
+    await expect(findInput(page)).toHaveValue("");
+    await expect(matchStatus(page)).toBeHidden();
+  });
+});

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -240,20 +240,37 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getFilterType,
   } = useLogListColumns(mode, scopeDir, scoresViewMode);
 
+  const toItem = useCallback(
+    (log: LogListingRow) => fileLogItem(log, itemView),
+    [itemView]
+  );
+
   const listData = useLogListData({
     items: logItems,
     scopeKey,
     getValue,
     getComparator,
     getFilterType,
-    // Match the row universe: folder mode lists the current directory, the
-    // flat tasks view lists the whole log dir (like `scopeDir` above) — a
-    // narrower Dexie scope would silently drop matching rows outside it.
-    databaseScope: {
+    listing: {
+      logDir,
+      // Match the row universe: folder mode lists the current directory, the
+      // flat tasks view lists the whole log dir (like `scopeDir` above) — a
+      // narrower scan prefix would silently drop matching rows outside it.
       prefix: mode === "logs" ? currentDir : logDir,
-      syncedPrefix: logDir,
+      // The query result depends on everything toItem reads, so its cache
+      // identity carries the display toggle along with the view scope.
+      universe:
+        scopeKey === undefined
+          ? undefined
+          : `${scopeKey}::retried=${showRetriedLogs}`,
+      toItem,
     },
   });
+
+  // The listing query is asynchronous by design: fold its first-read window
+  // into the busy indication so the grid shows "syncing" rather than a
+  // silently empty list.
+  const listBusy = busy || listData.pending;
 
   const currentColumnVisibility = useStore(
     (state) => state.logs.listing.columnVisibility
@@ -413,13 +430,13 @@ export const LogsPanel: FC<LogsPanelProps> = ({
               currentPath={currentDir}
               scopeKey={scopeKey}
               mode={mode}
-              busy={busy}
+              busy={listBusy}
             />
           </div>
           <LogListFooter
             itemCount={logItems.length}
             filteredCount={listData.filteredCount}
-            progressText={busy ? "Syncing data" : undefined}
+            progressText={listBusy ? "Syncing data" : undefined}
             progressBar={
               progress.total !== progress.complete ? (
                 <ProgressBar

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -24,6 +24,7 @@ import { logsUrl, tasksUrl, useLogRouteParams } from "../routing/url";
 import { useEvalSet } from "../server/useEvalSet";
 import { ColumnSelectorPopover } from "../shared/ColumnSelectorPopover";
 
+import { fileLogItem, type FileLogItemView } from "./fileLogItem";
 import { useLogListColumns, type ScoresViewMode } from "./grid/columns/hooks";
 import { LogListGrid } from "./grid/LogListGrid";
 import { useLogListData } from "./grid/useLogListData";
@@ -92,6 +93,11 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     });
   }, [logDir]);
 
+  const itemView: FileLogItemView = useMemo(
+    () => ({ mode, logDir, currentDir, showRetriedLogs }),
+    [mode, logDir, currentDir, showRetriedLogs]
+  );
+
   const [logItems, hasRetriedLogs]: [
     Array<FileLogItem | FolderLogItem | PendingTaskItem>,
     boolean,
@@ -111,17 +117,9 @@ export const LogsPanel: FC<LogsPanelProps> = ({
           _hasRetriedLogs = true;
         }
 
-        if (showRetriedLogs || !logFile.retried) {
-          const relativePath = directoryRelativeUrl(logFile.name, logDir);
-          const decodedPath = decodeURIComponent(relativePath);
-
-          fileItems.push({
-            id: logFile.name,
-            name: decodedPath,
-            type: "file",
-            url: tasksUrl(decodedPath, logDir),
-            log: logFile,
-          });
+        const item = fileLogItem(logFile, itemView);
+        if (item) {
+          fileItems.push(item);
         }
       }
 
@@ -177,27 +175,13 @@ export const LogsPanel: FC<LogsPanelProps> = ({
         : currentDir;
 
       if (isInDirectory(name, cleanDir)) {
-        const dirName = directoryRelativeUrl(currentDir, logDir);
-        const relativePath = directoryRelativeUrl(name, currentDir);
-
-        const fileOrFolderName = decodeURIComponent(rootName(relativePath));
-        const path = join(
-          decodeURIComponent(relativePath),
-          decodeURIComponent(dirName)
-        );
-
         if (logFile.retried) {
           _hasRetriedLogs = true;
         }
 
-        if (showRetriedLogs || !logFile.retried) {
-          fileItems.push({
-            id: fileOrFolderName,
-            name: fileOrFolderName,
-            type: "file",
-            url: logsUrl(path, logDir),
-            log: logFile,
-          });
+        const item = fileLogItem(logFile, itemView);
+        if (item) {
+          fileItems.push(item);
         }
       } else if (name.startsWith(dirWithSlash)) {
         // This is file that is next level (or deeper) child of the current directory
@@ -228,7 +212,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     );
 
     return [_logFiles, _hasRetriedLogs];
-  }, [mode, evalSet, logFiles, currentDir, logDir, showRetriedLogs]);
+  }, [mode, evalSet, logFiles, currentDir, logDir, itemView]);
 
   // In the folder view, scope the Metrics list to logs under the current
   // directory so descending into a subfolder shows only that folder's metrics.

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -33,8 +33,11 @@ import {
   type FileLogItemView,
 } from "./fileLogItem";
 import { useLogListColumns, type ScoresViewMode } from "./grid/columns/hooks";
+import type { LogListRow } from "./grid/columns/types";
 import { LogListGrid } from "./grid/LogListGrid";
+import { buildLogListRow } from "./grid/logListRow";
 import { useLogListData } from "./grid/useLogListData";
+import type { LogsListingDescriptor } from "./listing/useLogsListingQuery";
 import { FolderLogItem, PendingTaskItem } from "./LogItem";
 import { LogListFooter } from "./LogListFooter";
 import styles from "./LogsPanel.module.css";
@@ -169,9 +172,27 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getFilterType,
   } = useLogListColumns(mode, scopeDir, scoresViewMode);
 
-  const toItem = useCallback(
-    (log: LogListingRow) => fileLogItem(log, itemView),
+  const toRow = useCallback(
+    (log: LogListingRow) => {
+      const item = fileLogItem(log, itemView);
+      return item === undefined ? undefined : buildLogListRow(item);
+    },
     [itemView]
+  );
+
+  // One descriptor shared by the row query (useLogListData) and the grid's
+  // find-band match query, so they can never disagree about the universe.
+  const listing = useMemo<LogsListingDescriptor<LogListRow>>(
+    () => ({
+      logDir,
+      // Match the row universe: folder mode lists the current directory, the
+      // flat tasks view lists the whole log dir (like `scopeDir` above) — a
+      // narrower scan prefix would silently drop matching rows outside it.
+      prefix: mode === "logs" ? currentDir : logDir,
+      universe,
+      toRow,
+    }),
+    [logDir, mode, currentDir, universe, toRow]
   );
 
   const listData = useLogListData({
@@ -180,15 +201,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
-    listing: {
-      logDir,
-      // Match the row universe: folder mode lists the current directory, the
-      // flat tasks view lists the whole log dir (like `scopeDir` above) — a
-      // narrower scan prefix would silently drop matching rows outside it.
-      prefix: mode === "logs" ? currentDir : logDir,
-      universe,
-      toItem,
-    },
+    listing,
   });
 
   // Pre-filter row count — distinguishes "no items yet" (loading
@@ -354,6 +367,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
               scopeKey={scopeKey}
               mode={mode}
               busy={listBusy}
+              listing={listing}
             />
           </div>
           <LogListFooter

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -262,7 +262,13 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
-    databaseScope: { prefix: currentDir, syncedPrefix: logDir },
+    // Match the row universe: folder mode lists the current directory, the
+    // flat tasks view lists the whole log dir (like `scopeDir` above) — a
+    // narrower Dexie scope would silently drop matching rows outside it.
+    databaseScope: {
+      prefix: mode === "logs" ? currentDir : logDir,
+      syncedPrefix: logDir,
+    },
   });
 
   const currentColumnVisibility = useStore(

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -123,7 +123,6 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // The navbar bar tracks the sync round-trip only — engine background
   // fetching (`busy`) stays in the footer/overlay indications.
   const navbarLoading = sync.loading || overviewQuery.loading;
-  const error = sync.error ?? overviewQuery.error;
 
   // Presentation items with no database record: folders (pinned) and the
   // eval set's not-yet-run tasks. File rows come from the listing query.
@@ -214,6 +213,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // first-read window into the busy indication so the grid shows "syncing"
   // rather than a silently empty list.
   const listBusy = busy || listData.pending || overviewQuery.loading;
+  const error = sync.error ?? overviewQuery.error ?? listData.error;
 
   const currentColumnVisibility = useStore(
     (state) => state.logs.listing.columnVisibility

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -262,6 +262,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
+    databaseScope: { prefix: currentDir, syncedPrefix: logDir },
   });
 
   const currentColumnVisibility = useStore(

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -360,11 +360,17 @@ export const LogsPanel: FC<LogsPanelProps> = ({
       ) : (
         <>
           <div className={clsx(styles.list, "text-size-smaller")}>
+            {/* Keyed on the scope so switching folder/mode resets the grid
+                wholesale — scroll, selection, and the find band's state
+                (term + matches) belong to one scope and reset together. */}
             <LogListGrid
+              key={scopeKey ?? "pending"}
               rows={listData.rows}
               totalRowCount={totalRowCount}
               sorting={listData.sorting}
               columnFilters={listData.columnFilters}
+              filter={listData.filter}
+              orderBy={listData.orderBy}
               currentPath={currentDir}
               scopeKey={scopeKey}
               mode={mode}

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -5,10 +5,13 @@ import { Navigate } from "react-router-dom";
 import { EvalSet } from "@tsmono/inspect-common/types";
 import { ErrorPanel, ProgressBar } from "@tsmono/react/components";
 import { useProperty } from "@tsmono/react/hooks";
-import { dirname, isInDirectory } from "@tsmono/util";
 
 import { useLogDir } from "../../app_config";
-import { useLogListing, useLogsSync, type LogListingRow } from "../../log_data";
+import {
+  useLogsSync,
+  type LogListingRow,
+  type LogsOverview,
+} from "../../log_data";
 import { setDocumentTitle } from "../../state/actions";
 import { useLogsListing } from "../../state/hooks";
 import { useStore } from "../../state/store";
@@ -24,19 +27,18 @@ import { logsUrl, tasksUrl, useLogRouteParams } from "../routing/url";
 import { useEvalSet } from "../server/useEvalSet";
 import { ColumnSelectorPopover } from "../shared/ColumnSelectorPopover";
 
-import { fileLogItem, type FileLogItemView } from "./fileLogItem";
+import {
+  fileLogIdentity,
+  fileLogItem,
+  type FileLogItemView,
+} from "./fileLogItem";
 import { useLogListColumns, type ScoresViewMode } from "./grid/columns/hooks";
 import { LogListGrid } from "./grid/LogListGrid";
 import { useLogListData } from "./grid/useLogListData";
-import { FileLogItem, FolderLogItem, PendingTaskItem } from "./LogItem";
+import { FolderLogItem, PendingTaskItem } from "./LogItem";
 import { LogListFooter } from "./LogListFooter";
 import styles from "./LogsPanel.module.css";
-
-const rootName = (relativePath: string) => {
-  return relativePath.split("/")[0] ?? "";
-};
-
-const kNoListingRows: LogListingRow[] = [];
+import { useLogsOverview } from "./useLogsOverview";
 
 export type LogsPanelMode = "logs" | "tasks";
 
@@ -58,21 +60,14 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     (state) => state.setShowRetriedLogs
   );
   const logDir = useLogDir();
-  const listing = useLogListing(logDir);
-  const logFiles = listing.data ?? kNoListingRows;
   const { gridStateByScope, patchGridState } = useLogsListing();
 
   const { logPath } = useLogRouteParams();
   const evalSet = useEvalSet(logPath || "").data;
   // Sync the listing for this panel's scope; the error panel and busy
-  // indications derive from its status folded with the listing read's own
+  // indications derive from its status folded with the overview read's own
   // loading/error.
   const sync = useLogsSync(logDir, logPath ?? "");
-  const busy = sync.busy || listing.loading;
-  // The navbar bar tracks the sync round-trip only — engine background
-  // fetching (`busy`) stays in the footer/overlay indications.
-  const navbarLoading = sync.loading || listing.loading;
-  const error = sync.error ?? listing.error;
 
   const currentDir = join(logPath || "", logDir);
 
@@ -84,6 +79,14 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // own state. `undefined` until logDir hydrates so we never write under
   // a half-initialized scope.
   const scopeKey = logDir === undefined ? undefined : `${mode}::${currentDir}`;
+
+  // Cache identity of the row universe: the listing/overview queries depend
+  // on everything the view mapping reads, so it carries the display toggle
+  // along with the view scope.
+  const universe =
+    scopeKey === undefined
+      ? undefined
+      : `${scopeKey}::retried=${showRetriedLogs}`;
 
   const flowData = useFlowQuery(logPath || "").data;
 
@@ -98,121 +101,47 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     [mode, logDir, currentDir, showRetriedLogs]
   );
 
-  const [logItems, hasRetriedLogs]: [
-    Array<FileLogItem | FolderLogItem | PendingTaskItem>,
-    boolean,
-  ] = useMemo(() => {
-    if (mode === "tasks") {
-      // Flat mode: show all log files without folder grouping
-      const fileItems: Array<FileLogItem | PendingTaskItem> = [];
-      const existingLogTaskIds = new Set<string>();
-      let _hasRetriedLogs = false;
+  const isCandidate = useCallback(
+    (log: LogListingRow) => fileLogIdentity(log.name, itemView) !== undefined,
+    [itemView]
+  );
+  const overviewQuery = useLogsOverview({
+    logDir,
+    universe,
+    view: {
+      folderDir: mode === "logs" ? currentDir : undefined,
+      showRetriedLogs,
+      isCandidate,
+    },
+  });
+  const overview = overviewQuery.overview;
 
-      for (const logFile of logFiles) {
-        if (logFile.task_id) {
-          existingLogTaskIds.add(logFile.task_id);
-        }
+  const busy = sync.busy;
+  // The navbar bar tracks the sync round-trip only — engine background
+  // fetching (`busy`) stays in the footer/overlay indications.
+  const navbarLoading = sync.loading || overviewQuery.pending;
+  const error = sync.error ?? overviewQuery.error;
 
-        if (logFile.retried) {
-          _hasRetriedLogs = true;
-        }
+  // Presentation items with no database record: folders (pinned) and the
+  // eval set's not-yet-run tasks. File rows come from the listing query.
+  const logItems: Array<FolderLogItem | PendingTaskItem> = useMemo(() => {
+    const currentDirRelative = directoryRelativeUrl(currentDir, logDir);
+    const folderItems: Array<FolderLogItem | PendingTaskItem> = (
+      overview?.folders ?? []
+    ).map((folder) => ({
+      id: folder.name,
+      name: folder.name,
+      type: "folder",
+      url: logsUrl(
+        join(folder.name, decodeURIComponent(currentDirRelative)),
+        logDir
+      ),
+      itemCount: folder.itemCount,
+    }));
+    return appendPendingItems(evalSet, new Set(overview?.taskIds), folderItems);
+  }, [overview, evalSet, currentDir, logDir]);
 
-        const item = fileLogItem(logFile, itemView);
-        if (item) {
-          fileItems.push(item);
-        }
-      }
-
-      const allItems = appendPendingItems(
-        evalSet,
-        existingLogTaskIds,
-        fileItems
-      );
-      return [allItems, _hasRetriedLogs];
-    }
-
-    // Folder-grouped mode (default)
-    const folderItems: Array<FileLogItem | FolderLogItem | PendingTaskItem> =
-      [];
-    const fileItems: Array<FileLogItem | FolderLogItem | PendingTaskItem> = [];
-
-    // Track processed folders to avoid duplicates
-    const processedFolders = new Set<string>();
-    const existingLogTaskIds = new Set<string>();
-    let _hasRetriedLogs = false;
-
-    // Count logs under a path prefix via binary search rather than a full
-    // scan per folder (which made folder counting O(folders × logs)). Names
-    // sort into contiguous ranges, so a prefix count is two bound lookups.
-    const sortedNames = logFiles.map((f) => f.name).sort();
-    const lowerBound = (target: string): number => {
-      let lo = 0;
-      let hi = sortedNames.length;
-      while (lo < hi) {
-        const mid = (lo + hi) >> 1;
-        const name = sortedNames[mid];
-        if (name !== undefined && name < target) lo = mid + 1;
-        else hi = mid;
-      }
-      return lo;
-    };
-    const countWithPrefix = (prefix: string): number =>
-      lowerBound(prefix + "\uffff") - lowerBound(prefix);
-
-    for (const logFile of logFiles) {
-      if (logFile.task_id) {
-        existingLogTaskIds.add(logFile.task_id);
-      }
-
-      const name = logFile.name;
-
-      const cleanDir = currentDir.endsWith("/")
-        ? currentDir.slice(0, -1)
-        : currentDir;
-
-      const dirWithSlash = !currentDir.endsWith("/")
-        ? currentDir + "/"
-        : currentDir;
-
-      if (isInDirectory(name, cleanDir)) {
-        if (logFile.retried) {
-          _hasRetriedLogs = true;
-        }
-
-        const item = fileLogItem(logFile, itemView);
-        if (item) {
-          fileItems.push(item);
-        }
-      } else if (name.startsWith(dirWithSlash)) {
-        // This is file that is next level (or deeper) child of the current directory
-        const relativePath = directoryRelativeUrl(name, currentDir);
-
-        const dirName = decodeURIComponent(rootName(relativePath));
-        const currentDirRelative = directoryRelativeUrl(currentDir, logDir);
-        const url = join(dirName, decodeURIComponent(currentDirRelative));
-        if (!processedFolders.has(dirName)) {
-          folderItems.push({
-            id: dirName,
-            name: dirName,
-            type: "folder",
-            url: logsUrl(url, logDir),
-            itemCount: countWithPrefix(dirname(name)),
-          });
-          processedFolders.add(dirName);
-        }
-      }
-    }
-
-    const orderedItems = [...folderItems, ...fileItems];
-
-    const _logFiles = appendPendingItems(
-      evalSet,
-      existingLogTaskIds,
-      orderedItems
-    );
-
-    return [_logFiles, _hasRetriedLogs];
-  }, [mode, evalSet, logFiles, currentDir, logDir, itemView]);
+  const hasRetriedLogs = (overview?.retriedCount ?? 0) > 0;
 
   // In the folder view, scope the Metrics list to logs under the current
   // directory so descending into a subfolder shows only that folder's metrics.
@@ -246,7 +175,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   );
 
   const listData = useLogListData({
-    items: logItems,
+    overlayItems: logItems,
     scopeKey,
     getValue,
     getComparator,
@@ -257,20 +186,19 @@ export const LogsPanel: FC<LogsPanelProps> = ({
       // flat tasks view lists the whole log dir (like `scopeDir` above) — a
       // narrower scan prefix would silently drop matching rows outside it.
       prefix: mode === "logs" ? currentDir : logDir,
-      // The query result depends on everything toItem reads, so its cache
-      // identity carries the display toggle along with the view scope.
-      universe:
-        scopeKey === undefined
-          ? undefined
-          : `${scopeKey}::retried=${showRetriedLogs}`,
+      universe,
       toItem,
     },
   });
 
-  // The listing query is asynchronous by design: fold its first-read window
-  // into the busy indication so the grid shows "syncing" rather than a
-  // silently empty list.
-  const listBusy = busy || listData.pending;
+  // Pre-filter row count — distinguishes "no items yet" (loading
+  // empty-state) from "filters matched nothing".
+  const totalRowCount = (overview?.fileCount ?? 0) + logItems.length;
+
+  // The listing/overview queries are asynchronous by design: fold their
+  // first-read window into the busy indication so the grid shows "syncing"
+  // rather than a silently empty list.
+  const listBusy = busy || listData.pending || overviewQuery.pending;
 
   const currentColumnVisibility = useStore(
     (state) => state.logs.listing.columnVisibility
@@ -326,28 +254,23 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   );
 
   const progress = useMemo(() => {
-    let pending = 0;
-    let total = 0;
-    for (const item of logItems) {
-      if (item.type === "file" || item.type === "pending-task") {
-        total += 1;
-        if (item.type === "pending-task" || item.log?.status === "started") {
-          pending += 1;
-        }
-      }
-    }
+    const pendingTasks = logItems.filter(
+      (item) => item.type === "pending-task"
+    ).length;
+    const total = (overview?.fileCount ?? 0) + pendingTasks;
+    const running = (overview?.startedCount ?? 0) + pendingTasks;
     return {
-      complete: total - pending,
+      complete: total - running,
       total,
     };
-  }, [logItems]);
+  }, [logItems, overview]);
 
   // Single-log workspaces skip the pointless one-row list. `replace` keeps
   // this page out of history so back from the log doesn't bounce forward
   // again. Deliberately not gated on sync settling — see the audit doc.
-  const onlyItem = logItems.length === 1 ? logItems[0] : undefined;
-  if (maybeShowSingleLog && onlyItem?.url) {
-    return <Navigate to={onlyItem.url} replace />;
+  const soleItemUrl = soleItemRedirectUrl(overview, logItems, itemView);
+  if (maybeShowSingleLog && soleItemUrl) {
+    return <Navigate to={soleItemUrl} replace />;
   }
 
   return (
@@ -424,7 +347,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
           <div className={clsx(styles.list, "text-size-smaller")}>
             <LogListGrid
               rows={listData.rows}
-              totalRowCount={listData.totalRowCount}
+              totalRowCount={totalRowCount}
               sorting={listData.sorting}
               columnFilters={listData.columnFilters}
               currentPath={currentDir}
@@ -434,7 +357,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
             />
           </div>
           <LogListFooter
-            itemCount={logItems.length}
+            itemCount={totalRowCount}
             filteredCount={listData.filteredCount}
             progressText={listBusy ? "Syncing data" : undefined}
             progressBar={
@@ -454,11 +377,25 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   );
 };
 
+/** The redirect target when the view holds exactly one item (folder, file,
+ *  or pending task — the latter has no url, so no redirect). */
+const soleItemRedirectUrl = (
+  overview: LogsOverview | undefined,
+  logItems: Array<FolderLogItem | PendingTaskItem>,
+  itemView: FileLogItemView
+): string | undefined => {
+  if ((overview?.fileCount ?? 0) + logItems.length !== 1) return undefined;
+  if (logItems.length === 1) return logItems[0]?.url;
+  return overview?.soleFileName !== undefined
+    ? fileLogIdentity(overview.soleFileName, itemView)?.url
+    : undefined;
+};
+
 const appendPendingItems = (
   evalSet: EvalSet | undefined,
   tasksWithLogFiles: Set<string>,
-  collapsedLogItems: (FileLogItem | FolderLogItem | PendingTaskItem)[]
-): (FileLogItem | FolderLogItem | PendingTaskItem)[] => {
+  items: Array<FolderLogItem | PendingTaskItem>
+): Array<FolderLogItem | PendingTaskItem> => {
   const pendingTasks = new Array<PendingTaskItem>();
   for (const task of evalSet?.tasks || []) {
     if (!tasksWithLogFiles.has(task.task_id)) {
@@ -474,7 +411,7 @@ const appendPendingItems = (
   // Sort pending tasks by name
   pendingTasks.sort((a, b) => a.name.localeCompare(b.name));
 
-  collapsedLogItems.push(...pendingTasks);
+  items.push(...pendingTasks);
 
-  return collapsedLogItems;
+  return items;
 };

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -170,6 +170,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
+    accessorsKey,
   } = useLogListColumns(mode, scopeDir, scoresViewMode);
 
   const toRow = useCallback(
@@ -201,6 +202,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
     getValue,
     getComparator,
     getFilterType,
+    accessorsKey,
     listing,
   });
 

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -117,12 +117,12 @@ export const LogsPanel: FC<LogsPanelProps> = ({
       isCandidate,
     },
   });
-  const overview = overviewQuery.overview;
+  const overview = overviewQuery.data;
 
   const busy = sync.busy;
   // The navbar bar tracks the sync round-trip only — engine background
   // fetching (`busy`) stays in the footer/overlay indications.
-  const navbarLoading = sync.loading || overviewQuery.pending;
+  const navbarLoading = sync.loading || overviewQuery.loading;
   const error = sync.error ?? overviewQuery.error;
 
   // Presentation items with no database record: folders (pinned) and the
@@ -213,7 +213,7 @@ export const LogsPanel: FC<LogsPanelProps> = ({
   // The listing/overview queries are asynchronous by design: fold their
   // first-read window into the busy indication so the grid shows "syncing"
   // rather than a silently empty list.
-  const listBusy = busy || listData.pending || overviewQuery.pending;
+  const listBusy = busy || listData.pending || overviewQuery.loading;
 
   const currentColumnVisibility = useStore(
     (state) => state.logs.listing.columnVisibility

--- a/apps/inspect/src/app/log-list/fileLogItem.test.ts
+++ b/apps/inspect/src/app/log-list/fileLogItem.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { LogListingRow } from "../../log_data";
+
+import { fileLogItem, type FileLogItemView } from "./fileLogItem";
+
+const row = (name: string, retried?: boolean): LogListingRow =>
+  ({ name, retried }) as LogListingRow;
+
+const view = (overrides?: Partial<FileLogItemView>): FileLogItemView => ({
+  mode: "logs",
+  logDir: "/logs",
+  currentDir: "/logs",
+  showRetriedLogs: false,
+  ...overrides,
+});
+
+describe("fileLogItem", () => {
+  it("maps a tasks-mode row to a flat item keyed by the full name", () => {
+    const log = row("/logs/sub/2024_task.eval");
+    const item = fileLogItem(log, view({ mode: "tasks" }));
+    expect(item).toMatchObject({
+      id: "/logs/sub/2024_task.eval",
+      name: "sub/2024_task.eval",
+      type: "file",
+    });
+    expect(item?.url).toContain("2024_task.eval");
+    expect(item?.log).toBe(log);
+  });
+
+  it("hides retried rows unless the view shows them", () => {
+    const log = row("/logs/2024_task.eval", true);
+    expect(fileLogItem(log, view({ mode: "tasks" }))).toBeUndefined();
+    expect(fileLogItem(log, view())).toBeUndefined();
+    expect(
+      fileLogItem(log, view({ mode: "tasks", showRetriedLogs: true }))
+    ).toBeDefined();
+    expect(fileLogItem(log, view({ showRetriedLogs: true }))).toBeDefined();
+  });
+
+  it("maps a folder-mode row directly in the directory to its basename item", () => {
+    const item = fileLogItem(row("/logs/2024_task.eval"), view());
+    expect(item).toMatchObject({
+      id: "2024_task.eval",
+      name: "2024_task.eval",
+      type: "file",
+    });
+  });
+
+  it("returns undefined in folder mode for files below the directory", () => {
+    expect(
+      fileLogItem(row("/logs/sub/2024_task.eval"), view())
+    ).toBeUndefined();
+    expect(fileLogItem(row("/other/2024_task.eval"), view())).toBeUndefined();
+  });
+
+  it("keys drilled-down folder items relative to the current directory", () => {
+    const item = fileLogItem(
+      row("/logs/sub/2024_task.eval"),
+      view({ currentDir: "/logs/sub" })
+    );
+    expect(item).toMatchObject({ id: "2024_task.eval", type: "file" });
+    expect(item?.url).toContain("sub");
+  });
+
+  it("round-trips names with characters that need URL encoding", () => {
+    const item = fileLogItem(row("/logs/a b.eval"), view());
+    expect(item?.name).toBe("a b.eval");
+    expect(item?.id).toBe("a b.eval");
+  });
+});

--- a/apps/inspect/src/app/log-list/fileLogItem.ts
+++ b/apps/inspect/src/app/log-list/fileLogItem.ts
@@ -1,7 +1,7 @@
 import { isInDirectory } from "@tsmono/util";
 
 import type { LogListingRow } from "../../log_data";
-import { directoryRelativeUrl, join } from "../../utils/uri";
+import { directoryRelativeUrl, join, rootName } from "../../utils/uri";
 import { logsUrl, tasksUrl } from "../routing/url";
 
 import type { FileLogItem } from "./LogItem";
@@ -16,8 +16,6 @@ export interface FileLogItemView {
   currentDir: string;
   showRetriedLogs: boolean;
 }
-
-const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
 
 /**
  * The path-derived part of a file item — id, display name, and url — or
@@ -41,10 +39,7 @@ export const fileLogIdentity = (
     };
   }
 
-  const cleanDir = view.currentDir.endsWith("/")
-    ? view.currentDir.slice(0, -1)
-    : view.currentDir;
-  if (!isInDirectory(name, cleanDir)) return undefined;
+  if (!isInDirectory(name, view.currentDir)) return undefined;
 
   const dirName = directoryRelativeUrl(view.currentDir, view.logDir);
   const relativePath = directoryRelativeUrl(name, view.currentDir);

--- a/apps/inspect/src/app/log-list/fileLogItem.ts
+++ b/apps/inspect/src/app/log-list/fileLogItem.ts
@@ -20,10 +20,51 @@ export interface FileLogItemView {
 const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
 
 /**
+ * The path-derived part of a file item — id, display name, and url — or
+ * `undefined` when the path isn't a file row of the view (folder mode: not
+ * directly in the current directory; it displays through its folder
+ * instead). Pure path logic: display toggles like retried-hiding live in
+ * {@link fileLogItem}, so overview facts that need pre-hide membership (and
+ * URL derivations that have only a name) can use this directly.
+ */
+export const fileLogIdentity = (
+  name: string,
+  view: FileLogItemView
+): { id: string; name: string; url: string } | undefined => {
+  if (view.mode === "tasks") {
+    const relativePath = directoryRelativeUrl(name, view.logDir);
+    const decodedPath = decodeURIComponent(relativePath);
+    return {
+      id: name,
+      name: decodedPath,
+      url: tasksUrl(decodedPath, view.logDir),
+    };
+  }
+
+  const cleanDir = view.currentDir.endsWith("/")
+    ? view.currentDir.slice(0, -1)
+    : view.currentDir;
+  if (!isInDirectory(name, cleanDir)) return undefined;
+
+  const dirName = directoryRelativeUrl(view.currentDir, view.logDir);
+  const relativePath = directoryRelativeUrl(name, view.currentDir);
+  const fileOrFolderName = decodeURIComponent(rootName(relativePath));
+  const path = join(
+    decodeURIComponent(relativePath),
+    decodeURIComponent(dirName)
+  );
+  return {
+    id: fileOrFolderName,
+    name: fileOrFolderName,
+    url: logsUrl(path, view.logDir),
+  };
+};
+
+/**
  * Map a listing row to the file item it displays as under `view`, or
  * `undefined` when the view has no file row for it: a retried run while
  * retried logs are hidden, or (folder mode) a file that isn't directly in
- * the current directory (it displays through its folder instead).
+ * the current directory.
  *
  * This is the row-universe membership + identity function for the log list:
  * LogsPanel builds its items through it, and the listing query applies it to
@@ -34,36 +75,8 @@ export const fileLogItem = (
   view: FileLogItemView
 ): FileLogItem | undefined => {
   if (!view.showRetriedLogs && logFile.retried) return undefined;
-
-  if (view.mode === "tasks") {
-    const relativePath = directoryRelativeUrl(logFile.name, view.logDir);
-    const decodedPath = decodeURIComponent(relativePath);
-    return {
-      id: logFile.name,
-      name: decodedPath,
-      type: "file",
-      url: tasksUrl(decodedPath, view.logDir),
-      log: logFile,
-    };
-  }
-
-  const cleanDir = view.currentDir.endsWith("/")
-    ? view.currentDir.slice(0, -1)
-    : view.currentDir;
-  if (!isInDirectory(logFile.name, cleanDir)) return undefined;
-
-  const dirName = directoryRelativeUrl(view.currentDir, view.logDir);
-  const relativePath = directoryRelativeUrl(logFile.name, view.currentDir);
-  const fileOrFolderName = decodeURIComponent(rootName(relativePath));
-  const path = join(
-    decodeURIComponent(relativePath),
-    decodeURIComponent(dirName)
-  );
-  return {
-    id: fileOrFolderName,
-    name: fileOrFolderName,
-    type: "file",
-    url: logsUrl(path, view.logDir),
-    log: logFile,
-  };
+  const identity = fileLogIdentity(logFile.name, view);
+  return identity === undefined
+    ? undefined
+    : { ...identity, type: "file", log: logFile };
 };

--- a/apps/inspect/src/app/log-list/fileLogItem.ts
+++ b/apps/inspect/src/app/log-list/fileLogItem.ts
@@ -1,0 +1,69 @@
+import { isInDirectory } from "@tsmono/util";
+
+import type { LogListingRow } from "../../log_data";
+import { directoryRelativeUrl, join } from "../../utils/uri";
+import { logsUrl, tasksUrl } from "../routing/url";
+
+import type { FileLogItem } from "./LogItem";
+import type { LogsPanelMode } from "./LogsPanel";
+
+/** The view inputs that determine a log's file item (and whether it has one). */
+export interface FileLogItemView {
+  mode: LogsPanelMode;
+  logDir: string;
+  /** The directory being listed (folder mode lists it; tasks mode ignores it
+   *  and lists the whole `logDir`). */
+  currentDir: string;
+  showRetriedLogs: boolean;
+}
+
+const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
+
+/**
+ * Map a listing row to the file item it displays as under `view`, or
+ * `undefined` when the view has no file row for it: a retried run while
+ * retried logs are hidden, or (folder mode) a file that isn't directly in
+ * the current directory (it displays through its folder instead).
+ *
+ * This is the row-universe membership + identity function for the log list:
+ * LogsPanel builds its items through it, and the listing query applies it to
+ * database records, so the two can never disagree about which files are rows.
+ */
+export const fileLogItem = (
+  logFile: LogListingRow,
+  view: FileLogItemView
+): FileLogItem | undefined => {
+  if (!view.showRetriedLogs && logFile.retried) return undefined;
+
+  if (view.mode === "tasks") {
+    const relativePath = directoryRelativeUrl(logFile.name, view.logDir);
+    const decodedPath = decodeURIComponent(relativePath);
+    return {
+      id: logFile.name,
+      name: decodedPath,
+      type: "file",
+      url: tasksUrl(decodedPath, view.logDir),
+      log: logFile,
+    };
+  }
+
+  const cleanDir = view.currentDir.endsWith("/")
+    ? view.currentDir.slice(0, -1)
+    : view.currentDir;
+  if (!isInDirectory(logFile.name, cleanDir)) return undefined;
+
+  const dirName = directoryRelativeUrl(view.currentDir, view.logDir);
+  const relativePath = directoryRelativeUrl(logFile.name, view.currentDir);
+  const fileOrFolderName = decodeURIComponent(rootName(relativePath));
+  const path = join(
+    decodeURIComponent(relativePath),
+    decodeURIComponent(dirName)
+  );
+  return {
+    id: fileOrFolderName,
+    name: fileOrFolderName,
+    type: "file",
+    url: logsUrl(path, view.logDir),
+    log: logFile,
+  };
+};

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import clsx from "clsx";
 import {
@@ -12,18 +11,15 @@ import {
 } from "react";
 import { useNavigate } from "react-router-dom";
 
+import type { Condition, OrderByModel } from "@tsmono/inspect-common/query";
 import type {
   ColumnFilter,
   FilterSpec,
   FilterType,
 } from "@tsmono/inspect-components/columnFilter";
 import { FindBandUI, useFindBandShortcut } from "@tsmono/react/components";
-import { useDebouncedCallback, useProperty } from "@tsmono/react/hooks";
+import { useProperty } from "@tsmono/react/hooks";
 
-import {
-  databaseLogsListingKeyRoot,
-  readLogsListingMatches,
-} from "../../../log_data";
 import { useLogsListing } from "../../../state/hooks";
 import { DataGrid } from "../../shared/data-grid/DataGrid";
 import {
@@ -32,10 +28,8 @@ import {
   rowSearchText,
 } from "../../shared/data-grid/findMatches";
 import gridStyles from "../../shared/gridCells.module.css";
-import { combineFilters } from "../listing/combineFilters";
-import { createListingPlan } from "../listing/planner";
 import {
-  sortingStateToOrderBy,
+  useLogsListingMatches,
   type LogsListingDescriptor,
 } from "../listing/useLogsListingQuery";
 
@@ -57,11 +51,16 @@ interface LogListGridProps {
    *  state; changes persist via `setGridState`). */
   sorting: SortingState;
   columnFilters?: Record<string, ColumnFilter>;
+  /** The compiled query inputs the rows were produced under (from
+   *  `useLogListData`) — the find band's match query runs under the same
+   *  ones rather than re-deriving them. */
+  filter?: Condition;
+  orderBy?: OrderByModel[];
   currentPath?: string;
-  // Identifies the data scope of the current view (mode + directory). The
-  // grid is keyed on this so switching scope (folder/tasks) gets a fresh
-  // grid (scroll + selection reset). `undefined` means logDir is still
-  // hydrating.
+  // Identifies the data scope of the current view (mode + directory).
+  // LogsPanel keys this component on it, so switching scope (folder/tasks)
+  // gets a fresh grid: scroll, selection, and find state reset together.
+  // `undefined` means logDir is still hydrating.
   scopeKey?: string;
   mode?: LogListMode;
   /** The listing is still being brought up to date (drives the empty-state
@@ -78,6 +77,8 @@ export const LogListGrid: FC<LogListGridProps> = ({
   totalRowCount,
   sorting,
   columnFilters,
+  filter,
+  orderBy,
   currentPath,
   scopeKey,
   mode = "logs",
@@ -195,63 +196,41 @@ export const LogListGrid: FC<LogListGridProps> = ({
   // the DataGrid keeps scrolled into view.
   const [showFind, setShowFind] = useState(false);
   const [findTerm, setFindTerm] = useState("");
-  // The term the DB match query runs under, trailing `findTerm` by a
-  // type-ahead debounce: every distinct term is a fresh scan of the listing
-  // source, so keystrokes coalesce here while the input (and the cheap
-  // overlay match) stay live. Same 100ms as the shared FindBand's debounce.
-  const [matchTerm, setMatchTerm] = useState("");
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const findInputRef = useRef<HTMLInputElement>(null);
-  const syncMatchTerm = useDebouncedCallback(() => {
-    setMatchTerm(findInputRef.current?.value ?? "");
-  }, 100);
 
   const searchColumns = useMemo(
     () => columns.filter((col) => col.id !== undefined && visibility[col.id]),
     [columns, visibility]
   );
-
-  // Match membership is data-level, computed against the listing source
-  // under the same universe + filter + sort as the rows — so matches keep
-  // covering rows outside the loaded page once the listing paginates.
-  const filter = useMemo(() => combineFilters(columnFilters), [columnFilters]);
-  const orderBy = useMemo(() => sortingStateToOrderBy(sorting), [sorting]);
+  const searchKey = useMemo(
+    () => searchColumns.map((col) => col.id ?? ""),
+    [searchColumns]
+  );
   const rowText = useCallback(
     (row: LogListRow) => rowSearchText(row, searchColumns),
     [searchColumns]
   );
-  const fileMatches = useQuery({
-    queryKey: [
-      ...databaseLogsListingKeyRoot,
-      "find",
-      listing.universe ?? null,
-      accessorsKey,
-      filter ?? null,
-      orderBy,
-      matchTerm,
-      searchColumns.map((col) => col.id),
-    ],
-    queryFn: (): Promise<string[]> =>
-      readLogsListingMatches(
-        listing.logDir,
-        listing.prefix,
-        listing.toRow,
-        createListingPlan({
-          filter,
-          orderBy,
-          getValue,
-          getComparator,
-          getFilterType,
-        }),
-        { term: matchTerm, getRowId: (row: LogListRow) => row.id, rowText }
-      ),
-    enabled: showFind && matchTerm !== "" && listing.universe !== undefined,
-    // Keep the previous matches while a keystroke's refetch is in flight.
-    placeholderData: (previousData: string[] | undefined) => previousData,
-    staleTime: 0,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+  const getRowId = useCallback((row: LogListRow) => row.id, []);
+
+  // Match membership is data-level, computed against the listing source
+  // under the same universe + filter + sort as the rows — so matches keep
+  // covering rows outside the loaded page once the listing paginates.
+  const fileMatches = useLogsListingMatches({
+    filter,
+    orderBy,
+    getValue,
+    getComparator,
+    getFilterType,
+    accessorsKey,
+    listing,
+    term: findTerm,
+    enabled: showFind,
+    getRowId,
+    rowText,
+    searchKey,
   });
+  const { reset: resetMatches } = fileMatches;
 
   // Folders and pending tasks have no listing record; match them locally
   // over the (small) overlay slice of the display rows.
@@ -273,18 +252,17 @@ export const LogListGrid: FC<LogListGridProps> = ({
   const matchIds = useMemo(() => {
     if (!findTerm) return [];
     const matchSet = new Set([
-      ...(fileMatches.data ?? []),
+      ...(fileMatches.ids ?? []),
       ...(overlayIndex ? findMatches(overlayIndex, findTerm) : []),
     ]);
     return rows.filter((row) => matchSet.has(row.id)).map((row) => row.id);
-  }, [findTerm, fileMatches.data, overlayIndex, rows]);
+  }, [findTerm, fileMatches.ids, overlayIndex, rows]);
 
   const handleFindTermChange = useCallback(() => {
     setFindTerm(findInputRef.current?.value ?? "");
-    syncMatchTerm();
     // New term: jump back to the first match.
     setCurrentMatchIndex(0);
-  }, [syncMatchTerm]);
+  }, []);
 
   const goToMatch = useCallback(
     (index: number) => {
@@ -315,10 +293,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
     openBandMatchIdRef.current = undefined;
     setShowFind(false);
     setFindTerm("");
-    syncMatchTerm.cancel();
-    setMatchTerm("");
+    resetMatches();
     setCurrentMatchIndex(0);
-  }, [persistSelectedId, syncMatchTerm]);
+  }, [persistSelectedId, resetMatches]);
 
   // Same persistence for the leave-without-closing path: unmounting (e.g.
   // navigating away) with the band still open. Ref carries the latest match
@@ -370,14 +347,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
           disableNav={matchIds.length === 0}
           noResults={
             // Only claim "no results" once membership for the *displayed*
-            // term has landed: the debounce hasn't flushed yet while the
-            // terms differ, and a disabled/in-flight match query reads as
-            // pending (a disabled query stays pending — that's what
-            // suppresses the flash while the band hydrates).
-            !!findTerm &&
-            findTerm === matchTerm &&
-            matchIds.length === 0 &&
-            !fileMatches.isPending
+            // term has settled — debounce flushed and a real result (not a
+            // stale placeholder, not an error) landed for it.
+            !!findTerm && matchIds.length === 0 && fileMatches.settled
           }
           matchCount={findTerm ? matchIds.length : undefined}
           matchIndex={findTerm ? activeMatchIndex : undefined}
@@ -385,7 +357,6 @@ export const LogListGrid: FC<LogListGridProps> = ({
       )}
       <div className={clsx(gridStyles.gridContainer)}>
         <DataGrid<LogListRow>
-          key={scopeKey ?? "pending"}
           data={rows}
           columns={columns}
           columnVisibility={visibility}

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -18,7 +18,7 @@ import type {
   FilterType,
 } from "@tsmono/inspect-components/columnFilter";
 import { FindBandUI, useFindBandShortcut } from "@tsmono/react/components";
-import { useProperty } from "@tsmono/react/hooks";
+import { useDebouncedCallback, useProperty } from "@tsmono/react/hooks";
 
 import {
   databaseLogsListingKeyRoot,
@@ -97,8 +97,14 @@ export const LogListGrid: FC<LogListGridProps> = ({
     "mode",
     { defaultValue: "by-metric" }
   );
-  const { columns, visibility, getValue, getComparator, getFilterType } =
-    useLogListColumns(mode, scopeDir, scoresViewMode);
+  const {
+    columns,
+    visibility,
+    getValue,
+    getComparator,
+    getFilterType,
+    accessorsKey,
+  } = useLogListColumns(mode, scopeDir, scoresViewMode);
 
   const handleRowActivate = useCallback(
     (row: LogListRow) => {
@@ -189,8 +195,16 @@ export const LogListGrid: FC<LogListGridProps> = ({
   // the DataGrid keeps scrolled into view.
   const [showFind, setShowFind] = useState(false);
   const [findTerm, setFindTerm] = useState("");
+  // The term the DB match query runs under, trailing `findTerm` by a
+  // type-ahead debounce: every distinct term is a fresh scan of the listing
+  // source, so keystrokes coalesce here while the input (and the cheap
+  // overlay match) stay live. Same 100ms as the shared FindBand's debounce.
+  const [matchTerm, setMatchTerm] = useState("");
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const findInputRef = useRef<HTMLInputElement>(null);
+  const syncMatchTerm = useDebouncedCallback(() => {
+    setMatchTerm(findInputRef.current?.value ?? "");
+  }, 100);
 
   const searchColumns = useMemo(
     () => columns.filter((col) => col.id !== undefined && visibility[col.id]),
@@ -211,9 +225,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
       ...databaseLogsListingKeyRoot,
       "find",
       listing.universe ?? null,
+      accessorsKey,
       filter ?? null,
       orderBy,
-      findTerm,
+      matchTerm,
       searchColumns.map((col) => col.id),
     ],
     queryFn: (): Promise<string[]> =>
@@ -228,9 +243,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
           getComparator,
           getFilterType,
         }),
-        { term: findTerm, getRowId: (row: LogListRow) => row.id, rowText }
+        { term: matchTerm, getRowId: (row: LogListRow) => row.id, rowText }
       ),
-    enabled: showFind && findTerm !== "" && listing.universe !== undefined,
+    enabled: showFind && matchTerm !== "" && listing.universe !== undefined,
     // Keep the previous matches while a keystroke's refetch is in flight.
     placeholderData: (previousData: string[] | undefined) => previousData,
     staleTime: 0,
@@ -266,9 +281,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
 
   const handleFindTermChange = useCallback(() => {
     setFindTerm(findInputRef.current?.value ?? "");
+    syncMatchTerm();
     // New term: jump back to the first match.
     setCurrentMatchIndex(0);
-  }, []);
+  }, [syncMatchTerm]);
 
   const goToMatch = useCallback(
     (index: number) => {
@@ -299,8 +315,10 @@ export const LogListGrid: FC<LogListGridProps> = ({
     openBandMatchIdRef.current = undefined;
     setShowFind(false);
     setFindTerm("");
+    syncMatchTerm.cancel();
+    setMatchTerm("");
     setCurrentMatchIndex(0);
-  }, [persistSelectedId]);
+  }, [persistSelectedId, syncMatchTerm]);
 
   // Same persistence for the leave-without-closing path: unmounting (e.g.
   // navigating away) with the band still open. Ref carries the latest match
@@ -351,7 +369,15 @@ export const LogListGrid: FC<LogListGridProps> = ({
           onNext={() => goToMatch(activeMatchIndex + 1)}
           disableNav={matchIds.length === 0}
           noResults={
-            !!findTerm && matchIds.length === 0 && !fileMatches.isPending
+            // Only claim "no results" once membership for the *displayed*
+            // term has landed: the debounce hasn't flushed yet while the
+            // terms differ, and a disabled/in-flight match query reads as
+            // pending (a disabled query stays pending — that's what
+            // suppresses the flash while the band hydrates).
+            !!findTerm &&
+            findTerm === matchTerm &&
+            matchIds.length === 0 &&
+            !fileMatches.isPending
           }
           matchCount={findTerm ? matchIds.length : undefined}
           matchIndex={findTerm ? activeMatchIndex : undefined}

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import clsx from "clsx";
 import {
@@ -19,13 +20,24 @@ import type {
 import { FindBandUI, useFindBandShortcut } from "@tsmono/react/components";
 import { useProperty } from "@tsmono/react/hooks";
 
+import {
+  databaseLogsListingKeyRoot,
+  readLogsListingMatches,
+} from "../../../log_data";
 import { useLogsListing } from "../../../state/hooks";
 import { DataGrid } from "../../shared/data-grid/DataGrid";
 import {
   buildSearchIndex,
   findMatches,
+  rowSearchText,
 } from "../../shared/data-grid/findMatches";
 import gridStyles from "../../shared/gridCells.module.css";
+import { combineFilters } from "../listing/combineFilters";
+import { createListingPlan } from "../listing/planner";
+import {
+  sortingStateToOrderBy,
+  type LogsListingDescriptor,
+} from "../listing/useLogsListingQuery";
 
 import {
   useLogListColumns,
@@ -55,6 +67,10 @@ interface LogListGridProps {
   /** The listing is still being brought up to date (drives the empty-state
    *  loading indicator). */
   busy: boolean;
+  /** The listing source the rows were queried from — the find band runs its
+   *  match query against the same universe (so matches cover rows beyond
+   *  the loaded page once the listing paginates). */
+  listing: LogsListingDescriptor<LogListRow>;
 }
 
 export const LogListGrid: FC<LogListGridProps> = ({
@@ -66,6 +82,7 @@ export const LogListGrid: FC<LogListGridProps> = ({
   scopeKey,
   mode = "logs",
   busy,
+  listing,
 }) => {
   const { gridStateByScope, patchGridState } = useLogsListing();
 
@@ -80,11 +97,8 @@ export const LogListGrid: FC<LogListGridProps> = ({
     "mode",
     { defaultValue: "by-metric" }
   );
-  const { columns, visibility } = useLogListColumns(
-    mode,
-    scopeDir,
-    scoresViewMode
-  );
+  const { columns, visibility, getValue, getComparator, getFilterType } =
+    useLogListColumns(mode, scopeDir, scoresViewMode);
 
   const handleRowActivate = useCallback(
     (row: LogListRow) => {
@@ -183,19 +197,72 @@ export const LogListGrid: FC<LogListGridProps> = ({
     [columns, visibility]
   );
 
-  // Built only while the band is open; per-row text is then cached across
-  // keystrokes (each keystroke just re-scans the index).
-  const searchIndex = useMemo(
+  // Match membership is data-level, computed against the listing source
+  // under the same universe + filter + sort as the rows — so matches keep
+  // covering rows outside the loaded page once the listing paginates.
+  const filter = useMemo(() => combineFilters(columnFilters), [columnFilters]);
+  const orderBy = useMemo(() => sortingStateToOrderBy(sorting), [sorting]);
+  const rowText = useCallback(
+    (row: LogListRow) => rowSearchText(row, searchColumns),
+    [searchColumns]
+  );
+  const fileMatches = useQuery({
+    queryKey: [
+      ...databaseLogsListingKeyRoot,
+      "find",
+      listing.universe ?? null,
+      filter ?? null,
+      orderBy,
+      findTerm,
+      searchColumns.map((col) => col.id),
+    ],
+    queryFn: (): Promise<string[]> =>
+      readLogsListingMatches(
+        listing.logDir,
+        listing.prefix,
+        listing.toRow,
+        createListingPlan({
+          filter,
+          orderBy,
+          getValue,
+          getComparator,
+          getFilterType,
+        }),
+        { term: findTerm, getRowId: (row: LogListRow) => row.id, rowText }
+      ),
+    enabled: showFind && findTerm !== "" && listing.universe !== undefined,
+    // Keep the previous matches while a keystroke's refetch is in flight.
+    placeholderData: (previousData: string[] | undefined) => previousData,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  // Folders and pending tasks have no listing record; match them locally
+  // over the (small) overlay slice of the display rows.
+  const overlayIndex = useMemo(
     () =>
       showFind
-        ? buildSearchIndex(rows, searchColumns, (row) => row.id)
+        ? buildSearchIndex(
+            rows.filter((row) => row.type !== "file"),
+            searchColumns,
+            (row) => row.id
+          )
         : undefined,
     [showFind, rows, searchColumns]
   );
-  const matchIds = useMemo(
-    () => (searchIndex ? findMatches(searchIndex, findTerm) : []),
-    [searchIndex, findTerm]
-  );
+
+  // Display-order match list: membership from the queries, order from the
+  // rendered rows. (Under pagination the ordering piece moves to the
+  // snapshot key list; membership stays as-is.)
+  const matchIds = useMemo(() => {
+    if (!findTerm) return [];
+    const matchSet = new Set([
+      ...(fileMatches.data ?? []),
+      ...(overlayIndex ? findMatches(overlayIndex, findTerm) : []),
+    ]);
+    return rows.filter((row) => matchSet.has(row.id)).map((row) => row.id);
+  }, [findTerm, fileMatches.data, overlayIndex, rows]);
 
   const handleFindTermChange = useCallback(() => {
     setFindTerm(findInputRef.current?.value ?? "");
@@ -283,7 +350,9 @@ export const LogListGrid: FC<LogListGridProps> = ({
           onPrevious={() => goToMatch(activeMatchIndex - 1)}
           onNext={() => goToMatch(activeMatchIndex + 1)}
           disableNav={matchIds.length === 0}
-          noResults={!!findTerm && matchIds.length === 0}
+          noResults={
+            !!findTerm && matchIds.length === 0 && !fileMatches.isPending
+          }
           matchCount={findTerm ? matchIds.length : undefined}
           matchIndex={findTerm ? activeMatchIndex : undefined}
         />

--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -96,6 +96,12 @@ export const useLogListColumns = (
   getComparator: (columnId: string) => ColumnComparator | undefined;
   /** Per-column filter type (from column meta) for client-side filtering. */
   getFilterType: (columnId: string) => FilterType | undefined;
+  /** Cache identity of the accessors above: the scorer schema they're built
+   *  from. The schema arrives asynchronously, so a query that closes over
+   *  the accessors must carry this in its key — score-column semantics
+   *  (by-metric accessors, numeric comparators/filter types) change when it
+   *  lands, with no other query input changing. */
+  accessorsKey: string;
   setColumnVisibility: (visibility: Record<string, boolean>) => void;
 } => {
   const columnVisibility = useStore(
@@ -873,6 +879,18 @@ export const useLogListColumns = (
     [columnsById]
   );
 
+  // Everything the accessors read beyond the row and the column id: the
+  // scorer schema (`mode` also shapes the column set, but only in ways the
+  // accessors don't observe — and it's part of the listing universe anyway).
+  const accessorsKey = useMemo(
+    () =>
+      Object.entries(scorerMap)
+        .map(([key, { valueType }]) => `${key}:${valueType}`)
+        .sort()
+        .join(","),
+    [scorerMap]
+  );
+
   return {
     columns: allColumns,
     visibility,
@@ -880,6 +898,7 @@ export const useLogListColumns = (
     getValue,
     getComparator,
     getFilterType,
+    accessorsKey,
     setColumnVisibility,
   };
 };

--- a/apps/inspect/src/app/log-list/grid/logListRow.ts
+++ b/apps/inspect/src/app/log-list/grid/logListRow.ts
@@ -1,0 +1,71 @@
+import { LogListingRow } from "../../../log_data";
+import { FileLogItem, FolderLogItem, PendingTaskItem } from "../LogItem";
+
+import { LogListRow } from "./columns/types";
+
+export type LogListItem = FileLogItem | FolderLogItem | PendingTaskItem;
+
+const rowForItem = (item: LogListItem): LogListingRow | undefined =>
+  item.type === "file" ? item.log : undefined;
+
+// A projection, not a computation: every derived value is read off the row
+// (attached at ingestion by `detailTier`/`deriveLogFields`) so the grid can
+// never disagree with what the store holds.
+export const buildLogListRow = (item: LogListItem): LogListRow => {
+  const log = rowForItem(item);
+  const details = log?.header;
+  const derived = log?.derived;
+
+  const taskArgsSource =
+    details?.eval?.task_args_passed ?? details?.eval?.task_args;
+
+  const row: LogListRow = {
+    id: item.id,
+    name: item.name,
+    displayIndex:
+      item.type === "file" || item.type === "pending-task"
+        ? item.displayIndex
+        : undefined,
+    type: item.type,
+    url: item.url,
+    task: item.type === "file" ? (log?.task ?? undefined) : item.name,
+    model:
+      item.type === "file"
+        ? log?.model
+        : item.type === "pending-task"
+          ? item.model
+          : undefined,
+    modelRoles:
+      item.type === "file" ? (log?.model_roles ?? undefined) : undefined,
+    score: log?.primary_metric?.value,
+    status: log?.status,
+    completedAt: log?.completed_at,
+    itemCount: item.type === "folder" ? item.itemCount : undefined,
+    log: item.type === "file" ? item.log : undefined,
+    path: item.type === "file" ? item.name : undefined,
+    totalSamples: details?.results?.total_samples,
+    completedSamples: details?.results?.completed_samples,
+    sandbox: details?.eval?.sandbox?.type,
+    totalTokens: derived?.total_tokens,
+    duration: derived?.duration,
+    taskFile: details?.eval?.task_file ?? undefined,
+    taskArgs: derived?.task_args,
+    taskArgsRaw: taskArgsSource ?? undefined,
+    tags: details?.tags,
+    percentCompleted: derived?.percent_completed,
+    sampleErrors: details?.sampleErrorCount,
+    sampleLimits: derived?.sample_limits,
+    errorMessage: details?.error?.message,
+  };
+
+  // Individual scorer columns, keyed `score_<scorer>/<metric>`.
+  if (derived?.scores) {
+    for (const [scorerName, metrics] of Object.entries(derived.scores)) {
+      for (const [metricName, value] of Object.entries(metrics)) {
+        row[`score_${scorerName}/${metricName}`] = value;
+      }
+    }
+  }
+
+  return row;
+};

--- a/apps/inspect/src/app/log-list/grid/useLogListData.test.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+
+import type { LogListRow } from "./columns/types";
+import { dropSettledPendingRows } from "./useLogListData";
+
+const pending = (taskId: string): LogListRow => ({
+  id: taskId,
+  name: taskId,
+  type: "pending-task",
+});
+
+const file = (name: string, taskId?: string): LogListRow => ({
+  id: name,
+  name,
+  type: "file",
+  log: { name, task_id: taskId ?? null },
+});
+
+describe("dropSettledPendingRows", () => {
+  test("drops a pending task once a file row carries its task id", () => {
+    // The overview's taskIds and the file rows settle independently, so a
+    // task's first log can land before the overview stops calling it
+    // pending — the file row wins.
+    const rows = dropSettledPendingRows(
+      [pending("t-a"), pending("t-b")],
+      [file("/logs/a.eval", "t-a")]
+    );
+    expect(rows.map((row) => row.id)).toEqual(["t-b"]);
+  });
+
+  test("keeps pending tasks when no file row claims them", () => {
+    const pendingRows = [pending("t-a")];
+    expect(
+      dropSettledPendingRows(pendingRows, [file("/logs/x.eval", "t-x")])
+    ).toEqual(pendingRows);
+    // Rows without task ids can't claim anything: same list, by identity.
+    expect(dropSettledPendingRows(pendingRows, [file("/logs/y.eval")])).toBe(
+      pendingRows
+    );
+    expect(dropSettledPendingRows(pendingRows, [])).toBe(pendingRows);
+  });
+});

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -14,7 +14,7 @@ import type {
 } from "../listing/types";
 import {
   sortingStateToOrderBy,
-  useLogsListingQuery,
+  useDatabaseLogsListingQuery,
 } from "../listing/useLogsListingQuery";
 import { FileLogItem, FolderLogItem, PendingTaskItem } from "../LogItem";
 
@@ -95,6 +95,7 @@ interface UseLogListDataParams {
   getValue: ValueAccessor<LogListRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
+  databaseScope: { prefix: string; syncedPrefix: string };
 }
 
 export interface LogListData {
@@ -124,6 +125,7 @@ export const useLogListData = ({
   getValue,
   getComparator,
   getFilterType,
+  databaseScope,
 }: UseLogListDataParams): LogListData => {
   const { gridStateByScope } = useLogsListing();
 
@@ -173,13 +175,20 @@ export const useLogListData = ({
     return { folders, files };
   }, [data]);
 
-  const { items: sortedFiles, total_count } = useLogsListingQuery({
+  const database = {
+    scope: { prefix: databaseScope.prefix },
+    syncedPrefix: databaseScope.syncedPrefix,
+    rowKey: (row: LogListRow) =>
+      row.type === "file" ? row.log?.name : undefined,
+  };
+  const { items: sortedFiles, total_count } = useDatabaseLogsListingQuery({
     rows: files,
     filter,
     orderBy,
     getValue,
     getComparator,
     getFilterType,
+    database,
   });
 
   const rows = useMemo(

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -1,6 +1,7 @@
 import type { SortingState } from "@tanstack/react-table";
 import { useMemo } from "react";
 
+import type { Condition, OrderByModel } from "@tsmono/inspect-common/query";
 import type { ColumnFilter } from "@tsmono/inspect-components/columnFilter";
 
 import { useLogsListing } from "../../../state/hooks";
@@ -70,6 +71,11 @@ export interface LogListData {
    *  passed through so grid and query can't diverge. */
   sorting: SortingState;
   columnFilters?: Record<string, ColumnFilter>;
+  /** The compiled query inputs derived from them — passed through for the
+   *  find band's match query, so its membership can't drift from the rows
+   *  via a second derivation. */
+  filter?: Condition;
+  orderBy: OrderByModel[];
   /** The listing query has no result to show yet (first read in flight). */
   pending: boolean;
   /** The listing read failed — `rows` carries only the overlay items, so
@@ -203,6 +209,8 @@ export const useLogListData = ({
       folders.length + (result?.total_count ?? 0) + (overlay?.total_count ?? 0),
     sorting,
     columnFilters,
+    filter,
+    orderBy,
     pending,
     error,
   };

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -28,6 +28,22 @@ import { buildLogListRow } from "./logListRow";
 
 const kNoRows: LogListRow[] = [];
 
+/** Pending rows minus the tasks that already have a file row in `fileRows`
+ *  (pending row ids are task ids; file rows carry their record's task_id). */
+export const dropSettledPendingRows = (
+  pendingRows: LogListRow[],
+  fileRows: LogListRow[]
+): LogListRow[] => {
+  if (pendingRows.length === 0 || fileRows.length === 0) return pendingRows;
+  const fileTaskIds = new Set<string>();
+  for (const row of fileRows) {
+    const taskId = row.log?.task_id;
+    if (taskId) fileTaskIds.add(taskId);
+  }
+  if (fileTaskIds.size === 0) return pendingRows;
+  return pendingRows.filter((row) => !fileTaskIds.has(row.id));
+};
+
 interface UseLogListDataParams {
   /** Presentation rows with no database record: folders (pinned) and
    *  pending tasks (merged into the queried page as a sorted overlay).
@@ -133,20 +149,37 @@ export const useLogListData = ({
     listing,
   });
 
+  // The pending anti-join input (overview.taskIds) and the file rows are two
+  // independent async reads of the same store, so a settle-order skew can
+  // briefly keep a task's pending row while its first log file already
+  // renders. Re-derive against the queried page: a task with a file row is
+  // not pending, whatever the overview's snapshot said.
+  const visiblePendingRows = useMemo(
+    () => dropSettledPendingRows(pendingRows, result?.items ?? kNoRows),
+    [pendingRows, result]
+  );
+
   // Pending tasks have no database record: run the same query over them in
   // memory and merge the (small) result into the query's page.
   const overlay = useMemo(
     () =>
-      pendingRows.length === 0
+      visiblePendingRows.length === 0
         ? undefined
-        : applyListingQuery(pendingRows, {
+        : applyListingQuery(visiblePendingRows, {
             filter,
             orderBy,
             getValue,
             getComparator,
             getFilterType,
           }),
-    [pendingRows, filter, orderBy, getValue, getComparator, getFilterType]
+    [
+      visiblePendingRows,
+      filter,
+      orderBy,
+      getValue,
+      getComparator,
+      getFilterType,
+    ]
   );
 
   const files = useMemo(() => {

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -56,6 +56,9 @@ export interface LogListData {
   columnFilters?: Record<string, ColumnFilter>;
   /** The listing query has no result to show yet (first read in flight). */
   pending: boolean;
+  /** The listing read failed — `rows` carries only the overlay items, so
+   *  render this rather than an empty-looking list. */
+  error: Error | undefined;
 }
 
 /**
@@ -116,7 +119,11 @@ export const useLogListData = ({
   );
   const filter = useMemo(() => combineFilters(columnFilters), [columnFilters]);
 
-  const { result, pending } = useDatabaseLogsListingQuery<LogListRow>({
+  const {
+    data: result,
+    loading: pending,
+    error,
+  } = useDatabaseLogsListingQuery<LogListRow>({
     filter,
     orderBy,
     getValue,
@@ -164,5 +171,6 @@ export const useLogListData = ({
     sorting,
     columnFilters,
     pending,
+    error,
   };
 };

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -1,9 +1,8 @@
 import type { SortingState } from "@tanstack/react-table";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
 import type { ColumnFilter } from "@tsmono/inspect-components/columnFilter";
 
-import { LogListingRow } from "../../../log_data";
 import { useLogsListing } from "../../../state/hooks";
 import { useKeyedMemo } from "../../shared/useKeyedMemo";
 import {
@@ -20,79 +19,14 @@ import type {
 import {
   sortingStateToOrderBy,
   useDatabaseLogsListingQuery,
+  type LogsListingDescriptor,
 } from "../listing/useLogsListingQuery";
-import { FileLogItem, FolderLogItem, PendingTaskItem } from "../LogItem";
+import { FolderLogItem, PendingTaskItem } from "../LogItem";
 
 import { LogListRow } from "./columns/types";
-
-export type LogListItem = FileLogItem | FolderLogItem | PendingTaskItem;
+import { buildLogListRow } from "./logListRow";
 
 const kNoRows: LogListRow[] = [];
-
-const rowForItem = (item: LogListItem): LogListingRow | undefined =>
-  item.type === "file" ? item.log : undefined;
-
-// A projection, not a computation: every derived value is read off the row
-// (attached at ingestion by `detailTier`/`deriveLogFields`) so the grid can
-// never disagree with what the store holds.
-const buildLogListRow = (item: LogListItem): LogListRow => {
-  const log = rowForItem(item);
-  const details = log?.header;
-  const derived = log?.derived;
-
-  const taskArgsSource =
-    details?.eval?.task_args_passed ?? details?.eval?.task_args;
-
-  const row: LogListRow = {
-    id: item.id,
-    name: item.name,
-    displayIndex:
-      item.type === "file" || item.type === "pending-task"
-        ? item.displayIndex
-        : undefined,
-    type: item.type,
-    url: item.url,
-    task: item.type === "file" ? (log?.task ?? undefined) : item.name,
-    model:
-      item.type === "file"
-        ? log?.model
-        : item.type === "pending-task"
-          ? item.model
-          : undefined,
-    modelRoles:
-      item.type === "file" ? (log?.model_roles ?? undefined) : undefined,
-    score: log?.primary_metric?.value,
-    status: log?.status,
-    completedAt: log?.completed_at,
-    itemCount: item.type === "folder" ? item.itemCount : undefined,
-    log: item.type === "file" ? item.log : undefined,
-    path: item.type === "file" ? item.name : undefined,
-    totalSamples: details?.results?.total_samples,
-    completedSamples: details?.results?.completed_samples,
-    sandbox: details?.eval?.sandbox?.type,
-    totalTokens: derived?.total_tokens,
-    duration: derived?.duration,
-    taskFile: details?.eval?.task_file ?? undefined,
-    taskArgs: derived?.task_args,
-    taskArgsRaw: taskArgsSource ?? undefined,
-    tags: details?.tags,
-    percentCompleted: derived?.percent_completed,
-    sampleErrors: details?.sampleErrorCount,
-    sampleLimits: derived?.sample_limits,
-    errorMessage: details?.error?.message,
-  };
-
-  // Individual scorer columns, keyed `score_<scorer>/<metric>`.
-  if (derived?.scores) {
-    for (const [scorerName, metrics] of Object.entries(derived.scores)) {
-      for (const [metricName, value] of Object.entries(metrics)) {
-        row[`score_${scorerName}/${metricName}`] = value;
-      }
-    }
-  }
-
-  return row;
-};
 
 interface UseLogListDataParams {
   /** Presentation rows with no database record: folders (pinned) and
@@ -105,13 +39,7 @@ interface UseLogListDataParams {
   getValue: ValueAccessor<LogListRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
-  /** The listing query's source description — see `useDatabaseLogsListingQuery`. */
-  listing: {
-    logDir: string;
-    prefix: string;
-    universe: string | undefined;
-    toItem: (log: LogListingRow) => FileLogItem | undefined;
-  };
+  listing: LogsListingDescriptor<LogListRow>;
 }
 
 export interface LogListData {
@@ -185,27 +113,13 @@ export const useLogListData = ({
   );
   const filter = useMemo(() => combineFilters(columnFilters), [columnFilters]);
 
-  const toItem = listing.toItem;
-  const toRow = useCallback(
-    (log: LogListingRow): LogListRow | undefined => {
-      const item = toItem(log);
-      return item === undefined ? undefined : buildLogListRow(item);
-    },
-    [toItem]
-  );
-
   const { result, pending } = useDatabaseLogsListingQuery<LogListRow>({
     filter,
     orderBy,
     getValue,
     getComparator,
     getFilterType,
-    listing: {
-      logDir: listing.logDir,
-      prefix: listing.prefix,
-      universe: listing.universe,
-      toRow,
-    },
+    listing,
   });
 
   // Pending tasks have no database record: run the same query over them in

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -39,6 +39,8 @@ interface UseLogListDataParams {
   getValue: ValueAccessor<LogListRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
+  /** Cache identity of the accessors (see `useLogListColumns`). */
+  accessorsKey: string;
   listing: LogsListingDescriptor<LogListRow>;
 }
 
@@ -69,6 +71,7 @@ export const useLogListData = ({
   getValue,
   getComparator,
   getFilterType,
+  accessorsKey,
   listing,
 }: UseLogListDataParams): LogListData => {
   const { gridStateByScope } = useLogsListing();
@@ -119,6 +122,7 @@ export const useLogListData = ({
     getValue,
     getComparator,
     getFilterType,
+    accessorsKey,
     listing,
   });
 

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -1,12 +1,17 @@
 import type { SortingState } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { ColumnFilter } from "@tsmono/inspect-components/columnFilter";
 
 import { LogListingRow } from "../../../log_data";
 import { useLogsListing } from "../../../state/hooks";
 import { useKeyedMemo } from "../../shared/useKeyedMemo";
+import {
+  applyListingQuery,
+  mergeSortedRows,
+} from "../listing/applyListingQuery";
 import { combineFilters } from "../listing/combineFilters";
+import { compareByOrderBy } from "../listing/evaluator";
 import type {
   FilterTypeAccessor,
   ValueAccessor,
@@ -21,6 +26,8 @@ import { FileLogItem, FolderLogItem, PendingTaskItem } from "../LogItem";
 import { LogListRow } from "./columns/types";
 
 export type LogListItem = FileLogItem | FolderLogItem | PendingTaskItem;
+
+const kNoRows: LogListRow[] = [];
 
 const rowForItem = (item: LogListItem): LogListingRow | undefined =>
   item.type === "file" ? item.log : undefined;
@@ -88,6 +95,9 @@ const buildLogListRow = (item: LogListItem): LogListRow => {
 };
 
 interface UseLogListDataParams {
+  /** Presentation items: folders (pinned) and pending tasks (merged in as an
+   *  overlay — they have no database record). File items here are used only
+   *  for counts; file ROWS come from the listing query below. */
   items: LogListItem[];
   /** Per-scope sorting/filters are read under this key (`undefined` while
    *  logDir is still hydrating — defaults apply, nothing is written). */
@@ -95,7 +105,13 @@ interface UseLogListDataParams {
   getValue: ValueAccessor<LogListRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
-  databaseScope: { prefix: string; syncedPrefix: string };
+  /** The listing query's source description — see `useDatabaseLogsListingQuery`. */
+  listing: {
+    logDir: string;
+    prefix: string;
+    universe: string | undefined;
+    toItem: (log: LogListingRow) => FileLogItem | undefined;
+  };
 }
 
 export interface LogListData {
@@ -111,13 +127,16 @@ export interface LogListData {
    *  passed through so grid and query can't diverge. */
   sorting: SortingState;
   columnFilters?: Record<string, ColumnFilter>;
+  /** The listing query has no result to show yet (first read in flight). */
+  pending: boolean;
 }
 
 /**
- * The log-list data pipeline: shape items into rows, apply the scope's
- * persisted sorting/filters via the listing query, and pin folders on top.
- * Called by LogsPanel (the panel owns shaping — see `useLogsListingQuery`);
- * the grid just renders the result.
+ * The log-list data pipeline: run the scope's persisted sorting/filters as a
+ * listing query against the listing source (IndexedDB in dir mode), shape the
+ * resulting records into grid rows, merge in transient rows (pending tasks),
+ * and pin folders on top. Called by LogsPanel; the grid just renders the
+ * result.
  */
 export const useLogListData = ({
   items,
@@ -125,17 +144,19 @@ export const useLogListData = ({
   getValue,
   getComparator,
   getFilterType,
-  databaseScope,
+  listing,
 }: UseLogListDataParams): LogListData => {
   const { gridStateByScope } = useLogsListing();
 
-  // Reuse the prior row object for any item whose display inputs (the Log
-  // row, structural fields) are unchanged, so only changed rows pay the
-  // per-row rebuild. Keyed on store references (which stay stable across
-  // flushes for unchanged logs) rather than the `item` object, so it works
-  // even though `items` is rebuilt each flush upstream.
-  const data: LogListRow[] = useKeyedMemo(
-    items,
+  // Folders and pending tasks are presentation-only rows with no database
+  // record; shape them here. Reuse the prior row object for any item whose
+  // display inputs are unchanged, so only changed rows pay the rebuild.
+  const overlayItems = useMemo(
+    () => items.filter((item) => item.type !== "file"),
+    [items]
+  );
+  const overlayData: LogListRow[] = useKeyedMemo(
+    overlayItems,
     (item) => item.id,
     (item) => [
       item.id,
@@ -143,12 +164,19 @@ export const useLogListData = ({
       item.url,
       item.name,
       item.displayIndex,
-      rowForItem(item),
       item.type === "folder" ? item.itemCount : undefined,
       item.type === "pending-task" ? item.model : undefined,
     ],
     (item) => buildLogListRow(item)
   );
+  const { folders, pendingRows } = useMemo(() => {
+    const folders: LogListRow[] = [];
+    const pendingRows: LogListRow[] = [];
+    for (const row of overlayData) {
+      (row.type === "folder" ? folders : pendingRows).push(row);
+    }
+    return { folders, pendingRows };
+  }, [overlayData]);
 
   // Persisted sort for this scope drives the listing query's orderBy.
   const sorting = useMemo<SortingState>(
@@ -164,44 +192,67 @@ export const useLogListData = ({
   );
   const filter = useMemo(() => combineFilters(columnFilters), [columnFilters]);
 
-  // Folders (logs mode) are presentation: pinned on top, independent of sort.
-  // Sort/filter/paginate runs over the file rows only.
-  const { folders, files } = useMemo(() => {
-    const folders: LogListRow[] = [];
-    const files: LogListRow[] = [];
-    for (const row of data) {
-      (row.type === "folder" ? folders : files).push(row);
-    }
-    return { folders, files };
-  }, [data]);
+  const toItem = listing.toItem;
+  const toRow = useCallback(
+    (log: LogListingRow): LogListRow | undefined => {
+      const item = toItem(log);
+      return item === undefined ? undefined : buildLogListRow(item);
+    },
+    [toItem]
+  );
 
-  const database = {
-    scope: { prefix: databaseScope.prefix },
-    syncedPrefix: databaseScope.syncedPrefix,
-    view: scopeKey,
-    rowKey: (row: LogListRow) =>
-      row.type === "file" ? row.log?.name : undefined,
-  };
-  const { items: sortedFiles, total_count } = useDatabaseLogsListingQuery({
-    rows: files,
+  const { result, pending } = useDatabaseLogsListingQuery<LogListRow>({
     filter,
     orderBy,
     getValue,
     getComparator,
     getFilterType,
-    database,
+    listing: {
+      logDir: listing.logDir,
+      prefix: listing.prefix,
+      universe: listing.universe,
+      toRow,
+    },
   });
 
+  // Pending tasks have no database record: run the same query over them in
+  // memory and merge the (small) result into the query's page.
+  const overlay = useMemo(
+    () =>
+      pendingRows.length === 0
+        ? undefined
+        : applyListingQuery(pendingRows, {
+            filter,
+            orderBy,
+            getValue,
+            getComparator,
+            getFilterType,
+          }),
+    [pendingRows, filter, orderBy, getValue, getComparator, getFilterType]
+  );
+
+  const files = useMemo(() => {
+    const base = result?.items ?? kNoRows;
+    if (!overlay) return base;
+    const compare =
+      orderBy.length > 0
+        ? compareByOrderBy(orderBy, getValue, getComparator)
+        : undefined;
+    return mergeSortedRows(base, overlay.items, compare);
+  }, [result, overlay, orderBy, getValue, getComparator]);
+
   const rows = useMemo(
-    () => (folders.length > 0 ? [...folders, ...sortedFiles] : sortedFiles),
-    [folders, sortedFiles]
+    () => (folders.length > 0 ? [...folders, ...files] : files),
+    [folders, files]
   );
 
   return {
     rows,
-    totalRowCount: data.length,
-    filteredCount: folders.length + total_count,
+    totalRowCount: items.length,
+    filteredCount:
+      folders.length + (result?.total_count ?? 0) + (overlay?.total_count ?? 0),
     sorting,
     columnFilters,
+    pending,
   };
 };

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -95,10 +95,10 @@ const buildLogListRow = (item: LogListItem): LogListRow => {
 };
 
 interface UseLogListDataParams {
-  /** Presentation items: folders (pinned) and pending tasks (merged in as an
-   *  overlay — they have no database record). File items here are used only
-   *  for counts; file ROWS come from the listing query below. */
-  items: LogListItem[];
+  /** Presentation rows with no database record: folders (pinned) and
+   *  pending tasks (merged into the queried page as a sorted overlay).
+   *  File rows come from the listing query below. */
+  overlayItems: Array<FolderLogItem | PendingTaskItem>;
   /** Per-scope sorting/filters are read under this key (`undefined` while
    *  logDir is still hydrating — defaults apply, nothing is written). */
   scopeKey?: string;
@@ -117,9 +117,6 @@ interface UseLogListDataParams {
 export interface LogListData {
   /** Display rows: folders pinned on top, then the filtered+sorted files. */
   rows: LogListRow[];
-  /** Pre-filter row count — distinguishes "no items yet" (loading
-   *  empty-state) from "filters matched nothing". */
-  totalRowCount: number;
   /** Folders + matching files (reflects any active filter) — the footer
    *  count. */
   filteredCount: number;
@@ -139,7 +136,7 @@ export interface LogListData {
  * result.
  */
 export const useLogListData = ({
-  items,
+  overlayItems,
   scopeKey,
   getValue,
   getComparator,
@@ -151,10 +148,6 @@ export const useLogListData = ({
   // Folders and pending tasks are presentation-only rows with no database
   // record; shape them here. Reuse the prior row object for any item whose
   // display inputs are unchanged, so only changed rows pay the rebuild.
-  const overlayItems = useMemo(
-    () => items.filter((item) => item.type !== "file"),
-    [items]
-  );
   const overlayData: LogListRow[] = useKeyedMemo(
     overlayItems,
     (item) => item.id,
@@ -248,7 +241,6 @@ export const useLogListData = ({
 
   return {
     rows,
-    totalRowCount: items.length,
     filteredCount:
       folders.length + (result?.total_count ?? 0) + (overlay?.total_count ?? 0),
     sorting,

--- a/apps/inspect/src/app/log-list/grid/useLogListData.ts
+++ b/apps/inspect/src/app/log-list/grid/useLogListData.ts
@@ -178,6 +178,7 @@ export const useLogListData = ({
   const database = {
     scope: { prefix: databaseScope.prefix },
     syncedPrefix: databaseScope.syncedPrefix,
+    view: scopeKey,
     rowKey: (row: LogListRow) =>
       row.type === "file" ? row.log?.name : undefined,
   };

--- a/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
@@ -1,6 +1,6 @@
 import type { Pagination } from "@tsmono/inspect-common/query";
 
-import { compareByOrderBy, evaluateCondition } from "./evaluator";
+import { createListingPlan } from "./planner";
 import type { Cursor, ListingQuery, LogsListingResult } from "./types";
 
 const paginate = <TRow>(
@@ -30,31 +30,11 @@ export function applyListingQuery<TRow>(
   rows: TRow[],
   query: ListingQuery<TRow>
 ): LogsListingResult<TRow> {
-  const {
-    filter,
-    orderBy,
-    pagination,
-    getValue,
-    getComparator,
-    getFilterType,
-  } = query;
-
-  let result = filter
-    ? rows.filter((row) =>
-        evaluateCondition(row, filter, getValue, getFilterType)
-      )
-    : rows;
-
-  if (orderBy) {
-    const orderArr = Array.isArray(orderBy) ? orderBy : [orderBy];
-    if (orderArr.length > 0) {
-      result = [...result].sort(
-        compareByOrderBy(orderArr, getValue, getComparator)
-      );
-    }
-  }
+  const plan = createListingPlan(query);
+  let result = rows.filter(plan.matches);
+  if (plan.compare) result = [...result].sort(plan.compare);
 
   const total_count = result.length;
-  const { page, next_cursor } = paginate(result, pagination);
+  const { page, next_cursor } = paginate(result, plan.pagination);
   return { items: page, total_count, next_cursor };
 }

--- a/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
@@ -1,24 +1,7 @@
-import type { Pagination } from "@tsmono/inspect-common/query";
+import { pageRows } from "../../../client/database/listing";
 
 import { createListingPlan } from "./planner";
-import type { Cursor, ListingQuery, LogsListingResult } from "./types";
-
-const paginate = <TRow>(
-  rows: TRow[],
-  pagination?: Pagination
-): { page: TRow[]; next_cursor: Cursor | null } => {
-  if (!pagination) return { page: rows, next_cursor: null };
-  // Forward-only for now; `direction: "backward"` is unused client-side.
-  const offset =
-    pagination.cursor && typeof pagination.cursor.offset === "number"
-      ? pagination.cursor.offset
-      : 0;
-  const end = offset + pagination.limit;
-  return {
-    page: rows.slice(offset, end),
-    next_cursor: end < rows.length ? { offset: end } : null,
-  };
-};
+import type { ListingQuery, LogsListingResult } from "./types";
 
 /**
  * Merge two individually-sorted row lists into one sorted list; ties place
@@ -62,6 +45,5 @@ export function applyListingQuery<TRow>(
   if (plan.compare) result = [...result].sort(plan.compare);
 
   const total_count = result.length;
-  const { page, next_cursor } = paginate(result, plan.pagination);
-  return { items: page, total_count, next_cursor };
+  return { ...pageRows(result, plan.pagination), total_count };
 }

--- a/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/applyListingQuery.ts
@@ -21,6 +21,33 @@ const paginate = <TRow>(
 };
 
 /**
+ * Merge two individually-sorted row lists into one sorted list; ties place
+ * `base` rows first. Without a comparator the overlay is appended (the
+ * unsorted listing shows transient rows after files). This is how transient
+ * rows (e.g. pending tasks, which have no database record) join a
+ * database-produced page without forcing the whole listing back into memory.
+ */
+export function mergeSortedRows<TRow>(
+  base: TRow[],
+  overlay: TRow[],
+  compare?: (a: TRow, b: TRow) => number
+): TRow[] {
+  if (overlay.length === 0) return base;
+  if (!compare || base.length === 0) return [...base, ...overlay];
+  const merged: TRow[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < base.length && j < overlay.length) {
+    merged.push(
+      compare(base[i]!, overlay[j]!) <= 0 ? base[i++]! : overlay[j++]!
+    );
+  }
+  while (i < base.length) merged.push(base[i++]!);
+  while (j < overlay.length) merged.push(overlay[j++]!);
+  return merged;
+}
+
+/**
  * TRANSITIONAL client-side stand-in for a server `getLogsListing(dir, filter,
  * orderBy, pagination)`. Filters → sorts → paginates the in-memory rows and
  * returns a scout-shaped result. When inspect goes server-side this is replaced

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -9,7 +9,10 @@ import type { Condition } from "@tsmono/inspect-common/query";
 import type { DatabaseListingPlan } from "../../../client/database/listing";
 import type { LogListingRow } from "../../../log_data";
 
-import { useDatabaseLogsListingQuery } from "./useLogsListingQuery";
+import {
+  useDatabaseLogsListingQuery,
+  useLogsListingMatches,
+} from "./useLogsListingQuery";
 
 interface Row {
   name: string;
@@ -31,6 +34,7 @@ type ReadListing = <TRow>(
 const holder = vi.hoisted(() => ({
   records: [] as { name: string; model?: string }[],
   read: vi.fn(),
+  readMatches: vi.fn(),
 }));
 
 vi.mock("../../../log_data", () => ({
@@ -45,6 +49,8 @@ vi.mock("../../../log_data", () => ({
   readLogsListing: (
     ...args: Parameters<ReadListing>
   ): ReturnType<ReadListing> => holder.read(...args) as ReturnType<ReadListing>,
+  readLogsListingMatches: (...args: unknown[]): Promise<string[]> =>
+    holder.readMatches(...args) as Promise<string[]>,
 }));
 
 const records = [
@@ -244,5 +250,114 @@ describe("useDatabaseLogsListingQuery", () => {
     expect(result.current.data).toBeUndefined();
     expect(result.current.loading).toBe(true);
     await waitFor(() => expect(result.current.data).toBeDefined());
+  });
+});
+
+describe("useLogsListingMatches", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    holder.records = records;
+    holder.readMatches.mockReset();
+    // The seam double: lowercase-contains over the shaped records, like
+    // readLogsListingMatches over the scanned rows.
+    holder.readMatches.mockImplementation(
+      (
+        _logDir: string,
+        _prefix: string,
+        rowFor: (log: LogListingRow) => Row | undefined,
+        plan: DatabaseListingPlan<Row>,
+        find: {
+          term: string;
+          getRowId: (row: Row) => string;
+          rowText: (row: Row) => string;
+        }
+      ) => {
+        const rows = holder.records
+          .map((record) => rowFor(record as LogListingRow))
+          .filter((row): row is Row => row !== undefined)
+          .filter(plan.matches);
+        return Promise.resolve(
+          rows
+            .filter((row) =>
+              find.rowText(row).includes(find.term.toLowerCase())
+            )
+            .map(find.getRowId)
+        );
+      }
+    );
+  });
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const matchesParams = (overrides?: {
+    term?: string;
+    enabled?: boolean;
+    universe?: string;
+  }) => ({
+    ...listingParams({ universe: overrides?.universe ?? "logs::/logs" }),
+    term: overrides?.term ?? "",
+    enabled: overrides?.enabled ?? true,
+    getRowId: (row: Row) => row.name,
+    rowText: (row: Row) => `${row.name}\n${row.model}`.toLowerCase(),
+    searchKey: ["name", "model"],
+  });
+
+  test("reports ids as settled only after the debounced term's result lands", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useLogsListingMatches<Row>(props),
+      { wrapper, initialProps: matchesParams() }
+    );
+
+    rerender(matchesParams({ term: "claude" }));
+    // Debounce not flushed: no ids for the live term yet, and no
+    // "no results" claim may be made.
+    expect(result.current.ids).toBeUndefined();
+    expect(result.current.settled).toBe(false);
+
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.ids).toEqual(["/logs/b.eval"]);
+  });
+
+  test("keeps the previous term's ids as a placeholder but reports unsettled", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useLogsListingMatches<Row>(props),
+      { wrapper, initialProps: matchesParams({ term: "claude" }) }
+    );
+    await waitFor(() => expect(result.current.settled).toBe(true));
+
+    // New term: the previous ids keep showing (no flash to empty), but the
+    // result must not read as settled — a "no results" gate on pending
+    // alone would fire here while the new term's scan is in flight.
+    rerender(matchesParams({ term: "zzz" }));
+    expect(result.current.ids).toEqual(["/logs/b.eval"]);
+    expect(result.current.settled).toBe(false);
+
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.ids).toEqual([]);
+  });
+
+  test("does not serve one universe's ids to another", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useLogsListingMatches<Row>(props),
+      {
+        wrapper,
+        initialProps: matchesParams({ term: "claude" }),
+      }
+    );
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.ids).toEqual(["/logs/b.eval"]);
+
+    // Folder-mode ids are basenames, so another scope's ids could mark
+    // unrelated same-named rows as matches — they must not carry over.
+    rerender(matchesParams({ term: "claude", universe: "tasks::/logs" }));
+    expect(result.current.ids).toBeUndefined();
+    expect(result.current.settled).toBe(false);
+    await waitFor(() => expect(result.current.settled).toBe(true));
   });
 });

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -4,31 +4,33 @@ import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { Column } from "@tsmono/inspect-common/query";
+import type { Condition } from "@tsmono/inspect-common/query";
 
-import type { Log } from "../../../client/api/types";
-import type {
-  DatabaseListingPlan,
-  DatabaseListingResult,
-} from "../../../client/database/listing";
+import type { DatabaseListingPlan } from "../../../client/database/listing";
+import type { LogListingRow } from "../../../log_data";
 
 import { useDatabaseLogsListingQuery } from "./useLogsListingQuery";
 
 interface Row {
   name: string;
   model: string;
+  [k: string]: unknown;
 }
 
-type ReadListing = (
-  scope: unknown,
-  syncedPrefix: string,
-  toRow: (log: Log) => Row | undefined,
-  plan: DatabaseListingPlan<Row>
-) => Promise<DatabaseListingResult<Row> | null>;
+type ReadListing = <TRow>(
+  logDir: string,
+  prefix: string,
+  toRow: (log: LogListingRow) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>
+) => Promise<{
+  items: TRow[];
+  total_count: number;
+  next_cursor: null;
+}>;
 
 const holder = vi.hoisted(() => ({
-  opened: true,
-  read: vi.fn<ReadListing>(),
-  invalidate: vi.fn(),
+  records: [] as { name: string; model?: string }[],
+  read: vi.fn(),
 }));
 
 vi.mock("../../../log_data", () => ({
@@ -37,233 +39,174 @@ vi.mock("../../../log_data", () => ({
     "log_data",
     "dexie-listing",
     "logs",
-    ...parts,
+    ...parts.map((part) => part ?? null),
   ],
-  databaseLogsOpened: () => holder.opened,
-  invalidateDatabaseLogsListings: () => {
-    holder.invalidate();
-  },
-  readDatabaseLogsListing: (...args: Parameters<ReadListing>) =>
-    holder.read(...args),
+  readLogsListing: (
+    ...args: Parameters<ReadListing>
+  ): ReturnType<ReadListing> => holder.read(...args) as ReturnType<ReadListing>,
 }));
 
-const logs = [
-  { name: "/logs/a.eval", model: "gpt-4" },
+const records = [
   { name: "/logs/b.eval", model: "claude" },
-] as Log[];
-const rows: Row[] = logs.map(({ name, model }) => ({ name, model: model! }));
-const getValue = (row: Row, column: string): unknown =>
-  row[column as keyof Row];
+  { name: "/logs/a.eval", model: "gpt-4" },
+];
+
+const getValue = (row: Row, column: string): unknown => row[column];
+const toRow = (log: LogListingRow): Row | undefined =>
+  log.model === undefined
+    ? undefined
+    : { name: log.name, model: log.model ?? "" };
+
+const listingParams = (overrides?: {
+  filter?: Condition;
+  orderBy?: { column: string; direction: "ASC" | "DESC" }[];
+  universe?: string | undefined;
+}) => ({
+  filter: overrides?.filter,
+  orderBy: overrides?.orderBy,
+  getValue,
+  getComparator: () => undefined,
+  listing: {
+    logDir: "/logs",
+    prefix: "/logs",
+    universe:
+      overrides && "universe" in overrides ? overrides.universe : "logs::/logs",
+    toRow,
+  },
+});
 
 describe("useDatabaseLogsListingQuery", () => {
   let queryClient: QueryClient;
-  let getLogsListing: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
+    holder.records = records;
     holder.read.mockReset();
-    holder.invalidate.mockReset();
-    getLogsListing = holder.read.mockImplementation(
+    // The seam double: run the plan over the fake records like
+    // readLogsListing runs it over the scanned rows.
+    holder.read.mockImplementation(
       (
-        _scope: unknown,
-        _syncedPrefix: string,
-        toRow: (log: Log) => Row | undefined,
+        _logDir: string,
+        _prefix: string,
+        rowFor: (log: LogListingRow) => Row | undefined,
         plan: DatabaseListingPlan<Row>
-      ): Promise<DatabaseListingResult<Row>> => {
-        const items = [...logs]
-          .reverse()
-          .map(toRow)
+      ) => {
+        const rows = holder.records
+          .map((record) => rowFor(record as LogListingRow))
           .filter((row): row is Row => row !== undefined)
           .filter(plan.matches);
-        if (plan.compare) items.sort(plan.compare);
+        if (plan.compare) rows.sort(plan.compare);
         return Promise.resolve({
-          items,
-          total_count: items.length,
+          items: rows,
+          total_count: rows.length,
           next_cursor: null,
         });
       }
     );
-    holder.opened = true;
   });
 
-  test("runs active conditions through the Dexie listing service", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  test("shapes and queries source records through the listing seam", async () => {
     const { result } = renderHook(
       () =>
-        useDatabaseLogsListingQuery({
-          rows,
+        useDatabaseLogsListingQuery<Row>(
+          listingParams({
+            filter: new Column("model").eq("gpt-4"),
+            orderBy: [{ column: "name", direction: "ASC" }],
+          })
+        ),
+      { wrapper }
+    );
+
+    expect(result.current.pending).toBe(true);
+    await waitFor(() =>
+      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+      ])
+    );
+    expect(result.current.pending).toBe(false);
+  });
+
+  test("queries the seam even without an active filter", async () => {
+    const { result } = renderHook(
+      () => useDatabaseLogsListingQuery<Row>(listingParams()),
+      { wrapper }
+    );
+
+    // Source (listing) order is preserved when no sort is active.
+    await waitFor(() =>
+      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+        "/logs/b.eval",
+        "/logs/a.eval",
+      ])
+    );
+  });
+
+  test("stays disabled (pending) while the universe is hydrating", async () => {
+    const { result } = renderHook(
+      () =>
+        useDatabaseLogsListingQuery<Row>(
+          listingParams({ universe: undefined })
+        ),
+      { wrapper }
+    );
+
+    await Promise.resolve();
+    expect(holder.read).not.toHaveBeenCalled();
+    expect(result.current.pending).toBe(true);
+    expect(result.current.result).toBeUndefined();
+  });
+
+  test("keeps the previous result across re-filters within one universe", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useDatabaseLogsListingQuery<Row>(props),
+      {
+        wrapper,
+        initialProps: listingParams({
           filter: new Column("model").eq("gpt-4"),
-          orderBy: [{ column: "name", direction: "ASC" }],
-          getValue,
-          getComparator: () => undefined,
-          database: {
-            scope: { prefix: "/logs" },
-            syncedPrefix: "/logs",
-            view: "logs::/logs",
-            rowKey: (row) => row.name,
-          },
         }),
-      { wrapper }
-    );
-
-    await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
-    await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
-        "/logs/a.eval",
-      ])
-    );
-  });
-
-  test("keeps the in-memory fallback for scopes that were not persisted", async () => {
-    const read = vi.fn().mockResolvedValue(null);
-    holder.read.mockImplementation(read);
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const { result } = renderHook(
-      () =>
-        useDatabaseLogsListingQuery({
-          rows,
-          filter: new Column("model").eq("claude"),
-          getValue,
-          getComparator: () => undefined,
-          database: {
-            scope: { prefix: "/aliased" },
-            syncedPrefix: "/aliased",
-            view: "logs::/aliased",
-            rowKey: (row) => row.name,
-          },
-        }),
-      { wrapper }
-    );
-
-    await waitFor(() => expect(read).toHaveBeenCalledOnce());
-    expect(result.current.items.map((row) => row.name)).toEqual([
-      "/logs/b.eval",
-    ]);
-  });
-
-  test("preserves source order when no explicit sort is active", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const { result } = renderHook(
-      () =>
-        useDatabaseLogsListingQuery({
-          rows,
-          filter: new Column("model").ilike("%"),
-          getValue,
-          getComparator: () => undefined,
-          database: {
-            scope: { prefix: "/logs" },
-            syncedPrefix: "/logs",
-            view: "logs::/logs",
-            rowKey: (row) => row.name,
-          },
-        }),
-      { wrapper }
-    );
-
-    await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
-    await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
-        "/logs/a.eval",
-        "/logs/b.eval",
-      ])
-    );
-  });
-
-  test("refetches against fresh rows when the row set changes without a db write", async () => {
-    holder.invalidate.mockImplementation(() => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.invalidateQueries({
-        queryKey: ["log_data", "dexie-listing", "logs"],
-      });
-    });
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const makeProps = (viewRows: Row[]) => ({
-      rows: viewRows,
-      filter: new Column("model").ilike("%"),
-      orderBy: [{ column: "name", direction: "ASC" as const }],
-      getValue,
-      getComparator: () => undefined,
-      database: {
-        scope: { prefix: "/logs" },
-        syncedPrefix: "/logs",
-        view: "logs::/logs",
-        rowKey: (row: Row) => row.name,
-      },
-    });
-    const { result, rerender } = renderHook(
-      (props) => useDatabaseLogsListingQuery(props),
-      { wrapper, initialProps: makeProps([rows[0]!]) }
+      }
     );
     await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
+      expect(result.current.result?.items.map((row) => row.name)).toEqual([
         "/logs/a.eval",
       ])
     );
 
-    // Same view + filter (same query key), new row set with no db write —
-    // e.g. a pending task arriving. The hook must invalidate so the cached
-    // result isn't served from the old rows.
-    rerender(makeProps(rows));
-    await waitFor(() => expect(holder.invalidate).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
-        "/logs/a.eval",
-        "/logs/b.eval",
-      ])
-    );
-  });
-
-  test("does not serve one view's cached rows to another view at the same prefix", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const makeProps = (view: string, viewRows: Row[]) => ({
-      rows: viewRows,
-      filter: new Column("model").ilike("%"),
-      orderBy: [{ column: "name", direction: "ASC" as const }],
-      getValue,
-      getComparator: () => undefined,
-      database: {
-        scope: { prefix: "/logs" },
-        syncedPrefix: "/logs",
-        view,
-        rowKey: (row: Row) => row.name,
-      },
-    });
-    const { result, rerender } = renderHook(
-      (props) => useDatabaseLogsListingQuery(props),
-      { wrapper, initialProps: makeProps("logs::/logs", [rows[0]!]) }
-    );
-    await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
-        "/logs/a.eval",
-      ])
-    );
-
-    // Same prefix + filter, different view: the folder view's cache entry
-    // must not leak into the flat view — the synchronous fallback answers
-    // until this view's own read lands.
-    rerender(makeProps("tasks::/logs", rows));
-    expect(result.current.items.map((row) => row.name)).toEqual([
+    // Re-filter: the prior page keeps showing (no pending flash) until the
+    // new read lands.
+    rerender(listingParams({ filter: new Column("model").eq("claude") }));
+    expect(result.current.pending).toBe(false);
+    expect(result.current.result?.items.map((row) => row.name)).toEqual([
       "/logs/a.eval",
-      "/logs/b.eval",
     ]);
-    await waitFor(() => expect(getLogsListing).toHaveBeenCalledTimes(2));
     await waitFor(() =>
-      expect(result.current.items.map((row) => row.name)).toEqual([
-        "/logs/a.eval",
+      expect(result.current.result?.items.map((row) => row.name)).toEqual([
         "/logs/b.eval",
       ])
     );
+  });
+
+  test("does not serve one universe's rows to another", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useDatabaseLogsListingQuery<Row>(props),
+      {
+        wrapper,
+        initialProps: listingParams({ universe: "logs::/logs" }),
+      }
+    );
+    await waitFor(() => expect(result.current.result).toBeDefined());
+
+    // A different universe (e.g. the flat tasks view at the same prefix)
+    // must not show the folder view's rows while its own read is in flight.
+    rerender(listingParams({ universe: "tasks::/logs" }));
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.pending).toBe(true);
+    await waitFor(() => expect(result.current.result).toBeDefined());
   });
 });

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -126,13 +126,13 @@ describe("useDatabaseLogsListingQuery", () => {
       { wrapper }
     );
 
-    expect(result.current.pending).toBe(true);
+    expect(result.current.loading).toBe(true);
     await waitFor(() =>
-      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+      expect(result.current.data?.items.map((row) => row.name)).toEqual([
         "/logs/a.eval",
       ])
     );
-    expect(result.current.pending).toBe(false);
+    expect(result.current.loading).toBe(false);
   });
 
   test("queries the seam even without an active filter", async () => {
@@ -143,7 +143,7 @@ describe("useDatabaseLogsListingQuery", () => {
 
     // Source (listing) order is preserved when no sort is active.
     await waitFor(() =>
-      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+      expect(result.current.data?.items.map((row) => row.name)).toEqual([
         "/logs/b.eval",
         "/logs/a.eval",
       ])
@@ -161,8 +161,8 @@ describe("useDatabaseLogsListingQuery", () => {
 
     await Promise.resolve();
     expect(holder.read).not.toHaveBeenCalled();
-    expect(result.current.pending).toBe(true);
-    expect(result.current.result).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeUndefined();
   });
 
   test("keeps the previous result across re-filters within one universe", async () => {
@@ -176,7 +176,7 @@ describe("useDatabaseLogsListingQuery", () => {
       }
     );
     await waitFor(() =>
-      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+      expect(result.current.data?.items.map((row) => row.name)).toEqual([
         "/logs/a.eval",
       ])
     );
@@ -184,12 +184,12 @@ describe("useDatabaseLogsListingQuery", () => {
     // Re-filter: the prior page keeps showing (no pending flash) until the
     // new read lands.
     rerender(listingParams({ filter: new Column("model").eq("claude") }));
-    expect(result.current.pending).toBe(false);
-    expect(result.current.result?.items.map((row) => row.name)).toEqual([
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data?.items.map((row) => row.name)).toEqual([
       "/logs/a.eval",
     ]);
     await waitFor(() =>
-      expect(result.current.result?.items.map((row) => row.name)).toEqual([
+      expect(result.current.data?.items.map((row) => row.name)).toEqual([
         "/logs/b.eval",
       ])
     );
@@ -203,16 +203,29 @@ describe("useDatabaseLogsListingQuery", () => {
         initialProps: listingParams({ accessorsKey: "" }),
       }
     );
-    await waitFor(() => expect(result.current.result).toBeDefined());
+    await waitFor(() => expect(result.current.data).toBeDefined());
     expect(holder.read).toHaveBeenCalledTimes(1);
 
     // The scorer schema arriving changes what the plan computes without any
     // other query input changing — same universe, so the previous rows keep
     // showing while the re-evaluated read is in flight.
     rerender(listingParams({ accessorsKey: "grader/accuracy:number" }));
-    expect(result.current.pending).toBe(false);
-    expect(result.current.result).toBeDefined();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeDefined();
     await waitFor(() => expect(holder.read).toHaveBeenCalledTimes(2));
+  });
+
+  test("surfaces a failed read as an error, not an empty listing", async () => {
+    holder.read.mockRejectedValue(new Error("scan failed"));
+    const { result } = renderHook(
+      () => useDatabaseLogsListingQuery<Row>(listingParams()),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.error?.message).toBe("scan failed");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeUndefined();
   });
 
   test("does not serve one universe's rows to another", async () => {
@@ -223,13 +236,13 @@ describe("useDatabaseLogsListingQuery", () => {
         initialProps: listingParams({ universe: "logs::/logs" }),
       }
     );
-    await waitFor(() => expect(result.current.result).toBeDefined());
+    await waitFor(() => expect(result.current.data).toBeDefined());
 
     // A different universe (e.g. the flat tasks view at the same prefix)
     // must not show the folder view's rows while its own read is in flight.
     rerender(listingParams({ universe: "tasks::/logs" }));
-    expect(result.current.result).toBeUndefined();
-    expect(result.current.pending).toBe(true);
-    await waitFor(() => expect(result.current.result).toBeDefined());
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.data).toBeDefined());
   });
 });

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -41,6 +41,7 @@ vi.mock("../../../log_data", () => ({
     "logs",
     ...parts.map((part) => part ?? null),
   ],
+  listingKeyUniverse: (queryKey: readonly unknown[]) => queryKey[3],
   readLogsListing: (
     ...args: Parameters<ReadListing>
   ): ReturnType<ReadListing> => holder.read(...args) as ReturnType<ReadListing>,
@@ -61,11 +62,13 @@ const listingParams = (overrides?: {
   filter?: Condition;
   orderBy?: { column: string; direction: "ASC" | "DESC" }[];
   universe?: string | undefined;
+  accessorsKey?: string;
 }) => ({
   filter: overrides?.filter,
   orderBy: overrides?.orderBy,
   getValue,
   getComparator: () => undefined,
+  accessorsKey: overrides?.accessorsKey ?? "",
   listing: {
     logDir: "/logs",
     prefix: "/logs",
@@ -190,6 +193,26 @@ describe("useDatabaseLogsListingQuery", () => {
         "/logs/b.eval",
       ])
     );
+  });
+
+  test("re-queries when the accessor schema lands, keeping the rows as placeholder", async () => {
+    const { result, rerender } = renderHook(
+      (props) => useDatabaseLogsListingQuery<Row>(props),
+      {
+        wrapper,
+        initialProps: listingParams({ accessorsKey: "" }),
+      }
+    );
+    await waitFor(() => expect(result.current.result).toBeDefined());
+    expect(holder.read).toHaveBeenCalledTimes(1);
+
+    // The scorer schema arriving changes what the plan computes without any
+    // other query input changing — same universe, so the previous rows keep
+    // showing while the re-evaluated read is in flight.
+    rerender(listingParams({ accessorsKey: "grader/accuracy:number" }));
+    expect(result.current.pending).toBe(false);
+    expect(result.current.result).toBeDefined();
+    await waitFor(() => expect(holder.read).toHaveBeenCalledTimes(2));
   });
 
   test("does not serve one universe's rows to another", async () => {

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -28,6 +28,7 @@ type ReadListing = (
 const holder = vi.hoisted(() => ({
   opened: true,
   read: vi.fn<ReadListing>(),
+  invalidate: vi.fn(),
 }));
 
 vi.mock("../../../log_data", () => ({
@@ -39,6 +40,9 @@ vi.mock("../../../log_data", () => ({
     ...parts,
   ],
   databaseLogsOpened: () => holder.opened,
+  invalidateDatabaseLogsListings: () => {
+    holder.invalidate();
+  },
   readDatabaseLogsListing: (...args: Parameters<ReadListing>) =>
     holder.read(...args),
 }));
@@ -60,6 +64,7 @@ describe("useDatabaseLogsListingQuery", () => {
       defaultOptions: { queries: { retry: false } },
     });
     holder.read.mockReset();
+    holder.invalidate.mockReset();
     getLogsListing = holder.read.mockImplementation(
       (
         _scope: unknown,
@@ -164,6 +169,52 @@ describe("useDatabaseLogsListingQuery", () => {
     );
 
     await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+        "/logs/b.eval",
+      ])
+    );
+  });
+
+  test("refetches against fresh rows when the row set changes without a db write", async () => {
+    holder.invalidate.mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      queryClient.invalidateQueries({
+        queryKey: ["log_data", "dexie-listing", "logs"],
+      });
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const makeProps = (viewRows: Row[]) => ({
+      rows: viewRows,
+      filter: new Column("model").ilike("%"),
+      orderBy: [{ column: "name", direction: "ASC" as const }],
+      getValue,
+      getComparator: () => undefined,
+      database: {
+        scope: { prefix: "/logs" },
+        syncedPrefix: "/logs",
+        view: "logs::/logs",
+        rowKey: (row: Row) => row.name,
+      },
+    });
+    const { result, rerender } = renderHook(
+      (props) => useDatabaseLogsListingQuery(props),
+      { wrapper, initialProps: makeProps([rows[0]!]) }
+    );
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+      ])
+    );
+
+    // Same view + filter (same query key), new row set with no db write —
+    // e.g. a pending task arriving. The hook must invalidate so the cached
+    // result isn't served from the old rows.
+    rerender(makeProps(rows));
+    await waitFor(() => expect(holder.invalidate).toHaveBeenCalled());
     await waitFor(() =>
       expect(result.current.items.map((row) => row.name)).toEqual([
         "/logs/a.eval",

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -98,6 +98,7 @@ describe("useDatabaseLogsListingQuery", () => {
           database: {
             scope: { prefix: "/logs" },
             syncedPrefix: "/logs",
+            view: "logs::/logs",
             rowKey: (row) => row.name,
           },
         }),
@@ -128,6 +129,7 @@ describe("useDatabaseLogsListingQuery", () => {
           database: {
             scope: { prefix: "/aliased" },
             syncedPrefix: "/aliased",
+            view: "logs::/aliased",
             rowKey: (row) => row.name,
           },
         }),
@@ -154,6 +156,7 @@ describe("useDatabaseLogsListingQuery", () => {
           database: {
             scope: { prefix: "/logs" },
             syncedPrefix: "/logs",
+            view: "logs::/logs",
             rowKey: (row) => row.name,
           },
         }),
@@ -161,6 +164,50 @@ describe("useDatabaseLogsListingQuery", () => {
     );
 
     await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+        "/logs/b.eval",
+      ])
+    );
+  });
+
+  test("does not serve one view's cached rows to another view at the same prefix", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const makeProps = (view: string, viewRows: Row[]) => ({
+      rows: viewRows,
+      filter: new Column("model").ilike("%"),
+      orderBy: [{ column: "name", direction: "ASC" as const }],
+      getValue,
+      getComparator: () => undefined,
+      database: {
+        scope: { prefix: "/logs" },
+        syncedPrefix: "/logs",
+        view,
+        rowKey: (row: Row) => row.name,
+      },
+    });
+    const { result, rerender } = renderHook(
+      (props) => useDatabaseLogsListingQuery(props),
+      { wrapper, initialProps: makeProps("logs::/logs", [rows[0]!]) }
+    );
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+      ])
+    );
+
+    // Same prefix + filter, different view: the folder view's cache entry
+    // must not leak into the flat view — the synchronous fallback answers
+    // until this view's own read lands.
+    rerender(makeProps("tasks::/logs", rows));
+    expect(result.current.items.map((row) => row.name)).toEqual([
+      "/logs/a.eval",
+      "/logs/b.eval",
+    ]);
+    await waitFor(() => expect(getLogsListing).toHaveBeenCalledTimes(2));
     await waitFor(() =>
       expect(result.current.items.map((row) => row.name)).toEqual([
         "/logs/a.eval",

--- a/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
+++ b/apps/inspect/src/app/log-list/listing/databaseListing.test.tsx
@@ -1,0 +1,171 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Column } from "@tsmono/inspect-common/query";
+
+import type { Log } from "../../../client/api/types";
+import type {
+  DatabaseListingPlan,
+  DatabaseListingResult,
+} from "../../../client/database/listing";
+
+import { useDatabaseLogsListingQuery } from "./useLogsListingQuery";
+
+interface Row {
+  name: string;
+  model: string;
+}
+
+type ReadListing = (
+  scope: unknown,
+  syncedPrefix: string,
+  toRow: (log: Log) => Row | undefined,
+  plan: DatabaseListingPlan<Row>
+) => Promise<DatabaseListingResult<Row> | null>;
+
+const holder = vi.hoisted(() => ({
+  opened: true,
+  read: vi.fn<ReadListing>(),
+}));
+
+vi.mock("../../../log_data", () => ({
+  databaseLogsListingKeyRoot: ["log_data", "dexie-listing", "logs"],
+  databaseLogsListingKey: (...parts: unknown[]) => [
+    "log_data",
+    "dexie-listing",
+    "logs",
+    ...parts,
+  ],
+  databaseLogsOpened: () => holder.opened,
+  readDatabaseLogsListing: (...args: Parameters<ReadListing>) =>
+    holder.read(...args),
+}));
+
+const logs = [
+  { name: "/logs/a.eval", model: "gpt-4" },
+  { name: "/logs/b.eval", model: "claude" },
+] as Log[];
+const rows: Row[] = logs.map(({ name, model }) => ({ name, model: model! }));
+const getValue = (row: Row, column: string): unknown =>
+  row[column as keyof Row];
+
+describe("useDatabaseLogsListingQuery", () => {
+  let queryClient: QueryClient;
+  let getLogsListing: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    holder.read.mockReset();
+    getLogsListing = holder.read.mockImplementation(
+      (
+        _scope: unknown,
+        _syncedPrefix: string,
+        toRow: (log: Log) => Row | undefined,
+        plan: DatabaseListingPlan<Row>
+      ): Promise<DatabaseListingResult<Row>> => {
+        const items = [...logs]
+          .reverse()
+          .map(toRow)
+          .filter((row): row is Row => row !== undefined)
+          .filter(plan.matches);
+        if (plan.compare) items.sort(plan.compare);
+        return Promise.resolve({
+          items,
+          total_count: items.length,
+          next_cursor: null,
+        });
+      }
+    );
+    holder.opened = true;
+  });
+
+  test("runs active conditions through the Dexie listing service", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        useDatabaseLogsListingQuery({
+          rows,
+          filter: new Column("model").eq("gpt-4"),
+          orderBy: [{ column: "name", direction: "ASC" }],
+          getValue,
+          getComparator: () => undefined,
+          database: {
+            scope: { prefix: "/logs" },
+            syncedPrefix: "/logs",
+            rowKey: (row) => row.name,
+          },
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+      ])
+    );
+  });
+
+  test("keeps the in-memory fallback for scopes that were not persisted", async () => {
+    const read = vi.fn().mockResolvedValue(null);
+    holder.read.mockImplementation(read);
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        useDatabaseLogsListingQuery({
+          rows,
+          filter: new Column("model").eq("claude"),
+          getValue,
+          getComparator: () => undefined,
+          database: {
+            scope: { prefix: "/aliased" },
+            syncedPrefix: "/aliased",
+            rowKey: (row) => row.name,
+          },
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(read).toHaveBeenCalledOnce());
+    expect(result.current.items.map((row) => row.name)).toEqual([
+      "/logs/b.eval",
+    ]);
+  });
+
+  test("preserves source order when no explicit sort is active", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        useDatabaseLogsListingQuery({
+          rows,
+          filter: new Column("model").ilike("%"),
+          getValue,
+          getComparator: () => undefined,
+          database: {
+            scope: { prefix: "/logs" },
+            syncedPrefix: "/logs",
+            rowKey: (row) => row.name,
+          },
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(getLogsListing).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(result.current.items.map((row) => row.name)).toEqual([
+        "/logs/a.eval",
+        "/logs/b.eval",
+      ])
+    );
+  });
+});

--- a/apps/inspect/src/app/log-list/listing/listing.test.ts
+++ b/apps/inspect/src/app/log-list/listing/listing.test.ts
@@ -9,7 +9,7 @@ import type {
 
 import { numberCompare } from "../grid/columns/comparators";
 
-import { applyListingQuery } from "./applyListingQuery";
+import { applyListingQuery, mergeSortedRows } from "./applyListingQuery";
 import { combineFilters } from "./combineFilters";
 import { evaluateCondition } from "./evaluator";
 import type { ValueComparator } from "./types";
@@ -310,5 +310,33 @@ describe("type-aware filtering", () => {
       },
     } as unknown as Record<string, ColumnFilter>;
     expect(combineFilters(legacy)).toBeUndefined();
+  });
+});
+
+describe("mergeSortedRows", () => {
+  const byName = (a: Row, b: Row) => a.name.localeCompare(b.name);
+
+  it("returns the base list unchanged when the overlay is empty", () => {
+    const base = [r0, r1];
+    expect(mergeSortedRows(base, [])).toBe(base);
+  });
+
+  it("appends the overlay when no comparator is given", () => {
+    expect(mergeSortedRows([r2, r0], [r1])).toEqual([r2, r0, r1]);
+  });
+
+  it("interleaves overlay rows into sort position", () => {
+    // base: a, c — overlay: b, d
+    expect(mergeSortedRows([r0, r2], [r1, r3], byName)).toEqual([
+      r0,
+      r1,
+      r2,
+      r3,
+    ]);
+  });
+
+  it("places base rows before overlay rows on ties", () => {
+    const dupe: Row = { name: "a", model: "other" };
+    expect(mergeSortedRows([r0], [dupe], byName)).toEqual([r0, dupe]);
   });
 });

--- a/apps/inspect/src/app/log-list/listing/planner.ts
+++ b/apps/inspect/src/app/log-list/listing/planner.ts
@@ -5,10 +5,14 @@ import type { DatabaseListingPlan } from "../../../client/database/listing";
 import { compareByOrderBy, evaluateCondition } from "./evaluator";
 import type { ListingQuery } from "./types";
 
-/** Compile the wire filter and ordering into record-level listing operations. */
+/**
+ * Compile the wire filter and ordering into record-level listing operations.
+ *
+ * `compare` has no position tiebreak: executors sort stably over the
+ * source's listing order, so ties (and the unsorted listing) keep it.
+ */
 export const createListingPlan = <TRow>(
-  query: ListingQuery<TRow>,
-  stablePosition?: (row: TRow) => number
+  query: ListingQuery<TRow>
 ): DatabaseListingPlan<TRow> => {
   const { filter, getValue, getFilterType, getComparator, pagination } = query;
   const orderBy: OrderByModel[] = query.orderBy
@@ -17,19 +21,14 @@ export const createListingPlan = <TRow>(
       : [query.orderBy]
     : [];
 
-  const compare =
-    orderBy.length > 0
-      ? compareByOrderBy(orderBy, getValue, getComparator)
-      : undefined;
-
   return {
     matches: filter
       ? (row) => evaluateCondition(row, filter, getValue, getFilterType)
       : () => true,
-    compare: stablePosition
-      ? (a, b) =>
-          (compare?.(a, b) ?? 0) || stablePosition(a) - stablePosition(b)
-      : compare,
+    compare:
+      orderBy.length > 0
+        ? compareByOrderBy(orderBy, getValue, getComparator)
+        : undefined,
     pagination,
   };
 };

--- a/apps/inspect/src/app/log-list/listing/planner.ts
+++ b/apps/inspect/src/app/log-list/listing/planner.ts
@@ -7,7 +7,8 @@ import type { ListingQuery } from "./types";
 
 /** Compile the wire filter and ordering into record-level listing operations. */
 export const createListingPlan = <TRow>(
-  query: ListingQuery<TRow>
+  query: ListingQuery<TRow>,
+  stablePosition?: (row: TRow) => number
 ): DatabaseListingPlan<TRow> => {
   const { filter, getValue, getFilterType, getComparator, pagination } = query;
   const orderBy: OrderByModel[] = query.orderBy
@@ -16,14 +17,19 @@ export const createListingPlan = <TRow>(
       : [query.orderBy]
     : [];
 
+  const compare =
+    orderBy.length > 0
+      ? compareByOrderBy(orderBy, getValue, getComparator)
+      : undefined;
+
   return {
     matches: filter
       ? (row) => evaluateCondition(row, filter, getValue, getFilterType)
       : () => true,
-    compare:
-      orderBy.length > 0
-        ? compareByOrderBy(orderBy, getValue, getComparator)
-        : undefined,
+    compare: stablePosition
+      ? (a, b) =>
+          (compare?.(a, b) ?? 0) || stablePosition(a) - stablePosition(b)
+      : compare,
     pagination,
   };
 };

--- a/apps/inspect/src/app/log-list/listing/planner.ts
+++ b/apps/inspect/src/app/log-list/listing/planner.ts
@@ -1,0 +1,29 @@
+import type { OrderByModel } from "@tsmono/inspect-common/query";
+
+import type { DatabaseListingPlan } from "../../../client/database/listing";
+
+import { compareByOrderBy, evaluateCondition } from "./evaluator";
+import type { ListingQuery } from "./types";
+
+/** Compile the wire filter and ordering into record-level listing operations. */
+export const createListingPlan = <TRow>(
+  query: ListingQuery<TRow>
+): DatabaseListingPlan<TRow> => {
+  const { filter, getValue, getFilterType, getComparator, pagination } = query;
+  const orderBy: OrderByModel[] = query.orderBy
+    ? Array.isArray(query.orderBy)
+      ? query.orderBy
+      : [query.orderBy]
+    : [];
+
+  return {
+    matches: filter
+      ? (row) => evaluateCondition(row, filter, getValue, getFilterType)
+      : () => true,
+    compare:
+      orderBy.length > 0
+        ? compareByOrderBy(orderBy, getValue, getComparator)
+        : undefined,
+    pagination,
+  };
+};

--- a/apps/inspect/src/app/log-list/listing/types.ts
+++ b/apps/inspect/src/app/log-list/listing/types.ts
@@ -5,17 +5,7 @@ import type {
 } from "@tsmono/inspect-common/query";
 import type { FilterType } from "@tsmono/inspect-components/columnFilter";
 
-/**
- * Opaque pagination cursor for the client-side listing query. Mirrors scout's
- * cursor shape (`Pagination.cursor` is `{ [k]: unknown } | null`); we store a
- * simple offset.
- */
-export interface Cursor {
-  offset: number;
-  // Index signature so a Cursor satisfies the generated `Pagination.cursor`
-  // (`{ [key: string]: unknown } | null`).
-  [key: string]: unknown;
-}
+import type { Cursor } from "../../../client/database/listing";
 
 /**
  * Result of a listing query — mirrors scout's `TranscriptsResponse`

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -9,7 +9,11 @@ import type {
 } from "@tsmono/inspect-common/query";
 
 import type { LogListingRow } from "../../../log_data";
-import { databaseLogsListingKey, readLogsListing } from "../../../log_data";
+import {
+  databaseLogsListingKey,
+  listingKeyUniverse,
+  readLogsListing,
+} from "../../../log_data";
 
 import { applyListingQuery } from "./applyListingQuery";
 import { createListingPlan } from "./planner";
@@ -90,6 +94,10 @@ interface UseDatabaseLogsListingParams<TRow> {
   getValue: ValueAccessor<TRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
+  /** Cache identity of the accessors above (see `useLogListColumns`) — the
+   *  score-column schema lands asynchronously and changes what the plan
+   *  computes, so it must key the query alongside filter/orderBy. */
+  accessorsKey: string;
   listing: LogsListingDescriptor<TRow>;
 }
 
@@ -118,11 +126,18 @@ export function useDatabaseLogsListingQuery<TRow>({
   getValue,
   getComparator,
   getFilterType,
+  accessorsKey,
   listing,
 }: UseDatabaseLogsListingParams<TRow>): DatabaseLogsListing<TRow> {
   const { logDir, prefix, universe, toRow } = listing;
   const query = useQuery({
-    queryKey: databaseLogsListingKey(universe, filter, orderBy, pagination),
+    queryKey: databaseLogsListingKey(
+      universe,
+      accessorsKey,
+      filter,
+      orderBy,
+      pagination
+    ),
     queryFn: (): Promise<LogsListingResult<TRow>> =>
       readLogsListing(
         logDir,
@@ -138,13 +153,20 @@ export function useDatabaseLogsListingQuery<TRow>({
         })
       ),
     enabled: universe !== undefined,
-    // Keep showing the previous result across re-filters/sorts within one
-    // universe; a different universe's rows must not leak in.
+    // Keep showing the previous result across re-filters/sorts — and schema
+    // arrivals — within one universe (same row set, possibly re-evaluated);
+    // a different universe's rows must not leak in.
     placeholderData: (previousData, previousQuery) =>
-      universe !== undefined && previousQuery?.queryKey[3] === universe
+      universe !== undefined &&
+      previousQuery !== undefined &&
+      listingKeyUniverse(previousQuery.queryKey) === universe
         ? previousData
         : undefined,
     staleTime: 0,
+    // Transitional (pre-pagination): each key holds the full shaped row
+    // list, so the default 5-minute gc would keep a full copy per recent
+    // (schema, filter, orderBy) combination. Drop unobserved copies fast.
+    gcTime: 30_000,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import type {
   Condition,
@@ -8,15 +8,8 @@ import type {
   Pagination,
 } from "@tsmono/inspect-common/query";
 
-import type { Log } from "../../../client/api/types";
-import type { LogScope } from "../../../client/database";
-import {
-  databaseLogsListingKey,
-  databaseLogsListingKeyRoot,
-  databaseLogsOpened,
-  invalidateDatabaseLogsListings,
-  readDatabaseLogsListing,
-} from "../../../log_data";
+import type { LogListingRow } from "../../../log_data";
+import { databaseLogsListingKey, readLogsListing } from "../../../log_data";
 
 import { applyListingQuery } from "./applyListingQuery";
 import { createListingPlan } from "./planner";
@@ -43,10 +36,11 @@ interface UseLogsListingParams<TRow> {
 }
 
 /**
- * The log listing query: filter + sort + paginate over the rows. Mirrors
- * scout's `getTranscripts(filter, orderBy, pagination)` tail and response shape.
- *
- * The generic in-memory path is retained for samples and db-less listings.
+ * The generic in-memory listing query: filter + sort + paginate over the
+ * rows. Mirrors scout's `getTranscripts(filter, orderBy, pagination)` tail
+ * and response shape. Retained for samples listings, which don't have a
+ * database-backed path yet — the log list uses
+ * {@link useDatabaseLogsListingQuery}.
  */
 export function useLogsListingQuery<TRow>({
   rows,
@@ -71,111 +65,83 @@ export function useLogsListingQuery<TRow>({
   );
 }
 
-interface UseDatabaseLogsListingParams<
-  TRow,
-> extends UseLogsListingParams<TRow> {
-  database: {
-    scope: LogScope;
-    syncedPrefix: string;
-    /** Cache identity of the row universe (view mode + directory). Distinct
-     *  views can share a scope prefix, so the prefix alone can't key the
-     *  cache. `undefined` while the scope is still hydrating. */
-    view: string | undefined;
-    rowKey: (row: TRow) => string | undefined;
+interface UseDatabaseLogsListingParams<TRow> {
+  filter?: Condition;
+  orderBy?: OrderByModel[];
+  pagination?: Pagination;
+  getValue: ValueAccessor<TRow>;
+  getComparator: (columnId: string) => ValueComparator | undefined;
+  getFilterType?: FilterTypeAccessor;
+  listing: {
+    /** The synced directory whose rows are the source (see `readLogsListing`
+     *  for where they're read from). */
+    logDir: string;
+    /** Row-universe scan prefix (folder mode lists a subdirectory). */
+    prefix: string;
+    /** Cache identity of the row universe: everything `toRow` reads beyond
+     *  the record itself (view mode, directory, display toggles).
+     *  `undefined` while the scope is still hydrating — disables the query. */
+    universe: string | undefined;
+    /** Shape a source record into the view's row, or `undefined` when the
+     *  view has no row for it (row-universe membership). */
+    toRow: (log: LogListingRow) => TRow | undefined;
   };
 }
 
-/** Use Dexie for conditioned log listings, with the in-memory path as fallback. */
+export interface DatabaseLogsListing<TRow> {
+  /** The latest result for this universe (a placeholder from the previous
+   *  filter/sort while a refetch is in flight); `undefined` until the
+   *  universe's first read lands. */
+  result: LogsListingResult<TRow> | undefined;
+  /** No result to show yet — the universe is hydrating or its first read is
+   *  in flight. Rows stream in via write-path invalidation after that. */
+  pending: boolean;
+}
+
+/**
+ * The log listing query: rows are read from the listing source (IndexedDB
+ * in dir mode — see `readLogsListing`) and shaped per view inside the
+ * queryFn, so the full row list never has to live in memory for the grid's
+ * sake. Results are asynchronous by design: the first read shows whatever
+ * has replicated so far, and the write path's throttled invalidation
+ * streams further rows in as they land.
+ */
 export function useDatabaseLogsListingQuery<TRow>({
-  rows,
   filter,
   orderBy,
   pagination,
   getValue,
   getComparator,
   getFilterType,
-  database,
-}: UseDatabaseLogsListingParams<TRow>): LogsListingResult<TRow> {
-  const databaseEnabled = filter !== undefined && databaseLogsOpened();
-  const query = useMemo(
-    () => ({
-      filter,
-      orderBy,
-      pagination,
-      getValue,
-      getComparator,
-      getFilterType,
-    }),
-    [filter, orderBy, pagination, getValue, getComparator, getFilterType]
-  );
-
-  const dexieResult = useQuery({
-    queryKey: filter
-      ? databaseLogsListingKey(database.view, filter, orderBy, pagination)
-      : [...databaseLogsListingKeyRoot, "disabled"],
-    queryFn: async (): Promise<LogsListingResult<TRow> | null> => {
-      if (!filter) return null;
-      const byKey = new Map<string, TRow>();
-      const transient: TRow[] = [];
-      const position = new Map<TRow, number>();
-      for (const [index, row] of rows.entries()) {
-        position.set(row, index);
-        const key = database.rowKey(row);
-        if (key === undefined) transient.push(row);
-        else byKey.set(key, row);
-      }
-
-      const plan = createListingPlan(
-        transient.length > 0 ? { ...query, pagination: undefined } : query,
-        (row) => position.get(row) ?? Number.MAX_SAFE_INTEGER
-      );
-      const result = await readDatabaseLogsListing(
-        database.scope,
-        database.syncedPrefix,
-        (log: Log) => byKey.get(log.name),
-        plan
-      );
-      if (result === null) return null;
-      if (transient.length === 0) return result;
-      const included = new Set([...result.items, ...transient]);
-      return applyListingQuery(
-        rows.filter((row) => included.has(row)),
-        query
-      );
-    },
-    enabled: databaseEnabled,
+  listing,
+}: UseDatabaseLogsListingParams<TRow>): DatabaseLogsListing<TRow> {
+  const { logDir, prefix, universe, toRow } = listing;
+  const query = useQuery({
+    queryKey: databaseLogsListingKey(universe, filter, orderBy, pagination),
+    queryFn: (): Promise<LogsListingResult<TRow>> =>
+      readLogsListing(
+        logDir,
+        prefix,
+        toRow,
+        createListingPlan({
+          filter,
+          orderBy,
+          pagination,
+          getValue,
+          getComparator,
+          getFilterType,
+        })
+      ),
+    enabled: universe !== undefined,
+    // Keep showing the previous result across re-filters/sorts within one
+    // universe; a different universe's rows must not leak in.
     placeholderData: (previousData, previousQuery) =>
-      database.view !== undefined &&
-      previousQuery?.queryKey[3] === database.view
+      universe !== undefined && previousQuery?.queryKey[3] === universe
         ? previousData
         : undefined,
     staleTime: 0,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
-
-  // The query result is computed from `rows`, but `rows` isn't in the query
-  // key and only db writes fire the write-path invalidation. Cache-only row
-  // changes (retried-log toggling, pending tasks arriving, the post-write
-  // cache re-read) would otherwise serve a result built from stale rows, so
-  // nudge the shared invalidation whenever the row set changes. Declared
-  // after useQuery: react-query applies the observer's options (the fresh
-  // queryFn closure) in its own effect, and effects run in declaration
-  // order — before it, the refetch would still see the old rows.
-  const seenRows = useRef(rows);
-  useEffect(() => {
-    if (seenRows.current === rows) return;
-    seenRows.current = rows;
-    invalidateDatabaseLogsListings();
-  }, [rows]);
-
-  const databaseResult = databaseEnabled
-    ? (dexieResult.data ?? undefined)
-    : undefined;
-  const fallbackResult = useMemo(
-    () =>
-      databaseResult === undefined ? applyListingQuery(rows, query) : undefined,
-    [databaseResult, rows, query]
-  );
-  return databaseResult ?? fallbackResult!;
+  return { result: query.data, pending: query.isPending };
 }

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { useMemo } from "react";
 
@@ -7,6 +6,8 @@ import type {
   OrderByModel,
   Pagination,
 } from "@tsmono/inspect-common/query";
+import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
+import type { AsyncData } from "@tsmono/util";
 
 import type { LogListingRow } from "../../../log_data";
 import {
@@ -101,23 +102,15 @@ interface UseDatabaseLogsListingParams<TRow> {
   listing: LogsListingDescriptor<TRow>;
 }
 
-export interface DatabaseLogsListing<TRow> {
-  /** The latest result for this universe (a placeholder from the previous
-   *  filter/sort while a refetch is in flight); `undefined` until the
-   *  universe's first read lands. */
-  result: LogsListingResult<TRow> | undefined;
-  /** No result to show yet — the universe is hydrating or its first read is
-   *  in flight. Rows stream in via write-path invalidation after that. */
-  pending: boolean;
-}
-
 /**
  * The log listing query: rows are read from the listing source (IndexedDB
  * in dir mode — see `readLogsListing`) and shaped per view inside the
  * queryFn, so the full row list never has to live in memory for the grid's
  * sake. Results are asynchronous by design: the first read shows whatever
  * has replicated so far, and the write path's throttled invalidation
- * streams further rows in as they land.
+ * streams further rows in as they land. `loading` covers hydration and the
+ * universe's first read; within one universe a re-filter/sort reports the
+ * previous result as `data` (no loading flash) until the new read lands.
  */
 export function useDatabaseLogsListingQuery<TRow>({
   filter,
@@ -128,9 +121,9 @@ export function useDatabaseLogsListingQuery<TRow>({
   getFilterType,
   accessorsKey,
   listing,
-}: UseDatabaseLogsListingParams<TRow>): DatabaseLogsListing<TRow> {
+}: UseDatabaseLogsListingParams<TRow>): AsyncData<LogsListingResult<TRow>> {
   const { logDir, prefix, universe, toRow } = listing;
-  const query = useQuery({
+  return useAsyncDataFromQuery({
     queryKey: databaseLogsListingKey(
       universe,
       accessorsKey,
@@ -170,5 +163,4 @@ export function useDatabaseLogsListingQuery<TRow>({
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
-  return { result: query.data, pending: query.isPending };
 }

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -76,6 +76,10 @@ interface UseDatabaseLogsListingParams<
   database: {
     scope: LogScope;
     syncedPrefix: string;
+    /** Cache identity of the row universe (view mode + directory). Distinct
+     *  views can share a scope prefix, so the prefix alone can't key the
+     *  cache. `undefined` while the scope is still hydrating. */
+    view: string | undefined;
     rowKey: (row: TRow) => string | undefined;
   };
 }
@@ -106,12 +110,7 @@ export function useDatabaseLogsListingQuery<TRow>({
 
   const dexieResult = useQuery({
     queryKey: filter
-      ? databaseLogsListingKey(
-          database.scope.prefix,
-          filter,
-          orderBy,
-          pagination
-        )
+      ? databaseLogsListingKey(database.view, filter, orderBy, pagination)
       : [...databaseLogsListingKeyRoot, "disabled"],
     queryFn: async (): Promise<LogsListingResult<TRow> | null> => {
       if (!filter) return null;
@@ -145,7 +144,8 @@ export function useDatabaseLogsListingQuery<TRow>({
     },
     enabled: databaseEnabled,
     placeholderData: (previousData, previousQuery) =>
-      previousQuery?.queryKey[3] === database.scope.prefix
+      database.view !== undefined &&
+      previousQuery?.queryKey[3] === database.view
         ? previousData
         : undefined,
     staleTime: 0,

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { useMemo } from "react";
 
@@ -7,7 +8,17 @@ import type {
   Pagination,
 } from "@tsmono/inspect-common/query";
 
+import type { Log } from "../../../client/api/types";
+import type { LogScope } from "../../../client/database";
+import {
+  databaseLogsListingKey,
+  databaseLogsListingKeyRoot,
+  databaseLogsOpened,
+  readDatabaseLogsListing,
+} from "../../../log_data";
+
 import { applyListingQuery } from "./applyListingQuery";
+import { createListingPlan } from "./planner";
 import type {
   FilterTypeAccessor,
   LogsListingResult,
@@ -34,10 +45,7 @@ interface UseLogsListingParams<TRow> {
  * The log listing query: filter + sort + paginate over the rows. Mirrors
  * scout's `getTranscripts(filter, orderBy, pagination)` tail and response shape.
  *
- * Client-side for now — a derived `useMemo` over the (reactive) rows. The async
- * data source already lives in the react-query logs-content cache; when inspect
- * moves filter/sort server-side this hook becomes a `useQuery` that fetches a
- * filtered/sorted page instead.
+ * The generic in-memory path is retained for samples and db-less listings.
  */
 export function useLogsListingQuery<TRow>({
   rows,
@@ -60,4 +68,98 @@ export function useLogsListingQuery<TRow>({
       }),
     [rows, filter, orderBy, pagination, getValue, getComparator, getFilterType]
   );
+}
+
+interface UseDatabaseLogsListingParams<
+  TRow,
+> extends UseLogsListingParams<TRow> {
+  database: {
+    scope: LogScope;
+    syncedPrefix: string;
+    rowKey: (row: TRow) => string | undefined;
+  };
+}
+
+/** Use Dexie for conditioned log listings, with the in-memory path as fallback. */
+export function useDatabaseLogsListingQuery<TRow>({
+  rows,
+  filter,
+  orderBy,
+  pagination,
+  getValue,
+  getComparator,
+  getFilterType,
+  database,
+}: UseDatabaseLogsListingParams<TRow>): LogsListingResult<TRow> {
+  const databaseEnabled = filter !== undefined && databaseLogsOpened();
+  const query = useMemo(
+    () => ({
+      filter,
+      orderBy,
+      pagination,
+      getValue,
+      getComparator,
+      getFilterType,
+    }),
+    [filter, orderBy, pagination, getValue, getComparator, getFilterType]
+  );
+
+  const dexieResult = useQuery({
+    queryKey: filter
+      ? databaseLogsListingKey(
+          database.scope.prefix,
+          filter,
+          orderBy,
+          pagination
+        )
+      : [...databaseLogsListingKeyRoot, "disabled"],
+    queryFn: async (): Promise<LogsListingResult<TRow> | null> => {
+      if (!filter) return null;
+      const byKey = new Map<string, TRow>();
+      const transient: TRow[] = [];
+      const position = new Map<TRow, number>();
+      for (const [index, row] of rows.entries()) {
+        position.set(row, index);
+        const key = database.rowKey(row);
+        if (key === undefined) transient.push(row);
+        else byKey.set(key, row);
+      }
+
+      const plan = createListingPlan(
+        transient.length > 0 ? { ...query, pagination: undefined } : query,
+        (row) => position.get(row) ?? Number.MAX_SAFE_INTEGER
+      );
+      const result = await readDatabaseLogsListing(
+        database.scope,
+        database.syncedPrefix,
+        (log: Log) => byKey.get(log.name),
+        plan
+      );
+      if (result === null) return null;
+      if (transient.length === 0) return result;
+      const included = new Set([...result.items, ...transient]);
+      return applyListingQuery(
+        rows.filter((row) => included.has(row)),
+        query
+      );
+    },
+    enabled: databaseEnabled,
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[3] === database.scope.prefix
+        ? previousData
+        : undefined,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  const databaseResult = databaseEnabled
+    ? (dexieResult.data ?? undefined)
+    : undefined;
+  const fallbackResult = useMemo(
+    () =>
+      databaseResult === undefined ? applyListingQuery(rows, query) : undefined,
+    [databaseResult, rows, query]
+  );
+  return databaseResult ?? fallbackResult!;
 }

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -65,6 +65,24 @@ export function useLogsListingQuery<TRow>({
   );
 }
 
+/** The listing source a view queries — shared by the row query, the find
+ *  band's match query, and (eventually) the offset lookup, so they can
+ *  never disagree about the row universe. */
+export interface LogsListingDescriptor<TRow> {
+  /** The synced directory whose rows are the source (see `readLogsListing`
+   *  for where they're read from). */
+  logDir: string;
+  /** Row-universe scan prefix (folder mode lists a subdirectory). */
+  prefix: string;
+  /** Cache identity of the row universe: everything `toRow` reads beyond
+   *  the record itself (view mode, directory, display toggles).
+   *  `undefined` while the scope is still hydrating — disables queries. */
+  universe: string | undefined;
+  /** Shape a source record into the view's row, or `undefined` when the
+   *  view has no row for it (row-universe membership). */
+  toRow: (log: LogListingRow) => TRow | undefined;
+}
+
 interface UseDatabaseLogsListingParams<TRow> {
   filter?: Condition;
   orderBy?: OrderByModel[];
@@ -72,20 +90,7 @@ interface UseDatabaseLogsListingParams<TRow> {
   getValue: ValueAccessor<TRow>;
   getComparator: (columnId: string) => ValueComparator | undefined;
   getFilterType?: FilterTypeAccessor;
-  listing: {
-    /** The synced directory whose rows are the source (see `readLogsListing`
-     *  for where they're read from). */
-    logDir: string;
-    /** Row-universe scan prefix (folder mode lists a subdirectory). */
-    prefix: string;
-    /** Cache identity of the row universe: everything `toRow` reads beyond
-     *  the record itself (view mode, directory, display toggles).
-     *  `undefined` while the scope is still hydrating — disables the query. */
-    universe: string | undefined;
-    /** Shape a source record into the view's row, or `undefined` when the
-     *  view has no row for it (row-universe membership). */
-    toRow: (log: LogListingRow) => TRow | undefined;
-  };
+  listing: LogsListingDescriptor<TRow>;
 }
 
 export interface DatabaseLogsListing<TRow> {

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -1,12 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type {
   Condition,
   OrderByModel,
   Pagination,
 } from "@tsmono/inspect-common/query";
-import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
+import {
+  useAsyncDataFromQuery,
+  useDebouncedCallback,
+} from "@tsmono/react/hooks";
 import type { AsyncData } from "@tsmono/util";
 
 import type { LogListingRow } from "../../../log_data";
@@ -14,6 +18,7 @@ import {
   databaseLogsListingKey,
   listingKeyUniverse,
   readLogsListing,
+  readLogsListingMatches,
 } from "../../../log_data";
 
 import { applyListingQuery } from "./applyListingQuery";
@@ -163,4 +168,128 @@ export function useDatabaseLogsListingQuery<TRow>({
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+}
+
+interface UseLogsListingMatchesParams<TRow> {
+  /** The same query inputs the row query ran under (pass them through from
+   *  `useLogListData` rather than re-deriving — the match membership must
+   *  never disagree with the rendered rows). */
+  filter?: Condition;
+  orderBy?: OrderByModel[];
+  getValue: ValueAccessor<TRow>;
+  getComparator: (columnId: string) => ValueComparator | undefined;
+  getFilterType?: FilterTypeAccessor;
+  accessorsKey: string;
+  listing: LogsListingDescriptor<TRow>;
+  /** The live find term. The query runs under a debounced copy: every
+   *  distinct term is a fresh scan of the listing source, so keystrokes
+   *  coalesce here while the input (and cheap overlay matching) stay live. */
+  term: string;
+  /** Whether the find band is open — the query never runs while closed. */
+  enabled: boolean;
+  getRowId: (row: TRow) => string;
+  /** A row's searchable text, already lowercased (see `rowSearchText`). */
+  rowText: (row: TRow) => string;
+  /** Cache identity of `rowText` — the searchable (visible) column ids. */
+  searchKey: readonly string[];
+}
+
+export interface LogsListingMatches {
+  /** Ids of the file rows matching the debounced term — membership only;
+   *  display order comes from the rendered rows. */
+  ids: string[] | undefined;
+  /** `ids` is a real result for the live term under the current universe —
+   *  debounce flushed, not pending, not another key's placeholder, not an
+   *  error. Only then may the UI claim "no results". */
+  settled: boolean;
+  /** Cancel the pending debounce and clear the match term (band closed). */
+  reset: () => void;
+}
+
+/**
+ * The find band's data-level match query, beside the row query so the two
+ * share key shape and universe semantics: the key is the row query's key
+ * (same universe slot, so `listingKeyUniverse` and the root invalidation
+ * cover both) extended with the find-only inputs, and the placeholder keeps
+ * previous matches only within one universe — folder-mode row ids are
+ * basenames, so another directory's ids could otherwise mark unrelated
+ * same-named rows as matches while a scope change's refetch is in flight.
+ */
+export function useLogsListingMatches<TRow>({
+  filter,
+  orderBy,
+  getValue,
+  getComparator,
+  getFilterType,
+  accessorsKey,
+  listing,
+  term,
+  enabled,
+  getRowId,
+  rowText,
+  searchKey,
+}: UseLogsListingMatchesParams<TRow>): LogsListingMatches {
+  const [matchTerm, setMatchTerm] = useState("");
+  // Same 100ms as the shared FindBand's debounce. The debounced callback
+  // always runs the latest closure, so the flush reads the current term.
+  const syncMatchTerm = useDebouncedCallback(() => setMatchTerm(term), 100);
+  useEffect(() => {
+    syncMatchTerm();
+  }, [term, syncMatchTerm]);
+  const reset = useCallback(() => {
+    syncMatchTerm.cancel();
+    setMatchTerm("");
+  }, [syncMatchTerm]);
+
+  const { logDir, prefix, universe, toRow } = listing;
+  const query = useQuery({
+    queryKey: [
+      ...databaseLogsListingKey(universe, accessorsKey, filter, orderBy),
+      "find",
+      matchTerm,
+      searchKey,
+    ],
+    queryFn: (): Promise<string[]> =>
+      readLogsListingMatches(
+        logDir,
+        prefix,
+        toRow,
+        createListingPlan({
+          filter,
+          orderBy,
+          getValue,
+          getComparator,
+          getFilterType,
+        }),
+        { term: matchTerm, getRowId, rowText }
+      ),
+    enabled: enabled && matchTerm !== "" && universe !== undefined,
+    // Keep the previous matches while a keystroke's refetch is in flight —
+    // within one universe only (see the docstring above).
+    placeholderData: (previousData: string[] | undefined, previousQuery) =>
+      universe !== undefined &&
+      previousQuery !== undefined &&
+      listingKeyUniverse(previousQuery.queryKey) === universe
+        ? previousData
+        : undefined,
+    staleTime: 0,
+    // Transitional (pre-pagination): every distinct term parks a full id
+    // list per key; drop unobserved ones fast, like the row query.
+    gcTime: 30_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return {
+    ids: query.data,
+    // `isPending` alone can't gate "no results": a key change served from
+    // the placeholder reads as success while the new term's scan is still
+    // in flight, and an errored query reads as not-pending with no data.
+    settled:
+      term === matchTerm &&
+      !query.isPending &&
+      !query.isPlaceholderData &&
+      !query.isError,
+    reset,
+  };
 }

--- a/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
+++ b/apps/inspect/src/app/log-list/listing/useLogsListingQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import type {
   Condition,
@@ -14,6 +14,7 @@ import {
   databaseLogsListingKey,
   databaseLogsListingKeyRoot,
   databaseLogsOpened,
+  invalidateDatabaseLogsListings,
   readDatabaseLogsListing,
 } from "../../../log_data";
 
@@ -152,6 +153,21 @@ export function useDatabaseLogsListingQuery<TRow>({
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+
+  // The query result is computed from `rows`, but `rows` isn't in the query
+  // key and only db writes fire the write-path invalidation. Cache-only row
+  // changes (retried-log toggling, pending tasks arriving, the post-write
+  // cache re-read) would otherwise serve a result built from stale rows, so
+  // nudge the shared invalidation whenever the row set changes. Declared
+  // after useQuery: react-query applies the observer's options (the fresh
+  // queryFn closure) in its own effect, and effects run in declaration
+  // order — before it, the refetch would still see the old rows.
+  const seenRows = useRef(rows);
+  useEffect(() => {
+    if (seenRows.current === rows) return;
+    seenRows.current = rows;
+    invalidateDatabaseLogsListings();
+  }, [rows]);
 
   const databaseResult = databaseEnabled
     ? (dexieResult.data ?? undefined)

--- a/apps/inspect/src/app/log-list/useLogsOverview.ts
+++ b/apps/inspect/src/app/log-list/useLogsOverview.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  databaseLogsListingKeyRoot,
+  readLogsOverview,
+  type LogsOverview,
+  type LogsOverviewView,
+} from "../../log_data";
+
+interface UseLogsOverviewParams {
+  logDir: string;
+  /** Cache identity of the view (see `useDatabaseLogsListingQuery`'s
+   *  `universe`) — everything `view` reads beyond the records. `undefined`
+   *  while the scope is hydrating (disables the query). */
+  universe: string | undefined;
+  view: LogsOverviewView;
+}
+
+export interface LogsOverviewResult {
+  overview: LogsOverview | undefined;
+  /** No overview to show yet (hydrating or first read in flight). */
+  pending: boolean;
+  error: Error | undefined;
+}
+
+/**
+ * The page-level aggregates beside the row query (see `readLogsOverview`).
+ * Keyed under the listing root so the write path's throttled invalidation
+ * refreshes it alongside the row queries.
+ */
+export const useLogsOverview = ({
+  logDir,
+  universe,
+  view,
+}: UseLogsOverviewParams): LogsOverviewResult => {
+  const query = useQuery({
+    queryKey: [...databaseLogsListingKeyRoot, "overview", logDir, universe],
+    queryFn: () => readLogsOverview(logDir, view),
+    enabled: universe !== undefined,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+  return {
+    overview: query.data,
+    pending: query.isPending,
+    error: query.error ?? undefined,
+  };
+};

--- a/apps/inspect/src/app/log-list/useLogsOverview.ts
+++ b/apps/inspect/src/app/log-list/useLogsOverview.ts
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
+import { AsyncData } from "@tsmono/util";
 
 import {
   databaseLogsListingKeyRoot,
@@ -16,13 +17,6 @@ interface UseLogsOverviewParams {
   view: LogsOverviewView;
 }
 
-export interface LogsOverviewResult {
-  overview: LogsOverview | undefined;
-  /** No overview to show yet (hydrating or first read in flight). */
-  pending: boolean;
-  error: Error | undefined;
-}
-
 /**
  * The page-level aggregates beside the row query (see `readLogsOverview`).
  * Keyed under the listing root so the write path's throttled invalidation
@@ -32,8 +26,8 @@ export const useLogsOverview = ({
   logDir,
   universe,
   view,
-}: UseLogsOverviewParams): LogsOverviewResult => {
-  const query = useQuery({
+}: UseLogsOverviewParams): AsyncData<LogsOverview> => {
+  return useAsyncDataFromQuery({
     queryKey: [...databaseLogsListingKeyRoot, "overview", logDir, universe],
     queryFn: () => readLogsOverview(logDir, view),
     enabled: universe !== undefined,
@@ -41,9 +35,4 @@ export const useLogsOverview = ({
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
-  return {
-    overview: query.data,
-    pending: query.isPending,
-    error: query.error ?? undefined,
-  };
 };

--- a/apps/inspect/src/app/shared/data-grid/findMatches.ts
+++ b/apps/inspect/src/app/shared/data-grid/findMatches.ts
@@ -16,10 +16,32 @@ function primitiveText(value: unknown): string | null {
 }
 
 /**
- * Search index for the grid find band: lowercased plain-text per row id,
- * built from the visible columns' `textValue` (display formatting) or raw
- * accessor value. Data-level — searches all rows, not just the virtualized
- * window. Insertion order follows `rows`, so match order is row order.
+ * One row's searchable text: lowercased plain-text built from the visible
+ * columns' `textValue` (display formatting) or raw accessor value.
+ */
+export function rowSearchText<TRow>(
+  row: TRow,
+  columns: ExtendedColumnDef<TRow>[]
+): string {
+  const parts: string[] = [];
+  for (const column of columns) {
+    let text: string | null = null;
+    if (column.textValue) {
+      text = column.textValue(row);
+    } else if ("accessorFn" in column && column.accessorFn) {
+      text = primitiveText(column.accessorFn(row, 0));
+    }
+    if (text) parts.push(text);
+  }
+  // Newline separator: never matches a typed term, so a term can't match
+  // across the boundary between adjacent columns' text.
+  return parts.join("\n").toLowerCase();
+}
+
+/**
+ * Search index for the grid find band: searchable text per row id.
+ * Data-level — searches all rows, not just the virtualized window.
+ * Insertion order follows `rows`, so match order is row order.
  */
 export function buildSearchIndex<TRow>(
   rows: TRow[],
@@ -28,19 +50,7 @@ export function buildSearchIndex<TRow>(
 ): Map<string, string> {
   const index = new Map<string, string>();
   for (const row of rows) {
-    const parts: string[] = [];
-    for (const column of columns) {
-      let text: string | null = null;
-      if (column.textValue) {
-        text = column.textValue(row);
-      } else if ("accessorFn" in column && column.accessorFn) {
-        text = primitiveText(column.accessorFn(row, 0));
-      }
-      if (text) parts.push(text);
-    }
-    // Newline separator: never matches a typed term, so a term can't match
-    // across the boundary between adjacent columns' text.
-    index.set(getRowId(row), parts.join("\n").toLowerCase());
+    index.set(getRowId(row), rowSearchText(row, columns));
   }
   return index;
 }

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -12,12 +12,8 @@ import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { LogHandle } from "@tsmono/inspect-common";
-import { Column } from "@tsmono/inspect-common/query";
 
-import { applyListingQuery } from "../../app/log-list/listing/applyListingQuery";
-import { createListingPlan } from "../../app/log-list/listing/planner";
 import {
-  Log,
   LogDetails,
   LogFetchState,
   LogPreview,
@@ -213,63 +209,6 @@ describe("Database Service", () => {
       expect(row?.task).toBe("renamed-task");
       expect(row?.depth).toBe("previewed");
       expect(row?.status).toBe("success");
-    });
-
-    test("Dexie listings match the in-memory filter, sort, and pagination", async () => {
-      await databaseService.writeLogPreviews({
-        "/test/logs/a.json": createTestLogSummary({
-          model: "gpt-4",
-          status: "success",
-        }),
-        "/test/logs/b.json": createTestLogSummary({
-          model: "claude",
-          status: "success",
-        }),
-        "/test/logs/c.json": createTestLogSummary({
-          model: "gpt-4o",
-          status: "error",
-        }),
-        "/test/logs/d.json": createTestLogSummary({
-          model: "gpt-5",
-          status: "success",
-        }),
-        "/other/e.json": createTestLogSummary({
-          model: "gpt-5",
-          status: "success",
-        }),
-      });
-      const source = (await databaseService.readLogs({
-        prefix: "/test/logs",
-      })) as Log[];
-      const getValue = (row: Log, column: string): unknown =>
-        row[column as keyof Log];
-      const query = {
-        filter: new Column("model")
-          .ilike("gpt%")
-          .and(new Column("status").ne("error")),
-        orderBy: [{ column: "name", direction: "DESC" as const }],
-        pagination: { limit: 1, cursor: null, direction: "forward" as const },
-        getValue,
-        getComparator: () => undefined,
-      };
-
-      const expected = applyListingQuery(source, query);
-      const position = new Map(source.map((row, index) => [row.name, index]));
-      const actual = await databaseService.getLogsListing(
-        { prefix: "/test/logs" },
-        (row) => row,
-        createListingPlan(
-          query,
-          (row) => position.get(row.name) ?? Number.MAX_SAFE_INTEGER
-        )
-      );
-
-      expect(actual).toEqual(expected);
-      expect(actual.items.map((row) => row.name)).toEqual([
-        "/test/logs/d.json",
-      ]);
-      expect(actual.total_count).toBe(2);
-      expect(actual.next_cursor).toEqual({ offset: 1 });
     });
   });
 

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -12,8 +12,12 @@ import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { LogHandle } from "@tsmono/inspect-common";
+import { Column } from "@tsmono/inspect-common/query";
 
+import { applyListingQuery } from "../../app/log-list/listing/applyListingQuery";
+import { createListingPlan } from "../../app/log-list/listing/planner";
 import {
+  Log,
   LogDetails,
   LogFetchState,
   LogPreview,
@@ -209,6 +213,59 @@ describe("Database Service", () => {
       expect(row?.task).toBe("renamed-task");
       expect(row?.depth).toBe("previewed");
       expect(row?.status).toBe("success");
+    });
+
+    test("Dexie listings match the in-memory filter, sort, and pagination", async () => {
+      await databaseService.writeLogPreviews({
+        "/test/logs/a.json": createTestLogSummary({
+          model: "gpt-4",
+          status: "success",
+        }),
+        "/test/logs/b.json": createTestLogSummary({
+          model: "claude",
+          status: "success",
+        }),
+        "/test/logs/c.json": createTestLogSummary({
+          model: "gpt-4o",
+          status: "error",
+        }),
+        "/test/logs/d.json": createTestLogSummary({
+          model: "gpt-5",
+          status: "success",
+        }),
+        "/other/e.json": createTestLogSummary({
+          model: "gpt-5",
+          status: "success",
+        }),
+      });
+      const source = (await databaseService.readLogs({
+        prefix: "/test/logs",
+      })) as Log[];
+      const getValue = (row: Log, column: string): unknown =>
+        row[column as keyof Log];
+      const query = {
+        filter: new Column("model")
+          .ilike("gpt%")
+          .and(new Column("status").ne("error")),
+        orderBy: [{ column: "name", direction: "DESC" as const }],
+        pagination: { limit: 1, cursor: null, direction: "forward" as const },
+        getValue,
+        getComparator: () => undefined,
+      };
+
+      const expected = applyListingQuery(source, query);
+      const actual = await databaseService.getLogsListing(
+        { prefix: "/test/logs" },
+        (row) => row,
+        createListingPlan(query)
+      );
+
+      expect(actual).toEqual(expected);
+      expect(actual.items.map((row) => row.name)).toEqual([
+        "/test/logs/d.json",
+      ]);
+      expect(actual.total_count).toBe(2);
+      expect(actual.next_cursor).toEqual({ offset: 1 });
     });
   });
 

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -254,10 +254,14 @@ describe("Database Service", () => {
       };
 
       const expected = applyListingQuery(source, query);
+      const position = new Map(source.map((row, index) => [row.name, index]));
       const actual = await databaseService.getLogsListing(
         { prefix: "/test/logs" },
         (row) => row,
-        createListingPlan(query)
+        createListingPlan(
+          query,
+          (row) => position.get(row.name) ?? Number.MAX_SAFE_INTEGER
+        )
       );
 
       expect(actual).toEqual(expected);

--- a/apps/inspect/src/client/database/listing.ts
+++ b/apps/inspect/src/client/database/listing.ts
@@ -1,5 +1,3 @@
-import type { Collection } from "dexie";
-
 import type { Pagination } from "@tsmono/inspect-common/query";
 
 export interface DatabaseListingPlan<TRow> {
@@ -14,7 +12,8 @@ export interface DatabaseListingResult<TRow> {
   next_cursor: { offset: number; [key: string]: unknown } | null;
 }
 
-const pageRows = <TRow>(
+/** Slice one page (with its continuation cursor) off filtered+sorted rows. */
+export const pageRows = <TRow>(
   rows: TRow[],
   pagination?: Pagination
 ): Pick<DatabaseListingResult<TRow>, "items" | "next_cursor"> => {
@@ -28,26 +27,4 @@ const pageRows = <TRow>(
     items: rows.slice(offset, end),
     next_cursor: end < rows.length ? { offset: end } : null,
   };
-};
-
-/** Execute a listing plan while the scoped Dexie cursor is active. */
-export const queryDexieCollection = async <TRecord, TKey, TRow>(
-  collection: Collection<TRecord, TKey>,
-  toRow: (record: TRecord) => TRow | undefined,
-  plan: DatabaseListingPlan<TRow>
-): Promise<DatabaseListingResult<TRow>> => {
-  const records = await collection
-    .filter((record) => {
-      const row = toRow(record);
-      return row !== undefined && plan.matches(row);
-    })
-    .toArray();
-  const rows = records
-    .map(toRow)
-    .filter((row): row is TRow => row !== undefined);
-
-  if (plan.compare) rows.sort(plan.compare);
-
-  const total_count = rows.length;
-  return { ...pageRows(rows, plan.pagination), total_count };
 };

--- a/apps/inspect/src/client/database/listing.ts
+++ b/apps/inspect/src/client/database/listing.ts
@@ -6,10 +6,22 @@ export interface DatabaseListingPlan<TRow> {
   pagination?: Pagination;
 }
 
+/**
+ * Opaque pagination cursor for the client-side listing query. Mirrors scout's
+ * cursor shape (`Pagination.cursor` is `{ [k]: unknown } | null`); we store a
+ * simple offset.
+ */
+export interface Cursor {
+  offset: number;
+  // Index signature so a Cursor satisfies the generated `Pagination.cursor`
+  // (`{ [key: string]: unknown } | null`).
+  [key: string]: unknown;
+}
+
 export interface DatabaseListingResult<TRow> {
   items: TRow[];
   total_count: number;
-  next_cursor: { offset: number; [key: string]: unknown } | null;
+  next_cursor: Cursor | null;
 }
 
 /** Slice one page (with its continuation cursor) off filtered+sorted rows. */

--- a/apps/inspect/src/client/database/listing.ts
+++ b/apps/inspect/src/client/database/listing.ts
@@ -1,0 +1,53 @@
+import type { Collection } from "dexie";
+
+import type { Pagination } from "@tsmono/inspect-common/query";
+
+export interface DatabaseListingPlan<TRow> {
+  matches: (row: TRow) => boolean;
+  compare?: (a: TRow, b: TRow) => number;
+  pagination?: Pagination;
+}
+
+export interface DatabaseListingResult<TRow> {
+  items: TRow[];
+  total_count: number;
+  next_cursor: { offset: number; [key: string]: unknown } | null;
+}
+
+const pageRows = <TRow>(
+  rows: TRow[],
+  pagination?: Pagination
+): Pick<DatabaseListingResult<TRow>, "items" | "next_cursor"> => {
+  if (!pagination) return { items: rows, next_cursor: null };
+  const offset =
+    pagination.cursor && typeof pagination.cursor.offset === "number"
+      ? pagination.cursor.offset
+      : 0;
+  const end = offset + pagination.limit;
+  return {
+    items: rows.slice(offset, end),
+    next_cursor: end < rows.length ? { offset: end } : null,
+  };
+};
+
+/** Execute a listing plan while the scoped Dexie cursor is active. */
+export const queryDexieCollection = async <TRecord, TKey, TRow>(
+  collection: Collection<TRecord, TKey>,
+  toRow: (record: TRecord) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>
+): Promise<DatabaseListingResult<TRow>> => {
+  const records = await collection
+    .filter((record) => {
+      const row = toRow(record);
+      return row !== undefined && plan.matches(row);
+    })
+    .toArray();
+  const rows = records
+    .map(toRow)
+    .filter((row): row is TRow => row !== undefined);
+
+  if (plan.compare) rows.sort(plan.compare);
+
+  const total_count = rows.length;
+  return { ...pageRows(rows, plan.pagination), total_count };
+};

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -4,11 +4,6 @@ import { createLogger } from "@tsmono/util";
 import { Log, LogFetchState, LogPreview } from "../api/types";
 import { maxDepth, PreparedLogDetails, previewTier } from "../utils/type-utils";
 
-import {
-  DatabaseListingPlan,
-  DatabaseListingResult,
-  queryDexieCollection,
-} from "./listing";
 import { DatabaseManager } from "./manager";
 import {
   AppDatabase,
@@ -143,21 +138,6 @@ export class DatabaseService {
       log.error("Error retrieving log rows:", error);
       return null;
     }
-  }
-
-  async getLogsListing<TRow>(
-    scope: LogScope,
-    toRow: (log: Log) => TRow | undefined,
-    plan: DatabaseListingPlan<TRow>
-  ): Promise<DatabaseListingResult<TRow>> {
-    const records = this.getDb()
-      .logs.where("file_path")
-      .startsWith(scopePrefix(scope.prefix));
-    return queryDexieCollection(
-      records,
-      (record) => toRow(fromLogRecord(record)),
-      plan
-    );
   }
 
   async readLogRow(filePath: string): Promise<Log | null> {

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -4,6 +4,11 @@ import { createLogger } from "@tsmono/util";
 import { Log, LogFetchState, LogPreview } from "../api/types";
 import { maxDepth, PreparedLogDetails, previewTier } from "../utils/type-utils";
 
+import {
+  DatabaseListingPlan,
+  DatabaseListingResult,
+  queryDexieCollection,
+} from "./listing";
 import { DatabaseManager } from "./manager";
 import {
   AppDatabase,
@@ -138,6 +143,21 @@ export class DatabaseService {
       log.error("Error retrieving log rows:", error);
       return null;
     }
+  }
+
+  async getLogsListing<TRow>(
+    scope: LogScope,
+    toRow: (log: Log) => TRow | undefined,
+    plan: DatabaseListingPlan<TRow>
+  ): Promise<DatabaseListingResult<TRow>> {
+    const records = this.getDb()
+      .logs.where("file_path")
+      .startsWith(scopePrefix(scope.prefix));
+    return queryDexieCollection(
+      records,
+      (record) => toRow(fromLogRecord(record)),
+      plan
+    );
   }
 
   async readLogRow(filePath: string): Promise<Log | null> {

--- a/apps/inspect/src/log_data/databaseListings.ts
+++ b/apps/inspect/src/log_data/databaseListings.ts
@@ -15,6 +15,7 @@ export const databaseLogsListingKeyRoot = [
 
 export const databaseLogsListingKey = (
   universe: string | undefined,
+  accessorsKey: string,
   filter?: Condition,
   orderBy?: OrderByModel[],
   pagination?: Pagination
@@ -22,10 +23,16 @@ export const databaseLogsListingKey = (
   [
     ...databaseLogsListingKeyRoot,
     universe ?? null,
+    accessorsKey,
     filter ?? null,
     orderBy ?? null,
     pagination ?? null,
   ] as const;
+
+/** The universe slot of a {@link databaseLogsListingKey} — for same-universe
+ *  checks (placeholders) without hard-coding the key shape at call sites. */
+export const listingKeyUniverse = (queryKey: readonly unknown[]): unknown =>
+  queryKey[databaseLogsListingKeyRoot.length];
 
 /**
  * Coalesce replication bursts into at most one refetch of observed Dexie

--- a/apps/inspect/src/log_data/databaseListings.ts
+++ b/apps/inspect/src/log_data/databaseListings.ts
@@ -1,0 +1,62 @@
+import type {
+  Condition,
+  OrderByModel,
+  Pagination,
+} from "@tsmono/inspect-common/query";
+
+import type { Log } from "../client/api/types";
+import type { LogScope } from "../client/database";
+import type {
+  DatabaseListingPlan,
+  DatabaseListingResult,
+} from "../client/database/listing";
+import { queryClient } from "../state/queryClient";
+
+import { getDatabaseService } from "./databaseServiceInstance";
+
+export const databaseLogsListingKeyRoot = [
+  "log_data",
+  "dexie-listing",
+  "logs",
+] as const;
+
+export const databaseLogsListingKey = (
+  prefix: string,
+  filter: Condition,
+  orderBy?: OrderByModel[],
+  pagination?: Pagination
+) =>
+  [
+    ...databaseLogsListingKeyRoot,
+    prefix,
+    filter,
+    orderBy ?? null,
+    pagination ?? null,
+  ] as const;
+
+export const databaseLogsOpened = (): boolean => getDatabaseService().opened();
+
+export const readDatabaseLogsListing = async <TRow>(
+  scope: LogScope,
+  syncedPrefix: string,
+  toRow: (log: Log) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>
+): Promise<DatabaseListingResult<TRow> | null> => {
+  const database = getDatabaseService();
+  const synced = await database.getSyncScope(syncedPrefix);
+  return synced?.last_synced
+    ? database.getLogsListing(scope, toRow, plan)
+    : null;
+};
+
+let invalidationTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** Coalesce replication bursts into one refetch of observed Dexie listings. */
+export const invalidateDatabaseLogsListings = (): void => {
+  if (invalidationTimer !== undefined) clearTimeout(invalidationTimer);
+  invalidationTimer = setTimeout(() => {
+    invalidationTimer = undefined;
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    queryClient.invalidateQueries({ queryKey: databaseLogsListingKeyRoot });
+  }, 100);
+};

--- a/apps/inspect/src/log_data/databaseListings.ts
+++ b/apps/inspect/src/log_data/databaseListings.ts
@@ -21,14 +21,14 @@ export const databaseLogsListingKeyRoot = [
 ] as const;
 
 export const databaseLogsListingKey = (
-  prefix: string,
+  view: string | undefined,
   filter: Condition,
   orderBy?: OrderByModel[],
   pagination?: Pagination
 ) =>
   [
     ...databaseLogsListingKeyRoot,
-    prefix,
+    view ?? null,
     filter,
     orderBy ?? null,
     pagination ?? null,

--- a/apps/inspect/src/log_data/databaseListings.ts
+++ b/apps/inspect/src/log_data/databaseListings.ts
@@ -3,6 +3,7 @@ import type {
   OrderByModel,
   Pagination,
 } from "@tsmono/inspect-common/query";
+import { throttle } from "@tsmono/util";
 
 import type { Log } from "../client/api/types";
 import type { LogScope } from "../client/database";
@@ -49,14 +50,19 @@ export const readDatabaseLogsListing = async <TRow>(
     : null;
 };
 
-let invalidationTimer: ReturnType<typeof setTimeout> | undefined;
-
-/** Coalesce replication bursts into one refetch of observed Dexie listings. */
-export const invalidateDatabaseLogsListings = (): void => {
-  if (invalidationTimer !== undefined) clearTimeout(invalidationTimer);
-  invalidationTimer = setTimeout(() => {
-    invalidationTimer = undefined;
+/**
+ * Coalesce replication bursts into at most one refetch of observed Dexie
+ * listings per 100ms. A throttle, not a debounce: the flush loops can write
+ * back-to-back for a whole sync, and a trailing-only debounce would postpone
+ * the invalidation for the entire burst instead of updating incrementally.
+ */
+export const invalidateDatabaseLogsListings: () => void = throttle(
+  () => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    queryClient.invalidateQueries({ queryKey: databaseLogsListingKeyRoot });
-  }, 100);
-};
+    queryClient.invalidateQueries({
+      queryKey: databaseLogsListingKeyRoot,
+    });
+  },
+  100,
+  { leading: false }
+);

--- a/apps/inspect/src/log_data/databaseListings.ts
+++ b/apps/inspect/src/log_data/databaseListings.ts
@@ -5,15 +5,7 @@ import type {
 } from "@tsmono/inspect-common/query";
 import { throttle } from "@tsmono/util";
 
-import type { Log } from "../client/api/types";
-import type { LogScope } from "../client/database";
-import type {
-  DatabaseListingPlan,
-  DatabaseListingResult,
-} from "../client/database/listing";
 import { queryClient } from "../state/queryClient";
-
-import { getDatabaseService } from "./databaseServiceInstance";
 
 export const databaseLogsListingKeyRoot = [
   "log_data",
@@ -22,33 +14,18 @@ export const databaseLogsListingKeyRoot = [
 ] as const;
 
 export const databaseLogsListingKey = (
-  view: string | undefined,
-  filter: Condition,
+  universe: string | undefined,
+  filter?: Condition,
   orderBy?: OrderByModel[],
   pagination?: Pagination
 ) =>
   [
     ...databaseLogsListingKeyRoot,
-    view ?? null,
-    filter,
+    universe ?? null,
+    filter ?? null,
     orderBy ?? null,
     pagination ?? null,
   ] as const;
-
-export const databaseLogsOpened = (): boolean => getDatabaseService().opened();
-
-export const readDatabaseLogsListing = async <TRow>(
-  scope: LogScope,
-  syncedPrefix: string,
-  toRow: (log: Log) => TRow | undefined,
-  plan: DatabaseListingPlan<TRow>
-): Promise<DatabaseListingResult<TRow> | null> => {
-  const database = getDatabaseService();
-  const synced = await database.getSyncScope(syncedPrefix);
-  return synced?.last_synced
-    ? database.getLogsListing(scope, toRow, plan)
-    : null;
-};
 
 /**
  * Coalesce replication bursts into at most one refetch of observed Dexie

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -99,8 +99,11 @@ export {
 } from "./databaseListings";
 export {
   readLogsListing,
+  readLogsOverview,
   logsListingSource,
   type LogsListingSource,
+  type LogsOverview,
+  type LogsOverviewView,
 } from "./logsListingRead";
 export { useLogHeader, useLogFetchState } from "./log";
 export { type LogListingRow, useLogListing } from "./logListing";

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -99,6 +99,7 @@ export {
 } from "./databaseListings";
 export {
   readLogsListing,
+  readLogsListingMatches,
   readLogsOverview,
   logsListingSource,
   type LogsListingSource,

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -96,6 +96,7 @@ export {
   databaseLogsListingKey,
   databaseLogsListingKeyRoot,
   invalidateDatabaseLogsListings,
+  listingKeyUniverse,
 } from "./databaseListings";
 export {
   readLogsListing,

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -95,10 +95,13 @@ export { imperativeLogData } from "./imperativeLogData";
 export {
   databaseLogsListingKey,
   databaseLogsListingKeyRoot,
-  databaseLogsOpened,
   invalidateDatabaseLogsListings,
-  readDatabaseLogsListing,
 } from "./databaseListings";
+export {
+  readLogsListing,
+  logsListingSource,
+  type LogsListingSource,
+} from "./logsListingRead";
 export { useLogHeader, useLogFetchState } from "./log";
 export { type LogListingRow, useLogListing } from "./logListing";
 export { resolveLogKey } from "./logsContent";

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -101,10 +101,7 @@ export {
 export {
   readLogsListing,
   readLogsListingMatches,
-  readLogsListingOffset,
   readLogsOverview,
-  logsListingSource,
-  type LogsListingSource,
   type LogsOverview,
   type LogsOverviewView,
 } from "./logsListingRead";

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -92,6 +92,12 @@
 //   always present.
 // ---------------------------------------------------------------------------
 export { imperativeLogData } from "./imperativeLogData";
+export {
+  databaseLogsListingKey,
+  databaseLogsListingKeyRoot,
+  databaseLogsOpened,
+  readDatabaseLogsListing,
+} from "./databaseListings";
 export { useLogHeader, useLogFetchState } from "./log";
 export { type LogListingRow, useLogListing } from "./logListing";
 export { resolveLogKey } from "./logsContent";

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -100,6 +100,7 @@ export {
 export {
   readLogsListing,
   readLogsListingMatches,
+  readLogsListingOffset,
   readLogsOverview,
   logsListingSource,
   type LogsListingSource,

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -96,6 +96,7 @@ export {
   databaseLogsListingKey,
   databaseLogsListingKeyRoot,
   databaseLogsOpened,
+  invalidateDatabaseLogsListings,
   readDatabaseLogsListing,
 } from "./databaseListings";
 export { useLogHeader, useLogFetchState } from "./log";

--- a/apps/inspect/src/log_data/logsContent.test.ts
+++ b/apps/inspect/src/log_data/logsContent.test.ts
@@ -3,7 +3,7 @@
  * database.test.ts).
  */
 import Dexie from "dexie";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { DB_NAME } from "../client/database/schema";
 import {
@@ -12,7 +12,13 @@ import {
 } from "../client/database/service";
 import { queryClient } from "../state/queryClient";
 
-import { writeListing } from "./logsContent";
+import { clearFile, writeListing, writePreviews } from "./logsContent";
+
+const invalidateListings = vi.hoisted(() => vi.fn());
+vi.mock("./databaseListings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./databaseListings")>()),
+  invalidateDatabaseLogsListings: invalidateListings,
+}));
 
 describe("writeListing", () => {
   let db: DatabaseService;
@@ -52,5 +58,28 @@ describe("writeListing", () => {
     // ...and nothing was persisted where no scoped read could reach it.
     expect(await db.readLogs({ prefix: "~/logs" })).toHaveLength(0);
     expect(await db.getSyncScope("~/logs")).toBeUndefined();
+  });
+});
+
+describe("db-less write invalidation", () => {
+  // Listing queries in db-less sessions read from the react-query cache and
+  // only refetch on invalidation — so every cache-updating write must fire
+  // it, not just the persisted ones.
+  beforeEach(() => {
+    invalidateListings.mockClear();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  test("a db-less preview merge refreshes the listings", async () => {
+    await writePreviews(null, "/plain/logs", {});
+    expect(invalidateListings).toHaveBeenCalled();
+  });
+
+  test("a db-less file clear refreshes the listings", async () => {
+    await clearFile(null, "/plain/logs", "/plain/logs/a.eval");
+    expect(invalidateListings).toHaveBeenCalled();
   });
 });

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -16,6 +16,7 @@ import {
 } from "../client/utils/type-utils";
 import { queryClient } from "../state/queryClient";
 
+import { invalidateDatabaseLogsListings } from "./databaseListings";
 import type { LogsContentSink } from "./fetchEngine";
 import {
   invalidateSamplesListings,
@@ -242,6 +243,7 @@ export const writeListing = async (
   if (db?.opened() && namesInScope(logDir, handles)) {
     await db.writeLogs(handles);
     await db.markScopeSynced(logDir);
+    invalidateDatabaseLogsListings();
     const all = await db.readLogs({ prefix: logDir });
     if (all) {
       setRows(logDir, all);
@@ -264,6 +266,7 @@ export const writePreviews = async (
   mergePreviews(logDir, previews);
   if (db?.opened()) {
     await db.writeLogPreviews(previews);
+    invalidateDatabaseLogsListings();
   }
 };
 
@@ -301,6 +304,7 @@ export const writeDetails = async (
   );
   if (db?.opened()) {
     await db.writeLogDetails(Object.fromEntries(prepared));
+    invalidateDatabaseLogsListings();
     invalidateSamplesListings(logDir);
   }
 };
@@ -346,6 +350,7 @@ export const resetDepth = async (
   }
   if (db?.opened()) {
     await db.resetDepth(names);
+    invalidateDatabaseLogsListings();
   }
   invalidateSamplesListings(logDir);
 };
@@ -358,6 +363,7 @@ export const clearFile = async (
   evictFile(logDir, name);
   if (db?.opened()) {
     await db.clearCacheForFile(name);
+    invalidateDatabaseLogsListings();
   }
   // After the rows are gone (db) — or cache-only (db-less), where a refetch
   // correctly reads empty — refresh any samples listing that carried them.
@@ -375,6 +381,7 @@ export const clearAll = async (
     // under out-of-namespace names (see namesInScope). It's all a cache —
     // other scopes re-sync on their next listing.
     await db.clearAllData();
+    invalidateDatabaseLogsListings();
   }
 };
 

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -213,13 +213,23 @@ const clearCache = (logDir: string): void => {
  * remove. "Clear Local Database" (`clearAll`) wipes them along with
  * everything else.
  */
-const warnedScopes = new Set<string>();
+const cacheOnlyScopes = new Set<string>();
+
+/**
+ * Whether `logDir`'s listing degraded to cache-only persistence
+ * (out-of-namespace names — see `namesInScope`). Session-sticky: once a
+ * listing sync detects the degrade, listing reads for the dir serve from
+ * the react-query cache instead of the database.
+ */
+export const isCacheOnlyListingScope = (logDir: string): boolean =>
+  cacheOnlyScopes.has(scopePrefix(logDir));
+
 const namesInScope = (logDir: string, handles: LogHandle[]): boolean => {
   const prefix = scopePrefix(logDir);
   const misnamed = handles.find((handle) => !handle.name.startsWith(prefix));
   if (misnamed !== undefined) {
-    if (!warnedScopes.has(prefix)) {
-      warnedScopes.add(prefix);
+    if (!cacheOnlyScopes.has(prefix)) {
+      cacheOnlyScopes.add(prefix);
       log.warn(
         `Listing names (e.g. ${misnamed.name}) are outside the log dir's namespace (${prefix}); skipping persistence for this scope.`
       );
@@ -256,6 +266,10 @@ export const writeListing = async (
     }
   }
   setListing(logDir, handles);
+  // Cache-backed scopes (the out-of-namespace degrade, db-less sessions)
+  // have no db write to fire the listing invalidation, so fire it once the
+  // cache write lands — listing queries reading from the cache refetch here.
+  invalidateDatabaseLogsListings();
   return currentLogs(logDir);
 };
 
@@ -404,7 +418,10 @@ export const createLogsContentSink = (
     // A warm session coming online must refresh samples listings: a listing
     // query mounted before the db opened settled empty (staleTime: Infinity)
     // and a no-change boot performs none of the writes that would otherwise
-    // invalidate it — so /#/samples as the entry route stayed blank.
+    // invalidate it — so /#/samples as the entry route stayed blank. Log
+    // listings need the same nudge: one mounted before the db opened read
+    // nothing, and a no-change boot never writes.
+    invalidateDatabaseLogsListings();
     invalidateSamplesListings(logDir);
   },
   setListing: (handles) => setListing(logDir, handles),

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -256,14 +256,13 @@ export const writeListing = async (
     const all = await db.readLogs({ prefix: logDir });
     if (all) {
       setRows(logDir, all);
-    }
-    // Invalidate only after the re-read rows land in the cache: a listing
-    // refetch scheduled between the write and setRows would run against the
-    // pre-write rows and drop the newly written files from its result.
-    invalidateDatabaseLogsListings();
-    if (all) {
+      // Invalidate only after the re-read rows land in the cache: a listing
+      // refetch scheduled between the write and setRows would run against
+      // the pre-write rows and drop the newly written files from its result.
+      invalidateDatabaseLogsListings();
       return all;
     }
+    // A failed read-back degrades to the cache-only listing write below.
   }
   setListing(logDir, handles);
   // Cache-backed scopes (the out-of-namespace degrade, db-less sessions)
@@ -285,8 +284,11 @@ export const writePreviews = async (
   mergePreviews(logDir, previews);
   if (db?.opened()) {
     await db.writeLogPreviews(previews);
-    invalidateDatabaseLogsListings();
   }
+  // Unconditional (after the db write, so a refetch reads committed rows):
+  // cache-backed listings serve the merge above and refetch on the same
+  // nudge — a db-less session's preview columns must not stay blank.
+  invalidateDatabaseLogsListings();
 };
 
 /**
@@ -295,10 +297,11 @@ export const writePreviews = async (
  * own store. Cache updates land synchronously; samples rows land BEFORE the
  * row merge (the status flip is what drops a running log's pending-buffer
  * rows, so a render between the two updates must already have the settled
- * rows). Persistence is one transaction per call; the invalidation sweep
- * then refreshes prefix-scope listings from the committed rows. In db-less
- * sessions the pushes are the only landing spot, and invalidating would
- * clobber them with an empty read — so the sweep is persistence-gated.
+ * rows). Persistence is one transaction per call. The samples sweep is
+ * persistence-gated: samples listings read from the database, and in db-less
+ * sessions invalidating would clobber the pushes — the only landing spot —
+ * with an empty read. Log listings have a cache-backed read path, so their
+ * invalidation is unconditional.
  */
 export const writeDetails = async (
   db: DatabaseService | null | undefined,
@@ -323,9 +326,9 @@ export const writeDetails = async (
   );
   if (db?.opened()) {
     await db.writeLogDetails(Object.fromEntries(prepared));
-    invalidateDatabaseLogsListings();
     invalidateSamplesListings(logDir);
   }
+  invalidateDatabaseLogsListings();
 };
 
 export const writeFetchStates = async (
@@ -369,8 +372,8 @@ export const resetDepth = async (
   }
   if (db?.opened()) {
     await db.resetDepth(names);
-    invalidateDatabaseLogsListings();
   }
+  invalidateDatabaseLogsListings();
   invalidateSamplesListings(logDir);
 };
 
@@ -382,8 +385,8 @@ export const clearFile = async (
   evictFile(logDir, name);
   if (db?.opened()) {
     await db.clearCacheForFile(name);
-    invalidateDatabaseLogsListings();
   }
+  invalidateDatabaseLogsListings();
   // After the rows are gone (db) — or cache-only (db-less), where a refetch
   // correctly reads empty — refresh any samples listing that carried them.
   invalidateSamplesListings(logDir);
@@ -400,8 +403,8 @@ export const clearAll = async (
     // under out-of-namespace names (see namesInScope). It's all a cache —
     // other scopes re-sync on their next listing.
     await db.clearAllData();
-    invalidateDatabaseLogsListings();
   }
+  invalidateDatabaseLogsListings();
 };
 
 /**

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -243,10 +243,15 @@ export const writeListing = async (
   if (db?.opened() && namesInScope(logDir, handles)) {
     await db.writeLogs(handles);
     await db.markScopeSynced(logDir);
-    invalidateDatabaseLogsListings();
     const all = await db.readLogs({ prefix: logDir });
     if (all) {
       setRows(logDir, all);
+    }
+    // Invalidate only after the re-read rows land in the cache: a listing
+    // refetch scheduled between the write and setRows would run against the
+    // pre-write rows and drop the newly written files from its result.
+    invalidateDatabaseLogsListings();
+    if (all) {
       return all;
     }
   }

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -1,0 +1,166 @@
+/**
+ * readLogsListing: source dispatch (database vs cache), retried marking, and
+ * parity with the in-memory engine — the same fixtures through
+ * `applyListingQuery` and the seam must agree (the migration safety net).
+ * Uses fake-indexeddb (see setupTests) behind a real DatabaseService.
+ */
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Column } from "@tsmono/inspect-common/query";
+
+import { applyListingQuery } from "../app/log-list/listing/applyListingQuery";
+import { createListingPlan } from "../app/log-list/listing/planner";
+import type { Log, LogPreview } from "../client/api/types";
+import { DB_NAME } from "../client/database/schema";
+import {
+  createDatabaseService,
+  type DatabaseService,
+} from "../client/database/service";
+
+import { computeLogsWithRetried, type LogListingRow } from "./logListing";
+import { setRows } from "./logsContent";
+import { readLogsListing } from "./logsListingRead";
+
+const holder = vi.hoisted(() => {
+  const state: { service: DatabaseService | null } = { service: null };
+  return state;
+});
+
+vi.mock("./databaseServiceInstance", () => ({
+  getDatabaseService: () => holder.service,
+}));
+
+const preview = (overrides: Partial<LogPreview>): LogPreview => ({
+  eval_id: "eval-1",
+  run_id: "run-1",
+  task: "test-task",
+  task_id: "task-1",
+  task_version: 1,
+  version: 1,
+  status: "success",
+  error: null,
+  model: "gpt-4",
+  started_at: "2024-01-01T00:00:00Z",
+  completed_at: "2024-01-01T01:00:00Z",
+  ...overrides,
+});
+
+const getValue = (row: Log, column: string): unknown =>
+  row[column as keyof Log];
+
+describe("readLogsListing", () => {
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    databaseService = createDatabaseService();
+    holder.service = databaseService;
+    await databaseService.openDatabase();
+  });
+
+  afterEach(async () => {
+    try {
+      await databaseService.closeDatabase();
+    } catch {
+      // Already closed in the cache-dispatch test.
+    }
+    await Dexie.delete(DB_NAME);
+  });
+
+  test("matches the in-memory filter, sort, and pagination", async () => {
+    await databaseService.writeLogPreviews({
+      "/test/logs/a.json": preview({
+        model: "gpt-4",
+        status: "success",
+        task_id: "t-a",
+      }),
+      "/test/logs/b.json": preview({
+        model: "claude",
+        status: "success",
+        task_id: "t-b",
+      }),
+      "/test/logs/c.json": preview({
+        model: "gpt-4o",
+        status: "error",
+        task_id: "t-c",
+      }),
+      "/test/logs/d.json": preview({
+        model: "gpt-5",
+        status: "success",
+        task_id: "t-d",
+      }),
+      "/other/e.json": preview({ model: "gpt-5", status: "success" }),
+    });
+    const source = (await databaseService.readLogs({
+      prefix: "/test/logs",
+    })) as Log[];
+    const query = {
+      filter: new Column("model")
+        .ilike("gpt%")
+        .and(new Column("status").ne("error")),
+      orderBy: [{ column: "name", direction: "DESC" as const }],
+      pagination: { limit: 1, cursor: null, direction: "forward" as const },
+      getValue,
+      getComparator: () => undefined,
+    };
+
+    // The seam marks retried runs over its scan; mirror that on the
+    // in-memory side so the parity compare sees identical rows.
+    const expected = applyListingQuery(computeLogsWithRetried(source), query);
+    const actual = await readLogsListing(
+      "/test/logs",
+      "/test/logs",
+      (log: LogListingRow) => log as Log,
+      createListingPlan(query)
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual.items.map((row) => row.name)).toEqual(["/test/logs/d.json"]);
+    expect(actual.total_count).toBe(2);
+    expect(actual.next_cursor).toEqual({ offset: 1 });
+  });
+
+  test("marks retried runs across the scan and lets toRow drop them", async () => {
+    // Same parent dir + task_id: the newest successful run wins, the other
+    // is retried.
+    await databaseService.writeLogPreviews({
+      "/test/logs/2024-01-01_task.json": preview({ task_id: "shared" }),
+      "/test/logs/2024-01-02_task.json": preview({ task_id: "shared" }),
+    });
+
+    const rows = await readLogsListing(
+      "/test/logs",
+      "/test/logs",
+      (log: LogListingRow) => (log.retried ? undefined : log),
+      createListingPlan({ getValue, getComparator: () => undefined })
+    );
+    expect(rows.total_count).toBe(1);
+    expect(rows.items[0]?.name).toBe("/test/logs/2024-01-02_task.json");
+
+    const all = await readLogsListing(
+      "/test/logs",
+      "/test/logs",
+      (log: LogListingRow) => log,
+      createListingPlan({ getValue, getComparator: () => undefined })
+    );
+    expect(all.total_count).toBe(2);
+  });
+
+  test("serves from the react-query cache when the database is not open", async () => {
+    setRows("/cache/logs", [
+      { name: "/cache/logs/a.json", task: "t" } as Log,
+      { name: "/cache/logs-other/b.json", task: "t" } as Log,
+    ]);
+    await databaseService.closeDatabase();
+
+    const result = await readLogsListing(
+      "/cache/logs",
+      "/cache/logs",
+      (log: LogListingRow) => log,
+      createListingPlan({ getValue, getComparator: () => undefined })
+    );
+    // Scoped by boundary-safe prefix: the sibling dir's row is excluded.
+    expect(result.items.map((row) => row.name)).toEqual(["/cache/logs/a.json"]);
+  });
+});

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../client/database/service";
 
 import { computeLogsWithRetried, type LogListingRow } from "./logListing";
-import { setRows } from "./logsContent";
+import { setRows, writeListing } from "./logsContent";
 import {
   readLogsListing,
   readLogsListingMatches,
@@ -167,6 +167,28 @@ describe("readLogsListing", () => {
     );
     // Scoped by boundary-safe prefix: the sibling dir's row is excluded.
     expect(result.items.map((row) => row.name)).toEqual(["/cache/logs/a.json"]);
+  });
+
+  test("serves every cache row for an out-of-namespace (cache-only) scope", async () => {
+    // An older view server can report an aliased local path as log_dir while
+    // the listing names are file:// URIs; writeListing degrades the scope to
+    // cache-only. Those names never match the scope prefix, so the cache
+    // read must not prefix-filter them away.
+    await writeListing(databaseService, "/alias/logs", [
+      { name: "file:///real/logs/a.json" },
+      { name: "file:///real/logs/b.json" },
+    ]);
+
+    const result = await readLogsListing(
+      "/alias/logs",
+      "/alias/logs",
+      (log: LogListingRow) => log,
+      createListingPlan({ getValue, getComparator: () => undefined })
+    );
+    expect(result.items.map((row) => row.name).sort()).toEqual([
+      "file:///real/logs/a.json",
+      "file:///real/logs/b.json",
+    ]);
   });
 });
 
@@ -324,13 +346,31 @@ describe("readLogsListingOffset", () => {
 
     // Universe after filter+sort: [c, a] (b is filtered out).
     await expect(
-      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/a.json"))
+      readLogsListingOffset(
+        "/test/logs",
+        "/test/logs",
+        toRow,
+        plan,
+        target("/test/logs/a.json")
+      )
     ).resolves.toBe(1);
     await expect(
-      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/b.json"))
+      readLogsListingOffset(
+        "/test/logs",
+        "/test/logs",
+        toRow,
+        plan,
+        target("/test/logs/b.json")
+      )
     ).resolves.toBeUndefined();
     await expect(
-      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/c.json"))
+      readLogsListingOffset(
+        "/test/logs",
+        "/test/logs",
+        toRow,
+        plan,
+        target("/test/logs/c.json")
+      )
     ).resolves.toBe(0);
   });
 });

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -21,7 +21,7 @@ import {
 
 import { computeLogsWithRetried, type LogListingRow } from "./logListing";
 import { setRows } from "./logsContent";
-import { readLogsListing } from "./logsListingRead";
+import { readLogsListing, readLogsOverview } from "./logsListingRead";
 
 const holder = vi.hoisted(() => {
   const state: { service: DatabaseService | null } = { service: null };
@@ -162,5 +162,72 @@ describe("readLogsListing", () => {
     );
     // Scoped by boundary-safe prefix: the sibling dir's row is excluded.
     expect(result.items.map((row) => row.name)).toEqual(["/cache/logs/a.json"]);
+  });
+});
+
+describe("readLogsOverview", () => {
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    databaseService = createDatabaseService();
+    holder.service = databaseService;
+    await databaseService.openDatabase();
+  });
+
+  afterEach(async () => {
+    await databaseService.closeDatabase();
+    await Dexie.delete(DB_NAME);
+  });
+
+  const directChildOf =
+    (dir: string) =>
+    (log: LogListingRow): boolean =>
+      new RegExp(`^${dir}/[^/]+$`).test(log.name);
+
+  test("aggregates folders, counts, and task ids in one scan", async () => {
+    await databaseService.writeLogPreviews({
+      "/test/logs/a.json": preview({ task_id: "t-a", status: "started" }),
+      "/test/logs/b.json": preview({ task_id: "t-b" }),
+      "/test/logs/sub/c.json": preview({ task_id: "t-c" }),
+      "/test/logs/sub/d.json": preview({ task_id: "t-d" }),
+    });
+
+    const overview = await readLogsOverview("/test/logs", {
+      folderDir: "/test/logs",
+      showRetriedLogs: false,
+      isCandidate: directChildOf("/test/logs"),
+    });
+
+    expect(overview.taskIds.sort()).toEqual(["t-a", "t-b", "t-c", "t-d"]);
+    expect(overview.fileCount).toBe(2);
+    expect(overview.startedCount).toBe(1);
+    expect(overview.retriedCount).toBe(0);
+    expect(overview.soleFileName).toBeUndefined();
+    expect(overview.folders).toEqual([{ name: "sub", itemCount: 2 }]);
+  });
+
+  test("counts retried runs and applies retried-hiding to file facts", async () => {
+    await databaseService.writeLogPreviews({
+      "/test/logs/2024-01-01_task.json": preview({ task_id: "shared" }),
+      "/test/logs/2024-01-02_task.json": preview({ task_id: "shared" }),
+    });
+    const view = {
+      showRetriedLogs: false,
+      isCandidate: directChildOf("/test/logs"),
+    };
+
+    const hidden = await readLogsOverview("/test/logs", view);
+    expect(hidden.fileCount).toBe(1);
+    expect(hidden.retriedCount).toBe(1);
+    expect(hidden.soleFileName).toBe("/test/logs/2024-01-02_task.json");
+    expect(hidden.folders).toEqual([]);
+
+    const shown = await readLogsOverview("/test/logs", {
+      ...view,
+      showRetriedLogs: true,
+    });
+    expect(shown.fileCount).toBe(2);
+    expect(shown.retriedCount).toBe(1);
+    expect(shown.soleFileName).toBeUndefined();
   });
 });

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -21,7 +21,11 @@ import {
 
 import { computeLogsWithRetried, type LogListingRow } from "./logListing";
 import { setRows } from "./logsContent";
-import { readLogsListing, readLogsOverview } from "./logsListingRead";
+import {
+  readLogsListing,
+  readLogsListingMatches,
+  readLogsOverview,
+} from "./logsListingRead";
 
 const holder = vi.hoisted(() => {
   const state: { service: DatabaseService | null } = { service: null };
@@ -229,5 +233,58 @@ describe("readLogsOverview", () => {
     expect(shown.fileCount).toBe(2);
     expect(shown.retriedCount).toBe(1);
     expect(shown.soleFileName).toBeUndefined();
+  });
+});
+
+describe("readLogsListingMatches", () => {
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    databaseService = createDatabaseService();
+    holder.service = databaseService;
+    await databaseService.openDatabase();
+  });
+
+  afterEach(async () => {
+    await databaseService.closeDatabase();
+    await Dexie.delete(DB_NAME);
+  });
+
+  test("returns matching row ids in listing order under the active plan", async () => {
+    await databaseService.writeLogPreviews({
+      "/test/logs/a.json": preview({ task: "alpha", task_id: "t-a" }),
+      "/test/logs/b.json": preview({
+        task: "beta",
+        task_id: "t-b",
+        model: "gpt-4o",
+      }),
+      "/test/logs/c.json": preview({ task: "alphabet", task_id: "t-c" }),
+      // Text matches the term but the plan's filter excludes it: matches
+      // must respect the same filter as the row query.
+      "/test/logs/d.json": preview({
+        task: "alpha",
+        task_id: "t-d",
+        model: "claude",
+      }),
+    });
+
+    const matches = await readLogsListingMatches(
+      "/test/logs",
+      "/test/logs",
+      (log: LogListingRow) => log as Log,
+      createListingPlan({
+        filter: new Column("model").ilike("gpt%"),
+        orderBy: [{ column: "name", direction: "DESC" as const }],
+        getValue,
+        getComparator: () => undefined,
+      }),
+      {
+        term: "ALPHA",
+        getRowId: (row) => row.name,
+        rowText: (row) => `${row.name}\n${row.task ?? ""}`,
+      }
+    );
+
+    expect(matches).toEqual(["/test/logs/c.json", "/test/logs/a.json"]);
   });
 });

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -24,6 +24,7 @@ import { setRows } from "./logsContent";
 import {
   readLogsListing,
   readLogsListingMatches,
+  readLogsListingOffset,
   readLogsOverview,
 } from "./logsListingRead";
 
@@ -286,5 +287,50 @@ describe("readLogsListingMatches", () => {
     );
 
     expect(matches).toEqual(["/test/logs/c.json", "/test/logs/a.json"]);
+  });
+});
+
+describe("readLogsListingOffset", () => {
+  let databaseService: DatabaseService;
+
+  beforeEach(async () => {
+    databaseService = createDatabaseService();
+    holder.service = databaseService;
+    await databaseService.openDatabase();
+  });
+
+  afterEach(async () => {
+    await databaseService.closeDatabase();
+    await Dexie.delete(DB_NAME);
+  });
+
+  test("locates a row id within the filtered+sorted universe", async () => {
+    await databaseService.writeLogPreviews({
+      "/test/logs/a.json": preview({ task_id: "t-a" }),
+      "/test/logs/b.json": preview({ task_id: "t-b", model: "claude" }),
+      "/test/logs/c.json": preview({ task_id: "t-c" }),
+    });
+    const plan = createListingPlan({
+      filter: new Column("model").ilike("gpt%"),
+      orderBy: [{ column: "name", direction: "DESC" as const }],
+      getValue,
+      getComparator: () => undefined,
+    });
+    const target = (id: string) => ({
+      id,
+      getRowId: (row: Log) => row.name,
+    });
+    const toRow = (log: LogListingRow) => log as Log;
+
+    // Universe after filter+sort: [c, a] (b is filtered out).
+    await expect(
+      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/a.json"))
+    ).resolves.toBe(1);
+    await expect(
+      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/b.json"))
+    ).resolves.toBeUndefined();
+    await expect(
+      readLogsListingOffset("/test/logs", "/test/logs", toRow, plan, target("/test/logs/c.json"))
+    ).resolves.toBe(0);
   });
 });

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -24,7 +24,6 @@ import { setRows, writeListing } from "./logsContent";
 import {
   readLogsListing,
   readLogsListingMatches,
-  readLogsListingOffset,
   readLogsOverview,
 } from "./logsListingRead";
 
@@ -329,75 +328,13 @@ describe("readLogsListingMatches", () => {
         getComparator: () => undefined,
       }),
       {
+        // Lowercased per rowText's contract; the term may be any case.
         term: "ALPHA",
         getRowId: (row) => row.name,
-        rowText: (row) => `${row.name}\n${row.task ?? ""}`,
+        rowText: (row) => `${row.name}\n${row.task ?? ""}`.toLowerCase(),
       }
     );
 
     expect(matches).toEqual(["/test/logs/c.json", "/test/logs/a.json"]);
-  });
-});
-
-describe("readLogsListingOffset", () => {
-  let databaseService: DatabaseService;
-
-  beforeEach(async () => {
-    databaseService = createDatabaseService();
-    holder.service = databaseService;
-    await databaseService.openDatabase();
-  });
-
-  afterEach(async () => {
-    await databaseService.closeDatabase();
-    await Dexie.delete(DB_NAME);
-  });
-
-  test("locates a row id within the filtered+sorted universe", async () => {
-    await databaseService.writeLogPreviews({
-      "/test/logs/a.json": preview({ task_id: "t-a" }),
-      "/test/logs/b.json": preview({ task_id: "t-b", model: "claude" }),
-      "/test/logs/c.json": preview({ task_id: "t-c" }),
-    });
-    const plan = createListingPlan({
-      filter: new Column("model").ilike("gpt%"),
-      orderBy: [{ column: "name", direction: "DESC" as const }],
-      getValue,
-      getComparator: () => undefined,
-    });
-    const target = (id: string) => ({
-      id,
-      getRowId: (row: Log) => row.name,
-    });
-    const toRow = (log: LogListingRow) => log as Log;
-
-    // Universe after filter+sort: [c, a] (b is filtered out).
-    await expect(
-      readLogsListingOffset(
-        "/test/logs",
-        "/test/logs",
-        toRow,
-        plan,
-        target("/test/logs/a.json")
-      )
-    ).resolves.toBe(1);
-    await expect(
-      readLogsListingOffset(
-        "/test/logs",
-        "/test/logs",
-        toRow,
-        plan,
-        target("/test/logs/b.json")
-      )
-    ).resolves.toBeUndefined();
-    await expect(
-      readLogsListingOffset(
-        "/test/logs",
-        "/test/logs",
-        toRow,
-        plan,
-        target("/test/logs/c.json")
-      )
-    ).resolves.toBe(0);
   });
 });

--- a/apps/inspect/src/log_data/logsListingRead.test.ts
+++ b/apps/inspect/src/log_data/logsListingRead.test.ts
@@ -233,6 +233,33 @@ describe("readLogsOverview", () => {
     expect(overview.folders).toEqual([{ name: "sub", itemCount: 2 }]);
   });
 
+  test("folder counts don't bleed into prefix-sharing siblings or clip to a nested subtree", async () => {
+    await databaseService.writeLogPreviews({
+      // "sub" is a name-prefix of "sub2": each must count only its own logs.
+      "/test/logs/sub/nested/a.json": preview({ task_id: "t-a" }),
+      "/test/logs/sub/b.json": preview({ task_id: "t-b" }),
+      "/test/logs/sub2/c.json": preview({ task_id: "t-c" }),
+      "/test/logs/sub2/d.json": preview({ task_id: "t-d" }),
+      "/test/logs/sub2/e.json": preview({ task_id: "t-e" }),
+    });
+
+    const overview = await readLogsOverview("/test/logs", {
+      folderDir: "/test/logs",
+      showRetriedLogs: false,
+      isCandidate: directChildOf("/test/logs"),
+    });
+
+    // "sub" counts its whole subtree even when first seen via the nested
+    // file; "sub2" isn't inflated by "sub" rows (nor vice versa).
+    const folders = [...overview.folders].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+    expect(folders).toEqual([
+      { name: "sub", itemCount: 2 },
+      { name: "sub2", itemCount: 3 },
+    ]);
+  });
+
   test("counts retried runs and applies retried-hiding to file facts", async () => {
     await databaseService.writeLogPreviews({
       "/test/logs/2024-01-01_task.json": preview({ task_id: "shared" }),

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -1,0 +1,75 @@
+import type { Log } from "../client/api/types";
+import { scopePrefix } from "../client/database";
+import {
+  pageRows,
+  type DatabaseListingPlan,
+  type DatabaseListingResult,
+} from "../client/database/listing";
+
+import { getDatabaseService } from "./databaseServiceInstance";
+import { computeLogsWithRetried, type LogListingRow } from "./logListing";
+import { getLogRows, isCacheOnlyListingScope } from "./logsContent";
+
+export type LogsListingSource = "database" | "cache";
+
+/**
+ * Where listing queries for `logDir` read their rows — an explicit,
+ * scope-level decision rather than a per-query fallback:
+ *
+ * - "database": the normal dir-mode path; IndexedDB holds the replicated
+ *   rows and is the row source.
+ * - "cache": the react-query logs cache is the row source. This serves the
+ *   out-of-namespace degrade (listing persistence skipped — see
+ *   `namesInScope` in logsContent) and db-less sessions (the database
+ *   failed to open; single-file mode renders no log list at all).
+ */
+export const logsListingSource = (logDir: string): LogsListingSource =>
+  getDatabaseService().opened() && !isCacheOnlyListingScope(logDir)
+    ? "database"
+    : "cache";
+
+const scanRows = async (logDir: string, prefix: string): Promise<Log[]> => {
+  if (logsListingSource(logDir) === "database") {
+    const logs = await getDatabaseService().readLogs({ prefix });
+    if (logs !== null) return logs;
+    // A failed db read degrades to the cache for this query only.
+  }
+  const scope = scopePrefix(prefix);
+  return getLogRows(logDir).filter((row) => row.name.startsWith(scope));
+};
+
+/**
+ * Run a listing plan over `logDir`'s rows: scan the source, mark retried
+ * runs (a cross-row derivation, so it runs over the scan, before `toRow`),
+ * shape each record through `toRow` (which owns row-universe membership —
+ * it drops records the view has no row for), then filter, sort, paginate.
+ *
+ * Deliberately NOT gated on the scope's sync state: results reflect
+ * whatever has replicated so far — a warm cache from a prior session, or a
+ * partially-landed sync — and the write path's invalidation refreshes
+ * observers as further writes land. Callers surface sync progress
+ * separately rather than hiding rows behind it.
+ *
+ * `prefix` narrows the scan (folder mode lists a subdirectory). Retried
+ * grouping keys on a row's exact parent directory, so a boundary-safe
+ * prefix scan never splits a group and the marking matches a whole-dir
+ * scan's.
+ */
+export const readLogsListing = async <TRow>(
+  logDir: string,
+  prefix: string,
+  toRow: (log: LogListingRow) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>
+): Promise<DatabaseListingResult<TRow>> => {
+  const scanned = await scanRows(logDir, prefix);
+  const rows: TRow[] = [];
+  for (const log of computeLogsWithRetried(scanned)) {
+    const row = toRow(log);
+    if (row !== undefined && plan.matches(row)) rows.push(row);
+  }
+  // Stable sort over the scan's listing order (mtime-descending), so ties —
+  // and the unsorted listing — keep that order without a position tiebreak.
+  if (plan.compare) rows.sort(plan.compare);
+  const total_count = rows.length;
+  return { ...pageRows(rows, plan.pagination), total_count };
+};

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -7,13 +7,11 @@ import {
   type DatabaseListingPlan,
   type DatabaseListingResult,
 } from "../client/database/listing";
-import { directoryRelativeUrl } from "../utils/uri";
+import { directoryRelativeUrl, rootName } from "../utils/uri";
 
 import { getDatabaseService } from "./databaseServiceInstance";
 import { computeLogsWithRetried, type LogListingRow } from "./logListing";
 import { getLogRows, isCacheOnlyListingScope } from "./logsContent";
-
-export type LogsListingSource = "database" | "cache";
 
 /**
  * Where listing queries for `logDir` read their rows — an explicit,
@@ -26,7 +24,7 @@ export type LogsListingSource = "database" | "cache";
  *   `namesInScope` in logsContent) and db-less sessions (the database
  *   failed to open; single-file mode renders no log list at all).
  */
-export const logsListingSource = (logDir: string): LogsListingSource =>
+const logsListingSource = (logDir: string): "database" | "cache" =>
   getDatabaseService().opened() && !isCacheOnlyListingScope(logDir)
     ? "database"
     : "cache";
@@ -121,8 +119,6 @@ export interface LogsOverview {
   /** Folder-mode: the current directory's immediate subdirectories. */
   folders: { name: string; itemCount: number }[];
 }
-
-const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
 
 /** Immediate subdirectories of `currentDir` with per-folder log counts. */
 const deriveFolders = (
@@ -232,6 +228,8 @@ export const readLogsListingMatches = async <TRow>(
   find: {
     term: string;
     getRowId: (row: TRow) => string;
+    /** A row's searchable text, already lowercased (`rowSearchText`'s
+     *  contract) — the scan must not pay a second per-row lowering. */
     rowText: (row: TRow) => string;
   }
 ): Promise<string[]> => {
@@ -239,30 +237,9 @@ export const readLogsListingMatches = async <TRow>(
   const term = find.term.toLowerCase();
   const ids: string[] = [];
   for (const row of rows) {
-    if (find.rowText(row).toLowerCase().includes(term)) {
+    if (find.rowText(row).includes(term)) {
       ids.push(find.getRowId(row));
     }
   }
   return ids;
-};
-
-/**
- * Offset of the row with id `id` within the filtered+sorted universe, or
- * `undefined` when no such row exists (filtered out, or not a row of the
- * view). This is the restore-by-offset seam: when the listing paginates,
- * selected-row restore resolves the persisted selection to its offset
- * here, fetches pages through that offset, then scrolls — instead of
- * assuming the row is already in the rendered rows. Runs over the scan
- * today; under keys-first pagination it becomes a key-list lookup.
- */
-export const readLogsListingOffset = async <TRow>(
-  logDir: string,
-  prefix: string,
-  toRow: (log: LogListingRow) => TRow | undefined,
-  plan: DatabaseListingPlan<TRow>,
-  target: { id: string; getRowId: (row: TRow) => string }
-): Promise<number | undefined> => {
-  const rows = await scanListingRows(logDir, prefix, toRow, plan);
-  const index = rows.findIndex((row) => target.getRowId(row) === target.id);
-  return index === -1 ? undefined : index;
 };

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -1,4 +1,4 @@
-import { dirname, isInDirectory } from "@tsmono/util";
+import { ensureTrailingSlash, isInDirectory } from "@tsmono/util";
 
 import type { Log } from "../client/api/types";
 import { scopePrefix } from "../client/database";
@@ -124,17 +124,12 @@ export interface LogsOverview {
 
 const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
 
-/** Immediate subdirectories of `currentDir` with per-folder log counts —
- *  the same derivation LogsPanel's items loop used, preserved verbatim
- *  (including counting by the first-seen file's parent prefix). */
+/** Immediate subdirectories of `currentDir` with per-folder log counts. */
 const deriveFolders = (
   rows: LogListingRow[],
   currentDir: string
 ): { name: string; itemCount: number }[] => {
-  const cleanDir = currentDir.endsWith("/")
-    ? currentDir.slice(0, -1)
-    : currentDir;
-  const dirWithSlash = currentDir.endsWith("/") ? currentDir : currentDir + "/";
+  const dirWithSlash = ensureTrailingSlash(currentDir);
 
   // Count logs under a path prefix via binary search rather than a full
   // scan per folder. Names sort into contiguous ranges, so a prefix count
@@ -158,14 +153,23 @@ const deriveFolders = (
   const seen = new Set<string>();
   for (const row of rows) {
     const name = row.name;
-    if (isInDirectory(name, cleanDir) || !name.startsWith(dirWithSlash)) {
+    if (isInDirectory(name, currentDir) || !name.startsWith(dirWithSlash)) {
       continue;
     }
     const relativePath = directoryRelativeUrl(name, currentDir);
+    // encodeURIComponent/decodeURIComponent round-trip, so this is the raw
+    // first path segment under `currentDir` — the folder's own directory.
     const dirName = decodeURIComponent(rootName(relativePath));
     if (seen.has(dirName)) continue;
     seen.add(dirName);
-    folders.push({ name: dirName, itemCount: countWithPrefix(dirname(name)) });
+    // Count under the folder's path, slash-terminated: an unterminated
+    // prefix would also span sibling folders sharing the name as a prefix
+    // (sub vs sub2), and the first-seen file's parent dir would miss logs
+    // outside its own subtree when that file is nested deeper.
+    folders.push({
+      name: dirName,
+      itemCount: countWithPrefix(dirWithSlash + dirName + "/"),
+    });
   }
   return folders;
 };

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -1,3 +1,5 @@
+import { dirname, isInDirectory } from "@tsmono/util";
+
 import type { Log } from "../client/api/types";
 import { scopePrefix } from "../client/database";
 import {
@@ -5,6 +7,7 @@ import {
   type DatabaseListingPlan,
   type DatabaseListingResult,
 } from "../client/database/listing";
+import { directoryRelativeUrl } from "../utils/uri";
 
 import { getDatabaseService } from "./databaseServiceInstance";
 import { computeLogsWithRetried, type LogListingRow } from "./logListing";
@@ -55,12 +58,12 @@ const scanRows = async (logDir: string, prefix: string): Promise<Log[]> => {
  * prefix scan never splits a group and the marking matches a whole-dir
  * scan's.
  */
-export const readLogsListing = async <TRow>(
+const scanListingRows = async <TRow>(
   logDir: string,
   prefix: string,
   toRow: (log: LogListingRow) => TRow | undefined,
   plan: DatabaseListingPlan<TRow>
-): Promise<DatabaseListingResult<TRow>> => {
+): Promise<TRow[]> => {
   const scanned = await scanRows(logDir, prefix);
   const rows: TRow[] = [];
   for (const log of computeLogsWithRetried(scanned)) {
@@ -70,6 +73,138 @@ export const readLogsListing = async <TRow>(
   // Stable sort over the scan's listing order (mtime-descending), so ties —
   // and the unsorted listing — keep that order without a position tiebreak.
   if (plan.compare) rows.sort(plan.compare);
+  return rows;
+};
+
+export const readLogsListing = async <TRow>(
+  logDir: string,
+  prefix: string,
+  toRow: (log: LogListingRow) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>
+): Promise<DatabaseListingResult<TRow>> => {
+  const rows = await scanListingRows(logDir, prefix, toRow, plan);
   const total_count = rows.length;
   return { ...pageRows(rows, plan.pagination), total_count };
+};
+
+/** View inputs for {@link readLogsOverview}. */
+export interface LogsOverviewView {
+  /** Folder-mode current directory; unset in the flat tasks view (which
+   *  lists the whole dir and derives no folders). */
+  folderDir?: string;
+  showRetriedLogs: boolean;
+  /** Pre-hide row-universe membership for the view (`fileLogIdentity`
+   *  presence — path logic only; the overview applies retried-hiding
+   *  itself so it can also count what hiding removed). */
+  isCandidate: (log: LogListingRow) => boolean;
+}
+
+/** Aggregate facts about a scope that the log-list page needs beyond the
+ *  queried rows themselves. See {@link readLogsOverview}. */
+export interface LogsOverview {
+  /** Distinct task_ids with a log anywhere under the dir — the pending-task
+   *  anti-join input. */
+  taskIds: string[];
+  /** File rows in the view universe (retried-hidden excluded). */
+  fileCount: number;
+  /** Among `fileCount`, logs still running (status "started"). */
+  startedCount: number;
+  /** Retried runs in the view universe pre-hiding — drives the
+   *  "Show Retried Logs" toggle's visibility. */
+  retriedCount: number;
+  /** Set when exactly one file row exists (single-log workspace redirect). */
+  soleFileName: string | undefined;
+  /** Folder-mode: the current directory's immediate subdirectories. */
+  folders: { name: string; itemCount: number }[];
+}
+
+const rootName = (relativePath: string) => relativePath.split("/")[0] ?? "";
+
+/** Immediate subdirectories of `currentDir` with per-folder log counts —
+ *  the same derivation LogsPanel's items loop used, preserved verbatim
+ *  (including counting by the first-seen file's parent prefix). */
+const deriveFolders = (
+  rows: LogListingRow[],
+  currentDir: string
+): { name: string; itemCount: number }[] => {
+  const cleanDir = currentDir.endsWith("/")
+    ? currentDir.slice(0, -1)
+    : currentDir;
+  const dirWithSlash = currentDir.endsWith("/") ? currentDir : currentDir + "/";
+
+  // Count logs under a path prefix via binary search rather than a full
+  // scan per folder. Names sort into contiguous ranges, so a prefix count
+  // is two bound lookups.
+  const sortedNames = rows.map((row) => row.name).sort();
+  const lowerBound = (target: string): number => {
+    let lo = 0;
+    let hi = sortedNames.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      const name = sortedNames[mid];
+      if (name !== undefined && name < target) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  };
+  const countWithPrefix = (prefix: string): number =>
+    lowerBound(prefix + "￿") - lowerBound(prefix);
+
+  const folders: { name: string; itemCount: number }[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const name = row.name;
+    if (isInDirectory(name, cleanDir) || !name.startsWith(dirWithSlash)) {
+      continue;
+    }
+    const relativePath = directoryRelativeUrl(name, currentDir);
+    const dirName = decodeURIComponent(rootName(relativePath));
+    if (seen.has(dirName)) continue;
+    seen.add(dirName);
+    folders.push({ name: dirName, itemCount: countWithPrefix(dirname(name)) });
+  }
+  return folders;
+};
+
+/**
+ * One scan of `logDir`'s rows producing the page-level aggregates: pending
+ * anti-join input, progress/footer counts, retried presence, the sole-file
+ * redirect target, and folder summaries. These are the derivations that
+ * would otherwise force the full row list into memory beside the row query;
+ * keeping them behind one read means pagination only changes this module.
+ * Like `readLogsListing`, deliberately not gated on sync state.
+ */
+export const readLogsOverview = async (
+  logDir: string,
+  view: LogsOverviewView
+): Promise<LogsOverview> => {
+  const scanned = await scanRows(logDir, logDir);
+  const rows = computeLogsWithRetried(scanned);
+
+  const taskIds = new Set<string>();
+  let fileCount = 0;
+  let startedCount = 0;
+  let retriedCount = 0;
+  let soleFileName: string | undefined;
+  for (const log of rows) {
+    if (log.task_id) taskIds.add(log.task_id);
+    if (!view.isCandidate(log)) continue;
+    if (log.retried) {
+      retriedCount += 1;
+      if (!view.showRetriedLogs) continue;
+    }
+    fileCount += 1;
+    soleFileName = fileCount === 1 ? log.name : undefined;
+    if (log.status === "started") startedCount += 1;
+  }
+
+  return {
+    taskIds: [...taskIds],
+    fileCount,
+    startedCount,
+    retriedCount,
+    soleFileName,
+    folders:
+      view.folderDir === undefined ? [] : deriveFolders(rows, view.folderDir),
+  };
 };

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -237,3 +237,24 @@ export const readLogsListingMatches = async <TRow>(
   }
   return ids;
 };
+
+/**
+ * Offset of the row with id `id` within the filtered+sorted universe, or
+ * `undefined` when no such row exists (filtered out, or not a row of the
+ * view). This is the restore-by-offset seam: when the listing paginates,
+ * selected-row restore resolves the persisted selection to its offset
+ * here, fetches pages through that offset, then scrolls — instead of
+ * assuming the row is already in the rendered rows. Runs over the scan
+ * today; under keys-first pagination it becomes a key-list lookup.
+ */
+export const readLogsListingOffset = async <TRow>(
+  logDir: string,
+  prefix: string,
+  toRow: (log: LogListingRow) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>,
+  target: { id: string; getRowId: (row: TRow) => string }
+): Promise<number | undefined> => {
+  const rows = await scanListingRows(logDir, prefix, toRow, plan);
+  const index = rows.findIndex((row) => target.getRowId(row) === target.id);
+  return index === -1 ? undefined : index;
+};

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -37,6 +37,10 @@ const scanRows = async (logDir: string, prefix: string): Promise<Log[]> => {
     if (logs !== null) return logs;
     // A failed db read degrades to the cache for this query only.
   }
+  // An out-of-namespace scope's names never start with the scope prefix —
+  // that mismatch is what degraded it (see `namesInScope`) — so filtering
+  // would drop every row. Serve the whole listing; `toRow` owns membership.
+  if (isCacheOnlyListingScope(logDir)) return getLogRows(logDir);
   const scope = scopePrefix(prefix);
   return getLogRows(logDir).filter((row) => row.name.startsWith(scope));
 };

--- a/apps/inspect/src/log_data/logsListingRead.ts
+++ b/apps/inspect/src/log_data/logsListingRead.ts
@@ -208,3 +208,32 @@ export const readLogsOverview = async (
       view.folderDir === undefined ? [] : deriveFolders(rows, view.folderDir),
   };
 };
+
+/**
+ * Ids of the rows whose searchable text contains `term`
+ * (case-insensitive), in listing order under the same universe + plan as
+ * the row query — the find band's data-level backing. Runs over the scan
+ * today; under keys-first pagination it becomes a snapshot projection, so
+ * matches keep covering rows outside the loaded pages.
+ */
+export const readLogsListingMatches = async <TRow>(
+  logDir: string,
+  prefix: string,
+  toRow: (log: LogListingRow) => TRow | undefined,
+  plan: DatabaseListingPlan<TRow>,
+  find: {
+    term: string;
+    getRowId: (row: TRow) => string;
+    rowText: (row: TRow) => string;
+  }
+): Promise<string[]> => {
+  const rows = await scanListingRows(logDir, prefix, toRow, plan);
+  const term = find.term.toLowerCase();
+  const ids: string[] = [];
+  for (const row of rows) {
+    if (find.rowText(row).toLowerCase().includes(term)) {
+      ids.push(find.getRowId(row));
+    }
+  }
+  return ids;
+};

--- a/apps/inspect/src/utils/uri.ts
+++ b/apps/inspect/src/utils/uri.ts
@@ -1,3 +1,7 @@
+/** First segment of a relative path ("" when empty). */
+export const rootName = (relativePath: string): string =>
+  relativePath.split("/")[0] ?? "";
+
 export const directoryRelativeUrl = (file: string, dir?: string): string => {
   if (!dir) {
     return uriEncodePathSegments(file);

--- a/design/db-backed-listing-plan.md
+++ b/design/db-backed-listing-plan.md
@@ -25,10 +25,12 @@
 >   Folders/pending match locally; display *ordering* of matches still
 >   comes from rendered rows and moves to the snapshot key list with
 >   pagination.
-> - `readLogsListingOffset` — the restore-by-offset seam (decided over
->   restore-by-loaded-rows): resolve the persisted `selectedRowId` to its
->   offset, fetch pages through it, then scroll. Not yet wired — DataGrid's
->   `rows.findIndex` restore is correct while pages are complete.
+> - Restore-by-offset (decided over restore-by-loaded-rows): resolve the
+>   persisted `selectedRowId` to its offset in the filtered+sorted
+>   universe, fetch pages through it, then scroll. A `readLogsListingOffset`
+>   seam was pinned here and later removed as dead code while unwired
+>   (DataGrid's `rows.findIndex` restore is correct while pages are
+>   complete); re-add it from git history with the paging work.
 >
 > Still open: chunked listing *ingestion* (the server listing lands in one
 > shot, so a cold first sync on a huge dir still waits on that fetch),

--- a/design/db-backed-listing-plan.md
+++ b/design/db-backed-listing-plan.md
@@ -28,9 +28,12 @@
 > - Restore-by-offset (decided over restore-by-loaded-rows): resolve the
 >   persisted `selectedRowId` to its offset in the filtered+sorted
 >   universe, fetch pages through it, then scroll. A `readLogsListingOffset`
->   seam was pinned here and later removed as dead code while unwired
->   (DataGrid's `rows.findIndex` restore is correct while pages are
->   complete); re-add it from git history with the paging work.
+>   seam was pinned here (`a30188e8`, with signature + tests) and later
+>   removed as dead code while unwired (DataGrid's `rows.findIndex` restore
+>   is correct while pages are complete). Under keys-first snapshots the
+>   scan-based implementation is superseded anyway — the offset becomes a
+>   key-list lookup on the snapshot (step 5 below), so re-derive from the
+>   snapshot service rather than restoring the scan version verbatim.
 >
 > Still open: chunked listing *ingestion* (the server listing lands in one
 > shot, so a cold first sync on a huge dir still waits on that fetch),

--- a/design/db-backed-listing-plan.md
+++ b/design/db-backed-listing-plan.md
@@ -1,0 +1,302 @@
+# DB-backed listing queries (filter / sort / count / paginate in Dexie)
+
+> **Status.** The logs listing is now db-first: `readLogsListing`
+> (`log_data/logsListingRead.ts`) is the row source — the queryFn scans the
+> scope, marks retried runs, shapes records per view (`fileLogItem` owns
+> row-universe membership), and runs the plan; the grid no longer queries a
+> memory-resident row list, and the synchronous in-memory fallback is gone.
+> Where rows come from is an explicit scope-level dispatch
+> (`logsListingSource`: `"database"` | `"cache"`), the `last_synced` gate is
+> removed (reads serve warm/partial data; write-path invalidation streams
+> updates in), and pending tasks merge into the page as a sorted overlay
+> (`mergeSortedRows`).
+>
+> The page around the grid is also pagination-fenced. All full-list
+> derivations sit behind read-layer projections that share
+> `scanListingRows` (each becomes a snapshot projection under keys-first,
+> so pagination changes only this module):
+>
+> - `readLogsOverview` — folders, pending anti-join `taskIds`,
+>   progress/footer counts, retried presence, sole-file redirect. LogsPanel
+>   no longer subscribes to `useLogListing`.
+> - `readLogsListingMatches` — the find band's data-level backing (match
+>   ids in listing order under the same universe/filter/sort; a shared
+>   `LogsListingDescriptor` keeps it and the row query on one universe).
+>   Folders/pending match locally; display *ordering* of matches still
+>   comes from rendered rows and moves to the snapshot key list with
+>   pagination.
+> - `readLogsListingOffset` — the restore-by-offset seam (decided over
+>   restore-by-loaded-rows): resolve the persisted `selectedRowId` to its
+>   offset, fetch pages through it, then scroll. Not yet wired — DataGrid's
+>   `rows.findIndex` restore is correct while pages are complete.
+>
+> Still open: chunked listing *ingestion* (the server listing lands in one
+> shot, so a cold first sync on a huge dir still waits on that fetch),
+> keys-first snapshots + `useInfiniteQuery` paging (phases below), the
+> samples listing (still the in-memory `useLogsListingQuery`), and the
+> columns schema (`useScoreSchema` / `hasSampleLimits` in
+> `grid/columns/hooks.tsx`) — the last full-list subscriber on the list
+> page, a candidate for another overview-style aggregate.
+
+The `/tasks`, `/logs`, and `/samples` pages sort and filter via `Condition` /
+`OrderBy` types copied from scout. Scout ships the condition to its server,
+which compiles it to SQL and returns one page plus a total count; inspect
+replicates data into IndexedDB but still reads **entire tables into memory**
+and filters/sorts/counts there. This plan moves that work into Dexie queries,
+adds infinite scrolling via react-query `useInfiniteQuery`, and keeps the API
+client interface unchanged (the query layer sits *above* the api, unlike
+scout's). Target UX: scout's transcripts page — cursor-paged rows, a filtered
+`total_count` in the footer, `keepPreviousData` across re-filters.
+
+Two design decisions are already settled from prior discussion:
+
+1. **Keys-first snapshots** (not scout-style keyset cursors): one scan per
+   `(scope, filter, orderBy)` produces an ordered primary-key list; the count
+   is `keys.length` for free; each page is a cheap `bulkGet` of a key slice
+   with cursor `{ offset }` into the snapshot. Pages are mutually consistent
+   under concurrent replication writes (no dupes/gaps mid-scroll), which
+   neither live-offset nor keyset gives us.
+2. **Dexie's limits are acceptable.** We are not chasing SQL-grade query
+   planning; the win is ordered index iteration, early exit, not
+   materializing every record into JS rows, and correct counts.
+
+## Foundation already landed
+
+### Derived columns stored at ingestion (#421)
+
+Listing fields are computed once at write time and stored on the rows —
+grid columns project stored values and must never re-derive:
+
+- `Log.derived` (`LogDerived`): `total_tokens`, `duration`, `task_args`,
+  `percent_completed`, `sample_limits`, and `scores` (scorer → metric →
+  value). Attached by `detailTier()` in
+  `apps/inspect/src/client/utils/type-utils.ts`, so the react-query cache
+  and IndexedDB share one computation.
+- `SampleSummaryRecord.derived` (`SampleDerived`): `tokens`, `input`,
+  `target`, `fallbacks`, `scores` (name → raw value). Payloads are
+  normalized once via `prepareLogDetails()`; both stores consume the same
+  `PreparedLogDetails`.
+- Derivation lives in `apps/inspect/src/client/utils/derive.ts` under
+  `DERIVE_VERSION`, folded into `DB_VERSION` (`SCHEMA_VERSION * 100 +
+  DERIVE_VERSION` in `client/database/schema.ts`) — any derivation change
+  invalidates stored rows via the recreate-on-mismatch wipe.
+- Deliberately NOT stored: log-level context on sample rows (task / model /
+  status / created). It would go stale when the log row changes tier
+  (running → success arrives via a preview refresh that doesn't rewrite
+  samples). It stays a read-time join — see "sample scans join the logs
+  table" below.
+
+### Unified per-origin database (#421)
+
+One `InspectAI` database per origin; `file_path` (a full path/URI) is the
+identity, so overlapping dirs (`/logs`, `/logs/important`) share rows and
+replicate once. "Current log dir" is a **query scope** — a boundary-safe
+prefix (`scopePrefix()` guarantees `/logs/important` ≠ `/logs/important-2`)
+threaded through `readLogs`, `readSampleSummaries`, `getCacheStats`,
+`clearScope`, and engine seeding. A `sync_scopes` table (keys stored in
+`scopePrefix` form; transactional upserts because the DB is cross-tab
+shared) records `last_accessed` / `last_synced` per scope — the anchor for
+future eviction controls and multi-dir replication (one merged engine taking
+a scope set, per prior discussion).
+
+Indexes currently declared (`schema.ts`):
+
+- `logs`: `++id`, `&file_path`, `mtime`, `task`, `task_id`, `depth`,
+  `cached_at`, `[depth+file_path]`
+- `sample_summaries`: `[file_path+id+epoch]` (PK), `file_path`,
+  `summary.completed_at`
+
+Caveat to inherit: **out-of-namespace scopes degrade to cache-only** —
+`namesInScope()` in `log_data/logsContent.ts` skips listing persistence when
+listing names don't live under the scope prefix. The degrade is now an
+explicit, session-sticky scope property (`isCacheOnlyListingScope`) driving
+`logsListingSource`, which reads listings from the react-query cache for
+such scopes (and db-less sessions) instead of the database. Single-file
+mode never mounts the log list, so it needs no listing path at all.
+
+### FindBand consolidation (#415)
+
+`FindBandUI` (the presentational band: input, match counter, next/prev) is
+now separate from its backing, shared in `packages/react/src/components/`.
+The log list uses `FindBandUI` directly with a data-level backing —
+`buildSearchIndex` / `findMatches` in
+`apps/inspect/src/app/shared/data-grid/findMatches.ts`, built over **all**
+rows. That backing is exactly what breaks under pagination, and now it's a
+swappable seam: phase 3 replaces it with a DB-backed matcher without
+touching the UI.
+
+### The in-memory engine (now the plan compiler + overlay/samples path)
+
+`apps/inspect/src/app/log-list/listing/`:
+
+- `applyListingQuery.ts` — filter → sort → paginate over in-memory rows.
+  Serves the samples listing and the pending-task overlay; `mergeSortedRows`
+  (same file) merges the overlay into a db-produced page.
+- `planner.ts` — compiles `(filter, orderBy, pagination)` + column accessors
+  into a `DatabaseListingPlan` (`matches`/`compare`/`pagination`);
+  `readLogsListing` executes it over the scan. No position tiebreak:
+  executors sort stably over the scan's listing order (mtime-descending).
+- `evaluator.ts` — full `Condition` interpreter (all 16 operators, SQL
+  three-valued NULL semantics, LIKE→regex). The plan's `matches`, and later
+  the residual predicate once index-backed scans land.
+- `useLogsListingQuery.ts` — `useDatabaseLogsListingQuery` is the real
+  query hook (queryKey = universe + accessor schema + filter + orderBy +
+  pagination; results are async by design, with same-universe placeholders
+  and a short transitional `gcTime`, since each key holds a full row list
+  until pagination). The accessor-schema slot (`accessorsKey` from
+  `useLogListColumns`) exists because the queryFn closes over the column
+  accessors, whose score-column semantics (by-metric accessors, numeric
+  comparators/filter types) land asynchronously with the scorer schema —
+  without it a persisted score-column filter/sort computes against missing
+  accessors and never self-corrects. The in-memory `useLogsListingQuery`
+  remains for samples. `sortingStateToOrderBy` lives here.
+- `combineFilters.ts` — AND-combines persisted per-column `FilterSpec`s into
+  one wire `Condition` via the shared `specToCondition`
+  (`packages/inspect-components/src/columnFilter/`).
+
+Consumers: `grid/useLogListData.ts` (tasks/logs; splits pinned folders from
+files, runs the listing query over files only) and
+`shared/samples-grid/SamplesGrid.tsx` (cross-log samples). Both feed the
+shared `DataGrid` (`app/shared/data-grid/DataGrid.tsx`) — TanStack Table +
+react-virtual, which **virtualizes rendering but receives the complete
+array**; it has no infinite-load mechanism yet.
+
+### Scout's reference implementation
+
+`apps/scout/src/app/server/useServerTranscriptsInfinite.ts`: filter/orderBy/
+pageSize in the query key (plus `"transcripts-inv"` sentinels for SSE topic
+invalidation), `initialPageParam: undefined`,
+`getNextPageParam: (last) => last.next_cursor ?? undefined`,
+`placeholderData: keepPreviousData`, `fetchNextPage({ cancelRefetch:
+false })` from a scroll-near-end trigger (`checkScrollNearEnd`, threshold
+2000px, pageSize 500 — rationale comments in
+`apps/scout/src/app/transcripts/constants.ts`). `total_count` returns on
+every page; the UI reads `pages[0].total_count`. Server-side it's keyset
+pagination with a forced `transcript_id ASC` tiebreaker and a separate
+`COUNT(*)` per request — the parts we replace with the keys snapshot.
+
+## Constraints that shape the implementation
+
+**IndexedDB query reality.** One index per query; no index intersection; no
+mixed-direction multi-column sort (compound indexes are single-direction;
+`.reverse()` flips everything). `contains`/ILIKE filters — the majority —
+are unindexable and run as JS `.filter()` predicates over the scan. Nulls,
+undefined, and booleans are **absent from IndexedDB indexes**: iterating
+`orderBy('mtime')` silently drops rows with no mtime, which the current JS
+sort keeps — either union in a null-scan, store sentinels, or scan the
+scope's PK range and sort in JS (fine under keys-first, since the scan
+happens once per snapshot, not per page).
+
+**Counts are O(n) no matter what.** `count()` is only index-fast on a pure
+range; any residual predicate scans. This is *why* keys-first: the one scan
+that orders also counts. The logs footer needs **two** counts
+(`filteredCount / itemCount`) — the unfiltered one is a cheap scoped
+`count()` on the `file_path` range.
+
+**Dynamic score columns can't be index-backed.** `derived.scores` is a
+nested map (`score_<scorer>/<metric>` column ids); you can't index a
+wildcard path. Sorting/filtering on score columns is always residual — the
+scan reads records anyway under keys-first, so this costs nothing extra.
+
+**Sample scans join the logs table.** Filters on task/model/status/created
+in `/samples` refer to log-level context that is deliberately not
+denormalized. The scan prefetches the scope's log rows (small — one per
+log; `readLogRows` exists) into a map and joins in the residual predicate,
+mirroring what `samplesListing.ts` already does at read time.
+
+**A column-id → record-field mapping is a new artifact.** The planner needs
+to know that column `completedAt` reads `completed_at`, `totalTokens` reads
+`derived.total_tokens`, `score_grader/accuracy` reads
+`derived.scores.grader.accuracy`, etc., per page. Today `getValue` accessors
+live beside React column defs; the queryFn can't depend on those. Extract
+the mapping (and each column's `FilterType` for coercion) into plain data
+the service layer can own; column defs consume it rather than restating it.
+
+**Invalidation churn during replication.** The sink writes continuously
+during a cold sync, and invalidating an infinite query refetches **every
+loaded page**. Debounce/coalesce invalidation per scope (adopt scout's
+`-inv` key-sentinel convention with a prefix-match predicate: invalidate
+listing queries whose scope contains the written file_path), and consider
+`maxPages`. Snapshots make refetch cheap-ish (pages are bulkGets) but the
+snapshot scan itself reruns per invalidation — coalescing matters.
+
+**Stable tiebreakers.** Every orderBy gets a forced final tiebreaker so
+order is total: `file_path` for logs, `[file_path, id, epoch]` for samples
+(scout forces `transcript_id ASC` the same way).
+
+**Features that silently assume the full list in memory** — each needs an
+explicit answer in phase 3:
+
+- Cmd/F: swap the `buildSearchIndex`/`findMatches` backing behind
+  `FindBandUI` for a DB scan (it can reuse the snapshot's key list).
+- Sample prev/next navigation: `displayedSamples` in the store is fed from
+  displayed rows; with paging, adjacency should come from the snapshot key
+  list (it *is* the adjacency list — scout needed a dedicated
+  `useAdjacentTranscriptIds` server query for this).
+- Selected-row restore/scroll-to (`selectedRowId` in grid state): the row
+  may not be in a loaded page — find its offset in the key list, fetch
+  through that page.
+- Samples progress bar (`completedTaskCount`/`totalTaskCount`) and
+  `filteredSampleCount`: currently derived from fully-displayed rows via
+  `onDisplayedRowsChange`; become the snapshot count + small scoped
+  aggregate queries over the logs table.
+- Folders in the logs list are presentation: kept eager and pinned, only
+  file rows paginate; footer count stays `folders.length + total_count`.
+
+## Work breakdown
+
+Steps 1 and 3 are landed in their no-pagination form (plan compilation +
+`readLogsListing` as the executor; the hook swap — minus `useInfiniteQuery`,
+which arrives with step 2's snapshots). Parity tests live in
+`log_data/logsListingRead.test.ts`.
+
+1. **Query planner + record evaluation** (pure, heavily testable):
+   `(scope, Condition, OrderBy[], columnFieldMap)` → index choice +
+   direction + residual predicate (reusing `evaluator.ts` against records) +
+   sort comparator for the non-index-sortable cases. Parity tests: same
+   fixtures through `applyListingQuery` and the planner path must agree —
+   this is the migration safety net (extend
+   `app/log-list/listing/listing.test.ts` / `client/database/database.test.ts`).
+2. **Snapshot listing service** on `DatabaseService`:
+   `getLogsListing(scope, filter, orderBy, pagination)` and
+   `getSamplesListing(...)` returning `{ items, total_count, next_cursor }`;
+   snapshot = ordered PK list cached per query-key hash (decide: two-tier
+   react-query design — a keys+count query that page queries depend on — vs
+   a module-level LRU keyed by the query hash; two-tier is more idiomatic).
+   Handle snapshot staleness (a key deleted between scan and `bulkGet` →
+   drop the hole).
+3. **Hook swap**: `useLogsListingQuery` becomes a real `useInfiniteQuery`
+   mirroring scout's hook (filter/orderBy/scope in the key, skipToken
+   support, `keepPreviousData`); a samples sibling replaces
+   `useSamplesListing`'s one-big-page mode (its paged param scaffolding
+   already exists). Db-less / out-of-namespace scopes fall back to the
+   in-memory `applyListingQuery` inside the same queryFn — the hook
+   contract doesn't change. Wire debounced scope-prefix invalidation from
+   the sink.
+4. **Grid + pages**: port scout's `checkScrollNearEnd` into inspect's
+   `DataGrid`, `pages.flatMap(p => p.items)` in `useLogListData` /
+   `SamplesGrid`, footer counts from `total_count` + scoped `count()`,
+   folders eager.
+5. **Long tail**: Cmd/F backing swap, snapshot-based adjacent-sample nav,
+   selected-row restore, samples progress aggregates.
+6. **Cleanup**: `applyListingQuery` shrinks to the fallback path;
+   `evaluator.ts` loses its "delete me" banner (it's now the residual
+   predicate); revisit which indexes earn their keep (e.g. is
+   `summary.completed_at` the default samples sort index or is the scan +
+   JS sort fine at target scale — measure first).
+
+Phase 1→2 order matters less than it looks: 1 and 2 land invisible behind
+parity tests; 3+4 flip the pages over; 5 can trail.
+
+## Open questions for the implementer
+
+- Snapshot cache placement (two-tier queries vs side cache) — see step 2.
+- Page size / fetch threshold: start with scout's 500 / 2000px and measure.
+- `maxPages` on the infinite queries, given invalidation refetches all
+  loaded pages.
+- Whether any hot sort column deserves denormalization to a top-level
+  indexed field later (e.g. `summary.completed_at` already is one) — only
+  after measuring; keys-first makes most of this moot.
+- Scout reconciliation: `apps/scout/src/query/` still duplicates
+  `packages/inspect-common/src/query/` (a noted follow-up, orthogonal to
+  this work).


### PR DESCRIPTION
Our end goal is to truly paginate the data out of IndexedDB instead of holding everything in memory and filtering/sorting in memory. This is a step towards that goal.

Previously we held a full list of logs in component state and filtered/sorted at that level, but now, we've pushed all of that below the `queryFn` level. These interfaces now include `pagination` options, but the UI doesn't yet take advantage of it.

I started this branch thinking the next step was using Dexie as the query engine, but it's not where we ended up. Instead we're much more organized now and have the interfaces in place to start using it as we implement pagination.