### PR TITLE
Transcript navigation small followups

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -909,6 +909,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                   id={chatListId}
                   messages={effectiveMessages}
                   initialMessageId={sampleDetailNavigation.message}
+                  followRequested={sampleDetailNavigation.follow}
                   display={chatDisplay}
                   labels={messagesSearchLabels}
                   linking={chatLinking}

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { useSyncExternalStore } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "@tsmono/inspect-common/types";
+import { ExtendedFindProvider } from "@tsmono/react/components";
+import {
+  ComponentStateProvider,
+  type ComponentStateHooks,
+} from "@tsmono/react/state";
+
+import { ChatViewVirtualList } from "./ChatViewVirtualList";
+
+const messages = [
+  { id: "m-1", role: "assistant", content: "one" },
+  { id: "m-2", role: "assistant", content: "two" },
+] as unknown as ChatMessage[];
+
+// jsdom has no scrollTo; VirtualList calls it during mount/follow.
+beforeEach(() => {
+  Element.prototype.scrollTo = function () {};
+});
+
+/** Mounts the list over an inspectable store and returns the persisted follow flag. */
+function mountFollow(props: {
+  running: boolean;
+  initialMessageId?: string;
+  followRequested?: boolean;
+}) {
+  const store = new Map<string, unknown>();
+  const listeners = new Set<() => void>();
+  let version = 0;
+  const key = (id: string, prop: string) => `${id}::${prop}`;
+  const write = (id: string, prop: string, value: unknown) => {
+    store.set(key(id, prop), value);
+    version++;
+    listeners.forEach((l) => l());
+  };
+  const hooks: ComponentStateHooks = {
+    useValue: (id, prop, defaultValue) => {
+      useSyncExternalStore(
+        (cb) => (listeners.add(cb), () => listeners.delete(cb)),
+        () => version
+      );
+      return store.has(key(id, prop)) ? store.get(key(id, prop)) : defaultValue;
+    },
+    useSetValue: () => write,
+    useRemoveValue: () => (id, prop) => write(id, prop, undefined),
+    useEntries: () => undefined,
+    useRemoveAll: () => () => {},
+    useRemoveByPrefix: () => () => {},
+  };
+
+  render(
+    <ComponentStateProvider hooks={hooks}>
+      <ExtendedFindProvider>
+        <ChatViewVirtualList id="chat" messages={messages} {...props} />
+      </ExtendedFindProvider>
+    </ComponentStateProvider>
+  );
+  return store.get("chat-chat::follow");
+}
+
+describe("ChatViewVirtualList live-follow ownership", () => {
+  it("stands down on a ?message= landing into a live sample", () => {
+    // The landing owns the scroll position, so `live` must not arm the tail.
+    expect(mountFollow({ running: true, initialMessageId: "m-1" })).toBe(false);
+  });
+
+  it("an explicit follow=1 still arms on a ?message= landing", () => {
+    expect(
+      mountFollow({
+        running: true,
+        initialMessageId: "m-1",
+        followRequested: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 
 import type { ChatMessage } from "@tsmono/inspect-common/types";
@@ -65,6 +66,9 @@ export interface ChatViewVirtualListProps {
   messages: ChatMessage[];
   className?: string | string[];
   initialMessageId?: string | null;
+  /** Explicit `follow=1` URL param: arm live-tail at mount even on a
+   *  `?message=` landing, matching the transcript tab. */
+  followRequested?: boolean;
   scrollRef?: RefObject<HTMLDivElement | null>;
   running?: boolean;
   backfilling?: boolean;
@@ -84,6 +88,7 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
     id,
     messages,
     initialMessageId,
+    followRequested,
     className,
     scrollRef,
     running,
@@ -96,6 +101,10 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
     tools,
   }: ChatViewVirtualListProps) {
     const listHandle = useRef<VirtualListHandle>(null);
+
+    // Frozen at mount, mirroring TranscriptViewNodes: a ?message= landing owns
+    // the scroll position, so follow must not auto-arm from a live sample.
+    const [navOwned] = useState(() => !!initialMessageId);
 
     useEffect(() => {
       onNativeFindChanged?.(false);
@@ -238,6 +247,8 @@ export const ChatViewVirtualList: FC<ChatViewVirtualListProps> = memo(
         initialIndex={initialMessageIndex}
         scrollPaddingStart={kChatScrollPaddingStart}
         live={running}
+        navOwned={navOwned}
+        followRequested={followRequested}
         scrollToTopOnFinish={scrollToTopOnFinish}
         components={chatComponents}
         smoothScroll={false}

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -381,3 +381,78 @@ describe("useTranscriptTimeline punch-down views", () => {
     expect(result.current.views.stack).toHaveLength(0);
   });
 });
+
+// =============================================================================
+// Orphaned selection
+// =============================================================================
+
+describe("useTranscriptTimeline orphaned selection", () => {
+  const events = [
+    makeModelEvent("evt-main", 0, 3),
+    makeModelEvent("evt-util", 4, 8),
+  ];
+
+  const utilityTimeline: ServerTimeline = {
+    name: "default",
+    description: "Utility lane test",
+    root: makeServerSpan({
+      id: "root",
+      name: "Transcript",
+      content: [
+        makeServerEvent("evt-main"),
+        makeServerSpan({
+          id: "util-a",
+          name: "Utility A",
+          span_type: "agent",
+          utility: true,
+          content: [makeServerEvent("evt-util")],
+        }),
+      ],
+    }),
+  };
+  const serverTimelines = [utilityTimeline];
+
+  it("keeps the hidden events out when the utility toggle drops the selected lane", () => {
+    const { result, rerender } = renderHook(
+      (props: { includeUtility: boolean; selected: string | null }) =>
+        useTranscriptTimeline({
+          events,
+          serverTimelines,
+          timelineOptions: { includeUtility: props.includeUtility },
+          timelineProps: { selected: props.selected, onSelect: vi.fn() },
+        }),
+      {
+        initialProps: {
+          includeUtility: true,
+          selected: null as string | null,
+        },
+      }
+    );
+    const utilKey = result.current.state.rows.find(
+      (r) => r.name === "Utility A"
+    )?.key;
+    expect(utilKey).toBeDefined();
+
+    rerender({ includeUtility: true, selected: utilKey! });
+    expect(result.current.selection.events.map((e) => e.uuid)).toContain(
+      "evt-util"
+    );
+
+    // The selected row is gone now. Pre-fix this fell back to the unscoped
+    // stream, putting the just-hidden event back on screen.
+    rerender({ includeUtility: false, selected: utilKey! });
+    expect(result.current.selection.events.map((e) => e.uuid)).toEqual([
+      "evt-main",
+    ]);
+  });
+
+  it("still returns every event when the timeline has no swimlane rows", () => {
+    const { result } = renderHook(() =>
+      useTranscriptTimeline({ events: [makeModelEvent("flat-1", 0, 3)] })
+    );
+
+    expect(result.current.selection.events.map((e) => e.uuid)).toEqual([
+      "flat-1",
+    ]);
+  });
+});

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts
@@ -256,8 +256,19 @@ export function useTranscriptTimeline(
   );
 
   const { selectedEvents, sourceSpans, branchScrollTarget } = useMemo(() => {
-    const parsed = parseSelection(state.selected);
-    const spans = getSelectedSpans(state.rows, state.selected);
+    // A key that matches no row is orphaned, not "nothing selected" — the
+    // utility toggle hiding the selected lane is the common way to get here.
+    // Scope to the root row instead of the unscoped stream, which would put
+    // the just-hidden events back on screen and inflate outline/turn counts.
+    // The stale key is deliberately kept so re-enabling the toggle restores
+    // the selection.
+    let selection = state.selected;
+    let spans = getSelectedSpans(state.rows, selection);
+    if (spans.length === 0 && state.rows.length > 0) {
+      selection = state.rows[0]!.key;
+      spans = getSelectedSpans(state.rows, selection);
+    }
+    const parsed = parseSelection(selection);
     if (spans.length === 0) {
       return {
         selectedEvents: events,
@@ -287,7 +298,7 @@ export function useTranscriptTimeline(
       includeUtility,
       regionIndex: parsed?.regionIndex ?? null,
       showBranches,
-      branchPrefix: getBranchPrefix(state.rows, state.selected),
+      branchPrefix: getBranchPrefix(state.rows, selection),
     });
     return {
       selectedEvents: collected.events,


### PR DESCRIPTION
Two small follow-ups to #354 that Opus 5 triaged and I was able to reproduce the bugs on old version and the fixes:

1. An orphaned swimlane selection fell back to the unscoped event stream:
   hiding the selected lane (routine with the utility-agent toggle) put the
   hidden events back on screen and inflated turn counts. Regression from #354.
   It scopes to the root row and keeps the stale key, so re-enabling the toggle
   restores the selection — #431 clears instead, say if you'd prefer that.
2. A `?message=` deep link into a running sample armed live-follow and got
   yanked to the tail on the next event. `followRequested` is forwarded too, so
   an explicit `?follow=1` still tails.

Full report including repro steps in https://peter.hozak.info/claude/pr460-transcript-nav-followups.html