### PR TITLE
Add daily scheduled Claude Code run of dependabot-fix skill

### DIFF
--- a/.claude/skills/dependabot-fix/SKILL.md
+++ b/.claude/skills/dependabot-fix/SKILL.md
@@ -84,16 +84,37 @@ second major line or a scoped override that missed a parent.
 
 ### 5. Ship
 
-**One PR for the whole batch** — fix every actionable alert first, then
-branch and commit once. Don't open per-alert PRs; the override edits all land
-in the same two files (package.json + lockfile) anyway, and one PR keeps
-review/CI cost flat. Commit message: concise list of packages bumped and
+**One PR for the whole batch** — and one batch PR *across runs*: before
+branching, check for a still-open PR from a previous run (any open PR whose
+head branch starts with `dependabot-fix/`). If one exists, continue it
+instead of opening a second: check out its branch, merge the default branch
+into it (conflicts land in package.json overrides and the lockfile), apply
+the new fixes on top, re-run the verify loop, push, and update the PR body
+to cover the full batch. Otherwise fix every actionable alert first, then
+branch (`dependabot-fix/<short-description>`) and commit once. Don't open
+per-alert PRs; the override edits all land in the same two files
+(package.json + lockfile) anyway, and one PR keeps review/CI cost flat.
+Commit message: concise list of packages bumped and
 alert numbers. PR body: one line per alert (number, package, severity).
 Never write alert numbers as `#N` in PR titles/bodies — GitHub autolinks
 that to PR/issue N. Write "dependabot alert N", ideally linked to
 `https://github.com/meridianlabs-ai/ts-mono/security/dependabot/N`.
 Alerts auto-close once the merged lockfile no longer contains vulnerable
 versions — don't dismiss them manually.
