### PR TITLE
Stop transcript find from counting matches that aren't on screen

### DIFF
--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -150,6 +150,7 @@ describe("extractEventFields — model error / traceback", () => {
       event: {
         event: "model",
         model: "test/model",
+        input: [],
         error: "API rate limit exceeded",
         traceback: "Traceback (most recent call last): ...",
       },
@@ -887,5 +888,95 @@ describe("eventSearchText", () => {
       })
     );
     expect(texts).toEqual([]);
+  });
+});
+
+describe("extractEventFields — model input mirrors the SUMMARY panel", () => {
+  const modelEventNode = (
+    input: Record<string, unknown>[],
+    output: Record<string, unknown> = { choices: [] }
+  ) =>
+    makeNode({
+      event: "model",
+      model: "test/model",
+      role: null,
+      input,
+      output,
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+  it.each([
+    {
+      desc: "skips input messages the panel does not draw",
+      input: [
+        { role: "system", content: "HEAD_OF_HISTORY" },
+        { role: "user", content: "OLD_TURN" },
+        { role: "assistant", content: "old answer" },
+        { role: "tool", content: "tool result" },
+        { role: "user", content: "CURRENT_TURN" },
+      ],
+      indexed: ["CURRENT_TURN"],
+      skipped: ["HEAD_OF_HISTORY", "OLD_TURN"],
+    },
+    {
+      // [system, user] is entirely a trailing run, so nothing is hidden
+      desc: "indexes a first model call's input in full",
+      input: [
+        { role: "system", content: "TASK_PROMPT" },
+        { role: "user", content: "TASK_QUESTION" },
+      ],
+      indexed: ["TASK_PROMPT", "TASK_QUESTION"],
+      skipped: [],
+    },
+    {
+      desc: "indexes a trailing assistant compaction message, and only that",
+      input: [
+        { role: "user", content: "OLD_TURN" },
+        { role: "assistant", content: "COMPACTION_SUMMARY" },
+      ],
+      indexed: ["COMPACTION_SUMMARY"],
+      skipped: ["OLD_TURN"],
+    },
+    {
+      desc: "stops at a trailing tool message, which the panel omits by default",
+      input: [
+        { role: "user", content: "PROMPT" },
+        { role: "tool", content: "TOOL_RESULT" },
+      ],
+      indexed: [],
+      skipped: ["TOOL_RESULT", "PROMPT"],
+    },
+  ])("$desc", ({ input, indexed, skipped }) => {
+    const texts = eventSearchText(modelEventNode(input));
+    for (const text of indexed) {
+      expect(texts).toContain(text);
+    }
+    for (const text of skipped) {
+      expect(texts).not.toContain(text);
+    }
+  });
+
+  it("skips assistant tool_calls, which the following tool event draws", () => {
+    const texts = eventSearchText(
+      modelEventNode([{ role: "user", content: "prompt" }], {
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  function: "CANCEL_SCORE",
+                  arguments: { job_id: "JOB_ID_BLOB" },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+    expect(texts).not.toContain("CANCEL_SCORE");
+    expect(texts.join("\n")).not.toContain("JOB_ID_BLOB");
   });
 });

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -1,5 +1,6 @@
 import type { Content } from "@tsmono/inspect-common/types";
 
+import { recentInputMessages } from "./recentInputMessages";
 import type { EventType } from "./types";
 import { EventNode } from "./types";
 
@@ -64,7 +65,9 @@ export const extractEventFields = (event: EventType): [string, string][] => {
       if (modelEvent.model) {
         fields.push(["model", modelEvent.model]);
       }
-      // Extract text from model output
+      // Assistant `tool_calls` stay unindexed: the following tool event draws
+      // them and indexes `function`/`arguments` itself, and ModelEventView
+      // drops them entirely when `showToolCalls` is false.
       if (modelEvent.output?.choices) {
         for (const choice of modelEvent.output.choices) {
           for (const text of extractContentText(choice.message.content)) {
@@ -72,14 +75,21 @@ export const extractEventFields = (event: EventType): [string, string][] => {
           }
         }
       }
-      // Extract text from user/system input messages shown in the view
-      if (modelEvent.input) {
-        for (const msg of modelEvent.input) {
-          if (msg.role === "user" || msg.role === "system") {
-            for (const text of extractContentText(msg.content)) {
-              fields.push([msg.role, text]);
-            }
-          }
+      // Index only the messages ModelEventView draws. Text outside them never
+      // reaches the DOM, so `window.find` has nothing to anchor on and the
+      // match counter freezes mid-walk. This under-counts an expanded panel
+      // ("Show all messages", MESSAGES tab) — a miss beats a phantom.
+      //
+      // `hasToolEvents` stays undefined because `findAllMatches` re-derives
+      // fields from raw events, where no node context exists.
+      const drawnMessages = recentInputMessages(modelEvent.input, {
+        agentResultsFiltered: !!(modelEvent as Record<string, unknown>)
+          .agentResultsFiltered,
+        hasToolEvents: undefined,
+      });
+      for (const msg of drawnMessages) {
+        for (const text of extractContentText(msg.content)) {
+          fields.push([msg.role, text]);
         }
       }
       // API-call errors / tracebacks surfaced on the model event itself


### PR DESCRIPTION
## Summary

Searching a large transcript for `cancel` reported 280 matches, but 136 of them (49%) were in text the transcript never draws. The find index walked a model event's entire `input` history, while the SUMMARY panel draws only the trailing run of user/system messages. A phantom match has no DOM node for `window.find` to anchor on, so the find fails silently *after* the view has already scrolled — the counter freezes and Next walks turn after turn with nothing highlighted.

The index now consumes the same message-selection rule the panel renders from, extracted into a single module so the two can't drift apart again. On the sample that prompted this, the count drops from 280 to 146 and every reported match anchors in the DOM.

Assistant `tool_calls` remain deliberately unindexed on model events: the tool event immediately below draws them and already indexes `function` and `arguments`, so indexing them here would double-count — and would be a phantom whenever the panel omits them. A comment and a test record that.

## Notes for reviewers

**This also changes the text export.** `eventsToStr` backs "Copy → Transcript" and "Download → Transcript.txt" and shares `extractEventFields`, so it inherits the trailing-run rule. That drops a large duplication — the task prompt was repeated once per model call, 68 times on the sample above — but completeness is arguably the point of a text export, so it's a deliberate call rather than a side effect. A characterisation test pins the new shape either way. Happy to give the export its own scope rule instead if you'd rather.

**A latent rendering bug is preserved, not fixed.** In the extracted walk, `event.input.slice(offset)` with `offset = -1` yields only the *trailing* element, so when `input` ends with an assistant message the backward walk breaks on that same message and never reaches earlier user/system messages — the panel shows only the assistant message. The surrounding comment reads as though `slice(0, offset)` was intended. Fixing it changes what the SUMMARY panel draws, which this PR is scoped out of, so it is preserved, documented in the module, and pinned by a test. Happy to file it as a follow-up.

## Test plan

CI covers tests, types and lint. Beyond that, I ran the modified viewer against the sample that prompted the investigation (30,175 events, 2,655 turns, 162 MB uncompressed):

- Searching `cancel` reports **146** matches, down from 280.
- Stepping through with Next, the counter advances monotonically and every match resolves to a visible, highlighted node in the panel's Summary tab. Previously the counter froze partway and Next scrolled through turns with an empty selection.
