### PR TITLE
turbo: invalidate caches when shared tooling changes

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "//": "Shared tooling is outside every package's own input set, so without this a rule/compiler-option change is a cache hit and CI reports green without re-running lint or typecheck.",
+  "globalDependencies": [
+    "tooling/eslint-config/**",
+    "tooling/tsconfig/**",
+    "tooling/prettier-config/**"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

One-line-of-config fix with outsized consequences: turbo task caches (including CI's, restored via `restore-keys: turbo-`) did not invalidate when shared tooling changed.

## The bug

Shared tooling (`tooling/eslint-config`, `tooling/tsconfig`, `tooling/prettier-config`) sits outside every package's own input set, so a lint-rule or compiler-option change was a cache hit. Verified empirically: adding an error-level rule to `eslint-config/base.js` left `turbo run lint` reporting 9/9 successful (all cached) while `--force` failed 6 packages. In CI this means a PR that only tightens a shared rule reports green without linting anything.

## The fix

`globalDependencies` makes shared-tooling changes part of every task's hash. Verified the same experiment now invalidates and fails without `--force`.

## Scope note

Earlier revisions of this branch also enabled `@typescript-eslint/switch-exhaustiveness-check`; that was evaluated (7 sites, 2 minor pre-existing gaps in transcript search/copy text extraction, no fixes retained) and deliberately dropped. The two known gaps: checkpoint events emit no search/copy fields in `eventText.ts` (so `eventsToStr` omits them entirely), and `messageSearchText.ts` emits nothing for image/audio/video/data/document content that `MessageContent` renders findable text for.

https://claude.ai/code/session_01VRaoUuTbvv7GmEPDPiPHtv