### PR TITLE
Dedupe live sample summaries by (id, epoch) when reading journal files

### DIFF
--- a/apps/inspect/src/client/remote/remoteLogFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.test.ts
@@ -15,7 +15,9 @@
 
 import { describe, expect, test } from "vitest";
 
-import { headerFromLogStart, LogStart } from "./remoteLogFile";
+import { SampleSummary } from "../api/types";
+
+import { dedupeSummaries, headerFromLogStart, LogStart } from "./remoteLogFile";
 
 const baseEval = {
   // EvalSpec has more fields, but the helper only touches `tags` and
@@ -63,5 +65,40 @@ describe("headerFromLogStart", () => {
     // rely on stable references.
     expect(header.eval).toBe(start.eval);
     expect(header.plan).toBe(start.plan);
+  });
+});
+
+function makeSummary(
+  id: number | string,
+  epoch: number,
+  error?: string
+): SampleSummary {
+  // SampleSummary has more fields; the helper only touches id / epoch.
+  return { id, epoch, error } as SampleSummary;
+}
+
+describe("dedupeSummaries", () => {
+  test("keeps the last row per (id, epoch)", () => {
+    // a requeued sample journals its superseded prior attempt and, in a
+    // later journal file, its re-run — the re-run's row must win
+    const deduped = dedupeSummaries([
+      makeSummary("flaky", 1, "boom"),
+      makeSummary("steady", 1),
+      makeSummary("flaky", 1),
+    ]);
+    expect(deduped).toEqual([
+      makeSummary("flaky", 1),
+      makeSummary("steady", 1),
+    ]);
+  });
+
+  test("treats epochs of the same sample as distinct rows", () => {
+    const rows = [makeSummary("s1", 1), makeSummary("s1", 2)];
+    expect(dedupeSummaries(rows)).toEqual(rows);
+  });
+
+  test("does not conflate numeric and string ids", () => {
+    const rows = [makeSummary(1, 1), makeSummary("1", 1)];
+    expect(dedupeSummaries(rows)).toEqual(rows);
   });
 });

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -95,6 +95,29 @@ export const headerFromLogStart = (start: LogStart): EvalHeader => ({
   metadata: start.eval?.metadata ?? {},
 });
 
+const JOURNAL_SUMMARIES_DIR = "_journal/summaries/";
+
+// parseInt stops at the ".json" suffix
+const journalFileIndex = (filename: string): number =>
+  parseInt(filename.slice(JOURNAL_SUMMARIES_DIR.length), 10);
+
+/**
+ * Keep the last row per (id, epoch), matching the Python readers'
+ * last-entry-wins rule: a requeued sample's re-run is recorded after its
+ * superseded prior attempt.
+ *
+ * Exported for unit testing.
+ */
+export const dedupeSummaries = (
+  summaries: SampleSummary[]
+): SampleSummary[] => {
+  const byKey = new Map<string, SampleSummary>();
+  for (const summary of summaries) {
+    byKey.set(JSON.stringify([summary.id, summary.epoch]), summary);
+  }
+  return Array.from(byKey.values());
+};
+
 /**
  * Opens a remote log file and provides methods to read its contents.
  */
