### PR TITLE
Add connection limit history display to Stats tab

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/ModelsTab.tsx
@@ -24,7 +24,7 @@ export const useModelsTab = (
   return useMemo(() => {
     return {
       id: kLogViewModelsTabId,
-      label: "Models",
+      label: "Stats",
       scrollable: true,
       component: ModelTab,
       componentProps: {
@@ -126,6 +126,9 @@ export const ModelTab: FC<ModelTabProps> = ({
           args_by_role={argsByRole}
           role_aliases={roleAliases}
           meta={meta}
+          connection_limit_history={evalStats?.connection_limit_history}
+          started_at={evalStats?.started_at}
+          completed_at={evalStats?.completed_at}
         />
       </div>
     </div>

--- a/packages/inspect-common/src/types/index.ts
+++ b/packages/inspect-common/src/types/index.ts
@@ -36,6 +36,8 @@ export type EvalScore = S["EvalScore"];
 export type EvalScorer = S["EvalScorer"];
 export type EvalSpec = S["EvalSpec"];
 export type EvalStats = S["EvalStats"];
+export type ConnectionLimitChange = S["ConnectionLimitChange"];
+export type AdaptiveConcurrency = S["AdaptiveConcurrency"];
 export type EvalRetryError = S["EvalRetryError"];
 
 // Event types

--- a/packages/inspect-components/src/usage/ConnectionLogModal.module.css
+++ b/packages/inspect-components/src/usage/ConnectionLogModal.module.css
@@ -1,0 +1,95 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--bs-body-color);
+}
+
+.table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bs-body-bg);
+  text-align: left;
+  font-weight: 600;
+  color: var(--bs-secondary);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 10px 16px 8px;
+  border-bottom: 1px solid var(--bs-light-border-subtle);
+}
+
+.table tbody td {
+  padding: 7px 16px;
+  border-bottom: 1px solid var(--bs-light-border-subtle);
+  vertical-align: baseline;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.time {
+  color: var(--bs-secondary);
+  white-space: nowrap;
+}
+
+.limitHead {
+  text-align: right;
+}
+
+.limit {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.oldLimit {
+  color: var(--bs-secondary);
+}
+
+.arrowUp,
+.arrowDown {
+  margin: 0 5px;
+}
+
+.arrowUp {
+  color: var(--bs-secondary);
+}
+
+.arrowDown {
+  color: #b04a3c;
+}
+
+.newLimit {
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.badgeSlowStart {
+  background: #e7eef8;
+  color: #3a6ea8;
+}
+
+.badgeSteadyUp {
+  background: #e9f1eb;
+  color: #4a7a55;
+}
+
+.badgeRateLimit {
+  background: #f8e9e7;
+  color: #b04a3c;
+}
+
+.badgeManual {
+  background: #eceef0;
+  color: #5f6771;
+}

--- a/packages/inspect-components/src/usage/ConnectionLogModal.module.css
+++ b/packages/inspect-components/src/usage/ConnectionLogModal.module.css
@@ -93,3 +93,29 @@
   background: #eceef0;
   color: #5f6771;
 }
+
+/* Dark mode — dark tinted fills with light text (the light fills above are
+   near-white and glare on a dark surface). */
+:global([data-bs-theme="dark"]) .arrowDown {
+  color: #d98d7d;
+}
+
+:global([data-bs-theme="dark"]) .badgeSlowStart {
+  background: #253850;
+  color: #9dc0ea;
+}
+
+:global([data-bs-theme="dark"]) .badgeSteadyUp {
+  background: #253b2c;
+  color: #9ccaa8;
+}
+
+:global([data-bs-theme="dark"]) .badgeRateLimit {
+  background: #472a24;
+  color: #e39a8a;
+}
+
+:global([data-bs-theme="dark"]) .badgeManual {
+  background: #31353b;
+  color: #aeb6bf;
+}

--- a/packages/inspect-components/src/usage/ConnectionLogModal.tsx
+++ b/packages/inspect-components/src/usage/ConnectionLogModal.tsx
@@ -1,0 +1,89 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+import type { ConnectionLimitChange } from "@tsmono/inspect-common/types";
+import { Modal } from "@tsmono/react/components";
+
+import styles from "./ConnectionLogModal.module.css";
+import { fmtClock } from "./timeFormat";
+
+interface ConnectionLogModalProps {
+  model: string;
+  events: ConnectionLimitChange[];
+  show: boolean;
+  onHide: () => void;
+}
+
+const kReasonLabel: Record<ConnectionLimitChange["reason"], string> = {
+  slow_start: "slow start",
+  steady_state_up: "steady up",
+  rate_limit: "rate limit",
+  manual: "manual",
+};
+
+const kReasonBadge: Record<ConnectionLimitChange["reason"], string> = {
+  slow_start: styles.badgeSlowStart!,
+  steady_state_up: styles.badgeSteadyUp!,
+  rate_limit: styles.badgeRateLimit!,
+  manual: styles.badgeManual!,
+};
+
+export const ConnectionLogModal: FC<ConnectionLogModalProps> = ({
+  model,
+  events,
+  show,
+  onHide,
+}) => {
+  return (
+    <Modal
+      id="connection-log"
+      show={show}
+      onHide={onHide}
+      title={`Connection Log — ${model}`}
+      width="min(560px, 90vw)"
+      padded={false}
+      footer={
+        <button type="button" className="btn btn-secondary" onClick={onHide}>
+          Close
+        </button>
+      }
+    >
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th className={styles.limitHead}>Limit</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((e, i) => {
+            const down = e.new_limit < e.old_limit;
+            return (
+              <tr key={i}>
+                <td className={styles.time}>
+                  {fmtClock(new Date(e.timestamp * 1000).toISOString(), true)}
+                </td>
+                <td className={styles.limit}>
+                  <span className={styles.oldLimit}>{e.old_limit}</span>
+                  <span
+                    className={down ? styles.arrowDown : styles.arrowUp}
+                    aria-label={down ? "decreased to" : "increased to"}
+                  >
+                    {down ? "↓" : "↑"}
+                  </span>
+                  <span className={styles.newLimit}>{e.new_limit}</span>
+                </td>
+                <td>
+                  <span className={clsx(styles.badge, kReasonBadge[e.reason])}>
+                    {kReasonLabel[e.reason]}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Modal>
+  );
+};

--- a/packages/inspect-components/src/usage/ConnectionLogModal.tsx
+++ b/packages/inspect-components/src/usage/ConnectionLogModal.tsx
@@ -43,7 +43,11 @@ export const ConnectionLogModal: FC<ConnectionLogModalProps> = ({
       width="min(560px, 90vw)"
       padded={false}
       footer={
-        <button type="button" className="btn btn-secondary" onClick={onHide}>
+        <button
+          type="button"
+          className={clsx("btn", "btn-secondary", "text-size-smaller")}
+          onClick={onHide}
+        >
           Close
         </button>
       }

--- a/packages/inspect-components/src/usage/ConnectionsLane.module.css
+++ b/packages/inspect-components/src/usage/ConnectionsLane.module.css
@@ -97,3 +97,17 @@
   font-size: 9px;
   fill: var(--bs-secondary);
 }
+
+/* Dark mode — the light-theme series blue and rate-limit red are tuned for a
+   white surface and lose contrast on a dark one. */
+:global([data-bs-theme="dark"]) .rateLimits {
+  color: #d98d7d;
+}
+
+:global([data-bs-theme="dark"]) .series {
+  stroke: #6ba0e0;
+}
+
+:global([data-bs-theme="dark"]) .rateLimitDot {
+  fill: #d98d7d;
+}

--- a/packages/inspect-components/src/usage/ConnectionsLane.module.css
+++ b/packages/inspect-components/src/usage/ConnectionsLane.module.css
@@ -61,13 +61,21 @@
   color: var(--bs-body-color);
 }
 
+/* The svg is absolutely positioned so its fixed pixel width (set from the
+   measured container) never feeds back into table layout — otherwise the
+   table cell's min-content width is pinned to the last rendered width and
+   the table can never shrink below it when the viewport narrows. */
 .chart {
   margin-top: 6px;
   width: 100%;
+  position: relative;
 }
 
 .svg {
   display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .series {

--- a/packages/inspect-components/src/usage/ConnectionsLane.module.css
+++ b/packages/inspect-components/src/usage/ConnectionsLane.module.css
@@ -1,0 +1,99 @@
+.lane {
+  width: 100%;
+}
+
+.statsLine {
+  display: flex;
+  align-items: baseline;
+  gap: 11px;
+  flex-wrap: wrap;
+}
+
+.stripLabel {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--bs-secondary);
+  margin-right: 3px;
+}
+
+.stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.statLabel {
+  font-size: 0.7rem;
+  color: var(--bs-secondary);
+}
+
+.statValue {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--bs-body-color);
+  font-variant-numeric: tabular-nums;
+}
+
+.rateLimits {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #b04a3c;
+  white-space: nowrap;
+}
+
+.logButton {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 0.75rem;
+  color: var(--bs-secondary);
+  cursor: pointer;
+}
+
+.logButton:hover {
+  color: var(--bs-body-color);
+}
+
+.chart {
+  margin-top: 6px;
+  width: 100%;
+}
+
+.svg {
+  display: block;
+}
+
+.series {
+  fill: none;
+  stroke: #3a7bd5;
+  stroke-width: 1.5;
+}
+
+.rateLimitDot {
+  fill: #b04a3c;
+}
+
+.maxGuide {
+  stroke: var(--bs-light-border-subtle);
+  stroke-dasharray: 3 3;
+}
+
+.baseline {
+  stroke: var(--bs-border-color);
+}
+
+.tickMark {
+  stroke: var(--bs-border-color);
+}
+
+.tickLabel {
+  font-size: 9px;
+  fill: var(--bs-secondary);
+}

--- a/packages/inspect-components/src/usage/ConnectionsLane.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsLane.tsx
@@ -1,0 +1,221 @@
+import { FC, useCallback, useState } from "react";
+
+import { useResizeObserver } from "@tsmono/react/hooks";
+
+import type {
+  ConnectionLaneData,
+  ConnectionWindow,
+} from "./connectionHistory";
+import styles from "./ConnectionsLane.module.css";
+
+interface ConnectionsLaneProps {
+  data: ConnectionLaneData;
+  window: ConnectionWindow;
+  variant: "column" | "strip";
+  onShowLog?: () => void;
+}
+
+const kChartHeight = 70;
+const kPlotTop = 6;
+const kBaselineY = 52;
+const kTickLabelY = 66;
+const kNiceIntervals = [
+  60, 300, 900, 1800, 3600, 7200, 14400, 21600, 43200, 86400,
+];
+
+const fmtTickTime = (sec: number): string =>
+  new Date(sec * 1000).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+const fmtTickDate = (sec: number): string =>
+  new Date(sec * 1000).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+
+interface Tick {
+  x: number;
+  label: string;
+  anchor: "start" | "middle" | "end";
+}
+
+const buildTicks = (
+  window: ConnectionWindow,
+  width: number,
+  x: (t: number) => number
+): Tick[] => {
+  const span = window.end - window.start;
+  if (span <= 0 || width <= 0) return [];
+
+  const first: Tick = {
+    x: 0,
+    label: `${fmtTickDate(window.start)}, ${fmtTickTime(window.start)}`,
+    anchor: "start",
+  };
+  const last: Tick = {
+    x: width,
+    label: fmtTickTime(window.end),
+    anchor: "end",
+  };
+
+  const interval =
+    kNiceIntervals.find((i) => (i / span) * width >= 55) ??
+    kNiceIntervals[kNiceIntervals.length - 1]!;
+  const interior: Tick[] = [];
+  let prevDate = fmtTickDate(window.start);
+  for (
+    let t = Math.ceil(window.start / interval) * interval;
+    t < window.end;
+    t += interval
+  ) {
+    const px = x(t);
+    // keep clear of the (wider) dated first label and the last label
+    if (px < 80 || px > width - 45) continue;
+    const date = fmtTickDate(t);
+    const label =
+      date !== prevDate ? `${date}, ${fmtTickTime(t)}` : fmtTickTime(t);
+    prevDate = date;
+    interior.push({ x: px, label, anchor: "middle" });
+  }
+  return [first, ...interior, last];
+};
+
+export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
+  data,
+  window,
+  variant,
+  onShowLog,
+}) => {
+  const [width, setWidth] = useState(0);
+  const chartRef = useResizeObserver(
+    useCallback(
+      (entry: ResizeObserverEntry) => setWidth(entry.contentRect.width),
+      []
+    )
+  );
+
+  const span = window.end - window.start;
+  const yMax = Math.max(data.configuredMax ?? 0, data.peak) * 1.08 || 1;
+  const x = (t: number): number => {
+    const clamped = Math.min(Math.max(t, window.start), window.end);
+    return span > 0 ? ((clamped - window.start) / span) * width : 0;
+  };
+  const y = (v: number): number =>
+    kBaselineY - (v / yMax) * (kBaselineY - kPlotTop);
+
+  let path = `M ${x(window.start)} ${y(data.start)}`;
+  let prev = data.start;
+  for (const e of data.events) {
+    const ex = x(e.timestamp);
+    path += ` L ${ex} ${y(prev)} L ${ex} ${y(e.new_limit)}`;
+    prev = e.new_limit;
+  }
+  path += ` L ${width} ${y(prev)}`;
+
+  const ticks = width > 0 ? buildTicks(window, width, x) : [];
+
+  return (
+    <div className={styles.lane}>
+      <div className={styles.statsLine}>
+        {variant === "strip" && (
+          <span className={styles.stripLabel}>Connections</span>
+        )}
+        <span className={styles.stat}>
+          <span className={styles.statLabel}>start</span>
+          <span className={styles.statValue}>{data.start}</span>
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statLabel}>peak</span>
+          <span className={styles.statValue}>{data.peak}</span>
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statLabel}>avg</span>
+          <span className={styles.statValue}>{Math.round(data.avg)}</span>
+        </span>
+        <span className={styles.stat}>
+          <span className={styles.statLabel}>final</span>
+          <span className={styles.statValue}>{data.final}</span>
+        </span>
+        {data.rateLimitCount > 0 && (
+          <span className={styles.rateLimits}>
+            {data.rateLimitCount} rate limit
+            {data.rateLimitCount === 1 ? "" : "s"}
+          </span>
+        )}
+        {onShowLog && (
+          <button
+            type="button"
+            className={styles.logButton}
+            title="Change log"
+            aria-label={`Connection change log for ${data.model}`}
+            onClick={onShowLog}
+          >
+            <i className="bi bi-clock-history" aria-hidden="true" />
+            {variant === "strip" && <span>Change log</span>}
+          </button>
+        )}
+      </div>
+      <div ref={chartRef} className={styles.chart}>
+        {width > 0 && (
+          <svg
+            className={styles.svg}
+            width={width}
+            height={kChartHeight}
+            role="img"
+            aria-label={`Connection limit over time for ${data.model}`}
+          >
+            {data.configuredMax !== undefined && (
+              <line
+                className={styles.maxGuide}
+                x1={0}
+                x2={width}
+                y1={y(data.configuredMax)}
+                y2={y(data.configuredMax)}
+              />
+            )}
+            <line
+              className={styles.baseline}
+              x1={0}
+              x2={width}
+              y1={kBaselineY}
+              y2={kBaselineY}
+            />
+            <path className={styles.series} d={path} />
+            {data.events
+              .filter((e) => e.reason === "rate_limit")
+              .map((e, i) => (
+                <circle
+                  key={i}
+                  className={styles.rateLimitDot}
+                  cx={x(e.timestamp)}
+                  cy={y(e.new_limit)}
+                  r={2.5}
+                />
+              ))}
+            {ticks.map((tick, i) => (
+              <g key={i}>
+                <line
+                  className={styles.tickMark}
+                  x1={tick.x}
+                  x2={tick.x}
+                  y1={kBaselineY}
+                  y2={kBaselineY + 3}
+                />
+                <text
+                  className={styles.tickLabel}
+                  x={tick.x}
+                  y={kTickLabelY}
+                  textAnchor={tick.anchor}
+                >
+                  {tick.label}
+                </text>
+              </g>
+            ))}
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/inspect-components/src/usage/ConnectionsLane.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsLane.tsx
@@ -2,10 +2,7 @@ import { FC, useCallback, useState } from "react";
 
 import { useResizeObserver } from "@tsmono/react/hooks";
 
-import type {
-  ConnectionLaneData,
-  ConnectionWindow,
-} from "./connectionHistory";
+import type { ConnectionLaneData, ConnectionWindow } from "./connectionHistory";
 import styles from "./ConnectionsLane.module.css";
 
 interface ConnectionsLaneProps {

--- a/packages/inspect-components/src/usage/ConnectionsLane.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsLane.tsx
@@ -16,6 +16,10 @@ const kChartHeight = 70;
 const kPlotTop = 6;
 const kBaselineY = 52;
 const kTickLabelY = 66;
+const kAngledLabelY = 62;
+const kLabelAngle = -30;
+// rough 9px-font char width, used to reserve room below angled labels
+const kApproxCharPx = 5;
 const kNiceIntervals = [
   60, 300, 900, 1800, 3600, 7200, 14400, 21600, 43200, 86400,
 ];
@@ -36,6 +40,7 @@ interface Tick {
   x: number;
   label: string;
   anchor: "start" | "middle" | "end";
+  angled?: boolean;
 }
 
 const buildTicks = (
@@ -69,13 +74,14 @@ const buildTicks = (
     t += interval
   ) {
     const px = x(t);
-    // keep clear of the (wider) dated first label and the last label
-    if (px < 80 || px > width - 45) continue;
+    // keep clear of the (wider) dated first label and the last label —
+    // angled interior labels descend down-left from their anchor
+    if (px < 90 || px > width - 45) continue;
     const date = fmtTickDate(t);
     const label =
       date !== prevDate ? `${date}, ${fmtTickTime(t)}` : fmtTickTime(t);
     prevDate = date;
-    interior.push({ x: px, label, anchor: "middle" });
+    interior.push({ x: px, label, anchor: "end", angled: true });
   }
   return [first, ...interior, last];
 };
@@ -113,6 +119,16 @@ export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
   path += ` L ${width} ${y(prev)}`;
 
   const ticks = width > 0 ? buildTicks(timeWindow, width, x) : [];
+  // angled labels descend ~half their width below the axis (sin 30°), so
+  // grow the chart to fit the widest one
+  const maxAngledPx = ticks.reduce(
+    (m, t) => (t.angled ? Math.max(m, t.label.length * kApproxCharPx) : m),
+    0
+  );
+  const chartHeight = Math.max(
+    kChartHeight,
+    Math.ceil(kAngledLabelY + maxAngledPx / 2 + 4)
+  );
 
   return (
     <div className={styles.lane}>
@@ -155,12 +171,16 @@ export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
           </button>
         )}
       </div>
-      <div ref={chartRef} className={styles.chart}>
+      <div
+        ref={chartRef}
+        className={styles.chart}
+        style={{ height: chartHeight }}
+      >
         {width > 0 && (
           <svg
             className={styles.svg}
             width={width}
-            height={kChartHeight}
+            height={chartHeight}
             role="img"
             aria-label={`Connection limit over time for ${data.model}`}
           >
@@ -204,8 +224,13 @@ export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
                 <text
                   className={styles.tickLabel}
                   x={tick.x}
-                  y={kTickLabelY}
+                  y={tick.angled ? kAngledLabelY : kTickLabelY}
                   textAnchor={tick.anchor}
+                  transform={
+                    tick.angled
+                      ? `rotate(${kLabelAngle} ${tick.x} ${kAngledLabelY})`
+                      : undefined
+                  }
                 >
                   {tick.label}
                 </text>

--- a/packages/inspect-components/src/usage/ConnectionsLane.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsLane.tsx
@@ -7,7 +7,7 @@ import styles from "./ConnectionsLane.module.css";
 
 interface ConnectionsLaneProps {
   data: ConnectionLaneData;
-  window: ConnectionWindow;
+  timeWindow: ConnectionWindow;
   variant: "column" | "strip";
   onShowLog?: () => void;
 }
@@ -39,21 +39,21 @@ interface Tick {
 }
 
 const buildTicks = (
-  window: ConnectionWindow,
+  timeWindow: ConnectionWindow,
   width: number,
   x: (t: number) => number
 ): Tick[] => {
-  const span = window.end - window.start;
+  const span = timeWindow.end - timeWindow.start;
   if (span <= 0 || width <= 0) return [];
 
   const first: Tick = {
     x: 0,
-    label: `${fmtTickDate(window.start)}, ${fmtTickTime(window.start)}`,
+    label: `${fmtTickDate(timeWindow.start)}, ${fmtTickTime(timeWindow.start)}`,
     anchor: "start",
   };
   const last: Tick = {
     x: width,
-    label: fmtTickTime(window.end),
+    label: fmtTickTime(timeWindow.end),
     anchor: "end",
   };
 
@@ -61,10 +61,10 @@ const buildTicks = (
     kNiceIntervals.find((i) => (i / span) * width >= 55) ??
     kNiceIntervals[kNiceIntervals.length - 1]!;
   const interior: Tick[] = [];
-  let prevDate = fmtTickDate(window.start);
+  let prevDate = fmtTickDate(timeWindow.start);
   for (
-    let t = Math.ceil(window.start / interval) * interval;
-    t < window.end;
+    let t = Math.ceil(timeWindow.start / interval) * interval;
+    t < timeWindow.end;
     t += interval
   ) {
     const px = x(t);
@@ -81,7 +81,7 @@ const buildTicks = (
 
 export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
   data,
-  window,
+  timeWindow,
   variant,
   onShowLog,
 }) => {
@@ -93,16 +93,16 @@ export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
     )
   );
 
-  const span = window.end - window.start;
+  const span = timeWindow.end - timeWindow.start;
   const yMax = Math.max(data.configuredMax ?? 0, data.peak) * 1.08 || 1;
   const x = (t: number): number => {
-    const clamped = Math.min(Math.max(t, window.start), window.end);
-    return span > 0 ? ((clamped - window.start) / span) * width : 0;
+    const clamped = Math.min(Math.max(t, timeWindow.start), timeWindow.end);
+    return span > 0 ? ((clamped - timeWindow.start) / span) * width : 0;
   };
   const y = (v: number): number =>
     kBaselineY - (v / yMax) * (kBaselineY - kPlotTop);
 
-  let path = `M ${x(window.start)} ${y(data.start)}`;
+  let path = `M ${x(timeWindow.start)} ${y(data.start)}`;
   let prev = data.start;
   for (const e of data.events) {
     const ex = x(e.timestamp);
@@ -111,7 +111,7 @@ export const ConnectionsLane: FC<ConnectionsLaneProps> = ({
   }
   path += ` L ${width} ${y(prev)}`;
 
-  const ticks = width > 0 ? buildTicks(window, width, x) : [];
+  const ticks = width > 0 ? buildTicks(timeWindow, width, x) : [];
 
   return (
     <div className={styles.lane}>

--- a/packages/inspect-components/src/usage/ConnectionsLane.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsLane.tsx
@@ -57,9 +57,10 @@ const buildTicks = (
     anchor: "end",
   };
 
+  // day-multiple fallback preserves the 55px spacing rule on long windows
   const interval =
     kNiceIntervals.find((i) => (i / span) * width >= 55) ??
-    kNiceIntervals[kNiceIntervals.length - 1]!;
+    Math.ceil((55 * span) / width / 86400) * 86400;
   const interior: Tick[] = [];
   let prevDate = fmtTickDate(timeWindow.start);
   for (

--- a/packages/inspect-components/src/usage/ModelTokenTable.module.css
+++ b/packages/inspect-components/src/usage/ModelTokenTable.module.css
@@ -216,8 +216,13 @@
   vertical-align: top;
 }
 
+.table thead th.connectionsHead,
+.table tbody td.connectionsCell {
+  padding-left: 2rem;
+}
+
 .table tbody tr.connectionsStripRow td {
-  padding: 0 0 18px;
+  padding: 6px 0 18px;
   border-top: 0;
 }
 

--- a/packages/inspect-components/src/usage/ModelTokenTable.module.css
+++ b/packages/inspect-components/src/usage/ModelTokenTable.module.css
@@ -210,6 +210,17 @@
   margin-top: 0.15rem;
 }
 
+.connectionsCell {
+  width: 330px;
+  min-width: 240px;
+  vertical-align: top;
+}
+
+.table tbody tr.connectionsStripRow td {
+  padding: 0 0 18px;
+  border-top: 0;
+}
+
 .swatch {
   display: inline-block;
   width: 9px;

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -31,11 +31,7 @@ const fmtConfigVal = (v: unknown): string => {
 };
 
 type CategoryKey =
-  | "input"
-  | "cacheRead"
-  | "cacheWrite"
-  | "output"
-  | "reasoning";
+  "input" | "cacheRead" | "cacheWrite" | "output" | "reasoning";
 
 const CAT_ORDER: CategoryKey[] = [
   "input",

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -134,7 +134,9 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                 <th>Breakdown</th>
               </>
             )}
-            {showConnectionsColumn && <th>Connections</th>}
+            {showConnectionsColumn && (
+              <th className={styles.connectionsHead}>Connections</th>
+            )}
             {showPerSample && <th className={styles.num}>Per sample</th>}
           </tr>
         </thead>

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -154,6 +154,10 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
               usage && total > 0
                 ? Math.round(((usage.output_tokens ?? 0) / total) * 100)
                 : 0;
+            const showLog =
+              onShowConnectionLog && lane
+                ? () => onShowConnectionLog(lane.model)
+                : undefined;
             return (
               <Fragment key={modelId}>
                 <tr className={styles.modelRow}>
@@ -211,6 +215,9 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                       );
                     })()}
                   </td>
+                  {/* rows with connection history but no usage still need
+                      cells here to keep later columns aligned */}
+                  {showTokenColumns && !usage && <td colSpan={2} />}
                   {showTokenColumns && usage && (
                     <>
                       <td className={styles.composeCell}>
@@ -267,17 +274,14 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                       {lane && connections_window && (
                         <ConnectionsLane
                           data={lane}
-                          window={connections_window}
+                          timeWindow={connections_window}
                           variant="column"
-                          onShowLog={
-                            onShowConnectionLog
-                              ? () => onShowConnectionLog(lane.model)
-                              : undefined
-                          }
+                          onShowLog={showLog}
                         />
                       )}
                     </td>
                   )}
+                  {showPerSample && !usage && <td />}
                   {showPerSample && usage && (
                     <td className={clsx(styles.num, styles.perSampleCell)}>
                       {formatNumber(Math.round(total / samples))}
@@ -290,13 +294,9 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                     <td colSpan={columnCount}>
                       <ConnectionsLane
                         data={lane}
-                        window={connections_window}
+                        timeWindow={connections_window}
                         variant="strip"
-                        onShowLog={
-                          onShowConnectionLog
-                            ? () => onShowConnectionLog(lane.model)
-                            : undefined
-                        }
+                        onShowLog={showLog}
                       />
                     </td>
                   </tr>

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -4,10 +4,7 @@ import { FC, Fragment, useCallback, useState } from "react";
 import { useResizeObserver } from "@tsmono/react/hooks";
 import { formatNumber } from "@tsmono/util";
 
-import type {
-  ConnectionLaneData,
-  ConnectionWindow,
-} from "./connectionHistory";
+import type { ConnectionLaneData, ConnectionWindow } from "./connectionHistory";
 import { ConnectionsLane } from "./ConnectionsLane";
 import styles from "./ModelTokenTable.module.css";
 import { ModelUsageData } from "./ModelUsagePanel";
@@ -34,7 +31,11 @@ const fmtConfigVal = (v: unknown): string => {
 };
 
 type CategoryKey =
-  "input" | "cacheRead" | "cacheWrite" | "output" | "reasoning";
+  | "input"
+  | "cacheRead"
+  | "cacheWrite"
+  | "output"
+  | "reasoning";
 
 const CAT_ORDER: CategoryKey[] = [
   "input",

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -1,8 +1,14 @@
 import clsx from "clsx";
-import { FC, Fragment } from "react";
+import { FC, Fragment, useCallback, useState } from "react";
 
+import { useResizeObserver } from "@tsmono/react/hooks";
 import { formatNumber } from "@tsmono/util";
 
+import type {
+  ConnectionLaneData,
+  ConnectionWindow,
+} from "./connectionHistory";
+import { ConnectionsLane } from "./ConnectionsLane";
 import styles from "./ModelTokenTable.module.css";
 import { ModelUsageData } from "./ModelUsagePanel";
 
@@ -15,6 +21,9 @@ interface ModelTokenTableProps {
   model_aliases?: Record<string, string>;
   rowKeys?: string[];
   showTokenColumns?: boolean;
+  connections_by_row?: Record<string, ConnectionLaneData>;
+  connections_window?: ConnectionWindow;
+  onShowConnectionLog?: (model: string) => void;
 }
 
 const fmtConfigVal = (v: unknown): string => {
@@ -81,7 +90,19 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
   model_aliases,
   rowKeys,
   showTokenColumns = true,
+  connections_by_row,
+  connections_window,
+  onShowConnectionLog,
 }) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const wrapperRef = useResizeObserver(
+    useCallback(
+      (entry: ResizeObserverEntry) =>
+        setContainerWidth(entry.contentRect.width),
+      []
+    )
+  );
+
   const models =
     rowKeys ??
     (model_usage ? Object.keys(model_usage).filter((k) => model_usage[k]) : []);
@@ -90,8 +111,22 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
   const showPerSample =
     showTokenColumns && samples !== undefined && samples > 0;
 
+  const hasConnections =
+    !!connections_window &&
+    !!connections_by_row &&
+    models.some((m) => connections_by_row[m]);
+  // Below ~1000px the lane leaves the column and becomes a full-width strip
+  // row under its model's row.
+  const narrow = containerWidth > 0 && containerWidth < 1000;
+  const showConnectionsColumn = hasConnections && !narrow;
+  const columnCount =
+    1 +
+    (showTokenColumns ? 2 : 0) +
+    (showConnectionsColumn ? 1 : 0) +
+    (showPerSample ? 1 : 0);
+
   return (
-    <div className={clsx(styles.wrapper, className)}>
+    <div ref={wrapperRef} className={clsx(styles.wrapper, className)}>
       <table className={styles.table}>
         <thead>
           <tr>
@@ -102,12 +137,14 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                 <th>Breakdown</th>
               </>
             )}
+            {showConnectionsColumn && <th>Connections</th>}
             {showPerSample && <th className={styles.num}>Per sample</th>}
           </tr>
         </thead>
         <tbody>
           {models.map((modelId) => {
             const usage = model_usage?.[modelId];
+            const lane = connections_by_row?.[modelId];
             const composeSum = usage ? compositionTotal(usage) : 0;
             const total = usage ? usageTotal(usage) : 0;
             const cacheRate =
@@ -121,117 +158,153 @@ export const ModelTokenTable: FC<ModelTokenTableProps> = ({
                 ? Math.round(((usage.output_tokens ?? 0) / total) * 100)
                 : 0;
             return (
-              <tr key={modelId} className={styles.modelRow}>
-                <td className={styles.modelCell}>
-                  <span className={styles.modelName}>{modelId}</span>
-                  {model_aliases?.[modelId] && (
-                    <span className={styles.modelAlias}>
-                      {model_aliases[modelId]}
-                    </span>
-                  )}
-                  {showTokenColumns && (
-                    <span className={styles.modelTotal}>
-                      {formatNumber(total)}
-                      <small>tokens</small>
-                    </span>
-                  )}
-                  {(() => {
-                    const cfg = model_configs?.[modelId];
-                    const args = model_args?.[modelId];
-                    const cfgEntries = cfg
-                      ? Object.entries(cfg).filter(([, v]) => v != null)
-                      : [];
-                    const argEntries = args
-                      ? Object.entries(args).filter(([, v]) => v != null)
-                      : [];
-                    if (cfgEntries.length === 0 && argEntries.length === 0)
-                      return null;
-                    const renderSection = (
-                      label: string,
-                      entries: [string, unknown][]
-                    ) => (
-                      <>
-                        <div className={styles.configSectionLabel}>{label}</div>
-                        <dl className={styles.configTable}>
-                          {entries.map(([k, v]) => (
-                            <Fragment key={k}>
-                              <dt className={styles.configKey}>{k}</dt>
-                              <dd className={styles.configVal}>
-                                {fmtConfigVal(v)}
-                              </dd>
-                            </Fragment>
-                          ))}
-                        </dl>
-                      </>
-                    );
-                    return (
-                      <div className={styles.configSection}>
-                        {cfgEntries.length > 0 &&
-                          renderSection("config", cfgEntries)}
-                        {argEntries.length > 0 &&
-                          renderSection("args", argEntries)}
-                      </div>
-                    );
-                  })()}
-                </td>
-                {showTokenColumns && usage && (
-                  <>
-                    <td className={styles.composeCell}>
-                      <div className={styles.stack}>
-                        {composeSum > 0 &&
-                          CAT_ORDER.map((k) => {
+              <Fragment key={modelId}>
+                <tr className={styles.modelRow}>
+                  <td className={styles.modelCell}>
+                    <span className={styles.modelName}>{modelId}</span>
+                    {model_aliases?.[modelId] && (
+                      <span className={styles.modelAlias}>
+                        {model_aliases[modelId]}
+                      </span>
+                    )}
+                    {showTokenColumns && (
+                      <span className={styles.modelTotal}>
+                        {formatNumber(total)}
+                        <small>tokens</small>
+                      </span>
+                    )}
+                    {(() => {
+                      const cfg = model_configs?.[modelId];
+                      const args = model_args?.[modelId];
+                      const cfgEntries = cfg
+                        ? Object.entries(cfg).filter(([, v]) => v != null)
+                        : [];
+                      const argEntries = args
+                        ? Object.entries(args).filter(([, v]) => v != null)
+                        : [];
+                      if (cfgEntries.length === 0 && argEntries.length === 0)
+                        return null;
+                      const renderSection = (
+                        label: string,
+                        entries: [string, unknown][]
+                      ) => (
+                        <>
+                          <div className={styles.configSectionLabel}>
+                            {label}
+                          </div>
+                          <dl className={styles.configTable}>
+                            {entries.map(([k, v]) => (
+                              <Fragment key={k}>
+                                <dt className={styles.configKey}>{k}</dt>
+                                <dd className={styles.configVal}>
+                                  {fmtConfigVal(v)}
+                                </dd>
+                              </Fragment>
+                            ))}
+                          </dl>
+                        </>
+                      );
+                      return (
+                        <div className={styles.configSection}>
+                          {cfgEntries.length > 0 &&
+                            renderSection("config", cfgEntries)}
+                          {argEntries.length > 0 &&
+                            renderSection("args", argEntries)}
+                        </div>
+                      );
+                    })()}
+                  </td>
+                  {showTokenColumns && usage && (
+                    <>
+                      <td className={styles.composeCell}>
+                        <div className={styles.stack}>
+                          {composeSum > 0 &&
+                            CAT_ORDER.map((k) => {
+                              const v = categoryValue(usage, k);
+                              if (!v) return null;
+                              return (
+                                <span
+                                  key={k}
+                                  className={CAT_SWATCH[k]}
+                                  style={{
+                                    width: `${(v / composeSum) * 100}%`,
+                                  }}
+                                />
+                              );
+                            })}
+                        </div>
+                        <div className={styles.pcts}>
+                          <span>{cacheRate}% cache read</span>
+                          <span>{outputRate}% output</span>
+                        </div>
+                      </td>
+                      <td>
+                        <dl className={styles.breakdown}>
+                          {CAT_ORDER.map((k) => {
                             const v = categoryValue(usage, k);
                             if (!v) return null;
                             return (
-                              <span
-                                key={k}
-                                className={CAT_SWATCH[k]}
-                                style={{
-                                  width: `${(v / composeSum) * 100}%`,
-                                }}
-                              />
+                              <Fragment key={k}>
+                                <dt className={styles.breakdownLabel}>
+                                  <span
+                                    className={clsx(
+                                      styles.swatchSmall,
+                                      CAT_SWATCH[k]
+                                    )}
+                                  />
+                                  {CAT_LABEL[k]}
+                                </dt>
+                                <dd className={styles.breakdownLeader} />
+                                <dd className={styles.breakdownValue}>
+                                  {formatNumber(v)}
+                                </dd>
+                              </Fragment>
                             );
                           })}
-                      </div>
-                      <div className={styles.pcts}>
-                        <span>{cacheRate}% cache read</span>
-                        <span>{outputRate}% output</span>
-                      </div>
+                        </dl>
+                      </td>
+                    </>
+                  )}
+                  {showConnectionsColumn && (
+                    <td className={styles.connectionsCell}>
+                      {lane && connections_window && (
+                        <ConnectionsLane
+                          data={lane}
+                          window={connections_window}
+                          variant="column"
+                          onShowLog={
+                            onShowConnectionLog
+                              ? () => onShowConnectionLog(lane.model)
+                              : undefined
+                          }
+                        />
+                      )}
                     </td>
-                    <td>
-                      <dl className={styles.breakdown}>
-                        {CAT_ORDER.map((k) => {
-                          const v = categoryValue(usage, k);
-                          if (!v) return null;
-                          return (
-                            <Fragment key={k}>
-                              <dt className={styles.breakdownLabel}>
-                                <span
-                                  className={clsx(
-                                    styles.swatchSmall,
-                                    CAT_SWATCH[k]
-                                  )}
-                                />
-                                {CAT_LABEL[k]}
-                              </dt>
-                              <dd className={styles.breakdownLeader} />
-                              <dd className={styles.breakdownValue}>
-                                {formatNumber(v)}
-                              </dd>
-                            </Fragment>
-                          );
-                        })}
-                      </dl>
+                  )}
+                  {showPerSample && usage && (
+                    <td className={clsx(styles.num, styles.perSampleCell)}>
+                      {formatNumber(Math.round(total / samples))}
+                      <span className={styles.perSampleSub}>avg / sample</span>
                     </td>
-                  </>
+                  )}
+                </tr>
+                {hasConnections && narrow && lane && connections_window && (
+                  <tr className={styles.connectionsStripRow}>
+                    <td colSpan={columnCount}>
+                      <ConnectionsLane
+                        data={lane}
+                        window={connections_window}
+                        variant="strip"
+                        onShowLog={
+                          onShowConnectionLog
+                            ? () => onShowConnectionLog(lane.model)
+                            : undefined
+                        }
+                      />
+                    </td>
+                  </tr>
                 )}
-                {showPerSample && usage && (
-                  <td className={clsx(styles.num, styles.perSampleCell)}>
-                    {formatNumber(Math.round(total / samples))}
-                    <span className={styles.perSampleSub}>avg / sample</span>
-                  </td>
-                )}
-              </tr>
+              </Fragment>
             );
           })}
         </tbody>

--- a/packages/inspect-components/src/usage/UsagePanel.tsx
+++ b/packages/inspect-components/src/usage/UsagePanel.tsx
@@ -1,8 +1,17 @@
 import clsx from "clsx";
 import { Fragment, ReactNode, useState } from "react";
 
+import type { ConnectionLimitChange } from "@tsmono/inspect-common/types";
 import { SegmentedControl } from "@tsmono/react/components";
+import { useProperty } from "@tsmono/react/hooks";
 
+import {
+  adaptiveMaxFromConfig,
+  buildConnectionLanes,
+  connectionWindow,
+  type ConnectionLaneData,
+} from "./connectionHistory";
+import { ConnectionLogModal } from "./ConnectionLogModal";
 import { ModelTokenTable } from "./ModelTokenTable";
 import { ModelUsageData } from "./ModelUsagePanel";
 import styles from "./UsagePanel.module.css";
@@ -24,6 +33,9 @@ interface UsagePanelProps {
   samples?: number;
   meta?: MetaItem[];
   className?: string | string[];
+  connection_limit_history?: ConnectionLimitChange[];
+  started_at?: string | null;
+  completed_at?: string | null;
 }
 
 type Mode = "model" | "role";
@@ -40,6 +52,9 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
   samples,
   meta,
   className,
+  connection_limit_history,
+  started_at,
+  completed_at,
 }) => {
   const keysOf = (
     ...maps: (Record<string, unknown> | undefined)[]
@@ -49,7 +64,23 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
     return Array.from(out);
   };
 
-  const modelKeys = keysOf(model_usage, configs_by_model, args_by_model);
+  const usageWindow = connectionWindow(
+    connection_limit_history,
+    started_at,
+    completed_at
+  );
+  const lanesByModel = buildConnectionLanes(
+    connection_limit_history,
+    usageWindow,
+    (model) => adaptiveMaxFromConfig(configs_by_model?.[model])
+  );
+
+  const modelKeys = keysOf(
+    model_usage,
+    configs_by_model,
+    args_by_model,
+    lanesByModel
+  );
   const roleKeys = keysOf(
     role_usage,
     configs_by_role,
@@ -61,6 +92,11 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
   const hasRoleUsage = !!(role_usage && Object.keys(role_usage).length > 0);
 
   const [mode, setMode] = useState<Mode>(hasRoleUsage ? "role" : "model");
+  const [logModel, setLogModel] = useProperty<string | null>(
+    "usage-connections",
+    "log-model",
+    { defaultValue: null }
+  );
 
   if (!hasModel && !hasRole) return null;
 
@@ -75,6 +111,19 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
   const tableArgs = isModel ? args_by_model : args_by_role;
   const tableAliases = !isModel ? role_aliases : undefined;
   const tableRowKeys = isModel ? modelKeys : roleKeys;
+
+  // History is keyed by model; role rows resolve their lane through the
+  // role → model alias map (roles sharing a model show the same lane).
+  const connectionsByRow: Record<string, ConnectionLaneData> = {};
+  if (isModel) {
+    Object.assign(connectionsByRow, lanesByModel);
+  } else if (role_aliases) {
+    for (const [role, model] of Object.entries(role_aliases)) {
+      const lane = lanesByModel[model];
+      if (lane) connectionsByRow[role] = lane;
+    }
+  }
+  const logLane = logModel != null ? lanesByModel[logModel] : undefined;
 
   const metaItems = hasUsageData
     ? (meta?.filter((m) => m.value != null && m.value !== "") ?? [])
@@ -121,7 +170,18 @@ export const UsagePanel: React.FC<UsagePanelProps> = ({
         showTokenColumns={hasUsageData}
         samples={samples}
         className={styles.tableNoTop}
+        connections_by_row={connectionsByRow}
+        connections_window={usageWindow}
+        onShowConnectionLog={setLogModel}
       />
+      {logLane && (
+        <ConnectionLogModal
+          model={logLane.model}
+          events={logLane.events}
+          show={true}
+          onHide={() => setLogModel(null)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/inspect-components/src/usage/connectionHistory.test.ts
+++ b/packages/inspect-components/src/usage/connectionHistory.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConnectionLimitChange } from "@tsmono/inspect-common/types";
+
+import {
+  adaptiveMaxFromConfig,
+  buildConnectionLanes,
+  connectionWindow,
+} from "./connectionHistory";
+
+const change = (
+  overrides: Partial<ConnectionLimitChange> &
+    Pick<ConnectionLimitChange, "timestamp" | "old_limit" | "new_limit">
+): ConnectionLimitChange => ({
+  model: "openai/gpt-4o",
+  reason: "slow_start",
+  ...overrides,
+});
+
+describe("connectionWindow", () => {
+  it("returns undefined for empty or missing history", () => {
+    expect(connectionWindow(undefined)).toBeUndefined();
+    expect(connectionWindow([])).toBeUndefined();
+  });
+
+  it("uses eval start/end when they bound the events", () => {
+    const history = [change({ timestamp: 1000, old_limit: 20, new_limit: 40 })];
+    const window = connectionWindow(
+      history,
+      new Date(500 * 1000).toISOString(),
+      new Date(2000 * 1000).toISOString()
+    );
+    expect(window).toEqual({ start: 500, end: 2000 });
+  });
+
+  it("expands to cover events outside the eval bounds", () => {
+    const history = [
+      change({ timestamp: 100, old_limit: 20, new_limit: 40 }),
+      change({ timestamp: 3000, old_limit: 40, new_limit: 80 }),
+    ];
+    const window = connectionWindow(
+      history,
+      new Date(500 * 1000).toISOString(),
+      new Date(2000 * 1000).toISOString()
+    );
+    expect(window).toEqual({ start: 100, end: 3000 });
+  });
+
+  it("falls back to the event range for live evals", () => {
+    const history = [
+      change({ timestamp: 1000, old_limit: 20, new_limit: 40 }),
+      change({ timestamp: 1500, old_limit: 40, new_limit: 80 }),
+    ];
+    const window = connectionWindow(
+      history,
+      new Date(800 * 1000).toISOString(),
+      ""
+    );
+    expect(window).toEqual({ start: 800, end: 1500 });
+  });
+});
+
+describe("buildConnectionLanes", () => {
+  it("groups by model and derives start/peak/final/rate limits", () => {
+    const history = [
+      change({ timestamp: 100, old_limit: 20, new_limit: 40 }),
+      change({
+        timestamp: 200,
+        old_limit: 40,
+        new_limit: 32,
+        reason: "rate_limit",
+      }),
+      change({
+        model: "anthropic/claude-sonnet-4-5",
+        timestamp: 150,
+        old_limit: 20,
+        new_limit: 60,
+      }),
+    ];
+    const lanes = buildConnectionLanes(history, { start: 0, end: 400 });
+    expect(Object.keys(lanes).sort()).toEqual([
+      "anthropic/claude-sonnet-4-5",
+      "openai/gpt-4o",
+    ]);
+    const gpt = lanes["openai/gpt-4o"]!;
+    expect(gpt.start).toBe(20);
+    expect(gpt.peak).toBe(40);
+    expect(gpt.final).toBe(32);
+    expect(gpt.rateLimitCount).toBe(1);
+    expect(lanes["anthropic/claude-sonnet-4-5"]!.rateLimitCount).toBe(0);
+  });
+
+  it("sorts events by timestamp before deriving", () => {
+    const history = [
+      change({ timestamp: 200, old_limit: 40, new_limit: 80 }),
+      change({ timestamp: 100, old_limit: 20, new_limit: 40 }),
+    ];
+    const lane = buildConnectionLanes(history, { start: 0, end: 300 })[
+      "openai/gpt-4o"
+    ]!;
+    expect(lane.start).toBe(20);
+    expect(lane.final).toBe(80);
+    expect(lane.events.map((e) => e.timestamp)).toEqual([100, 200]);
+  });
+
+  it("computes a time-weighted average over the window", () => {
+    // 20 for [0,100), 40 for [100,200), 80 for [200,400) → avg = 55
+    const history = [
+      change({ timestamp: 100, old_limit: 20, new_limit: 40 }),
+      change({ timestamp: 200, old_limit: 40, new_limit: 80 }),
+    ];
+    const lane = buildConnectionLanes(history, { start: 0, end: 400 })[
+      "openai/gpt-4o"
+    ]!;
+    expect(lane.avg).toBe(55);
+  });
+
+  it("clamps event timestamps to the window when averaging", () => {
+    const history = [change({ timestamp: 50, old_limit: 20, new_limit: 40 })];
+    const lane = buildConnectionLanes(history, { start: 100, end: 200 })[
+      "openai/gpt-4o"
+    ]!;
+    expect(lane.avg).toBe(40);
+  });
+
+  it("resolves configured max per model", () => {
+    const history = [change({ timestamp: 100, old_limit: 20, new_limit: 40 })];
+    const lanes = buildConnectionLanes(
+      history,
+      { start: 0, end: 200 },
+      () => 64
+    );
+    expect(lanes["openai/gpt-4o"]!.configuredMax).toBe(64);
+  });
+
+  it("returns empty for empty history or missing window", () => {
+    expect(buildConnectionLanes([], { start: 0, end: 1 })).toEqual({});
+    expect(
+      buildConnectionLanes(
+        [change({ timestamp: 1, old_limit: 1, new_limit: 2 })],
+        undefined
+      )
+    ).toEqual({});
+  });
+});
+
+describe("adaptiveMaxFromConfig", () => {
+  it("handles absent/disabled config", () => {
+    expect(adaptiveMaxFromConfig(undefined)).toBeUndefined();
+    expect(adaptiveMaxFromConfig({})).toBeUndefined();
+    expect(
+      adaptiveMaxFromConfig({ adaptive_connections: false })
+    ).toBeUndefined();
+    expect(
+      adaptiveMaxFromConfig({ adaptive_connections: null })
+    ).toBeUndefined();
+  });
+
+  it("uses the schema default max for `true`", () => {
+    expect(adaptiveMaxFromConfig({ adaptive_connections: true })).toBe(100);
+  });
+
+  it("treats a bare number as the max", () => {
+    expect(adaptiveMaxFromConfig({ adaptive_connections: 50 })).toBe(50);
+  });
+
+  it("parses string shorthands", () => {
+    expect(adaptiveMaxFromConfig({ adaptive_connections: "10-80" })).toBe(80);
+    expect(adaptiveMaxFromConfig({ adaptive_connections: "10-20-120" })).toBe(
+      120
+    );
+  });
+
+  it("reads max from an AdaptiveConcurrency object", () => {
+    expect(
+      adaptiveMaxFromConfig({ adaptive_connections: { min: 5, max: 40 } })
+    ).toBe(40);
+    expect(adaptiveMaxFromConfig({ adaptive_connections: {} })).toBe(100);
+  });
+});

--- a/packages/inspect-components/src/usage/connectionHistory.ts
+++ b/packages/inspect-components/src/usage/connectionHistory.ts
@@ -1,0 +1,121 @@
+import type {
+  AdaptiveConcurrency,
+  ConnectionLimitChange,
+} from "@tsmono/inspect-common/types";
+
+export interface ConnectionWindow {
+  start: number;
+  end: number;
+}
+
+export interface ConnectionLaneData {
+  model: string;
+  events: ConnectionLimitChange[];
+  start: number;
+  peak: number;
+  final: number;
+  avg: number;
+  rateLimitCount: number;
+  configuredMax?: number;
+}
+
+const kAdaptiveDefaultMax = 100;
+
+const isoToEpoch = (iso?: string | null): number | undefined => {
+  if (!iso) return undefined;
+  const ms = new Date(iso).getTime();
+  return Number.isFinite(ms) ? ms / 1000 : undefined;
+};
+
+// History timestamps are epoch seconds while started_at/completed_at are ISO
+// strings; normalize here. The window expands to cover any events outside the
+// eval bounds (clock skew, live evals with no completed_at yet).
+export const connectionWindow = (
+  history: ConnectionLimitChange[] | undefined,
+  startedAt?: string | null,
+  completedAt?: string | null
+): ConnectionWindow | undefined => {
+  if (!history || history.length === 0) return undefined;
+  let first = Infinity;
+  let last = -Infinity;
+  for (const e of history) {
+    if (e.timestamp < first) first = e.timestamp;
+    if (e.timestamp > last) last = e.timestamp;
+  }
+  const start = Math.min(isoToEpoch(startedAt) ?? first, first);
+  const end = Math.max(isoToEpoch(completedAt) ?? last, last);
+  return { start, end };
+};
+
+// adaptive_connections is boolean | number | AdaptiveConcurrency | null, plus
+// the "min-max" / "min-start-max" string shorthand accepted by CLI flags.
+export const adaptiveMaxFromConfig = (
+  config?: Record<string, unknown>
+): number | undefined => {
+  const adaptive = config?.["adaptive_connections"];
+  if (adaptive == null || adaptive === false) return undefined;
+  if (adaptive === true) return kAdaptiveDefaultMax;
+  if (typeof adaptive === "number") return adaptive;
+  if (typeof adaptive === "string") {
+    const parts = adaptive.split("-");
+    const max = Number(parts[parts.length - 1]);
+    return Number.isFinite(max) ? max : kAdaptiveDefaultMax;
+  }
+  if (typeof adaptive === "object") {
+    const max = (adaptive as Partial<AdaptiveConcurrency>).max;
+    return typeof max === "number" ? max : kAdaptiveDefaultMax;
+  }
+  return undefined;
+};
+
+export const buildConnectionLanes = (
+  history: ConnectionLimitChange[] | undefined,
+  window: ConnectionWindow | undefined,
+  configuredMax?: (model: string) => number | undefined
+): Record<string, ConnectionLaneData> => {
+  const lanes: Record<string, ConnectionLaneData> = {};
+  if (!history || history.length === 0 || !window) return lanes;
+
+  const byModel: Record<string, ConnectionLimitChange[]> = {};
+  for (const e of history) (byModel[e.model] ??= []).push(e);
+
+  for (const [model, events] of Object.entries(byModel)) {
+    events.sort((a, b) => a.timestamp - b.timestamp);
+    const start = events[0]!.old_limit;
+    const final = events[events.length - 1]!.new_limit;
+
+    let peak = start;
+    let rateLimitCount = 0;
+    for (const e of events) {
+      peak = Math.max(peak, e.old_limit, e.new_limit);
+      if (e.reason === "rate_limit") rateLimitCount += 1;
+    }
+
+    // Time-weighted average: the limit between entries is the previous
+    // new_limit, extended to the window edges on both sides.
+    let weighted = 0;
+    let prevT = window.start;
+    let prevV = start;
+    for (const e of events) {
+      const t = Math.min(Math.max(e.timestamp, window.start), window.end);
+      weighted += prevV * (t - prevT);
+      prevT = t;
+      prevV = e.new_limit;
+    }
+    weighted += prevV * (window.end - prevT);
+    const span = window.end - window.start;
+    const avg = span > 0 ? weighted / span : final;
+
+    lanes[model] = {
+      model,
+      events,
+      start,
+      peak,
+      final,
+      avg,
+      rateLimitCount,
+      configuredMax: configuredMax?.(model),
+    };
+  }
+  return lanes;
+};

--- a/packages/inspect-components/src/usage/index.ts
+++ b/packages/inspect-components/src/usage/index.ts
@@ -14,8 +14,5 @@ export {
   buildConnectionLanes,
   connectionWindow,
 } from "./connectionHistory";
-export type {
-  ConnectionLaneData,
-  ConnectionWindow,
-} from "./connectionHistory";
+export type { ConnectionLaneData, ConnectionWindow } from "./connectionHistory";
 export { fmtClock, fmtCompactDuration } from "./timeFormat";

--- a/packages/inspect-components/src/usage/index.ts
+++ b/packages/inspect-components/src/usage/index.ts
@@ -9,4 +9,13 @@ export {
   buildConfigsByModel,
   buildConfigsByRole,
 } from "./configsForUsage";
+export {
+  adaptiveMaxFromConfig,
+  buildConnectionLanes,
+  connectionWindow,
+} from "./connectionHistory";
+export type {
+  ConnectionLaneData,
+  ConnectionWindow,
+} from "./connectionHistory";
 export { fmtClock, fmtCompactDuration } from "./timeFormat";


### PR DESCRIPTION
Fixes #445

Renames the log viewer's Models tab to Stats and visualizes
EvalStats.connection_limit_history (adaptive-connections controller
scale changes) per the design handoff in #445:

- CONNECTIONS lane in the usage table: start/peak/avg/final stats
  (time-weighted avg), rate-limit count, and an SVG step chart with a
  time axis, configured-max guide, and rate-limit backoff dots
- Per-model change-log modal (Scoring Detail pattern) with time,
  old/new limit, and reason badges
- Narrow (<1000px) layout moves the lane to a full-width strip row
  under its model's row
- Roles view resolves lanes through the role → model alias map
- Lane renders during live evals; hidden for empty/legacy histories

<img width="1195" height="517" alt="Screenshot 2026-07-20 at 7 49 25 PM" src="https://github.com/user-attachments/assets/b1afb15d-a927-4b11-af53-7fa5c32c7125" />

<img width="1193" height="424" alt="Screenshot 2026-07-20 at 7 49 32 PM" src="https://github.com/user-attachments/assets/e20d160a-8af5-4d02-994e-a732e2f4ba6a" />






Co-authored-by: Charles Teague <261654+dragonstyle@users.noreply.github.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


