### PR TITLE
Add ContentDocument.citations field to generated types

### DIFF
--- a/apps/inspect/e2e/chat-components.spec.ts
+++ b/apps/inspect/e2e/chat-components.spec.ts
@@ -221,6 +221,7 @@ test.describe("chat message rendering", () => {
             document: `${MEDIA_ORIGIN}/document.png`,
             filename: "document.png",
             mime_type: "image/png",
+            citations: false,
           },
         ],
       },

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1128,6 +1128,11 @@ export interface components {
          * @description Document content (e.g. a PDF).
          */
         ContentDocument: {
+            /**
+             * Citations
+             * @default false
+             */
+            citations: boolean;
             /** Document */
             document: string;
             /** Filename */

--- a/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
+++ b/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
@@ -25,6 +25,7 @@ const DOC = {
   document: "data:application/pdf;base64,abc123",
   filename: "report.pdf",
   mime_type: "application/pdf",
+  citations: false,
 };
 
 function toolNode(


### PR DESCRIPTION
Regenerated `packages/inspect-common/src/types/generated.ts` to include the new `citations` field on `ContentDocument`:

- `citations` (boolean, default `false`) - opt-in to enable model-generated citations for text or PDF documents (Anthropic).

Pairs with [UKGovernmentBEIS/inspect_ai#4527](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4527). The inspect_ai PR adds this field to the Python `ContentDocument` model and bumps the OpenAPI schema; once this ts-mono PR merges, that PR will bump its `ts-mono` submodule pin so `check-schema-and-types` can pass.

Generated by `python src/inspect_ai/_view/schema.py` against inspect_ai's updated `inspect-openapi.json` (cherry-picked citations commits onto current inspect_ai main to avoid stale-branch drift). Verified locally: `pnpm --filter @tsmono/inspect-common run typecheck`, `test`, `lint`, and `format:check` all pass; diff is limited to the single additive field.