+
+## Unattended runs
+
+When run headless (e.g. the scheduled `dependabot-fix.yml` workflow) there is
+no user to ask, so wherever this skill says to ask, defer instead:
+
+- Alerts whose only patched version is still inside the soak window: defer —
+  never add a `minimumReleaseAgeExclude` entry. They fix cleanly on a later
+  run.
+- Unfixable alerts (no patched version, or the fix requires an incompatible
+  major): defer likewise.
+- List every deferred alert and the reason in the PR body.
+- If nothing is actionable and no open PR needs updating, stop — no branch,
+  no PR.
 
 ## Gotchas
 

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -1,0 +1,132 @@
+# Daily scheduled Claude Code run of the dependabot-fix skill
+# (.claude/skills/dependabot-fix/SKILL.md): clear open dependabot alerts via
+# pnpm overrides, one PR per batch.
+#
+# Standalone (not the agents-repo reusable workflow — that one is built around
+# issue/comment triggers). Uses claude-code-action automation mode (`prompt`).
+# Model auth is Workload Identity Federation (same IDs as
+# meridianlabs-ai/agents claude.yml); requires id-token: write.
+#
+# MARVIN_TOKEN (org secret, machine-account PAT) is required, for two reasons
+# GITHUB_TOKEN can't cover: reading the dependabot alerts API (no workflow
+# permission key exists for it), and opening a PR that triggers CI (recursion
+# guard blocks GITHUB_TOKEN-authored PRs). PAT must have Dependabot alerts:
+# read on this repo — the preflight step fails loudly if not.
+
+name: Dependabot Fix
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # 6am EDT / 5am EST (cron is UTC-only)
+  workflow_dispatch:
+
+concurrency:
+  group: dependabot-fix
+  cancel-in-progress: false
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read # checkout only; writes go through MARVIN_TOKEN
+      id-token: write # WIF OIDC exchange
+    steps:
+      - name: Preflight - MARVIN_TOKEN can read dependabot alerts
+        env:
+          GH_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::MARVIN_TOKEN secret is not set; this workflow cannot run without it."
+            exit 1
+          fi
+          if ! gh api "repos/$REPO/dependabot/alerts?per_page=1" --silent; then
+            echo "::error::MARVIN_TOKEN cannot read dependabot alerts on $REPO — grant the PAT 'Dependabot alerts: read'."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Cache Turbo
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: turbo-${{ github.sha }}
+          restore-keys: turbo-
+
+      # Pre-install so the agent's pnpm why/audit/check/build/test work
+      # immediately (and hit the pnpm store cache).
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - uses: anthropics/claude-code-action@v1
+        id: claude
+        with:
+          anthropic_federation_rule_id: fdrl_01GpNgJm9jE6ZfvcqoJYQL2Y
+          anthropic_organization_id: be5d0086-bc43-45d2-9184-20ecdd647aa7
+          anthropic_service_account_id: svac_01RL4wYD7ikbypwYKf4wFojv
+          anthropic_workspace_id: wrkspc_01RKCQ5DTPBatQ7kHLkaEueD
+          github_token: ${{ secrets.MARVIN_TOKEN }}
+          # Default-deny: headless runs auto-deny anything not allowed. gh for
+          # alerts API + PR creation, pnpm for the verify loop, git scoped to
+          # branch/commit/push + read-only subcommands, echo for the
+          # GITHUB_STEP_SUMMARY status line.
+          settings: |
+            {"permissions":{"allow":["Read","Edit","Write",
+            "Bash(pnpm:*)","Bash(gh:*)","Bash(grep:*)","Bash(echo:*)",
+            "Bash(git fetch:*)","Bash(git merge:*)",
+            "Bash(git checkout:*)","Bash(git switch:*)",
+            "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
+            "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
+            "Bash(git remote:*)","Bash(git add:*)","Bash(git commit:*)",
+            "Bash(git push:*)","Bash(git config:*)"]}}
+          claude_args: --model fable --fallback-model default
+          prompt: |
+            Run the dependabot-fix skill (.claude/skills/dependabot-fix/SKILL.md)
+            to clear the currently open GitHub dependabot security alerts.
+
+            This is an unattended scheduled run — follow the skill's
+            "Unattended runs" rules.
+
+            Finish every run — including no-op runs — by appending a brief
+            status (alerts fixed, alerts deferred, PR link or "no action") to
+            the file named by the GITHUB_STEP_SUMMARY environment variable.
+
+      # The action can finish green even when the agent errored (model
+      # overload etc.). Fail the run so a scheduled failure is visible.
+      - name: Surface agent errors
+        if: always()
+        env:
+          EXEC: ${{ steps.claude.outputs.execution_file }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+        run: |
+          set -uo pipefail
+          file="${EXEC:-/home/runner/work/_temp/claude-execution-output.json}"
+          err=""
+          [ -f "$file" ] && err=$(jq -r '(if type=="array" then . else .messages end) | map(select(.type=="result" and .is_error==true)) | last | .result // empty' "$file" 2>/dev/null || true)
+          if [ -z "$err" ] && [ "$CLAUDE_OUTCOME" = "failure" ]; then
+            err="the Claude Code step failed before producing a result (see the job logs)."
+          fi
+          [ -z "$err" ] && { echo "No agent error detected."; exit 0; }
+          echo "::error::Claude run did not complete: $err"
+          exit 1
+
+      - name: Upload execution log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: claude-execution-output
+          path: /home/runner/work/_temp/claude-execution-output.json
+          if-no-files-found: ignore

--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -114,8 +114,15 @@ jobs:
         run: |
           set -uo pipefail
           file="${EXEC:-/home/runner/work/_temp/claude-execution-output.json}"
+          # The action re-points origin at an x-access-token URL embedding
+          # MARVIN_TOKEN; a git remote -v/git config --list in a tool result
+          # would land the raw PAT in this file, and artifacts are publicly
+          # downloadable without log masking. Scrub before upload.
+          [ -f "$file" ] && sed -E -i 's#x-access-token:[^@"]*@#x-access-token:***@#g' "$file"
           err=""
-          [ -f "$file" ] && err=$(jq -r '(if type=="array" then . else .messages end) | map(select(.type=="result" and .is_error==true)) | last | .result // empty' "$file" 2>/dev/null || true)
+          # SDK error results (error_max_turns, error_during_execution, ...)
+          # carry no .result field — fall back to .subtype.
+          [ -f "$file" ] && err=$(jq -r '(if type=="array" then . else .messages end) | map(select(.type=="result" and .is_error==true)) | last | (.result // .subtype) // empty' "$file" 2>/dev/null || true)
           if [ -z "$err" ] && [ "$CLAUDE_OUTCOME" = "failure" ]; then
             err="the Claude Code step failed before producing a result (see the job logs)."
           fi
@@ -128,5 +135,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: claude-execution-output
-          path: /home/runner/work/_temp/claude-execution-output.json
+          path: ${{ steps.claude.outputs.execution_file || '/home/runner/work/_temp/claude-execution-output.json' }}
           if-no-files-found: ignore


### PR DESCRIPTION
Daily 10:00 UTC (6am EDT / 5am EST) GitHub Action that runs Claude Code in automation mode against the `dependabot-fix` skill, plus `workflow_dispatch` for manual runs.

## Workflow (`.github/workflows/dependabot-fix.yml`)
- `claude-code-action@v1` automation mode (`prompt:`), WIF model auth (same IDs as the agents repo)
- `MARVIN_TOKEN` as github_token — required for both the dependabot alerts API (no workflow permission key exists for it) and PRs that trigger CI; preflight step fails loudly if the PAT lacks `Dependabot alerts: read`
- Same setup as CI (pnpm, node 22, turbo cache, `pnpm install`) so the skill's verify loop works
- Default-deny permission allow-list: pnpm, gh, scoped git, file edits
- Agent errors fail the run even when the action exits green; execution log uploaded as artifact
- Every run appends a status line to the Actions run summary, so no-op runs leave a visible record

## Skill (`SKILL.md`)
Run-context-independent logic moved into the skill:
- One batch PR **across runs**: an open `dependabot-fix/*` PR is continued (checkout, merge default branch, add fixes, re-verify, push, update body) instead of stacking a duplicate
- Branch naming convention `dependabot-fix/<short-description>`
- New **Unattended runs** section: defer instead of ask — soaking alerts never get `minimumReleaseAgeExclude`, unfixables are deferred, deferrals listed in the PR body, clean no-op when nothing's actionable

## Before merging
- [ ] Verify the marvin PAT has **Dependabot alerts: read** on this repo
- [ ] Confirm `MARVIN_TOKEN` org secret is visible to this repo's Actions
- [ ] After merge: kick a `workflow_dispatch` run (first run will exercise the defer path — brace-expansion@2 soaks until 2026-08-06)