### PR TITLE
ci: skip auto-review on draft PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,8 @@ jobs:
     # token and the job would only fail. The `permissions:` block can't override
     # this. Those PRs are instead reviewed on demand via an `@review` comment,
     # which runs as `issue_comment` in the base-repo context (full token access).
+    # Skip draft PRs (auto-reviewed when marked Ready for review; an explicit
+    # `@review` comment still works on a draft).
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.draft != true &&

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,7 @@ jobs:
     # which runs as `issue_comment` in the base-repo context (full token access).
     if: >
       (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft != true &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.actor != 'dependabot[bot]') ||
       (github.event.issue.pull_request != null &&


### PR DESCRIPTION
Adds the example stub's `draft != true` guard this copy predates: draft PRs are no longer auto-reviewed on open/reopen. They get their auto-review when marked **Ready for review** (`ready_for_review` is already subscribed), and an explicit `@review` comment still works on a draft. Local customizations (bot/fork exclusions) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)