### PR TITLE
Regenerate types: ContentDocument.citations

### DIFF
--- a/apps/inspect/e2e/chat-components.spec.ts
+++ b/apps/inspect/e2e/chat-components.spec.ts
@@ -221,6 +221,7 @@ test.describe("chat message rendering", () => {
             document: `${MEDIA_ORIGIN}/document.png`,
             filename: "document.png",
             mime_type: "image/png",
+            citations: false,
           },
         ],
       },

--- a/apps/scout/e2e/chat-components.spec.ts
+++ b/apps/scout/e2e/chat-components.spec.ts
@@ -279,6 +279,7 @@ test.describe("chat message rendering", () => {
                 document: `${MEDIA_ORIGIN}/document.png`,
                 filename: "document.png",
                 mime_type: "image/png",
+                citations: false,
               },
             ],
           },

--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1276,6 +1276,11 @@ export interface components {
          * @description Document content (e.g. a PDF).
          */
         ContentDocument: {
+            /**
+             * Citations
+             * @default false
+             */
+            citations: boolean;
             /** Document */
             document: string;
             /** Filename */

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1128,6 +1128,11 @@ export interface components {
          * @description Document content (e.g. a PDF).
          */
         ContentDocument: {
+            /**
+             * Citations
+             * @default false
+             */
+            citations: boolean;
             /** Document */
             document: string;
             /** Filename */

--- a/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
+++ b/packages/inspect-components/src/transcript/transcriptVisualActions.test.ts
@@ -25,6 +25,7 @@ const DOC = {
   document: "data:application/pdf;base64,abc123",
   filename: "report.pdf",
   mime_type: "application/pdf",
+  citations: false,
 };
 
 function toolNode(


### PR DESCRIPTION
Regenerated types for `ContentDocument.citations` (new required bool) added in UKGovernmentBEIS/inspect_ai#4642.

- `packages/inspect-common/src/types/generated.ts` — regenerated via `schema.py` in inspect_ai
- `apps/scout/src/types/generated.ts` — regenerated via `export_openapi_schema.py` in inspect_scout with the inspect_ai branch installed (required field on a shared type breaks structural compat with scout's duplicate otherwise)
- e2e/test fixtures constructing `ContentDocument` literals gain `citations: false`

Merge order: this PR merges first, then the inspect_ai PR bumps its submodule pointer. Please merge only when UKGovernmentBEIS/inspect_ai#4642 is otherwise green and approved, and merge that promptly after.