### PR TITLE
feat: add results_buffer to scout generated types

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -792,6 +792,8 @@ export interface components {
             project_dir: string;
             /** Results */
             results?: string | null;
+            /** Results Buffer */
+            results_buffer?: number | null;
             /** Scanners */
             scanners?: components["schemas"]["ScannerSpec"][] | {
                 [key: string]: components["schemas"]["ScannerSpec"];
@@ -2508,6 +2510,8 @@ export interface components {
             name?: string | null;
             /** Results */
             results?: string | null;
+            /** Results Buffer */
+            results_buffer?: number | null;
             /** Scanners */
             scanners?: components["schemas"]["ScannerSpec"][] | {
                 [key: string]: components["schemas"]["ScannerSpec"];
@@ -2566,6 +2570,8 @@ export interface components {
             name?: string | null;
             /** Results */
             results?: string | null;
+            /** Results Buffer */
+            results_buffer?: number | null;
             /** Scanners */
             scanners?: components["schemas"]["ScannerSpec"][] | {
                 [key: string]: components["schemas"]["ScannerSpec"];
@@ -2863,6 +2869,8 @@ export interface components {
             name?: string | null;
             /** Results */
             results?: string | null;
+            /** Results Buffer */
+            results_buffer?: number | null;
             /** Scanners */
             scanners?: components["schemas"]["ScannerSpec"][] | {
                 [key: string]: components["schemas"]["ScannerSpec"];
@@ -2954,6 +2962,8 @@ export interface components {
              * @default 25
              */
             max_transcripts: number;
+            /** Results Buffer */
+            results_buffer?: number | null;
             /** Shuffle */
             shuffle?: boolean | number | null;
         };


### PR DESCRIPTION
Companion to meridianlabs-ai/inspect_scout#550, which adds a `results_buffer` scan option (periodic sync of in-progress results to the scan location). That option is persisted on `ScanOptions`/`ScanJobConfig`, so scout's OpenAPI schema gains an optional field; this PR carries the matching regeneration of `apps/scout/src/types/generated.ts` (produced by inspect_scout's `scripts/export_openapi_schema.py`).

Type-only change: the optional `results_buffer?: number | null` field added to five schemas. `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass at this commit.

**Merge order (two-phase landing):** inspect_scout#550 currently pins its ts-mono gitlink to this branch's head, which turns its `check-schema-and-types` green and leaves only `submodule-on-main` red. Once this PR merges, the gitlink on #550 gets bumped to the merged main SHA and #550 can land. Please don't enable auto-merge here — merging this opens the window where ts-mono main references a not-yet-merged inspect_scout schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127Dxge9RML8K6Ajej9BfNa

---
_Generated by [Claude Code](https://claude.ai/code/session_0127Dxge9RML8K6Ajej9BfNa)_