@@ -282,24 +305,24 @@ export const openRemoteLogFile = async (
    * Reads individual summary files when summaries.json is not available.
    */
   const readFallbackSummaries = async (): Promise<SampleSummary[]> => {
-    const summaryFiles = Array.from(
-      remoteZipFile.centralDirectory.keys()
-    ).filter(
-      (filename) =>
-        filename.startsWith("_journal/summaries/") && filename.endsWith(".json")
-    );
+    // sorted numerically so the merge below is deterministic: reads complete
+    // out of order, and dedupe needs the later journal file's rows to win
+    const summaryFiles = Array.from(remoteZipFile.centralDirectory.keys())
+      .filter(
+        (filename) =>
+          filename.startsWith(JOURNAL_SUMMARIES_DIR) &&
+          filename.endsWith(".json")
+      )
+      .sort((a, b) => journalFileIndex(a) - journalFileIndex(b));
 
-    const summaries: SampleSummary[] = [];
+    const perFile: SampleSummary[][] = [];
     const errors: unknown[] = [];
 
     await Promise.all(
-      summaryFiles.map((filename) =>
+      summaryFiles.map((filename, index) =>
         queue.enqueue(async () => {
           try {
-            const partialSummary = (await readJSONFile(
-              filename
-            )) as SampleSummary[];
-            summaries.push(...partialSummary);
+            perFile[index] = (await readJSONFile(filename)) as SampleSummary[];
           } catch (error) {
             errors.push(error);
           }
@@ -314,7 +337,8 @@ export const openRemoteLogFile = async (
       );
     }
 
-    return summaries;
+    // flat() skips the holes failed reads leave behind
+    return dedupeSummaries(perFile.flat());
   };
 
   /**
@@ -322,7 +346,12 @@ export const openRemoteLogFile = async (
    */
   const readSampleSummaries = async (): Promise<SampleSummary[]> => {
     if (remoteZipFile.centralDirectory.has("summaries.json")) {
-      return (await readJSONFile("summaries.json")) as SampleSummary[];
+      // deduped defensively, like the Python reader: a log finalized before
+      // the recorder superseded re-logged samples in its flush buffer can
+      // carry both a requeued sample's rows
+      return dedupeSummaries(
+        (await readJSONFile("summaries.json")) as SampleSummary[]
+      );
     } else {
       return readFallbackSummaries();
     }

--- a/apps/inspect/src/client/remote/remoteLogFile.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.ts
@@ -322,7 +322,11 @@ export const openRemoteLogFile = async (
       summaryFiles.map((filename, index) =>
         queue.enqueue(async () => {
           try {
-            perFile[index] = (await readJSONFile(filename)) as SampleSummary[];
+            const parsed = await readJSONFile(filename);
+            if (!Array.isArray(parsed)) {
+              throw new Error(`Expected an array in ${filename}`);
+            }
+            perFile[index] = parsed as SampleSummary[];
           } catch (error) {
             errors.push(error);
           }


### PR DESCRIPTION
## What

When the inspect viewer reads an in-progress `.eval` file directly (no control server), it falls back to concatenating the `_journal/summaries/*.json` files. With sample requeue landing in inspect_ai (UKGovernmentBEIS/inspect_ai#4649), a requeued sample's superseded prior attempt and its re-run appear in *different* journal files under the same `(id, epoch)` — the viewer showed the sample twice, and row order was nondeterministic (parallel reads pushed rows in completion order).

## Changes

- `readFallbackSummaries` now sorts journal files numerically, collects each file's rows into a slot indexed by that order, then flattens and dedupes — so the later journal file's row wins deterministically regardless of read-completion order. Failed file reads leave holes that `flat()` skips (preserving the previous error tolerance).
- New `dedupeSummaries` helper: last row per `(id, epoch)`, keyed via `JSON.stringify([id, epoch])` so numeric and string ids can't collide — matching the Python readers' last-entry-wins rule.
- The `summaries.json` path is deduped too, defensively, mirroring the Python reader (a log finalized before the recorder superseded re-logged samples in its flush buffer can carry both rows).

The rest of the viewer is already safe: the zip central directory parses into a `Map` keyed by filename, so duplicate zip members collapse last-wins for `listSamples` / `readSample` / `zipAccess`. The journal-summaries concatenation was the only gap.

## Testing

- New unit tests for `dedupeSummaries` (superseding row wins, epochs distinct, numeric vs string ids not conflated).
- `pnpm typecheck` and `pnpm test` from the repo root: 9/9 tasks, 1012 tests passing.

Follow-up requested by @dragonstyle in review of UKGovernmentBEIS/inspect_ai#4649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)