### PR TITLE
feat(inspect): let embedders render their own chrome around <App/>

### DIFF
--- a/apps/inspect/src/app_config/index.ts
+++ b/apps/inspect/src/app_config/index.ts
@@ -18,6 +18,7 @@ export {
   APP_CONFIG_KEY, // TODO: Exported for tests?! review
   getApi,
   useAppConfig,
+  useAppConfigAsync,
   useAbsLogDir,
   useLogDir,
 } from "./hooks";

--- a/apps/inspect/src/embed.tsx
+++ b/apps/inspect/src/embed.tsx
@@ -1,0 +1,34 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { FC, ReactNode } from "react";
+
+import { useAppConfigAsync } from "./app_config";
+import { queryClient } from "./state/queryClient";
+
+/**
+ * Supplies the viewer's react-query client to a subtree.
+ *
+ * Standalone `inspect view` gets this from `<App/>` internally. External
+ * embedders that call the viewer's selection hooks (`useSelectedSampleSummary`,
+ * `useSelectedScores`, `useLogSelection`) from their OWN chrome — rendered as a
+ * sibling of `<App/>`, not a descendant — must wrap that chrome in this provider
+ * so those hooks resolve the same react-query client the viewer uses internally
+ * (the data-flow refactor in #389 moved config/sample loading onto react-query).
+ * Without it the hooks throw "No QueryClient set". Safe to nest: `<App/>`
+ * provides the same client again for its own subtree.
+ */
+export const InspectQueryClientProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+/**
+ * Whether the viewer's app config has resolved. `<App/>` gates its own content
+ * on this via `<AppConfigGate>`, but the viewer's data hooks (`useLogDir`,
+ * `useSelectedSampleSummary`, ...) THROW ("App config not loaded") if called
+ * before it resolves. Embedders calling those hooks in their own chrome must
+ * hold off until this returns true. Must be called within an
+ * `<InspectQueryClientProvider>`.
+ */
+export const useViewerReady = (): boolean =>
+  useAppConfigAsync().data !== undefined;

--- a/apps/inspect/src/index.ts
+++ b/apps/inspect/src/index.ts
@@ -21,6 +21,12 @@ export { viewServerApi as createViewServerApi } from "./client/api/view-server/a
 // different dir (rebuilding the api through the same factory).
 export { setApiFactory, setLogRoot } from "./app_config";
 
+// Embedder react-query provider — wrap chrome that calls the viewer's selection
+// hooks outside <App/> so they resolve the viewer's react-query client.
+// useViewerReady gates that chrome until app config resolves (the hooks throw
+// before then).
+export { InspectQueryClientProvider, useViewerReady } from "./embed";
+
 // Client API - Types
 export type {
   Capabilities,


### PR DESCRIPTION
## Summary

An app that hosts the viewer in-process and renders its own chrome around `<App/>` — a status bar, a side pane keyed to the selected sample — has to read the viewer's selection state from outside `<App/>`. Since #389 it can't: the selection hooks (`useSelectedSampleSummary`, `useSelectedScores`, `useLogSelection`) resolve through react-query and the gated app config, so calling them from a sibling of `<App/>` throws `No QueryClient set`, and then `App config not loaded` once a provider is added — the hooks keep throwing until the config query settles. Neither piece is reachable from outside the package: `queryClient` is a private module singleton, and nothing reports when the config has resolved.

Export both, so an embedder can wrap its chrome in the viewer's own react-query client and hold that chrome off until the hooks are safe to call. Standalone `inspect view` is unaffected — `<App/>` already provides both for its own subtree.

## Usage

The provider goes above both, so the chrome and the viewer share one client:

```tsx
<InspectQueryClientProvider>
  <MyChrome />   {/* renders its hook-using parts only once useViewerReady() */}
  <App />
</InspectQueryClientProvider>
```
