### PR TITLE
Fix dependabot alerts: react-router 7->8, brace-expansion@5 override

### DIFF
--- a/.claude/skills/dependabot-fix/SKILL.md
+++ b/.claude/skills/dependabot-fix/SKILL.md
@@ -89,6 +89,9 @@ branch and commit once. Don't open per-alert PRs; the override edits all land
 in the same two files (package.json + lockfile) anyway, and one PR keeps
 review/CI cost flat. Commit message: concise list of packages bumped and
 alert numbers. PR body: one line per alert (number, package, severity).
+Never write alert numbers as `#N` in PR titles/bodies — GitHub autolinks
+that to PR/issue N. Write "dependabot alert N", ideally linked to
+`https://github.com/meridianlabs-ai/ts-mono/security/dependabot/N`.
 Alerts auto-close once the merged lockfile no longer contains vulnerable
 versions — don't dismiss them manually.
 

--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -125,7 +125,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-popper": "^2.3.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {

--- a/apps/inspect/src/app/App.tsx
+++ b/apps/inspect/src/app/App.tsx
@@ -18,7 +18,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
 import ClipboardJS from "clipboard";
 import { FC, useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router/dom";
 
 import {
   ComponentIconProvider,

--- a/apps/inspect/src/app/flow/FlowButton.tsx
+++ b/apps/inspect/src/app/flow/FlowButton.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { forwardRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 import { ApplicationIcons } from "../appearance/icons";
 import { useLogOrSampleRouteParams } from "../routing/url";

--- a/apps/inspect/src/app/flow/FlowPanel.tsx
+++ b/apps/inspect/src/app/flow/FlowPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { usePrismHighlight } from "@tsmono/react/hooks";
 import { dirname } from "@tsmono/util";

--- a/apps/inspect/src/app/log-list/LogsPanel.tsx
+++ b/apps/inspect/src/app/log-list/LogsPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 
 import { EvalSet } from "@tsmono/inspect-common/types";
 import { ErrorPanel, ProgressBar } from "@tsmono/react/components";

--- a/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
+++ b/apps/inspect/src/app/log-list/grid/LogListGrid.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import type { Condition, OrderByModel } from "@tsmono/inspect-common/query";
 import type {

--- a/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
+++ b/apps/inspect/src/app/log-view/LogSampleDetailView.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useEffect } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 
 import { useAppConfig } from "../../app_config";
 import { kLogViewSamplesTabId } from "../../constants";

--- a/apps/inspect/src/app/log-view/LogViewContainer.tsx
+++ b/apps/inspect/src/app/log-view/LogViewContainer.tsx
@@ -4,7 +4,7 @@ import {
   useLocation,
   useNavigate,
   useSearchParams,
-} from "react-router-dom";
+} from "react-router";
 
 import { kLogViewSamplesTabId } from "../../constants";
 import { selectLogFile, unloadLog } from "../../state/actions";

--- a/apps/inspect/src/app/navbar/Navbar.tsx
+++ b/apps/inspect/src/app/navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, Fragment, ReactNode, useMemo, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { useBreadcrumbTruncation } from "@tsmono/react/hooks";
 import { basename, dirname, ensureTrailingSlash } from "@tsmono/util";

--- a/apps/inspect/src/app/navbar/ViewSegmentedControl.tsx
+++ b/apps/inspect/src/app/navbar/ViewSegmentedControl.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { SegmentedControl } from "@tsmono/react/components";
 

--- a/apps/inspect/src/app/routing/AppRouter.tsx
+++ b/apps/inspect/src/app/routing/AppRouter.tsx
@@ -5,7 +5,7 @@ import {
   Outlet,
   useLocation,
   useNavigate,
-} from "react-router-dom";
+} from "react-router";
 
 import {
   AppErrorBoundary,

--- a/apps/inspect/src/app/routing/logNavigation.ts
+++ b/apps/inspect/src/app/routing/logNavigation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router";
 
 import { useLogDir } from "../../app_config";
 import { useStore } from "../../state/store";

--- a/apps/inspect/src/app/routing/sampleNavigation.ts
+++ b/apps/inspect/src/app/routing/sampleNavigation.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import { navigateAndForget } from "@tsmono/react/hooks";
 

--- a/apps/inspect/src/app/routing/url.ts
+++ b/apps/inspect/src/app/routing/url.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router";
 
 import { useLogDir } from "../../app_config";
 import {

--- a/apps/inspect/src/app/routing/urlLinking.test.tsx
+++ b/apps/inspect/src/app/routing/urlLinking.test.tsx
@@ -8,7 +8,7 @@
 // (which, when embedded — e.g. Hawk's /eval-set/<id> page — is not just "/").
 import { renderHook } from "@testing-library/react";
 import { ReactNode } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { StoreState } from "../../state/store";

--- a/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
+++ b/apps/inspect/src/app/samples-panel/SampleDetailView.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { useAppConfig, useLogDir } from "../../app_config";
 import { useStore } from "../../state/store";

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { EvalSample, EvalSpec } from "@tsmono/inspect-common/types";
 import {

--- a/apps/inspect/src/app/samples/event/SampleEventView.tsx
+++ b/apps/inspect/src/app/samples/event/SampleEventView.tsx
@@ -1,5 +1,5 @@
 import { FC, useCallback, useEffect, useMemo } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import {
   FocusTurnView,

--- a/apps/inspect/src/app/samples/print/SamplePrintView.tsx
+++ b/apps/inspect/src/app/samples/print/SamplePrintView.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useMemo, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { ChatView } from "@tsmono/inspect-components/chat";

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
@@ -8,7 +8,7 @@
 // navigation (markers, outline links) must still use the bare hash route.
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createRef } from "react";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { isHostedEnvironment } from "@tsmono/util";

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
   useRef,
 } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router";
 
 import type { Timeline as ServerTimeline } from "@tsmono/inspect-common/types";
 import {

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -101,7 +101,7 @@ export default defineConfig(({ mode }) => {
             globals: {
               react: "React",
               "react-dom": "ReactDOM",
-              "react-router-dom": "ReactRouterDOM",
+              "react-router": "ReactRouterDOM",
             },
             assetFileNames: (assetInfo) => {
               if (assetInfo.name && assetInfo.name.endsWith(".css")) {

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -98,11 +98,6 @@ export default defineConfig(({ mode }) => {
             id.startsWith("mathjax-full/") ||
             id === "markdown-it-mathjax3",
           output: {
-            globals: {
-              react: "React",
-              "react-dom": "ReactDOM",
-              "react-router": "ReactRouterDOM",
-            },
             assetFileNames: (assetInfo) => {
               if (assetInfo.name && assetInfo.name.endsWith(".css")) {
                 return "styles/[name].[ext]";

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -118,7 +118,7 @@
     "markdown-it": "^14.3.0",
     "prismjs": "^1.30.0",
     "react-popper": "^2.3.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "zustand": "^5.0.14"
   }
 }

--- a/apps/scout/src/App.tsx
+++ b/apps/scout/src/App.tsx
@@ -10,7 +10,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "@vscode/codicons/dist/codicon.css";
 
 import { createContext, FC, useEffect, useLayoutEffect, useMemo } from "react";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router/dom";
 
 import "prismjs";
 import "prismjs/components/prism-bash";

--- a/apps/scout/src/AppRouter.tsx
+++ b/apps/scout/src/AppRouter.tsx
@@ -1,10 +1,5 @@
 import { FC, useCallback, useEffect, useMemo } from "react";
-import {
-  createHashRouter,
-  Outlet,
-  useLocation,
-  useParams,
-} from "react-router-dom";
+import { createHashRouter, Outlet, useLocation, useParams } from "react-router";
 
 import {
   ComponentNavigationProvider,

--- a/apps/scout/src/app/components/ActivityBarLayout.tsx
+++ b/apps/scout/src/app/components/ActivityBarLayout.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { useLoggingNavigate } from "../../debugging/navigationDebugging";
 import {

--- a/apps/scout/src/app/components/BreadCrumbs.tsx
+++ b/apps/scout/src/app/components/BreadCrumbs.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, Fragment, useMemo, useRef } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import {
   BreadcrumbSegment,

--- a/apps/scout/src/app/components/NavButtons.tsx
+++ b/apps/scout/src/app/components/NavButtons.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import styles from "./NavButtons.module.css";
 

--- a/apps/scout/src/app/components/ProjectBar.tsx
+++ b/apps/scout/src/app/components/ProjectBar.tsx
@@ -1,6 +1,6 @@
 import { clsx } from "clsx";
 import { FC } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { useLoggingNavigate } from "../../debugging/navigationDebugging";
 import { ApplicationIcons } from "../../icons";

--- a/apps/scout/src/app/components/ScansNavbar.tsx
+++ b/apps/scout/src/app/components/ScansNavbar.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode, useContext, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { dirname } from "@tsmono/util";
 

--- a/apps/scout/src/app/components/TranscriptsNavbar.tsx
+++ b/apps/scout/src/app/components/TranscriptsNavbar.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext, useMemo } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router";
 
 import { AppModeContext } from "../../App";
 import { ApplicationIcons } from "../../icons";

--- a/apps/scout/src/app/hooks/useScanRoute.ts
+++ b/apps/scout/src/app/hooks/useScanRoute.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 import { join } from "@tsmono/util";
 

--- a/apps/scout/src/app/project/ProjectPanel.tsx
+++ b/apps/scout/src/app/project/ProjectPanel.tsx
@@ -4,7 +4,7 @@ import {
   VscodeFormHelper,
 } from "@vscode-elements/react-elements";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useBlocker } from "react-router-dom";
+import { useBlocker } from "react-router";
 
 import { Modal } from "@tsmono/react/components";
 import { useDocumentTitle } from "@tsmono/react/hooks";

--- a/apps/scout/src/app/scan/ScanPanel.tsx
+++ b/apps/scout/src/app/scan/ScanPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import React, { useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { ErrorPanel, LoadingBar } from "@tsmono/react/components";
 import { useDocumentTitle } from "@tsmono/react/hooks";

--- a/apps/scout/src/app/scan/ScanPanelBody.tsx
+++ b/apps/scout/src/app/scan/ScanPanelBody.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import {
   JSONPanel,

--- a/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
+++ b/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, Fragment, useCallback, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { LabeledValue } from "@tsmono/react/components";
 import { VirtualList } from "@tsmono/react/virtual";

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, Fragment, useCallback, useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { PopOver } from "@tsmono/react/components";
 

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx
@@ -1,7 +1,7 @@
 import { ColumnTable } from "arquero";
 import clsx from "clsx";
 import { FC, useCallback, useEffect, useMemo, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { LoadingBar, NoContentsPanel } from "@tsmono/react/components";
 import { VirtualList } from "@tsmono/react/virtual";

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, memo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { MarkdownReference } from "@tsmono/react/components";
 import {

--- a/apps/scout/src/app/scan/scanners/results/ScannerResultsBody.tsx
+++ b/apps/scout/src/app/scan/scanners/results/ScannerResultsBody.tsx
@@ -1,7 +1,7 @@
 import { ColumnTable } from "arquero";
 import clsx from "clsx";
 import { FC, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { ErrorPanel, NoContentsPanel } from "@tsmono/react/components";
 

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import {
   JSONPanel,

--- a/apps/scout/src/app/scannerResult/result/ResultBody.test.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultBody.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Event } from "@tsmono/inspect-common/types";

--- a/apps/scout/src/app/scannerResult/result/ResultBody.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultBody.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { FC, useEffect, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { ChatViewVirtualList } from "@tsmono/inspect-components/chat";
 import { NoContentsPanel } from "@tsmono/react/components";

--- a/apps/scout/src/app/scannerResult/useScannerResultPrevNext.ts
+++ b/apps/scout/src/app/scannerResult/useScannerResultPrevNext.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { navigateAndForget } from "@tsmono/react/hooks";
 

--- a/apps/scout/src/app/timeline/hooks/useActiveTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useActiveTimeline.ts
@@ -2,11 +2,11 @@
  * Scout-specific active timeline hook.
  *
  * Thin wrapper around the shared `useActiveTimeline` that persists the
- * active timeline index in URL search params via react-router-dom.
+ * active timeline index in URL search params via react-router.
  */
 
 import { useCallback, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import {
   useActiveTimeline as useActiveTimelineShared,

--- a/apps/scout/src/app/timeline/hooks/useTimeline.test.ts
+++ b/apps/scout/src/app/timeline/hooks/useTimeline.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { createElement, type PropsWithChildren } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { describe, expect, it } from "vitest";
 
 import { isSingleSpan } from "@tsmono/inspect-components/transcript";

--- a/apps/scout/src/app/timeline/hooks/useTimeline.ts
+++ b/apps/scout/src/app/timeline/hooks/useTimeline.ts
@@ -2,11 +2,11 @@
  * Scout-specific timeline state hook.
  *
  * Thin wrapper around the shared `useTimeline` that persists selection
- * state in URL search params via react-router-dom.
+ * state in URL search params via react-router.
  */
 
 import { useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import {
   clearDeepLinkParams,

--- a/apps/scout/src/app/transcript/SearchPanel.test.tsx
+++ b/apps/scout/src/app/transcript/SearchPanel.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { forwardRef, type PropsWithChildren } from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import {
   ChatViewVirtualList,

--- a/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
+++ b/apps/scout/src/app/transcript/TranscriptEventPanel.tsx
@@ -1,6 +1,6 @@
 import { skipToken } from "@tanstack/react-query";
 import { FC, useCallback, useMemo } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 
 import type { Event } from "@tsmono/inspect-common/types";
 import {

--- a/apps/scout/src/app/transcript/TranscriptPanel.tsx
+++ b/apps/scout/src/app/transcript/TranscriptPanel.tsx
@@ -1,7 +1,7 @@
 import { skipToken } from "@tanstack/react-query";
 import clsx from "clsx";
 import { FC, useEffect, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { ErrorPanel, LoadingBar } from "@tsmono/react/components";
 import {

--- a/apps/scout/src/app/transcript/hooks/useTranscriptNavigation.ts
+++ b/apps/scout/src/app/transcript/hooks/useTranscriptNavigation.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router";
 
 import { useOpenEventFocus } from "@tsmono/react/hooks";
 

--- a/apps/scout/src/app/transcript/hooks/useTranscriptPrevNext.ts
+++ b/apps/scout/src/app/transcript/hooks/useTranscriptPrevNext.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { navigateAndForget } from "@tsmono/react/hooks";
 

--- a/apps/scout/src/app/utils/refs.tsx
+++ b/apps/scout/src/app/utils/refs.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode, useCallback, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import type { Event } from "@tsmono/inspect-common/types";
 import { ChatView } from "@tsmono/inspect-components/chat";

--- a/apps/scout/src/app/utils/router.ts
+++ b/apps/scout/src/app/utils/router.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 import { decodeBase64Url } from "@tsmono/util";
 

--- a/apps/scout/src/app/validation/components/ValidationCaseCard.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseCard.tsx
@@ -1,6 +1,6 @@
 import { VscodeCheckbox } from "@vscode-elements/react-elements";
 import React, { CSSProperties, FC, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Modal } from "@tsmono/react/components";
 

--- a/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseEditor.tsx
@@ -6,7 +6,7 @@ import {
 } from "@vscode-elements/react-elements";
 import clsx from "clsx";
 import React, { FC, ReactNode, useCallback, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import type { JsonValue } from "@tsmono/inspect-common/types";
 import {

--- a/apps/scout/src/debugging/navigationDebugging.tsx
+++ b/apps/scout/src/debugging/navigationDebugging.tsx
@@ -7,7 +7,7 @@ import {
   To,
   useLocation,
   useNavigate,
-} from "react-router-dom";
+} from "react-router";
 
 const NAVIGATION_LOGGING_ENABLED = false;
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "seroval": ">=1.4.1",
       "seroval-plugins": ">=1.4.1",
       "minimatch@3": "^5.1.9",
+      "brace-expansion@5": "^5.0.8",
       "@microsoft/api-extractor": "^7.57.6",
       "rollup": "^4.59.0",
       "fast-uri": "^3.1.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
     "mathjax-full": "^3.2.2",
     "prismjs": "^1.30.0",
     "react": "^19.0.0",
-    "react-router-dom": "^7.0.0"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@storybook/react": "^10.5.3",
@@ -68,7 +68,7 @@
     "prismjs": "^1.30.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "storybook": "^10.5.3",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.65.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
     "json5": "^2.2.3",
     "mathjax-full": "^3.2.2",
     "prismjs": "^1.30.0",
-    "react": "^19.0.0",
+    "react": "^19.2.7",
     "react-router": "^8.3.0"
   },
   "devDependencies": {

--- a/packages/react/src/hooks/navigateAndForget.ts
+++ b/packages/react/src/hooks/navigateAndForget.ts
@@ -1,4 +1,4 @@
-import type { NavigateFunction, NavigateOptions, To } from "react-router-dom";
+import type { NavigateFunction, NavigateOptions, To } from "react-router";
 
 /**
  * Fire a react-router navigation and ignore its result. Data routers return

--- a/packages/react/src/hooks/useEventUrlSync.ts
+++ b/packages/react/src/hooks/useEventUrlSync.ts
@@ -3,7 +3,7 @@ import {
   useLocation,
   useNavigate,
   type SetURLSearchParams,
-} from "react-router-dom";
+} from "react-router";
 
 import { navigateAndForget } from "./navigateAndForget";
 

--- a/packages/react/src/hooks/useRequiredParams.ts
+++ b/packages/react/src/hooks/useRequiredParams.ts
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 
 export function useRequiredParams<T extends string>(
   ...keys: T[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   seroval: '>=1.4.1'
   seroval-plugins: '>=1.4.1'
   minimatch@3: ^5.1.9
+  brace-expansion@5: ^5.0.8
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
   fast-uri: ^3.1.4
@@ -146,9 +147,9 @@ importers:
       react-popper:
         specifier: ^2.3.0
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -351,9 +352,9 @@ importers:
       react-popper:
         specifier: ^2.3.0
         version: 2.3.0(@popperjs/core@2.11.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -700,9 +701,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.5.3
         version: 10.5.3(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7)
@@ -3151,9 +3152,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3264,6 +3265,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -4672,19 +4676,12 @@ packages:
       react: ^19.2.0
       react-dom: ^19.1.1
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -4838,9 +4835,6 @@ packages:
   seroval@1.5.4:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
@@ -7458,7 +7452,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7584,6 +7578,8 @@ snapshots:
       proto-list: 1.2.4
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
 
@@ -8710,12 +8706,12 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
     optional: true
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@5.1.9:
     dependencies:
@@ -9117,17 +9113,10 @@ snapshots:
       react-fast-compare: 3.2.2
       warning: 4.0.3
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.7
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
@@ -9328,8 +9317,6 @@ snapshots:
       seroval: 1.5.4
 
   seroval@1.5.4: {}
-
-  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.2: {}
 


### PR DESCRIPTION
- [Dependabot alert 63](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/63) react-router (high, RSC CSRF GHSA-qwww-vcr4-c8h2): react-router-dom 7.18.1 -> react-router 8.3.0 in apps/inspect, apps/scout, packages/react. v8 dropped the react-router-dom package; all imports rewritten to react-router (RouterProvider from react-router/dom). RSC mode isn't used here, but only fix line is 8.x.
- [Dependabot alert 64](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/64) brace-expansion (high, DoS GHSA-mh99-v99m-4gvg): override brace-expansion@5 -> ^5.0.8 (minimatch 10 dependents). **Partial** — the 2.x line (minimatch 5/9) is deferred: backported fixes 2.1.3/2.1.4 are still inside the 7-day soak window, and forcing 5.x would break minimatch's default-import of the package. Alert stays open until next round.

Verified: pnpm check / build / test all green (1009 tests). Notes: react-router 8 declares node >=22.22 engines (warning only, browser-side package); pnpm audit still reports GHSA-mh99-v99m-4gvg for the deferred brace-expansion 2.1.2.