### PR TITLE
ci: pass MARVIN_TOKEN to the reviewer for ack/stage steps

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,11 @@ jobs:
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review'))
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main
+    # Machine-account PAT for the deterministic ack/stage steps only (eyes
+    # reaction + board stage); never handed to the review agent, which stays
+    # read-only. Absent -> those steps no-op.
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Enables the reviewer's new 👀 ack on `@review` comments and the immediate **Agent Working** stage move when a review starts (reusable-side change: meridianlabs-ai/agents `e1d4061`). The token is consumed only by deterministic pre-checkout steps — never handed to the review agent, which stays read-only. Without this the reviewer keeps prior behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)