### PR TITLE
Rewrite Origin header in dev-server API proxies

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -29,6 +29,8 @@ function copyToPythonRepo(): Plugin {
   };
 }
 
+const viewServerUrl = "http://127.0.0.1:7575";
+
 export default defineConfig(({ mode }) => {
   const isLibrary = mode === "library";
 
@@ -126,8 +128,13 @@ export default defineConfig(({ mode }) => {
       server: {
         proxy: {
           "/api": {
-            target: "http://127.0.0.1:7575",
+            target: viewServerUrl,
             changeOrigin: true,
+            // changeOrigin only rewrites Host, not Origin, so mutating
+            // requests (e.g. saving tags) reach the view server with the
+            // dev server's origin and its CSRF check rejects them with
+            // 403 "Forbidden browser origin". Rewrite Origin to match.
+            headers: { origin: viewServerUrl },
           },
         },
       },

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -11,7 +11,10 @@ import {
   findPythonRepoRoot,
   warnIfWatchingWithoutSubmodule,
 } from "../../tooling/python-repo/index.js";
-import { inlineThemeBootstrap } from "../../tooling/vite-plugins/index.js";
+import {
+  inlineThemeBootstrap,
+  rewriteLoopbackOrigin,
+} from "../../tooling/vite-plugins/index.js";
 
 function copyToPythonRepo(): Plugin {
   return {
@@ -130,11 +133,7 @@ export default defineConfig(({ mode }) => {
           "/api": {
             target: viewServerUrl,
             changeOrigin: true,
-            // changeOrigin only rewrites Host, not Origin, so mutating
-            // requests (e.g. saving tags) reach the view server with the
-            // dev server's origin and its CSRF check rejects them with
-            // 403 "Forbidden browser origin". Rewrite Origin to match.
-            headers: { origin: viewServerUrl },
+            configure: rewriteLoopbackOrigin(viewServerUrl),
           },
         },
       },

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -29,6 +29,8 @@ function copyToPythonRepo(): Plugin {
   };
 }
 
+const scoutServerUrl = "http://127.0.0.1:7576";
+
 export default defineConfig(({ mode }) => {
   const isLibrary = mode === "library";
   const baseConfig = {
@@ -110,8 +112,13 @@ export default defineConfig(({ mode }) => {
       server: {
         proxy: {
           "/api": {
-            target: "http://127.0.0.1:7576",
+            target: scoutServerUrl,
             changeOrigin: true,
+            // changeOrigin only rewrites Host, not Origin, so mutating
+            // requests reach the scout server with the dev server's origin
+            // and its CSRF check rejects them with 403 "Forbidden browser
+            // origin". Rewrite Origin to match.
+            headers: { origin: scoutServerUrl },
           },
         },
       },

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -11,7 +11,10 @@ import {
   findPythonRepoRoot,
   warnIfWatchingWithoutSubmodule,
 } from "../../tooling/python-repo/index.js";
-import { inlineThemeBootstrap } from "../../tooling/vite-plugins/index.js";
+import {
+  inlineThemeBootstrap,
+  rewriteLoopbackOrigin,
+} from "../../tooling/vite-plugins/index.js";
 
 function copyToPythonRepo(): Plugin {
   return {
@@ -114,11 +117,7 @@ export default defineConfig(({ mode }) => {
           "/api": {
             target: scoutServerUrl,
             changeOrigin: true,
-            // changeOrigin only rewrites Host, not Origin, so mutating
-            // requests reach the scout server with the dev server's origin
-            // and its CSRF check rejects them with 403 "Forbidden browser
-            // origin". Rewrite Origin to match.
-            headers: { origin: scoutServerUrl },
+            configure: rewriteLoopbackOrigin(scoutServerUrl),
           },
         },
       },

--- a/tooling/vite-plugins/index.js
+++ b/tooling/vite-plugins/index.js
@@ -4,6 +4,31 @@
 
 import { context as esbuildContext } from "esbuild";
 
+const LOOPBACK_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
+
+/**
+ * Proxy `configure` hook that rewrites loopback `Origin` headers to the
+ * proxy target.
+ *
+ * `changeOrigin` only rewrites Host, not Origin, so mutating requests reach
+ * the proxied server with the dev server's origin and its CSRF check rejects
+ * them with 403 "Forbidden browser origin". Rewrite only loopback origins so
+ * genuinely cross-site writes still fail that check.
+ *
+ * @param {string} target the proxy target url, e.g. "http://127.0.0.1:7575"
+ * @returns {import("vite").ProxyOptions["configure"]}
+ */
+export function rewriteLoopbackOrigin(target) {
+  return (proxy) => {
+    proxy.on("proxyReq", (proxyReq, req) => {
+      const origin = req.headers.origin;
+      if (origin && LOOPBACK_ORIGIN.test(origin)) {
+        proxyReq.setHeader("origin", target);
+      }
+    });
+  };
+}
+
 /**
  * Inline a theme-bootstrap module into index.html as a synchronous,
  * render-blocking <script>.


### PR DESCRIPTION
## Problem

Saving a tag in the viewer while running via the vite dev server fails with **403 "Forbidden browser origin"** in the tag dialog.

The error comes from inspect_ai's view server: its `BrowserOriginMiddleware` (CSRF protection) rejects mutating requests whose `Origin` header doesn't match the server's own loopback origin. The vite dev proxy forwards the browser's `Origin: http://localhost:5173` untouched — `changeOrigin: true` only rewrites `Host` — so the view server on `127.0.0.1:7575` sees a foreign origin and rejects the request. Reads still work because browsers don't attach `Origin` to same-origin GETs; only writes (like tag edits) hit the check.

## Fix

Rewrite the `Origin` header to the proxy target in the dev-server `/api` proxy, so the local dev hop presents an origin the view server trusts:

- `apps/inspect/vite.config.ts` — proxy to inspect view server (`127.0.0.1:7575`)
- `apps/scout/vite.config.ts` — same latent issue for the scout server (`127.0.0.1:7576`)

Note: if pointing the viewer directly at a view server on another origin via `VIEW_SERVER_API_URL` (bypassing the proxy), the server must instead be started with `--trusted-origin <dev server origin>`.

## Testing

- Both app typechecks (`pnpm typecheck`) pass
- Both vite configs load cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYuJTNSBZ9A2iAf2riNcD1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYuJTNSBZ9A2iAf2riNcD1)_