### PR TITLE
perf(viewer): production build configuration

### DIFF
--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -113,7 +113,7 @@ export default defineConfig(({ mode }) => {
         },
         cssCodeSplit: false,
         sourcemap: true,
-        minify: false,
+        minify: true,
       },
     };
   } else {
@@ -126,7 +126,6 @@ export default defineConfig(({ mode }) => {
         warnIfWatchingWithoutSubmodule("inspect_ai"),
         copyToPythonRepo(),
       ],
-      mode: "development",
       base: "",
       server: {
         // Pinned so `pnpm dev` from the root always gives inspect 5173 and
@@ -144,12 +143,23 @@ export default defineConfig(({ mode }) => {
       build: {
         outDir: "dist",
         emptyOutDir: true,
-        minify: false,
+        minify: mode !== "development",
         rollupOptions: {
           output: {
-            entryFileNames: `assets/index.js`,
-            chunkFileNames: `assets/[name].js`,
-            assetFileNames: `assets/[name].[ext]`,
+            entryFileNames: `assets/[name]-[hash].js`,
+            chunkFileNames: `assets/[name]-[hash].js`,
+            assetFileNames: `assets/[name]-[hash].[ext]`,
+            manualChunks(id) {
+              if (
+                id.includes("mathjax") ||
+                id.includes("markdown-it-mathjax3")
+              ) {
+                return "vendor-mathjax";
+              }
+              if (id.includes("@codemirror") || id.includes("@lezer")) {
+                return "vendor-codemirror";
+              }
+            },
           },
         },
         sourcemap: true,


### PR DESCRIPTION
Replaces #343 after rebasing onto the current main.

- enable production minification
- split MathJax and CodeMirror vendor chunks
- emit content-hashed JavaScript and asset filenames