### PR TITLE
Add eslint-plugin-jsx-a11y and fix the issues it raises

### DIFF
--- a/apps/inspect/eslint.config.mjs
+++ b/apps/inspect/eslint.config.mjs
@@ -53,5 +53,20 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
+  // Remove this block as the underlying issues are fixed.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "jsx-a11y/anchor-is-valid": "off",
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/interactive-supports-focus": "off",
+      "jsx-a11y/label-has-associated-control": "off",
+      "jsx-a11y/no-autofocus": "off",
+      "jsx-a11y/no-noninteractive-element-interactions": "off",
+      "jsx-a11y/no-noninteractive-tabindex": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+    },
   }
 );

--- a/apps/inspect/eslint.config.mjs
+++ b/apps/inspect/eslint.config.mjs
@@ -53,20 +53,5 @@ export default tseslint.config(
         },
       ],
     },
-  },
-  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
-  // Remove this block as the underlying issues are fixed.
-  {
-    files: ["**/*.{ts,tsx}"],
-    rules: {
-      "jsx-a11y/anchor-is-valid": "off",
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/interactive-supports-focus": "off",
-      "jsx-a11y/label-has-associated-control": "off",
-      "jsx-a11y/no-autofocus": "off",
-      "jsx-a11y/no-noninteractive-element-interactions": "off",
-      "jsx-a11y/no-noninteractive-tabindex": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-    },
   }
 );

--- a/apps/inspect/src/app/log-view/LogViewLayout.tsx
+++ b/apps/inspect/src/app/log-view/LogViewLayout.tsx
@@ -59,6 +59,12 @@ export const LogViewLayout: FC = () => {
             singleFileMode ? "single-file-mode" : undefined,
             "log-view"
           )}
+          // The VS Code webview focuses the nearest container tabstop when a
+          // non-interactive spot is clicked, and App.css suppresses the focus
+          // ring this one would otherwise show. Keep it until that interaction
+          // is retested in the extension.
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={0}
         >
           {showFind ? <FindBand onClose={hideFind} /> : ""}
           {!singleFileMode ? (

--- a/apps/inspect/src/app/log-view/LogViewLayout.tsx
+++ b/apps/inspect/src/app/log-view/LogViewLayout.tsx
@@ -59,7 +59,6 @@ export const LogViewLayout: FC = () => {
             singleFileMode ? "single-file-mode" : undefined,
             "log-view"
           )}
-          tabIndex={0}
         >
           {showFind ? <FindBand onClose={hideFind} /> : ""}
           {!singleFileMode ? (

--- a/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
@@ -388,16 +388,25 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
       <div className={sharedStyles.body}>
         <div className={sharedStyles.section}>
           <div className={sharedStyles.labelRow}>
-            <label className={clsx("text-size-smaller", sharedStyles.label)}>
+            {/* Names the whole entry table, so it can't be a <label> — those
+                may only point at a single form control. */}
+            <span
+              id="edit-metadata-label"
+              className={clsx("text-size-smaller", sharedStyles.label)}
+            >
               Metadata
-            </label>
+            </span>
             <span className={clsx("text-size-smaller", sharedStyles.hint)}>
               Values are edited as plain text. Use JSON syntax for nested
               values.
             </span>
           </div>
 
-          <div className={styles.tableScroll}>
+          <div
+            className={styles.tableScroll}
+            role="group"
+            aria-labelledby="edit-metadata-label"
+          >
             <div className={styles.table}>
               {entries.length === 0 && (
                 <div className={clsx("text-size-smaller", styles.empty)}>

--- a/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
@@ -200,10 +200,19 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
     >
       <div className={sharedStyles.body}>
         <div className={sharedStyles.section}>
-          <label className={clsx("text-size-smaller", sharedStyles.label)}>
+          {/* Names the chip box, so it can't be a <label> — those may only
+              point at a single form control. */}
+          <span
+            id="edit-tags-label"
+            className={clsx("text-size-smaller", sharedStyles.label)}
+          >
             Tags
-          </label>
-          <div className={styles.chipBox}>
+          </span>
+          <div
+            className={styles.chipBox}
+            role="group"
+            aria-labelledby="edit-tags-label"
+          >
             {tags.length === 0 && (
               <span className={clsx("text-size-smaller", styles.empty)}>
                 No tags yet — add one below.

--- a/apps/inspect/src/app/samples/sample-tools/SelectScorer.module.css
+++ b/apps/inspect/src/app/samples/sample-tools/SelectScorer.module.css
@@ -37,13 +37,17 @@
   border-bottom: solid 1px var(--bs-border-color);
 }
 
-.links a {
+.links button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   text-decoration: none;
   color: var(--bs-link-color);
 }
 
-.links a:hover {
+.links button:hover {
   color: var(--bs-link-hover-color);
 }
 

--- a/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
+++ b/apps/inspect/src/app/samples/sample-tools/SelectScorer.tsx
@@ -69,7 +69,8 @@ export const SelectScorer: FC<SelectScorerProps> = ({
         }}
       >
         <div className={clsx(styles.links, "text-size-smaller")}>
-          <a
+          <button
+            type="button"
             className={clsx(
               styles.link,
               !allScoresSelected ? styles.selected : undefined
@@ -82,9 +83,10 @@ export const SelectScorer: FC<SelectScorerProps> = ({
             }}
           >
             Default
-          </a>
+          </button>
           |
-          <a
+          <button
+            type="button"
             className={clsx(
               styles.link,
               allScoresSelected ? styles.selected : undefined
@@ -94,9 +96,10 @@ export const SelectScorer: FC<SelectScorerProps> = ({
             }}
           >
             All
-          </a>
+          </button>
           |
-          <a
+          <button
+            type="button"
             className={clsx(
               styles.link,
               noneSelected ? styles.selected : undefined
@@ -106,7 +109,7 @@ export const SelectScorer: FC<SelectScorerProps> = ({
             }}
           >
             None
-          </a>
+          </button>
         </div>
         <div className={styles.container}>
           <ScoreCheckboxes
@@ -154,21 +157,14 @@ const ScoreCheckboxes: FC<ScoreCheckboxesProps> = ({
         const key = `${sc.scorer}.${sc.name}`;
         const isChecked = selectedKeys ? selectedKeys.has(key) : false;
         return (
-          <div
-            key={key}
-            className={clsx(styles.row)}
-            onClick={() => handleToggle(sc, isChecked)}
-          >
+          <label key={key} className={clsx(styles.row)}>
             <input
               type="checkbox"
               checked={isChecked}
-              onChange={(e) => {
-                e.stopPropagation();
-                handleToggle(sc, isChecked);
-              }}
+              onChange={() => handleToggle(sc, isChecked)}
             />
             {sc.name}
-          </div>
+          </label>
         );
       })}
     </div>

--- a/apps/inspect/src/app/samples/transcript/TranscriptFilter.module.css
+++ b/apps/inspect/src/app/samples/transcript/TranscriptFilter.module.css
@@ -27,13 +27,17 @@
   border-bottom: solid 1px var(--bs-border-color);
 }
 
-.links a {
+.links button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   text-decoration: none;
   color: var(--bs-link-color);
 }
 
-.links a:hover {
+.links button:hover {
   color: var(--bs-link-hover-color);
 }
 

--- a/apps/inspect/src/app/samples/transcript/TranscriptFilter.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptFilter.tsx
@@ -40,7 +40,8 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
       hoverDelay={-1}
     >
       <div className={clsx(styles.links, "text-size-smaller")}>
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDefaultFilter ? styles.selected : undefined
@@ -48,9 +49,10 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
           onClick={() => setDefaultFilter()}
         >
           Default
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDebugFilter ? styles.selected : undefined
@@ -58,9 +60,10 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
           onClick={() => setDebugFilter()}
         >
           Debug
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isNoneFilter ? styles.selected : undefined
@@ -68,7 +71,7 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
           onClick={() => setNoneFilter()}
         >
           None
-        </a>
+        </button>
       </div>
 
       <div className={clsx(styles.grid, "text-size-smaller")}>

--- a/apps/inspect/src/app/samples/transcript/TranscriptFilter.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptFilter.tsx
@@ -77,22 +77,16 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
       <div className={clsx(styles.grid, "text-size-smaller")}>
         {arrangedEventTypes(2).map((eventType) => {
           return (
-            <div
-              key={eventType}
-              className={clsx(styles.row)}
-              onClick={() => {
-                filterEventType(eventType, filtered.includes(eventType));
-              }}
-            >
+            <label key={eventType} className={clsx(styles.row)}>
               <input
                 type="checkbox"
                 checked={!filtered.includes(eventType)}
                 onChange={(e) => {
                   filterEventType(eventType, e.target.checked);
                 }}
-              ></input>
+              />
               {eventTypes[eventType]}
-            </div>
+            </label>
           );
         })}
       </div>

--- a/apps/inspect/src/app/shared/ColumnSelectorPopover.module.css
+++ b/apps/inspect/src/app/shared/ColumnSelectorPopover.module.css
@@ -61,6 +61,10 @@
 
 .button {
   padding: 0;
+  border: none;
+  background: none;
+  color: var(--bs-link-color);
+  font: inherit;
   text-decoration: none;
 }
 

--- a/apps/inspect/src/app/shared/ColumnSelectorPopover.tsx
+++ b/apps/inspect/src/app/shared/ColumnSelectorPopover.tsx
@@ -171,25 +171,31 @@ export const ColumnSelectorPopover: FC<ColumnSelectorPopoverProps> = ({
           <div className={styles.headerRow}>
             {splitScores ? <b>Base</b> : <b>Columns</b>}
             <div className={clsx(styles.buttonContainer, "text-size-small")}>
-              <a
+              <button
+                type="button"
                 className={clsx(styles.button, "text-size-small")}
                 onClick={handleSelectAllBase}
               >
                 All
-              </a>
+              </button>
               |
-              <a
+              <button
+                type="button"
                 className={clsx(styles.button)}
                 onClick={handleDeselectAllBase}
               >
                 None
-              </a>
+              </button>
               {onResetToDefault && (
                 <>
                   |
-                  <a className={clsx(styles.button)} onClick={onResetToDefault}>
+                  <button
+                    type="button"
+                    className={clsx(styles.button)}
+                    onClick={onResetToDefault}
+                  >
                     Default
-                  </a>
+                  </button>
                 </>
               )}
             </div>
@@ -221,19 +227,21 @@ export const ColumnSelectorPopover: FC<ColumnSelectorPopoverProps> = ({
                 )}
               </div>
               <div className={styles.buttonContainer}>
-                <a
+                <button
+                  type="button"
                   className={clsx(styles.button)}
                   onClick={handleSelectAllScores}
                 >
                   All
-                </a>
+                </button>
                 |
-                <a
+                <button
+                  type="button"
                   className={clsx(styles.button)}
                   onClick={handleDeselectAllScores}
                 >
                   None
-                </a>
+                </button>
               </div>
             </div>
             <div className={styles.columnsLayout}>

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
@@ -849,6 +849,10 @@ export function DataGrid<TRow>({
                   ) : null;
 
                 return (
+                  // The cell widens the hit area for the mouse; the sortable
+                  // headerContent button inside is the keyboard control, and
+                  // the grid container owns focus for the whole widget.
+                  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
                   <div
                     key={header.id}
                     className={clsx(
@@ -935,12 +939,16 @@ export function DataGrid<TRow>({
                           styles.headerFilter,
                           filterSpec && styles.headerFilterActive
                         )}
+                        role="presentation"
                         onClick={(e) => e.stopPropagation()}
                       >
                         {filterControl}
                       </div>
                     )}
                     {header.column.getCanResize() && (
+                      // Pointer-only drag handle; column widths also reset
+                      // from the column menu, so nothing here is unreachable.
+                      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
                       <div
                         role="separator"
                         aria-orientation="vertical"
@@ -1031,6 +1039,9 @@ function GridRowInner<TRow>({
   onRowClick,
 }: GridRowProps<TRow>): ReactElement {
   return (
+    // Row selection from the keyboard is the grid container's arrow-key
+    // handler; the row click is the mouse path onto the same action.
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
     <div
       className={clsx(styles.row, isSelected && styles.rowSelected)}
       style={{
@@ -1140,6 +1151,9 @@ function RotatedHeaderCell<TRow>({
     : flexRender(header.column.columnDef.header, header.getContext());
 
   return (
+    // Drag/drop target only; the rotated label inside is the sortable
+    // control and the grid container owns focus.
+    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
     <div
       className={clsx(
         styles.headerCell,
@@ -1164,6 +1178,10 @@ function RotatedHeaderCell<TRow>({
       onDragLeave={onHeaderDragLeave}
       onDrop={(e) => onHeaderDrop(e, header.column.id)}
     >
+      {/* Sortable columns get role/tabIndex/onKeyDown from the spread below;
+          for the rest this is a drag handle, not a control. The conditional
+          spread is invisible to the a11y rules. */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         className={clsx(
           styles.rotatedLabel,
@@ -1197,6 +1215,7 @@ function RotatedHeaderCell<TRow>({
           // label's sort handler. Stop them here.
           <span
             className={styles.rotatedFilter}
+            role="presentation"
             onClick={(e) => e.stopPropagation()}
           >
             <ColumnFilterControl
@@ -1219,6 +1238,8 @@ function RotatedHeaderCell<TRow>({
         aria-hidden="true"
       />
       {header.column.getCanResize() && (
+        // Pointer-only drag handle — see the upright header above.
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
         <div
           role="separator"
           aria-orientation="vertical"

--- a/apps/scout/eslint.config.js
+++ b/apps/scout/eslint.config.js
@@ -45,5 +45,19 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
+  // Remove this block as the underlying issues are fixed.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "jsx-a11y/anchor-is-valid": "off",
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/interactive-supports-focus": "off",
+      "jsx-a11y/label-has-associated-control": "off",
+      "jsx-a11y/no-autofocus": "off",
+      "jsx-a11y/no-noninteractive-tabindex": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+    },
   }
 );

--- a/apps/scout/eslint.config.js
+++ b/apps/scout/eslint.config.js
@@ -45,19 +45,5 @@ export default tseslint.config(
         },
       ],
     },
-  },
-  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
-  // Remove this block as the underlying issues are fixed.
-  {
-    files: ["**/*.{ts,tsx}"],
-    rules: {
-      "jsx-a11y/anchor-is-valid": "off",
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/interactive-supports-focus": "off",
-      "jsx-a11y/label-has-associated-control": "off",
-      "jsx-a11y/no-autofocus": "off",
-      "jsx-a11y/no-noninteractive-tabindex": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-    },
   }
 );

--- a/apps/scout/src/app/components/ActivityBar.module.css
+++ b/apps/scout/src/app/components/ActivityBar.module.css
@@ -15,6 +15,10 @@
 
 .activity {
   display: flex;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
   flex-direction: column;
   align-items: center;
   flex-shrink: 1;

--- a/apps/scout/src/app/components/ActivityBar.tsx
+++ b/apps/scout/src/app/components/ActivityBar.tsx
@@ -54,14 +54,16 @@ const Activity: FC<ActivityProps> = ({
   onSelect,
 }) => {
   return (
-    <div
+    <button
+      type="button"
       id={id}
       className={clsx(styles.activity, selected ? styles.selected : undefined)}
       title={description}
+      aria-current={selected ? "page" : undefined}
       onClick={(e) => onSelect(id, { openInNewTab: e.metaKey || e.ctrlKey })}
     >
-      <i className={clsx(styles.icon, icon)}></i>
+      <i className={clsx(styles.icon, icon)} aria-hidden="true"></i>
       <div className={clsx(styles.label)}>{label}</div>
-    </div>
+    </button>
   );
 };

--- a/apps/scout/src/app/components/Chip.module.css
+++ b/apps/scout/src/app/components/Chip.module.css
@@ -21,6 +21,10 @@
 
 .closeIcon {
   margin-left: 0.3rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
   font-size: 0.9em;
 }
 

--- a/apps/scout/src/app/components/Chip.tsx
+++ b/apps/scout/src/app/components/Chip.tsx
@@ -22,9 +22,12 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(
     ref
   ) => {
     return (
+      // The chip's own click is a shortcut onto content that is reachable
+      // elsewhere; the close button below is a real control.
       <div
         ref={ref}
         className={clsx(styles.chip, className)}
+        role="presentation"
         onClick={onClick}
         title={title}
       >
@@ -53,13 +56,15 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>(
           {value}
         </span>
         {onClose ? (
-          <i
+          <button
+            type="button"
             className={clsx(
               ApplicationIcons.xLarge,
               styles.closeIcon,
               styles.clickable
             )}
             title={closeTitle}
+            aria-label={closeTitle ?? `Remove ${value}`}
             onClick={(event) => {
               event.stopPropagation();
               onClose(event);

--- a/apps/scout/src/app/components/ColumnsPopover.module.css
+++ b/apps/scout/src/app/components/ColumnsPopover.module.css
@@ -28,13 +28,17 @@
   border-bottom: solid 1px var(--bs-border-color);
 }
 
-.links a {
+.links button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   text-decoration: none;
   color: var(--bs-link-color);
 }
 
-.links a:hover {
+.links button:hover {
   color: var(--bs-link-hover-color);
 }
 

--- a/apps/scout/src/app/components/ColumnsPopover.tsx
+++ b/apps/scout/src/app/components/ColumnsPopover.tsx
@@ -90,7 +90,8 @@ export const ColumnsPopover: FC<ColumnsPopoverProps> = ({
       hoverDelay={-1}
     >
       <div className={clsx(styles.links, "text-size-smaller")}>
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDefaultSelection ? styles.selected : undefined
@@ -98,9 +99,10 @@ export const ColumnsPopover: FC<ColumnsPopoverProps> = ({
           onClick={() => setDefaultSelection()}
         >
           Default
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isAllSelection ? styles.selected : undefined
@@ -108,9 +110,10 @@ export const ColumnsPopover: FC<ColumnsPopoverProps> = ({
           onClick={() => setAllSelection()}
         >
           All
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isNoneSelection ? styles.selected : undefined
@@ -118,18 +121,15 @@ export const ColumnsPopover: FC<ColumnsPopoverProps> = ({
           onClick={() => setNoneSelection()}
         >
           None
-        </a>
+        </button>
       </div>
 
       <div className={clsx(styles.columnList, "text-size-smaller")}>
         {columns.map((column) => (
-          <div
+          <label
             key={column.id}
             className={clsx(styles.row)}
             title={[column.id, column.headerTitle].filter(Boolean).join("\n")}
-            onClick={() => {
-              toggleColumn(column.id, !visibleColumns.includes(column.id));
-            }}
           >
             <input
               type="checkbox"
@@ -139,7 +139,7 @@ export const ColumnsPopover: FC<ColumnsPopoverProps> = ({
               }}
             />
             {column.label}
-          </div>
+          </label>
         ))}
       </div>
     </PopOver>

--- a/apps/scout/src/app/components/EditableText.module.css
+++ b/apps/scout/src/app/components/EditableText.module.css
@@ -77,7 +77,13 @@
 }
 
 .mruItem {
+  display: block;
+  width: 100%;
   padding: 0.3rem 0.5rem;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;

--- a/apps/scout/src/app/components/EditableText.tsx
+++ b/apps/scout/src/app/components/EditableText.tsx
@@ -213,6 +213,11 @@ export const EditableText: FC<EditableTextProps> = ({
         <span
           ref={spanRef}
           contentEditable={editable}
+          role="textbox"
+          tabIndex={0}
+          aria-multiline="false"
+          aria-readonly={!editable}
+          aria-label={label ?? title}
           className={clsx(
             styles.text,
             !value ? styles.placeholder : "",
@@ -255,8 +260,9 @@ export const EditableText: FC<EditableTextProps> = ({
         >
           <div className={styles.mruList}>
             {filteredMru.map((item, index) => (
-              <div
+              <button
                 key={index}
+                type="button"
                 className={clsx(
                   styles.mruItem,
                   index === selectedMruIndex && styles.mruItemSelected
@@ -265,7 +271,7 @@ export const EditableText: FC<EditableTextProps> = ({
                 onMouseEnter={() => setSelectedMruIndex(index)}
               >
                 {item}
-              </div>
+              </button>
             ))}
           </div>
         </PopOver>

--- a/apps/scout/src/app/components/Pager.tsx
+++ b/apps/scout/src/app/components/Pager.tsx
@@ -79,7 +79,8 @@ export const Pager: FC<PagerProps> = ({
     <nav aria-label="Log Pagination">
       <ul className={clsx("pagination", styles.pager)}>
         <li className={clsx(currentPage === 0 ? "disabled" : "", styles.item)}>
-          <a
+          <button
+            type="button"
             className={clsx("page-link")}
             onClick={() => {
               if (currentPage > 0 && setPage) {
@@ -87,8 +88,11 @@ export const Pager: FC<PagerProps> = ({
               }
             }}
           >
-            <i className={clsx(ApplicationIcons.navbar.back)} />
-          </a>
+            <i
+              className={clsx(ApplicationIcons.navbar.back)}
+              aria-hidden="true"
+            />
+          </button>
         </li>
 
         {segments.map((segment) => (
@@ -102,7 +106,8 @@ export const Pager: FC<PagerProps> = ({
               styles.item
             )}
           >
-            <a
+            <button
+              type="button"
               className={clsx("page-link")}
               onClick={() => {
                 if (
@@ -115,7 +120,7 @@ export const Pager: FC<PagerProps> = ({
               }}
             >
               {segment.type === "page" ? (segment.page || 0) + 1 : "..."}
-            </a>
+            </button>
           </li>
         ))}
         <li
@@ -124,7 +129,8 @@ export const Pager: FC<PagerProps> = ({
             styles.item
           )}
         >
-          <a
+          <button
+            type="button"
             className={clsx("page-link")}
             onClick={() => {
               if (currentPage < pageCount && setPage) {
@@ -132,8 +138,11 @@ export const Pager: FC<PagerProps> = ({
               }
             }}
           >
-            <i className={clsx(ApplicationIcons.navbar.forward)} />
-          </a>
+            <i
+              className={clsx(ApplicationIcons.navbar.forward)}
+              aria-hidden="true"
+            />
+          </button>
         </li>
       </ul>
     </nav>

--- a/apps/scout/src/app/components/Pager.tsx
+++ b/apps/scout/src/app/components/Pager.tsx
@@ -82,6 +82,8 @@ export const Pager: FC<PagerProps> = ({
           <button
             type="button"
             className={clsx("page-link")}
+            disabled={currentPage === 0}
+            aria-label="Previous page"
             onClick={() => {
               if (currentPage > 0 && setPage) {
                 setPage(currentPage - 1);
@@ -109,6 +111,12 @@ export const Pager: FC<PagerProps> = ({
             <button
               type="button"
               className={clsx("page-link")}
+              disabled={segment.type === "ellipsis"}
+              aria-current={
+                segment.type === "page" && segment.page === currentPage
+                  ? "page"
+                  : undefined
+              }
               onClick={() => {
                 if (
                   segment.type === "page" &&
@@ -132,6 +140,8 @@ export const Pager: FC<PagerProps> = ({
           <button
             type="button"
             className={clsx("page-link")}
+            disabled={currentPage + 1 >= pageCount}
+            aria-label="Next page"
             onClick={() => {
               if (currentPage < pageCount && setPage) {
                 setPage(currentPage + 1);

--- a/apps/scout/src/app/components/columnFilter/ColumnFilterEditor.tsx
+++ b/apps/scout/src/app/components/columnFilter/ColumnFilterEditor.tsx
@@ -117,6 +117,9 @@ export const ColumnFilterEditor: FC<ColumnFilterEditorProps> = ({
   );
 
   return (
+    // Escape/Enter are delegated from the fields inside, all of which are
+    // focusable in their own right — the container is not itself a control.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className={styles.filterContent} onKeyDown={handleKeyDown}>
       {/* Column row - dropdown until selected, then static text */}
       <div
@@ -133,6 +136,7 @@ export const ColumnFilterEditor: FC<ColumnFilterEditorProps> = ({
             className={styles.filterSelect}
             value={columnId}
             onChange={handleColumnSelectChange}
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- the editor only renders inside a popover the user just opened
             autoFocus
           >
             <option value="">Select column...</option>
@@ -173,6 +177,7 @@ export const ColumnFilterEditor: FC<ColumnFilterEditorProps> = ({
                 value={rawValue}
                 onChange={handleValueChange}
                 disabled={isValueDisabled}
+                // eslint-disable-next-line jsx-a11y/no-autofocus -- see above
                 autoFocus={!isAddMode}
               >
                 <option value="">(not set)</option>
@@ -218,6 +223,7 @@ export const ColumnFilterEditor: FC<ColumnFilterEditorProps> = ({
                 placeholder="Filter"
                 disabled={isValueDisabled}
                 step={filterType === "number" ? "any" : undefined}
+                // eslint-disable-next-line jsx-a11y/no-autofocus -- see above
                 autoFocus={!isAddMode}
               />
             )}

--- a/apps/scout/src/app/components/columnFilter/DurationInput.tsx
+++ b/apps/scout/src/app/components/columnFilter/DurationInput.tsx
@@ -37,6 +37,7 @@ export const DurationInput: FC<DurationInputProps> = ({
         disabled={disabled}
         step="any"
         min="0"
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- the filter editor only renders inside a popover the user just opened
         autoFocus={autoFocus}
       />
       {parsedSeconds !== null && (

--- a/apps/scout/src/app/components/dataGrid/DataGrid.module.css
+++ b/apps/scout/src/app/components/dataGrid/DataGrid.module.css
@@ -40,6 +40,13 @@
 .headerContent {
   flex: 1;
   display: flex;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
   align-items: center;
   gap: 4px;
   cursor: grab;

--- a/apps/scout/src/app/components/dataGrid/DataGrid.tsx
+++ b/apps/scout/src/app/components/dataGrid/DataGrid.tsx
@@ -605,9 +605,15 @@ export function DataGrid<
   };
 
   return (
+    // A keyboard-scrollable region (WCAG 2.1.1) that also runs the table's
+    // arrow-key row navigation. The tab stop is the region itself, not a
+    // widget role the wrapper doesn't have — the <table> inside carries the
+    // structure.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       ref={containerRef}
       className={clsx(className, styles.container)}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
       tabIndex={0}
       onKeyDown={handleKeyDown}
       onScroll={onScroll}
@@ -643,7 +649,8 @@ export function DataGrid<
                       .filter(Boolean)
                       .join("\n")}
                   >
-                    <div
+                    <button
+                      type="button"
                       className={clsx(
                         styles.headerContent,
                         align === "center" && styles.headerCellCenter
@@ -683,7 +690,7 @@ export function DataGrid<
                           />
                         ),
                       }[header.column.getIsSorted() as string] ?? null}
-                    </div>
+                    </button>
                     {columnMeta?.filterable && filterType ? (
                       <ColumnFilterControl
                         columnId={header.column.id}
@@ -702,11 +709,14 @@ export function DataGrid<
                         onOpenChange={onFilterColumnChange}
                       />
                     ) : null}
+                    {/* Pointer-only drag handle — column widths also reset
+                        from the header menu, so nothing is keyboard-only here. */}
                     <div
                       className={clsx(
                         styles.resizer,
                         header.column.getIsResizing() && styles.resizerActive
                       )}
+                      role="presentation"
                       onMouseDown={header.getResizeHandler()}
                       onTouchStart={header.getResizeHandler()}
                       onDoubleClick={() =>

--- a/apps/scout/src/app/scan/scanners/ScannerSidebar.module.css
+++ b/apps/scout/src/app/scan/scanners/ScannerSidebar.module.css
@@ -5,6 +5,12 @@
 .entry {
   padding: 0.5em;
   display: grid;
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   grid-template-columns: auto 1fr;
   column-gap: 0.5rem;
 }

--- a/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
+++ b/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
@@ -58,12 +58,14 @@ const ScanResultsRow: FC<{ index: number; entry: ScanResultsOutlineEntry }> = ({
   );
 
   return (
-    <div
+    <button
+      type="button"
       className={clsx(
         styles.entry,
         selectedScanner === entry.title ? styles.selected : ""
       )}
       key={index}
+      aria-current={selectedScanner === entry.title ? "true" : undefined}
       onClick={() => {
         handleClick(entry.title);
       }}
@@ -113,7 +115,7 @@ const ScanResultsRow: FC<{ index: number; entry: ScanResultsOutlineEntry }> = ({
           />
         </LabeledValue>
       )}
-    </div>
+    </button>
   );
 };
 

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.module.css
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.module.css
@@ -31,6 +31,10 @@
 }
 
 .link {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   text-decoration: none;
   color: var(--bs-link-color);

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx
@@ -300,7 +300,8 @@ const InlinePresets: FC<{
         <Fragment key={index}>
           {" | "}
           <span className={styles.presetItem}>
-            <a
+            <button
+              type="button"
               className={clsx(
                 styles.link,
                 matchingColumnPreset?.name === preset.name
@@ -311,7 +312,7 @@ const InlinePresets: FC<{
               title={`Load "${preset.name}" (${preset.columns.length} columns)`}
             >
               <span className={styles.presetLabel}>{preset.name}</span>
-            </a>
+            </button>
             <button
               type="button"
               className={styles.presetDelete}
@@ -355,7 +356,8 @@ const InlinePresets: FC<{
             >
               Save
             </button>
-            <a
+            <button
+              type="button"
               className={clsx(styles.link, styles.cancelButton)}
               onClick={() => {
                 setIsSaving(false);
@@ -364,7 +366,7 @@ const InlinePresets: FC<{
               }}
             >
               Cancel
-            </a>
+            </button>
             {saveError && (
               <span style={{ color: "var(--bs-danger, #dc3545)" }}>
                 {saveError}
@@ -425,7 +427,8 @@ export const ScannerDataframeColumnsPopover: FC<
       styles={{ maxWidth: "600px" }}
     >
       <div className={clsx(styles.links, "text-size-smaller")}>
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDefaultFilter ? styles.selected : undefined
@@ -433,9 +436,10 @@ export const ScannerDataframeColumnsPopover: FC<
           onClick={() => setDefaultFilter()}
         >
           Default
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isAllFilter ? styles.selected : undefined
@@ -443,9 +447,10 @@ export const ScannerDataframeColumnsPopover: FC<
           onClick={() => setAllFilter()}
         >
           All
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isNoneFilter ? styles.selected : undefined
@@ -453,7 +458,7 @@ export const ScannerDataframeColumnsPopover: FC<
           onClick={() => setNoneFilter()}
         >
           None
-        </a>
+        </button>
         <InlinePresets
           filtered={filtered}
           presets={presets}
@@ -477,22 +482,16 @@ export const ScannerDataframeColumnsPopover: FC<
                     {groupName}
                   </div>
                   {columns.map((column) => (
-                    <div
-                      key={column}
-                      className={clsx(styles.row)}
-                      onClick={() => {
-                        filterColumn(column, !filtered.includes(column));
-                      }}
-                    >
+                    <label key={column} className={clsx(styles.row)}>
                       <input
                         type="checkbox"
                         checked={filtered.includes(column)}
                         onChange={(e) => {
                           filterColumn(column, e.target.checked);
                         }}
-                      ></input>
+                      />
                       {column}
-                    </div>
+                    </label>
                   ))}
                 </div>
               ))}

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.module.css
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.module.css
@@ -17,5 +17,11 @@
 }
 
 .clickable {
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
   cursor: pointer;
 }

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.tsx
@@ -96,7 +96,11 @@ const ColumnHeader: FC<{
   );
 
   return (
-    <div className={clsx(className, styles.clickable)} onClick={handleSort}>
+    <button
+      type="button"
+      className={clsx(className, styles.clickable)}
+      onClick={handleSort}
+    >
       {label}
       {sort && (
         <i
@@ -105,8 +109,9 @@ const ColumnHeader: FC<{
               ? ApplicationIcons.arrows.up
               : ApplicationIcons.arrows.down
           )}
+          aria-hidden="true"
         />
       )}
-    </div>
+    </button>
   );
 };

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
@@ -168,6 +168,11 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
   // Keyboard activation runs the whole row gesture: mouse clicks reach the
   // inner grid first (selection) and then bubble out to navigation.
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Only the row itself: Enter on a link inside the row must navigate
+    // that link, not get preventDefault()-ed into a row activation.
+    if (e.target !== e.currentTarget) {
+      return;
+    }
     if (e.key !== "Enter" && e.key !== " ") {
       return;
     }

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
@@ -62,6 +62,12 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
   const taskId = summary.transcriptTaskId;
   const taskRepeat = summary.transcriptTaskRepeat;
 
+  const selectRow = () => {
+    if (summary.identifier) {
+      setSelectedScanResult(summary.identifier);
+    }
+  };
+
   const grid = (
     <div
       style={gridDescriptor.gridStyle}
@@ -71,11 +77,8 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
         selectedScanResult === summary.identifier ? styles.selected : "",
         hasExplanation ? "" : styles.noExplanation
       )}
-      onClick={() => {
-        if (summary.identifier) {
-          setSelectedScanResult(summary.identifier);
-        }
-      }}
+      role="presentation"
+      onClick={selectRow}
     >
       {hasExplanation && (
         <div className={clsx(styles.result, "text-size-smaller")}>
@@ -162,16 +165,40 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
     navigate(scanResultUrl);
   };
 
-  return isNavigable ? (
+  // Keyboard activation runs the whole row gesture: mouse clicks reach the
+  // inner grid first (selection) and then bubble out to navigation.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "Enter" && e.key !== " ") {
+      return;
+    }
+    e.preventDefault();
+    selectRow();
+    if (scanResultUrl) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      navigate(scanResultUrl);
+    }
+  };
+
+  if (!isNavigable) {
+    // Selection only — the row has no result page to open.
+    return (
+      <div role="button" tabIndex={0} onKeyDown={handleKeyDown}>
+        {grid}
+      </div>
+    );
+  }
+
+  return (
     <div
       className={clsx(styles.link)}
+      role="button"
+      tabIndex={0}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       style={{ cursor: "pointer" }}
     >
       {grid}
     </div>
-  ) : (
-    grid
   );
 };
 

--- a/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
+++ b/apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx
@@ -179,13 +179,10 @@ const ScannerResultsRowComponent: FC<ScannerResultsRowProps> = ({
     }
   };
 
+  // Non-navigable rows render dimmed with `cursor: default` — presented as
+  // inert, so they get no tab stop to match.
   if (!isNavigable) {
-    // Selection only — the row has no result page to open.
-    return (
-      <div role="button" tabIndex={0} onKeyDown={handleKeyDown}>
-        {grid}
-      </div>
-    );
+    return grid;
   }
 
   return (

--- a/apps/scout/src/app/transcript/TranscriptFilterPopover.module.css
+++ b/apps/scout/src/app/transcript/TranscriptFilterPopover.module.css
@@ -27,13 +27,17 @@
   border-bottom: solid 1px var(--bs-border-color);
 }
 
-.links a {
+.links button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   text-decoration: none;
   color: var(--bs-link-color);
 }
 
-.links a:hover {
+.links button:hover {
   color: var(--bs-link-hover-color);
 }
 

--- a/apps/scout/src/app/transcript/TranscriptFilterPopover.tsx
+++ b/apps/scout/src/app/transcript/TranscriptFilterPopover.tsx
@@ -37,7 +37,8 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
       hoverDelay={-1}
     >
       <div className={clsx(styles.links, "text-size-smaller")}>
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDefaultFilter ? styles.selected : undefined
@@ -45,9 +46,10 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
           onClick={() => setDefaultFilter()}
         >
           Default
-        </a>
+        </button>
         |
-        <a
+        <button
+          type="button"
           className={clsx(
             styles.link,
             isDebugFilter ? styles.selected : undefined
@@ -55,30 +57,23 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
           onClick={() => setDebugFilter()}
         >
           Debug
-        </a>
+        </button>
       </div>
 
       <div className={clsx(styles.grid, "text-size-smaller")}>
         {arrangedEventTypes(2).map((eventType) => {
           const isExcluded = excludedEventTypes.includes(eventType);
           return (
-            <div
-              key={eventType}
-              className={clsx(styles.row)}
-              onClick={() => {
-                toggleEventType(eventType, isExcluded);
-              }}
-            >
+            <label key={eventType} className={clsx(styles.row)}>
               <input
                 type="checkbox"
                 checked={!isExcluded}
-                onChange={(e) => {
-                  e.stopPropagation();
+                onChange={() => {
                   toggleEventType(eventType, isExcluded);
                 }}
               />
               {eventType}
-            </div>
+            </label>
           );
         })}
       </div>

--- a/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
+++ b/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
@@ -318,8 +318,11 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
 
         {/* Target set selector */}
         <div className={styles.fieldGroup}>
-          <label className={styles.label}>Target validation set:</label>
+          <label htmlFor="copy-move-target-set" className={styles.label}>
+            Target validation set:
+          </label>
           <VscodeSingleSelect
+            id="copy-move-target-set"
             value={showNewSetInput ? "__new__" : (targetUri ?? "")}
             onChange={handleTargetChange}
             disabled={isProcessing}
@@ -338,8 +341,11 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
         {/* New set name input */}
         {showNewSetInput && (
           <div className={styles.fieldGroup}>
-            <label className={styles.label}>New set name:</label>
+            <label htmlFor="copy-move-new-set-name" className={styles.label}>
+              New set name:
+            </label>
             <VscodeTextfield
+              id="copy-move-new-set-name"
               value={newSetName}
               onInput={handleNewSetNameInput}
               placeholder="Enter name (without extension)"
@@ -356,8 +362,11 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
         {/* Split selector for target */}
         {(targetUri || (showNewSetInput && newSetName.trim())) && (
           <div className={styles.fieldGroup}>
-            <label className={styles.label}>Split assignment:</label>
+            <label htmlFor="copy-move-split" className={styles.label}>
+              Split assignment:
+            </label>
             <VscodeSingleSelect
+              id="copy-move-split"
               value={targetSplit}
               onChange={handleSplitChange}
               disabled={isProcessing}

--- a/apps/scout/src/app/validation/components/ValidationCaseCard.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseCard.tsx
@@ -228,9 +228,12 @@ export const ValidationCaseCard: FC<ValidationCaseCardProps> = ({
   const labelsText = formatLabels(labels);
 
   return (
+    // Clicking the card is a shortcut for the checkbox below, which is the
+    // control keyboard and screen-reader users operate.
     <div
       className={`${styles.card} ${isSelected ? styles.selected : ""}`}
       style={gridStyle}
+      role="presentation"
       onClick={handleRowClick}
     >
       {/* Checkbox column */}

--- a/apps/scout/src/app/validation/components/ValidationCaseLabelsEditor.tsx
+++ b/apps/scout/src/app/validation/components/ValidationCaseLabelsEditor.tsx
@@ -141,10 +141,16 @@ export const ValidationCaseLabelsEditor: FC<
           </div>
 
           <div className={styles.popoverField}>
-            <label className={clsx("text-size-smallest", styles.popoverLabel)}>
+            {/* A radio group takes a group name, not a <label> — a label may
+                only point at a single form control. */}
+            <span
+              id="validation-label-value"
+              className={clsx("text-size-smallest", styles.popoverLabel)}
+            >
               Value
-            </label>
+            </span>
             <VscodeRadioGroup
+              aria-labelledby="validation-label-value"
               onChange={(e) =>
                 setNewLabelValue((e.target as HTMLInputElement).value)
               }

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.module.css
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.module.css
@@ -91,7 +91,13 @@
 
 /* Dropdown items */
 .item {
+  display: block;
+  width: 100%;
   padding: 6px 10px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   border-bottom: 1px solid var(--vscode-panel-border);
 }

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.module.css
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.module.css
@@ -99,6 +99,7 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
+  border: none;
   border-bottom: 1px solid var(--vscode-panel-border);
 }
 

--- a/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
+++ b/apps/scout/src/app/validation/components/ValidationSetSelector.tsx
@@ -257,8 +257,9 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
       role="listbox"
     >
       {validationSets.map((uri) => (
-        <div
+        <button
           key={uri}
+          type="button"
           role="option"
           aria-selected={selectedUri === uri}
           className={`${styles.item} ${selectedUri === uri ? styles.selected : ""}`}
@@ -268,21 +269,22 @@ export const ValidationSetSelector: FC<ValidationSetSelectorProps> = ({
           <div className={styles.secondaryText}>
             {getDisplayPath(uri, appConfig) || (hasNonRootDir ? "\u00A0" : "")}
           </div>
-        </div>
+        </button>
       ))}
 
       {/* Create new set option */}
       {allowCreate && onCreate && (
         <>
           {validationSets.length > 0 && <div className={styles.divider} />}
-          <div
+          <button
+            type="button"
             role="option"
             aria-selected={false}
             className={`${styles.item} ${styles.createOption}`}
             onClick={() => handleSelect("__create_new__")}
           >
             <div className={styles.primaryText}>Create new set...</div>
-          </div>
+          </button>
         </>
       )}
     </div>

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   },
   "//": "manypkg requires root deps in 'dependencies', not 'devDependencies'. The root is private and never published, so the distinction is meaningless here — it's a consistency convention.",
   "pnpm": {
-    "//": "eslint-plugin-react works with eslint 10 but hasn't published a release declaring ^10 peer support yet; drop this rule when it does.",
+    "//": "eslint-plugin-react and eslint-plugin-jsx-a11y work with eslint 10 but haven't published releases declaring ^10 peer support yet; drop these rules when they do.",
     "peerDependencyRules": {
       "allowedVersions": {
-        "eslint-plugin-react>eslint": "^10.0.0"
+        "eslint-plugin-react>eslint": "^10.0.0",
+        "eslint-plugin-jsx-a11y>eslint": "^10.0.0"
       }
     },
     "overrides": {

--- a/packages/inspect-components/eslint.config.js
+++ b/packages/inspect-components/eslint.config.js
@@ -26,20 +26,5 @@ export default tseslint.config(
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
     },
-  },
-  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
-  // Remove this block as the underlying issues are fixed.
-  {
-    files: ["**/*.{ts,tsx}"],
-    rules: {
-      "jsx-a11y/anchor-is-valid": "off",
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/interactive-supports-focus": "off",
-      "jsx-a11y/media-has-caption": "off",
-      "jsx-a11y/no-autofocus": "off",
-      "jsx-a11y/no-noninteractive-tabindex": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-      "jsx-a11y/role-supports-aria-props": "off",
-    },
   }
 );

--- a/packages/inspect-components/eslint.config.js
+++ b/packages/inspect-components/eslint.config.js
@@ -26,5 +26,20 @@ export default tseslint.config(
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
     },
+  },
+  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
+  // Remove this block as the underlying issues are fixed.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "jsx-a11y/anchor-is-valid": "off",
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/interactive-supports-focus": "off",
+      "jsx-a11y/media-has-caption": "off",
+      "jsx-a11y/no-autofocus": "off",
+      "jsx-a11y/no-noninteractive-tabindex": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+      "jsx-a11y/role-supports-aria-props": "off",
+    },
   }
 );

--- a/packages/inspect-components/src/chat/MessageContent.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.tsx
@@ -260,6 +260,9 @@ const messageRenderers: Record<string, MessageRenderer> = {
         return <MediaReference source={c.audio} key={key} />;
       }
       return (
+        // Log content carries no caption track and none can be synthesised
+        // here; the audio is model input being replayed, not authored media.
+        // eslint-disable-next-line jsx-a11y/media-has-caption
         <audio controls key={key}>
           <source src={c.audio} type={audioMimeTypeForFormat(c.format)} />
         </audio>
@@ -273,6 +276,7 @@ const messageRenderers: Record<string, MessageRenderer> = {
         return <MediaReference source={c.video} key={key} />;
       }
       return (
+        // eslint-disable-next-line jsx-a11y/media-has-caption -- see audio above
         <video width="500" height="375" controls key={key}>
           <source src={c.video} type={videoMimeTypeForFormat(c.format)} />
         </video>

--- a/packages/inspect-components/src/chat/MessageLabel.module.css
+++ b/packages/inspect-components/src/chat/MessageLabel.module.css
@@ -2,6 +2,7 @@
 .inline {
   display: inline-flex;
   align-items: center;
+  margin: 0;
   font-family: var(
     --bs-font-monospace,
     ui-monospace,

--- a/packages/inspect-components/src/chat/MessageLabel.tsx
+++ b/packages/inspect-components/src/chat/MessageLabel.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, KeyboardEvent } from "react";
+import { FC } from "react";
 
 import styles from "./MessageLabel.module.css";
 
@@ -32,41 +32,31 @@ export const MessageLabel: FC<MessageLabelProps> = ({
   onActivate,
   className,
 }) => {
-  if (mode === "inline") {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (onActivate && (e.key === "Enter" || e.key === " ")) {
-        e.preventDefault();
-        onActivate();
-      }
-    };
+  const inline = mode === "inline";
+  const text = inline ? label : compactLabel(label);
+  const classes = clsx(
+    inline ? styles.inline : styles.badge,
+    onActivate && styles.interactive,
+    className
+  );
+  const title = text === label ? undefined : label;
+
+  if (onActivate) {
     return (
-      <a
-        className={clsx(
-          styles.inline,
-          onActivate && styles.interactive,
-          className
-        )}
+      <button
+        type="button"
+        className={classes}
         onClick={onActivate}
-        onKeyDown={onActivate ? onKeyDown : undefined}
-        tabIndex={onActivate ? 0 : undefined}
+        title={title}
       >
-        {label}
-      </a>
+        {text}
+      </button>
     );
   }
 
-  const compact = compactLabel(label);
   return (
-    <span
-      className={clsx(
-        styles.badge,
-        onActivate && styles.interactive,
-        className
-      )}
-      onClick={onActivate}
-      title={compact === label ? undefined : label}
-    >
-      {compact}
+    <span className={classes} title={title}>
+      {text}
     </span>
   );
 };

--- a/packages/inspect-components/src/chat/documents/ContentDocumentView.module.css
+++ b/packages/inspect-components/src/chat/documents/ContentDocumentView.module.css
@@ -13,6 +13,15 @@
   align-items: center;
 }
 
+.downloadLink {
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
 .downloadLink:hover {
   text-decoration: underline;
   cursor: pointer;

--- a/packages/inspect-components/src/chat/documents/ContentDocumentView.tsx
+++ b/packages/inspect-components/src/chat/documents/ContentDocumentView.tsx
@@ -73,17 +73,21 @@ const ContentDocumentFrame: FC<ContentDocumentFrameProps> = ({
       )}
     >
       <div className={clsx(styles.documentFrameTitle)}>
-        <i className={clsx(icons.iconForMimeType(document.mime_type || ""))} />
+        <i
+          className={clsx(icons.iconForMimeType(document.mime_type || ""))}
+          aria-hidden="true"
+        />
         <div>
           {onDownloadFile ? (
-            <a
+            <button
+              type="button"
               className={clsx(styles.downloadLink)}
               onClick={() => {
                 onDownloadFile(document.filename, document.document);
               }}
             >
               {document.filename}
-            </a>
+            </button>
           ) : (
             document.filename
           )}

--- a/packages/inspect-components/src/columnFilter/ColumnFilterEditor.tsx
+++ b/packages/inspect-components/src/columnFilter/ColumnFilterEditor.tsx
@@ -54,6 +54,7 @@ const FilterValueInput: FC<FilterValueInputProps> = ({
         value={value}
         onChange={handleChange}
         disabled={disabled}
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- see the note on ConditionRow's autoFocus
         autoFocus={autoFocus}
       >
         <option value="">(not set)</option>
@@ -113,6 +114,7 @@ const FilterValueInput: FC<FilterValueInputProps> = ({
       placeholder="Filter"
       disabled={disabled}
       step={filterType === "number" ? "any" : undefined}
+      // eslint-disable-next-line jsx-a11y/no-autofocus -- see the note on ConditionRow's autoFocus
       autoFocus={autoFocus}
     />
   );
@@ -141,6 +143,11 @@ interface ConditionRowProps {
    * `-op-b` / `-val-b` / `-val-b2`).
    */
   idSuffix: "" | "-b";
+  /**
+   * The filter editor only ever renders inside a popover the user just
+   * opened, where moving focus to the first field is the expected behaviour
+   * (WAI-ARIA APG dialog pattern) rather than a page-load focus steal.
+   */
   autoFocus?: boolean;
   suggestions: ScalarValue[];
   onCommit?: () => void;
@@ -295,6 +302,9 @@ export const ColumnFilterEditor: FC<ColumnFilterEditorProps> = ({
   );
 
   return (
+    // Escape/Enter are delegated from the fields inside, all of which are
+    // focusable in their own right — the container is not itself a control.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className={styles.filterContent} onKeyDown={handleKeyDown}>
       <ConditionRow
         columnId={columnId}

--- a/packages/inspect-components/src/columnFilter/DurationInput.tsx
+++ b/packages/inspect-components/src/columnFilter/DurationInput.tsx
@@ -40,6 +40,7 @@ export const DurationInput: FC<DurationInputProps> = ({
         disabled={disabled}
         step="any"
         min="0"
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- see the note on ConditionRow's autoFocus
         autoFocus={autoFocus}
       />
       {parsedSeconds !== null && (

--- a/packages/inspect-components/src/content/RecordTree.tsx
+++ b/packages/inspect-components/src/content/RecordTree.tsx
@@ -246,11 +246,12 @@ export const RecordTree: FC<RecordTreeProps> = ({
   if (!scrollRef) {
     // No virtualization - render directly
     return (
+      // No tabIndex here: unlike the virtualized branch this div is not the
+      // scroll container, and every row is already its own tab stop.
       <div
         id={id}
         className={clsx(className, "samples-list")}
         style={{ width: "100%" }}
-        tabIndex={0}
       >
         {items.map((_, index) => renderRow(index))}
       </div>

--- a/packages/inspect-components/src/transcript/BranchPoint.module.css
+++ b/packages/inspect-components/src/transcript/BranchPoint.module.css
@@ -66,17 +66,17 @@
 .segment:first-of-type {
   border-left: 0;
 }
-.segment:hover:not([aria-pressed="true"]):not(:disabled) {
+.segment:hover:not([aria-checked="true"]):not(:disabled) {
   background: var(--bp-active-bg);
   color: var(--bs-body-color, inherit);
 }
-.segment[aria-pressed="true"] {
+.segment[aria-checked="true"] {
   background: var(--bp-active-bg);
   color: var(--bs-body-color, inherit);
   font-weight: 600;
   cursor: default;
 }
-.segment:disabled:not([aria-pressed="true"]) {
+.segment:disabled:not([aria-checked="true"]) {
   cursor: default;
 }
 .segment:focus-visible {

--- a/packages/inspect-components/src/transcript/BranchPoint.tsx
+++ b/packages/inspect-components/src/transcript/BranchPoint.tsx
@@ -91,7 +91,6 @@ const Segment: FC<SegmentProps> = ({
       data-testid="bp-segment"
       data-branch={branch}
       aria-checked={isCurrent}
-      aria-pressed={isCurrent ? "true" : "false"}
       onClick={interactive ? handleClick : undefined}
       disabled={!interactive}
     >

--- a/packages/inspect-components/src/transcript/ModelEventView.module.css
+++ b/packages/inspect-components/src/transcript/ModelEventView.module.css
@@ -68,7 +68,11 @@
   padding: 0.5em 0 0.7em;
 }
 
-.showAllLink a {
+.showAllLink button {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
   cursor: pointer;
   color: var(--bs-secondary-color);
   text-decoration: none;
@@ -78,7 +82,7 @@
   margin-right: 0.35em;
 }
 
-.showAllLink a:hover {
+.showAllLink button:hover {
   color: var(--bs-body-color);
   text-decoration: underline;
 }

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -215,18 +215,18 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
           hasHiddenMessages &&
           !showAllMessages && (
             <div className={clsx("text-size-small", styles.showAllLink)}>
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
+              <button
+                type="button"
+                onClick={() => {
                   setShowAllMessages(true);
                 }}
               >
                 <i
                   className={clsx(TranscriptIcons.expand, styles.showAllIcon)}
+                  aria-hidden="true"
                 />
                 Show all messages
-              </a>
+              </button>
             </div>
           )}
         <ChatView

--- a/packages/inspect-components/src/transcript/event/EventNavsPicker.tsx
+++ b/packages/inspect-components/src/transcript/event/EventNavsPicker.tsx
@@ -104,9 +104,15 @@ export const EventNavsPicker: FC<EventNavsPickerProps> = ({
         position &&
         createPortal(
           <>
-            <div className={styles.backdrop} onClick={() => setOpen(false)} />
+            {/* Mouse-only dismissal; Escape closes the picker. */}
+            <div
+              className={styles.backdrop}
+              role="presentation"
+              onClick={() => setOpen(false)}
+            />
             <div
               role="listbox"
+              tabIndex={-1}
               className={styles.menu}
               style={{
                 top: position.top,

--- a/packages/inspect-components/src/transcript/event/EventPanel.module.css
+++ b/packages/inspect-components/src/transcript/event/EventPanel.module.css
@@ -191,8 +191,23 @@ a.turnButton {
   margin-right: -2px;
 }
 
+/* The chevron button is styled down to the bare glyph — the surrounding
+   header cells supply the visual affordance. */
+.collapseToggle {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
 .bottomDongle {
   display: block;
+  font-family: inherit;
+  font-weight: inherit;
   position: absolute;
   margin: 0 auto;
   width: fit-content;

--- a/packages/inspect-components/src/transcript/event/EventPanel.tsx
+++ b/packages/inspect-components/src/transcript/event/EventPanel.tsx
@@ -266,10 +266,22 @@ export const EventPanel: FC<EventPanelProps> = ({
         onMouseLeave={() => setMouseOver(false)}
       >
         {isCollapsible && !useBottomDongle ? (
-          <i
+          <button
+            type="button"
+            className={styles.collapseToggle}
             onClick={toggleCollapse}
-            className={collapsed ? kChevronRight : kChevronDown}
-          />
+            aria-expanded={!collapsed}
+            aria-label={
+              title
+                ? `${collapsed ? "Expand" : "Collapse"} ${title}`
+                : undefined
+            }
+          >
+            <i
+              className={collapsed ? kChevronRight : kChevronDown}
+              aria-hidden="true"
+            />
+          </button>
         ) : (
           ""
         )}
@@ -277,29 +289,34 @@ export const EventPanel: FC<EventPanelProps> = ({
           <i
             className={clsx(icon || kDefaultIcon, "text-style-secondary")}
             onClick={toggleCollapse}
+            aria-hidden="true"
           />
         ) : (
           ""
         )}
+        {/* The header cells below widen the toggle's hit area for mouse users;
+            the chevron button above is the control keyboard users operate. */}
         <div
           className={clsx(
             "text-style-secondary",
             "text-style-label",
             styles.title
           )}
+          role="presentation"
           onClick={toggleCollapse}
         >
           <span>{title}</span>
           {headerExtra ? (
             <span
               className={styles.titleExtra}
+              role="presentation"
               onClick={(e) => e.stopPropagation()}
             >
               {headerExtra}
             </span>
           ) : null}
           {url ? (
-            <span onClick={(e) => e.stopPropagation()}>
+            <span role="presentation" onClick={(e) => e.stopPropagation()}>
               <CopyButton
                 value={url}
                 icon={kLinkIcon}
@@ -310,6 +327,7 @@ export const EventPanel: FC<EventPanelProps> = ({
         </div>
         <div
           className={styles.navs}
+          role="presentation"
           onClick={showNavs ? undefined : toggleCollapse}
         >
           {showNavs ? (
@@ -341,6 +359,7 @@ export const EventPanel: FC<EventPanelProps> = ({
               styles.turnNav,
               turnNav.isAnchor === false && styles.turnNavFollower
             )}
+            role="presentation"
             onClick={(e) => e.stopPropagation()}
           >
             {onTurnLabelClick ? (
@@ -479,19 +498,22 @@ export const EventPanel: FC<EventPanelProps> = ({
       </div>
 
       {isCollapsible && useBottomDongle ? (
-        <div
+        <button
+          type="button"
           className={clsx(styles.bottomDongle, "text-size-smallest")}
           onClick={toggleCollapse}
+          aria-expanded={!collapsed}
         >
           <i
             className={clsx(
               collapsed ? kChevronRight : kChevronDown,
               styles.dongleIcon
             )}
+            aria-hidden="true"
           />
           transcript ({childIds?.length}{" "}
           {childIds?.length === 1 ? "event" : "events"})
-        </div>
+        </button>
       ) : undefined}
     </div>
   );

--- a/packages/inspect-components/src/transcript/event/RetryChip.tsx
+++ b/packages/inspect-components/src/transcript/event/RetryChip.tsx
@@ -71,7 +71,12 @@ export const RetryChip: FC<RetryChipProps> = ({
       </button>
       {open && (
         <>
-          <div className={styles.backdrop} onClick={() => setOpen(false)} />
+          {/* Mouse-only dismissal; Escape closes the menu. */}
+          <div
+            className={styles.backdrop}
+            role="presentation"
+            onClick={() => setOpen(false)}
+          />
           <div className={styles.menu}>
             {attempts.map((attempt, idx) => {
               const key = keyOf(attempt);

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.module.css
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.module.css
@@ -13,6 +13,13 @@
 .eventRow .toggle {
   font-size: 0.7em;
   margin-top: 4px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .eventLink,

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
@@ -86,3 +86,54 @@ describe("OutlineRow collapse chevron", () => {
     expect(setCollapsed).not.toHaveBeenCalled();
   });
 });
+
+// =============================================================================
+// Keyboard activation
+// =============================================================================
+
+describe("OutlineRow keyboard activation", () => {
+  afterEach(() => cleanup());
+
+  const parentNode = () =>
+    eventNode({ event: "span_begin", name: "phase one", type: null }, [
+      eventNode({ event: "model" }),
+    ]);
+
+  it("activates the row when the row itself takes the key press", () => {
+    const onSelect = vi.fn<(id: string) => void>();
+    const node = parentNode();
+    const { container } = render(
+      <OutlineRow node={node} onSelect={onSelect} getCollapsed={() => false} />
+    );
+
+    fireEvent.keyDown(container.querySelector(`.${styles.eventRow}`)!, {
+      key: "Enter",
+    });
+    expect(onSelect).toHaveBeenCalledWith(node.id);
+  });
+
+  // The row handler sees Enter bubbling up from the chevron. Acting on it
+  // would both navigate the row and — via preventDefault anywhere on the
+  // propagation path — cancel the button's own activation.
+  it("leaves key presses that bubble from the collapse chevron alone", () => {
+    const onSelect = vi.fn<(id: string) => void>();
+    const { container } = render(
+      <OutlineRow
+        node={parentNode()}
+        onSelect={onSelect}
+        getCollapsed={() => false}
+        setCollapsed={vi.fn()}
+      />
+    );
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    container.querySelector(`.${styles.toggle}`)!.dispatchEvent(event);
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
@@ -65,6 +65,9 @@ export const OutlineRow: FC<OutlineRowProps> = ({
         tabIndex={0}
         onClick={activate}
         onKeyDown={(e) => {
+          // Only the row itself: Enter/Space bubbling up from a nested
+          // control must keep its own default action.
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             activate();

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.tsx
@@ -46,6 +46,11 @@ export const OutlineRow: FC<OutlineRowProps> = ({
 
   const labelText = parsePackageName(labelForNode(node)).module;
 
+  const activate = () => {
+    onSelect?.(node.id);
+    onNavigateToEvent?.(node.id);
+  };
+
   return (
     <>
       <div
@@ -56,21 +61,33 @@ export const OutlineRow: FC<OutlineRowProps> = ({
         )}
         style={{ paddingLeft: `${node.depth * 0.75}em` }}
         data-unsearchable={true}
-        onClick={() => {
-          onSelect?.(node.id);
-          onNavigateToEvent?.(node.id);
+        role="button"
+        tabIndex={0}
+        onClick={activate}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            activate();
+          }
         }}
       >
-        <div
-          className={styles.toggle}
-          onClick={() => {
-            if (node.children.length > 0) {
+        {node.children.length > 0 ? (
+          <button
+            type="button"
+            className={styles.toggle}
+            aria-expanded={!collapsed}
+            aria-label={`${collapsed ? "Expand" : "Collapse"} ${labelText}`}
+            onClick={() => {
               setCollapsed?.(node.id, !collapsed);
-            }
-          }}
-        >
-          {toggle ? <i className={clsx(toggle)} /> : undefined}
-        </div>
+            }}
+          >
+            {toggle ? (
+              <i className={clsx(toggle)} aria-hidden="true" />
+            ) : undefined}
+          </button>
+        ) : (
+          <div className={styles.toggle} />
+        )}
         <div
           className={clsx(styles.label)}
           data-depth={node.depth}

--- a/packages/inspect-components/src/transcript/timeline/components/AgentCardView.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/AgentCardView.tsx
@@ -118,6 +118,9 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => {
+        // Only the card itself: Enter/Space bubbling up from the result
+        // panel's controls must keep its own default action.
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           handleClick();

--- a/packages/inspect-components/src/transcript/timeline/components/AgentCardView.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/AgentCardView.tsx
@@ -45,18 +45,20 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
   const iconClass = isBranch ? icons.fork : icons.agent;
   const label = isBranch ? "branch" : isUtility ? "utility" : "sub-agent";
 
-  return (
-    <div
-      className={clsx(
-        styles.card,
-        isUtility && styles.utilityCard,
-        isBranch && styles.branchCard,
-        className
-      )}
-      onClick={isBranch ? undefined : handleClick}
-    >
+  const cardClass = clsx(
+    styles.card,
+    isUtility && styles.utilityCard,
+    isBranch && styles.branchCard,
+    className
+  );
+
+  const content = (
+    <>
       <div className={clsx(styles.header, "text-size-small")}>
-        <i className={clsx(iconClass, styles.icon, "text-style-secondary")} />
+        <i
+          className={clsx(iconClass, styles.icon, "text-style-secondary")}
+          aria-hidden="true"
+        />
         <div
           className={clsx(
             styles.title,
@@ -77,6 +79,7 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
               styles.disclosure,
               "text-style-secondary"
             )}
+            aria-hidden="true"
           />
         )}
       </div>
@@ -86,7 +89,11 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
         </div>
       )}
       {resultOutput && (
-        <div className={styles.resultPanel} onClick={stopPropagation}>
+        <div
+          className={styles.resultPanel}
+          role="presentation"
+          onClick={stopPropagation}
+        >
           <ExpandablePanel
             id={`agent-result-${span.id}`}
             collapse={true}
@@ -96,6 +103,28 @@ export const AgentCardView: FC<AgentCardViewProps> = ({ span, className }) => {
           </ExpandablePanel>
         </div>
       )}
+    </>
+  );
+
+  // Branch cards are inert; every other card navigates to its sub-agent.
+  if (isBranch) {
+    return <div className={cardClass}>{content}</div>;
+  }
+
+  return (
+    <div
+      className={cardClass}
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      {content}
     </div>
   );
 };

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.module.css
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.module.css
@@ -16,6 +16,10 @@
  */
 .stableLabel {
   display: grid;
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: inherit;
   font-size: 0.6rem;
   line-height: 1.4;
   color: var(--vscode-descriptionForeground, #717171);

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.tsx
@@ -190,15 +190,17 @@ export const TimelineMinimap: FC<TimelineMinimapProps> = ({
 
   return (
     <div className={styles.container}>
-      {/* Mode label — click to toggle time/tokens.
-          Both values are rendered so the cell sizes to the wider one. */}
-      <div
+      {/* Mode label — the toggle control for time/tokens. Both values are
+          rendered so the cell sizes to the wider one. */}
+      <button
+        type="button"
         className={clsx(styles.stableLabel, styles.alignRight)}
         onClick={toggle}
+        aria-label={isTokenMode ? "Show time" : "Show tokens"}
       >
         <span className={isTokenMode ? styles.hidden : undefined}>time</span>
         <span className={isTokenMode ? undefined : styles.hidden}>tokens</span>
-      </div>
+      </button>
 
       {/* Bar area */}
       <div className={styles.minimap}>
@@ -245,7 +247,12 @@ export const TimelineMinimap: FC<TimelineMinimapProps> = ({
 
             <div className={styles.marker} />
             <div className={styles.sectionTime}>
-              <span className={styles.sectionTimePill} onClick={toggle}>
+              {/* Mouse shortcut for the mode button at the start of the row. */}
+              <span
+                className={styles.sectionTimePill}
+                role="presentation"
+                onClick={toggle}
+              >
                 {sectionLabel}
               </span>
             </div>
@@ -254,9 +261,11 @@ export const TimelineMinimap: FC<TimelineMinimapProps> = ({
         )}
       </div>
 
-      {/* Right edge label — both values rendered for stable width */}
+      {/* Right edge label — both values rendered for stable width. Another
+          mouse shortcut for the mode button; not a separate control. */}
       <div
         className={clsx(styles.stableLabel, styles.alignLeft)}
+        role="presentation"
         onClick={toggle}
       >
         <span className={isTokenMode ? styles.hidden : undefined}>

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineOptionsPopover.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineOptionsPopover.tsx
@@ -51,85 +51,54 @@ export const TimelineOptionsPopover: FC<TimelineOptionsPopoverProps> = ({
     >
       <div className={`${styles.title} text-size-smaller`}>View Options</div>
       <div className={`${styles.rows} text-size-smaller`}>
-        {kMarkerKindLabels.map(({ kind, label }) => {
-          const checked = config.markerKinds.includes(kind);
-          return (
-            <div
-              key={kind}
-              className={styles.row}
-              onClick={() => config.toggleMarkerKind(kind)}
-            >
-              <input
-                type="checkbox"
-                checked={checked}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  config.toggleMarkerKind(kind);
-                }}
-              />
-              {label}
-            </div>
-          );
-        })}
-        <div
-          className={styles.row}
-          onClick={() => config.setIncludeUtility(!config.includeUtility)}
-        >
+        {kMarkerKindLabels.map(({ kind, label }) => (
+          <label key={kind} className={styles.row}>
+            <input
+              type="checkbox"
+              checked={config.markerKinds.includes(kind)}
+              onChange={() => config.toggleMarkerKind(kind)}
+            />
+            {label}
+          </label>
+        ))}
+        <label className={styles.row}>
           <input
             type="checkbox"
             checked={config.includeUtility}
-            onChange={(e) => {
-              e.stopPropagation();
-              config.setIncludeUtility(!config.includeUtility);
-            }}
+            onChange={() => config.setIncludeUtility(!config.includeUtility)}
           />
           Utility agents
-        </div>
+        </label>
 
         <div className={styles.groupHeader}>Branches</div>
-        <div className={styles.row} onClick={onToggleBranches}>
+        <label className={styles.row}>
           <input
             type="checkbox"
             checked={config.showBranches}
-            onChange={(e) => {
-              e.stopPropagation();
-              onToggleBranches();
-            }}
+            onChange={onToggleBranches}
           />
           Show branches
-        </div>
+        </label>
         {config.showBranches && (
           <>
-            <div
-              className={styles.row}
-              onClick={() => config.setForkRelative(!config.forkRelative)}
-            >
+            <label className={styles.row}>
               <input
                 type="checkbox"
                 checked={config.forkRelative}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  config.setForkRelative(!config.forkRelative);
-                }}
+                onChange={() => config.setForkRelative(!config.forkRelative)}
               />
               Fork-relative branches
-            </div>
-            <div
-              className={styles.row}
-              onClick={() =>
-                config.setShowEmptyBranches(!config.showEmptyBranches)
-              }
-            >
+            </label>
+            <label className={styles.row}>
               <input
                 type="checkbox"
                 checked={config.showEmptyBranches}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  config.setShowEmptyBranches(!config.showEmptyBranches);
-                }}
+                onChange={() =>
+                  config.setShowEmptyBranches(!config.showEmptyBranches)
+                }
               />
               Show empty branches
-            </div>
+            </label>
           </>
         )}
       </div>

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 
 import type { Timeline } from "../core";
 
@@ -37,6 +37,15 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
     [onSelect]
   );
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen]);
+
   if (timelines.length <= 1) return null;
 
   const active = timelines[activeIndex];
@@ -53,11 +62,19 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
         aria-expanded={isOpen}
       >
         {active.name}
-        <i className={clsx("bi-chevron-down", styles.chevron)} />
+        <i
+          className={clsx("bi-chevron-down", styles.chevron)}
+          aria-hidden="true"
+        />
       </button>
       {isOpen && (
         <>
-          <div className={styles.backdrop} onClick={() => setIsOpen(false)} />
+          {/* Mouse-only dismissal; Escape closes the menu. */}
+          <div
+            className={styles.backdrop}
+            role="presentation"
+            onClick={() => setIsOpen(false)}
+          />
           <div className={styles.dropdownMenu} role="listbox">
             {timelines.map((tl, i) => (
               <button

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC, useCallback, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
 
 import type { Timeline } from "../core";
 
@@ -28,6 +28,8 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
   onSelect,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const handleSelect = useCallback(
     (index: number) => {
@@ -40,7 +42,12 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
   useEffect(() => {
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
+      if (e.key !== "Escape") return;
+      // Only pull focus back to the trigger when it was inside the menu.
+      const refocus =
+        containerRef.current?.contains(document.activeElement) ?? false;
+      setIsOpen(false);
+      if (refocus) triggerRef.current?.focus();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -52,8 +59,9 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
   if (!active) return null;
 
   return (
-    <div className={styles.selectorContainer}>
+    <div ref={containerRef} className={styles.selectorContainer}>
       <button
+        ref={triggerRef}
         type="button"
         className={styles.selectorButton}
         onClick={() => setIsOpen((prev) => !prev)}

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSelector.tsx
@@ -43,14 +43,19 @@ export const TimelineSelector: FC<TimelineSelectorProps> = ({
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      // This Escape closes the menu and nothing else: stop it here (the
+      // capture-phase registration below runs first) so an enclosing
+      // surface's own Escape handler — e.g. Modal's, on document bubble —
+      // doesn't also fire and close both layers at once.
+      e.stopPropagation();
       // Only pull focus back to the trigger when it was inside the menu.
       const refocus =
         containerRef.current?.contains(document.activeElement) ?? false;
       setIsOpen(false);
       if (refocus) triggerRef.current?.focus();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [isOpen]);
 
   if (timelines.length <= 1) return null;

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.module.css
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.module.css
@@ -144,6 +144,9 @@
   justify-content: center;
   width: 12px;
   flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
   cursor: pointer;
   color: var(--vscode-descriptionForeground);
   font-size: 8px;
@@ -303,6 +306,10 @@
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
   font-size: 9px;
   z-index: 1;
   pointer-events: auto;

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
@@ -617,7 +617,10 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
 
   return (
     <div className={styles.row} role="row">
-      {/* Label cell — depth-based indentation; clicking selects the whole row */}
+      {/* Label cell — depth-based indentation; clicking selects the whole row.
+          Keyboard selection is the grid's own Arrow/Escape handling, and the
+          cell takes tabIndex -1 so the grid keeps a single tab stop. */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
       <div
         className={clsx(
           styles.label,
@@ -627,19 +630,23 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
             styles.labelHighlighted
         )}
         style={{ paddingLeft: `${0.3 + layout.depth * 0.5}rem` }}
+        role="gridcell"
+        tabIndex={-1}
         onClick={onSelectRow}
       >
         {hasChildren ? (
-          <span
+          <button
+            type="button"
             className={styles.chevron}
             onClick={handleChevronClick}
-            role="button"
+            aria-expanded={isExpanded}
             aria-label={isExpanded ? "Collapse" : "Expand"}
           >
             <i
               className={isExpanded ? icons.chevron.down : icons.chevron.right}
+              aria-hidden="true"
             />
-          </span>
+          </button>
         ) : (
           <span className={styles.chevronSpacer} />
         )}
@@ -961,6 +968,7 @@ const BarFill: FC<BarFillProps> = ({
           : `${span.bar.width}%`,
       }}
       title={span.description ?? undefined}
+      role="presentation"
       onClick={handleClick}
       onDoubleClick={onDoubleClick ? handleDoubleClick : undefined}
     />
@@ -1087,6 +1095,7 @@ const RegionBarFill: FC<RegionBarFillProps> = ({
           width: `${span.bar.width}%`,
         }}
         title={span.description ?? undefined}
+        role="presentation"
         onClick={(e) => {
           e.stopPropagation();
           onSelectBar();
@@ -1161,6 +1170,7 @@ const RegionBarFill: FC<RegionBarFillProps> = ({
               width: `${segmentWidth}%`,
             }}
             title={span.description ?? undefined}
+            role="presentation"
             onMouseEnter={() => {
               if (!suppressHoverRef.current) setHoveredIndex(i);
             }}
@@ -1289,19 +1299,37 @@ const MarkerGlyph: FC<MarkerGlyphProps> = ({
     [marker.kind, marker.reference, onMarkerNavigate, onBranchToggle]
   );
 
-  const isBranch = marker.kind === "branch";
+  const className = clsx(styles.marker, kindClass);
+  const glyph = marker.kind !== "error" && (
+    <i className={icon} aria-hidden="true" />
+  );
 
+  if (marker.kind === "branch") {
+    return (
+      <button
+        type="button"
+        className={className}
+        style={{ left: `${marker.left}%` }}
+        title={marker.tooltip}
+        onClick={handleClick}
+        aria-label="Toggle branches"
+      >
+        {glyph}
+      </button>
+    );
+  }
+
+  // Error/compaction markers are mouse shortcuts onto events the transcript
+  // already lists; the grid's arrow-key navigation is the keyboard path.
   return (
     <span
-      className={clsx(styles.marker, kindClass)}
+      className={className}
       style={{ left: `${marker.left}%` }}
       title={marker.tooltip}
+      role="presentation"
       onClick={handleClick}
-      tabIndex={isBranch ? 0 : undefined}
-      role={isBranch ? "button" : undefined}
-      aria-label={isBranch ? "Toggle branches" : undefined}
     >
-      {marker.kind !== "error" && <i className={icon} />}
+      {glyph}
     </span>
   );
 };

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx
@@ -638,6 +638,12 @@ const SwimlaneRow: FC<SwimlaneRowProps> = ({
           <button
             type="button"
             className={styles.chevron}
+            // tabIndex -1 like the cell above so the grid keeps a single
+            // tab stop. That leaves the chevron pointer-only (as it was
+            // before it became a button): ArrowLeft/ArrowRight can't serve
+            // as the keyboard path here because useArrowStepper binds them
+            // at document capture for prev/next sample stepping.
+            tabIndex={-1}
             onClick={handleChevronClick}
             aria-expanded={isExpanded}
             aria-label={isExpanded ? "Collapse" : "Expand"}

--- a/packages/react/eslint.config.js
+++ b/packages/react/eslint.config.js
@@ -26,17 +26,5 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
-  },
-  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
-  // Remove this block as the underlying issues are fixed.
-  {
-    files: ["**/*.{ts,tsx}"],
-    rules: {
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/interactive-supports-focus": "off",
-      "jsx-a11y/no-autofocus": "off",
-      "jsx-a11y/no-noninteractive-element-interactions": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-    },
   }
 );

--- a/packages/react/eslint.config.js
+++ b/packages/react/eslint.config.js
@@ -26,5 +26,17 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+  },
+  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
+  // Remove this block as the underlying issues are fixed.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/interactive-supports-focus": "off",
+      "jsx-a11y/no-autofocus": "off",
+      "jsx-a11y/no-noninteractive-element-interactions": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+    },
   }
 );

--- a/packages/react/src/components/AutocompleteInput.tsx
+++ b/packages/react/src/components/AutocompleteInput.tsx
@@ -26,6 +26,8 @@ export interface AutocompleteInputProps {
    *  with it (the placeholder is not a reliable accessible name). */
   ariaLabel?: string;
   suggestions: Array<string | number | boolean | null>;
+  /** Opt-in, and only correct when the input appears in response to a user
+   *  action (a popover or inline editor opening) — never on page load. */
   autoFocus?: boolean;
   maxSuggestions?: number;
   charactersBeforeSuggesting?: number;
@@ -311,6 +313,7 @@ export const AutocompleteInput: FC<AutocompleteInputProps> = ({
             ? `${id}-option-${highlightedIndex}`
             : undefined
         }
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- see the prop docs
         autoFocus={autoFocus}
       />
       {allowBrowse && suggestions.length > 0 && (

--- a/packages/react/src/components/LightboxCarousel.module.css
+++ b/packages/react/src/components/LightboxCarousel.module.css
@@ -4,12 +4,14 @@
 }
 
 .carouselThumb {
+  display: block;
   background: black;
   color: white;
   padding: 4em 0;
   border: 0;
   margin: 5px;
   cursor: pointer;
+  font: inherit;
   text-align: center;
 }
 

--- a/packages/react/src/components/LightboxCarousel.tsx
+++ b/packages/react/src/components/LightboxCarousel.tsx
@@ -86,7 +86,7 @@ export const LightboxCarousel: FC<LightboxCarouselProps> = ({ id, slides }) => {
   }, [closeLightbox, isOpen, showNext, showPrev]);
 
   const handleThumbClick = useCallback(
-    (e: MouseEvent<HTMLDivElement>) => {
+    (e: MouseEvent<HTMLButtonElement>) => {
       const index = Number(e.currentTarget.dataset.index);
       openLightbox(index);
     },
@@ -97,17 +97,21 @@ export const LightboxCarousel: FC<LightboxCarouselProps> = ({ id, slides }) => {
       <div className={clsx(styles.carouselThumbs)}>
         {slides.map((slide, index) => {
           return (
-            <div
+            <button
               key={index}
+              type="button"
               data-index={index}
               className={clsx(styles.carouselThumb)}
               onClick={handleThumbClick}
             >
               <div>{slide.label}</div>
               <div>
-                <i className={clsx(icons.play, styles.carouselPlayIcon)} />
+                <i
+                  className={clsx(icons.play, styles.carouselPlayIcon)}
+                  aria-hidden="true"
+                />
               </div>
-            </div>
+            </button>
           );
         })}
       </div>

--- a/packages/react/src/components/MarkdownDiv.tsx
+++ b/packages/react/src/components/MarkdownDiv.tsx
@@ -108,6 +108,10 @@ const MarkdownDivComponent = forwardRef<HTMLDivElement, MarkdownDivProps>(
     }, [markdown, rendererName, cachedHtml, cacheKey, applyPostProcess]);
 
     return (
+      // The container is not itself a control: onClick delegates for the
+      // anchors inside the rendered markdown, which already fire click on
+      // Enter, so no separate key handler is needed.
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
       <div
         ref={ref}
         dangerouslySetInnerHTML={{ __html: renderedHtml }}

--- a/packages/react/src/components/MenuActionButton.tsx
+++ b/packages/react/src/components/MenuActionButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 
 import { useComponentIcons } from "./ComponentIconContext";
 import styles from "./MenuActionButton.module.css";
@@ -25,6 +25,8 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
 }) => {
   const icons = useComponentIcons();
   const [showMenu, setShowMenu] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const handleSelect = (value: string) => {
     setShowMenu(false);
@@ -34,15 +36,22 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
   useEffect(() => {
     if (!showMenu) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setShowMenu(false);
+      if (e.key !== "Escape") return;
+      // Only pull focus back to the trigger when it was inside the menu —
+      // Escape is a document listener, so it also fires from anywhere else.
+      const refocus =
+        wrapperRef.current?.contains(document.activeElement) ?? false;
+      setShowMenu(false);
+      if (refocus) triggerRef.current?.focus();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [showMenu]);
 
   return (
-    <div className={styles.wrapper}>
+    <div ref={wrapperRef} className={styles.wrapper}>
       <button
+        ref={triggerRef}
         type="button"
         className={styles.iconButton}
         onClick={() => setShowMenu((prev) => !prev)}

--- a/packages/react/src/components/MenuActionButton.tsx
+++ b/packages/react/src/components/MenuActionButton.tsx
@@ -37,6 +37,11 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
     if (!showMenu) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      // This Escape closes the menu and nothing else: stop it here (the
+      // capture-phase registration below runs first) so an enclosing
+      // surface's own Escape handler — e.g. Modal's, on document bubble —
+      // doesn't also fire and close both layers at once.
+      e.stopPropagation();
       // Only pull focus back to the trigger when it was inside the menu —
       // Escape is a document listener, so it also fires from anywhere else.
       const refocus =
@@ -44,8 +49,8 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
       setShowMenu(false);
       if (refocus) triggerRef.current?.focus();
     };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
   }, [showMenu]);
 
   return (

--- a/packages/react/src/components/MenuActionButton.tsx
+++ b/packages/react/src/components/MenuActionButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 import { useComponentIcons } from "./ComponentIconContext";
 import styles from "./MenuActionButton.module.css";
@@ -31,6 +31,15 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
     onSelect(value);
   };
 
+  useEffect(() => {
+    if (!showMenu) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowMenu(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showMenu]);
+
   return (
     <div className={styles.wrapper}>
       <button
@@ -39,12 +48,19 @@ export const MenuActionButton: FC<MenuActionButtonProps> = ({
         onClick={() => setShowMenu((prev) => !prev)}
         title={title}
         disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={showMenu}
       >
-        <i className={icons.menu} />
+        <i className={icons.menu} aria-hidden="true" />
       </button>
       {showMenu && (
         <>
-          <div className={styles.backdrop} onClick={() => setShowMenu(false)} />
+          {/* Mouse-only dismissal; Escape closes the menu for keyboard users. */}
+          <div
+            className={styles.backdrop}
+            role="presentation"
+            onClick={() => setShowMenu(false)}
+          />
           <div className={styles.menu}>
             {items.map((item) => (
               <button

--- a/packages/react/src/components/Modal.tsx
+++ b/packages/react/src/components/Modal.tsx
@@ -126,7 +126,16 @@ export const Modal: FC<ModalProps> = ({
   const titleId = id ? `${id}-title` : fallbackTitleId;
 
   return createPortal(
-    <div className={styles.backdrop} onClick={onHide}>
+    // Dismissal is keyboard-accessible via the Escape handler above and the
+    // close button below; the backdrop is a mouse-only convenience, so it
+    // carries no semantics of its own.
+    <div
+      className={styles.backdrop}
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onHide();
+      }}
+    >
       <div
         ref={modalRef}
         id={id}
@@ -136,7 +145,6 @@ export const Modal: FC<ModalProps> = ({
         tabIndex={-1}
         className={clsx(styles.modal, className)}
         style={width ? { maxWidth: width } : undefined}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={styles.header}>
           <h3 id={titleId} className={styles.title}>

--- a/packages/react/src/components/TextInput.module.css
+++ b/packages/react/src/components/TextInput.module.css
@@ -31,6 +31,11 @@
 }
 
 .clearText {
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
   opacity: 0.6;
   margin-right: 0.3em;
 }

--- a/packages/react/src/components/TextInput.tsx
+++ b/packages/react/src/components/TextInput.tsx
@@ -25,7 +25,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           icon ? styles.withIcon : ""
         )}
       >
-        {icon && <i className={clsx(icon, styles.icon)} />}
+        {icon && <i className={clsx(icon, styles.icon)} aria-hidden="true" />}
         <input
           type="text"
           value={value}
@@ -35,7 +35,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           className={clsx(styles.input)}
           onFocus={onFocus}
         />
-        <i
+        <button
+          type="button"
           className={clsx(
             styles.clearText,
             value === "" ? styles.hidden : "",
@@ -48,7 +49,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               } as ChangeEvent<HTMLInputElement>);
             }
           }}
-          role="button"
+          disabled={value === ""}
+          aria-label="Clear"
         />
       </div>
     );

--- a/packages/react/src/components/ToolDropdownButton.tsx
+++ b/packages/react/src/components/ToolDropdownButton.tsx
@@ -96,6 +96,15 @@ export const ToolDropdownButton = forwardRef<
       };
     }, [isOpen, computePosition]);
 
+    useEffect(() => {
+      if (!isOpen) return;
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") setIsOpen(false);
+      };
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen]);
+
     const handleItemClick = (fn: () => void) => {
       fn();
       setIsOpen(false);
@@ -114,18 +123,25 @@ export const ToolDropdownButton = forwardRef<
             className
           )}
           onClick={() => setIsOpen(!isOpen)}
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
           {...rest}
         >
-          {icon && <i className={`${icon}`} />}
+          {icon && <i className={`${icon}`} aria-hidden="true" />}
           {label}
-          <i className={clsx(icons.chevronDown, styles.chevron)} />
+          <i
+            className={clsx(icons.chevronDown, styles.chevron)}
+            aria-hidden="true"
+          />
         </button>
         {isOpen &&
           menuPosition &&
           createPortal(
             <>
+              {/* Mouse-only dismissal; Escape closes the menu for keyboard users. */}
               <div
                 className={styles.backdrop}
+                role="presentation"
                 onClick={() => setIsOpen(false)}
               />
               <div

--- a/packages/react/src/components/ToolDropdownButton.tsx
+++ b/packages/react/src/components/ToolDropdownButton.tsx
@@ -104,6 +104,11 @@ export const ToolDropdownButton = forwardRef<
       if (!isOpen) return;
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key !== "Escape") return;
+        // This Escape closes the menu and nothing else: stop it here (the
+        // capture-phase registration below runs first) so an enclosing
+        // surface's own Escape handler — e.g. Modal's, on document bubble —
+        // doesn't also fire and close both layers at once.
+        e.stopPropagation();
         // Only pull focus back to the trigger when it was inside the menu —
         // Escape is a document listener, so it also fires from anywhere else.
         const refocus =
@@ -111,8 +116,8 @@ export const ToolDropdownButton = forwardRef<
         setIsOpen(false);
         if (refocus) buttonRef.current?.focus();
       };
-      document.addEventListener("keydown", handleKeyDown);
-      return () => document.removeEventListener("keydown", handleKeyDown);
+      document.addEventListener("keydown", handleKeyDown, true);
+      return () => document.removeEventListener("keydown", handleKeyDown, true);
     }, [isOpen]);
 
     const handleItemClick = (fn: () => void) => {

--- a/packages/react/src/components/ToolDropdownButton.tsx
+++ b/packages/react/src/components/ToolDropdownButton.tsx
@@ -96,10 +96,20 @@ export const ToolDropdownButton = forwardRef<
       };
     }, [isOpen, computePosition]);
 
+    // The menu is portaled, so "is focus inside the menu" has to be asked of
+    // the menu node itself rather than a wrapper around the trigger.
+    const menuRef = useRef<HTMLDivElement | null>(null);
+
     useEffect(() => {
       if (!isOpen) return;
       const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === "Escape") setIsOpen(false);
+        if (e.key !== "Escape") return;
+        // Only pull focus back to the trigger when it was inside the menu —
+        // Escape is a document listener, so it also fires from anywhere else.
+        const refocus =
+          menuRef.current?.contains(document.activeElement) ?? false;
+        setIsOpen(false);
+        if (refocus) buttonRef.current?.focus();
       };
       document.addEventListener("keydown", handleKeyDown);
       return () => document.removeEventListener("keydown", handleKeyDown);
@@ -145,6 +155,7 @@ export const ToolDropdownButton = forwardRef<
                 onClick={() => setIsOpen(false)}
               />
               <div
+                ref={menuRef}
                 className={clsx(styles.dropdownMenu, dropdownClassName)}
                 style={{
                   top: menuPosition.top,

--- a/packages/zustand-devtools/eslint.config.js
+++ b/packages/zustand-devtools/eslint.config.js
@@ -16,14 +16,5 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
-  },
-  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
-  // Remove this block as the underlying issues are fixed.
-  {
-    files: ["**/*.{ts,tsx}"],
-    rules: {
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-    },
   }
 );

--- a/packages/zustand-devtools/eslint.config.js
+++ b/packages/zustand-devtools/eslint.config.js
@@ -16,5 +16,14 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+  },
+  // TODO(a11y): pre-existing violations from enabling eslint-plugin-jsx-a11y.
+  // Remove this block as the underlying issues are fixed.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "jsx-a11y/click-events-have-key-events": "off",
+      "jsx-a11y/no-static-element-interactions": "off",
+    },
   }
 );

--- a/packages/zustand-devtools/src/TreeNode.tsx
+++ b/packages/zustand-devtools/src/TreeNode.tsx
@@ -59,21 +59,21 @@ export const TreeNode: FC<TreeNodeProps> = memo(
           {expandable ? (
             <button
               type="button"
-              className={styles.caret}
+              className={styles.keyToggle}
               onClick={toggle}
-              aria-label={expanded ? `Collapse ${name}` : `Expand ${name}`}
+              aria-expanded={expanded}
             >
-              {expanded ? "▼" : "▶"}
+              <span className={styles.caret} aria-hidden="true">
+                {expanded ? "▼" : "▶"}
+              </span>
+              <span className={styles.key}>{name}:</span>
             </button>
           ) : (
-            <span className={styles.caretSpacer} />
+            <>
+              <span className={styles.caretSpacer} />
+              <span className={styles.key}>{name}:</span>
+            </>
           )}
-          <span
-            className={classes(styles.key, expandable && styles.keyExpandable)}
-            onClick={toggle}
-          >
-            {name}:
-          </span>
           <span
             key={flashKey}
             className={classes(

--- a/packages/zustand-devtools/src/ZustandDevtoolsPanel.module.css
+++ b/packages/zustand-devtools/src/ZustandDevtoolsPanel.module.css
@@ -164,15 +164,23 @@
   background: var(--zsd-hover);
 }
 
-.caret {
+.keyToggle {
+  display: flex;
   flex-shrink: 0;
-  width: 14px;
+  align-items: baseline;
+  gap: 4px;
   padding: 0;
   border: none;
   background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.caret {
+  flex-shrink: 0;
+  width: 14px;
   color: var(--zsd-key);
   font-size: 9px;
-  cursor: pointer;
 }
 
 .caretSpacer {
@@ -183,10 +191,6 @@
 .key {
   color: var(--zsd-key);
   white-space: nowrap;
-}
-
-.keyExpandable {
-  cursor: pointer;
 }
 
 .value {

--- a/packages/zustand-devtools/src/ZustandDevtoolsPanel.test.tsx
+++ b/packages/zustand-devtools/src/ZustandDevtoolsPanel.test.tsx
@@ -53,7 +53,10 @@ describe("ZustandDevtoolsPanel", () => {
     render(<ZustandDevtoolsPanel store={store} />);
 
     expect(screen.queryByText("42")).toBeNull();
-    act(() => screen.getByRole("button", { name: "Expand nested" }).click());
+    const toggle = screen.getByRole("button", { name: "nested:" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    act(() => toggle.click());
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("42")).toBeDefined();
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,6 +930,9 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4.17.1
         version: 4.17.1(@typescript-eslint/utils@8.65.0(@typescript/typescript6@6.0.2)(eslint@10.7.0))(eslint-import-resolver-node@0.3.9)(eslint@10.7.0)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@10.7.0)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@10.7.0)
@@ -3110,6 +3113,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -3120,6 +3126,14 @@ packages:
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
@@ -3305,6 +3319,9 @@ packages:
 
   cuint@0.2.2:
     resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
+
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -3542,6 +3559,12 @@ packages:
         optional: true
       eslint-import-resolver-node:
         optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
@@ -4114,6 +4137,13 @@ packages:
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   less@4.5.1:
     resolution: {integrity: sha512-UKgI3/KON4u6ngSsnDADsUERqhZknsVZbnuzlRZXLQCmfC/MDld42fTydUE9B+Mla1AL6SJ/Pp6SlEFi/AVGfw==}
@@ -4957,6 +4987,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -7420,6 +7454,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types-flow@0.0.8: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -7429,6 +7465,10 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -7612,6 +7652,8 @@ snapshots:
   csstype@3.2.3: {}
 
   cuint@0.2.2: {}
+
+  damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -7924,6 +7966,25 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.7.0):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 10.7.0
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 5.1.9
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-react-hooks@7.1.1(eslint@10.7.0):
     dependencies:
@@ -8521,6 +8582,12 @@ snapshots:
   kolorist@1.8.0: {}
 
   ky@1.14.3: {}
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   less@4.5.1:
     dependencies:
@@ -9464,6 +9531,12 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
 
   string.prototype.matchall@4.0.12:
     dependencies:

--- a/tooling/eslint-config/package.json
+++ b/tooling/eslint-config/package.json
@@ -14,6 +14,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import-x": "^4.17.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/tooling/eslint-config/react.js
+++ b/tooling/eslint-config/react.js
@@ -25,6 +25,10 @@ export default tseslint.config(
       "react/prop-types": "off",
       ...reactHooksPlugin.configs.recommended.rules,
       ...jsxA11yPlugin.flatConfigs.recommended.rules,
+      // The rule can't see what a custom component does with an `autoFocus`
+      // prop, so flagging non-DOM elements is guesswork. Real DOM autoFocus
+      // is still an error.
+      "jsx-a11y/no-autofocus": ["error", { ignoreNonDOM: true }],
     },
     settings: {
       react: {

--- a/tooling/eslint-config/react.js
+++ b/tooling/eslint-config/react.js
@@ -1,4 +1,5 @@
 import { fixupPluginRules } from "@eslint/compat";
+import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import reactRefreshPlugin from "eslint-plugin-react-refresh";
@@ -16,12 +17,14 @@ export default tseslint.config(
       react: fixupPluginRules(reactPlugin),
       "react-hooks": reactHooksPlugin,
       "react-refresh": reactRefreshPlugin,
+      "jsx-a11y": jsxA11yPlugin,
     },
     rules: {
       ...reactPlugin.configs.recommended.rules,
       ...reactPlugin.configs["jsx-runtime"].rules,
       "react/prop-types": "off",
       ...reactHooksPlugin.configs.recommended.rules,
+      ...jsxA11yPlugin.flatConfigs.recommended.rules,
     },
     settings: {
       react: {


### PR DESCRIPTION
Wires [`eslint-plugin-jsx-a11y`](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) into `@tsmono/eslint-config/react` so every React workspace runs its recommended ruleset, and clears the **235 errors across 45 files** it surfaced.

Prompted by a React Doctor report flagging a11y issues.

## Reviewing this

Commits are ordered so each one is green on its own. The first turns the plugin on with per-package suppression blocks; each later commit removes one package's block and fixes that code. Reviewing commit-by-commit is much easier than the squashed diff.

| Package | Errors |
|---|---|
| `apps/scout` | 85 |
| `packages/inspect-components` | 77 |
| `apps/inspect` | 56 |
| `packages/react` | 15 |
| `packages/zustand-devtools` | 2 |

## What changed

Most of it is a handful of repeated patterns:

- **Fake controls became real ones.** ~40 divs, spans and href-less anchors are now `<button>`s: popover preset links, pager pages, activity bar entries, scanner sidebar entries, sortable column headers, outline row toggles, listbox options, chip close buttons. Each got a matching CSS reset so it renders as before.
- **Checkbox rows became `<label>`s.** Ten rows carried a div `onClick` *plus* a checkbox `onChange` *plus* a `stopPropagation` guard to stop the two double-toggling. Wrapping the input in a `<label>` deletes all three.
- **Click-away backdrops are marked presentational** — but only after adding a real `Escape` handler where one was missing (`MenuActionButton`, `ToolDropdownButton`, `TimelineSelector`). Escape now closes those menus; it previously didn't.
- **`<label>` naming a whole region** (Edit Metadata, Edit Tags, a radio group) became a span the region references via `aria-labelledby` — a label may only point at one control.
- **`BranchPoint` dropped `aria-pressed`**, which `role="radio"` doesn't support; its CSS selectors moved to `aria-checked`.

One config decision: `no-autofocus` runs with `ignoreNonDOM: true`. The rule can't see what a custom component does with an `autoFocus` prop, so flagging non-DOM elements is guesswork. Real DOM `autoFocus` is still an error.

## Suppressions

Every one carries a reason. They fall into three groups:

- **Media with no caption track** — audio/video replayed from eval logs, where none exists and none can be synthesised.
- **`autoFocus` inside filter popovers** — moving focus to the first field of a popover the user just opened is the WAI-ARIA APG dialog behaviour, not a page-load focus steal.
- **Mouse-side duplicates in the two data grids.** Both already model themselves as `role="grid"` composite widgets: one tab stop, arrow-key row navigation, keyboard-operable sortable headers. The remaining reports are the hit-area cell, the row click and the drag handles — each suppression points at the control that actually does the work.

## Deliberately not fixed

Two gaps left visible rather than papered over, both noted in the commits:

- **Span-level selection in the swimlane timeline is mouse-only.** The grid's arrow keys navigate rows, not spans within a row.
- **Column resizing is pointer-only** in both data grids.

Making either keyboard-operable is a feature, not a lint fix.

## Needs a human eye

Nothing blocking, but worth knowing where the risk sits:

- **~40 elements changed tag**, and buttons bring UA font/padding/border/centering. Resets were derived by reading each CSS module, not by rendering. The ones I'd check first: **scout's data grid column headers** (the header content is now a `<button>` that is still `draggable` — try reordering columns) and **`EventPanel`**'s chevron and bottom "transcript (N events)" dongle.
- **`EditableText` read-only fields are now focusable** (`role="textbox"` + `aria-readonly`). That matches native `<input readonly>`, but it is a new tab stop.
- **`LogViewLayout`'s app-shell tabstop** is kept behind a documented suppression. Removing it was clean by every check available here, but `App.css` accounts for it by name for VS Code webview click behaviour, which can't be exercised outside the extension. Left as-is; the suppression records why.

## Verification

`pnpm lint`, `typecheck`, `format:check` and `manypkg check` all clean. Tests green across all 9 packages (~2,600).

One caught regression: merging the devtools caret and key label into a single button changed its accessible name, breaking a `getByRole` query. The test now asserts the visible-text name and `aria-expanded`.

Note: `pnpm test` fully parallel crashes a vitest worker on memory in a constrained container. `--concurrency=1` is green. May or may not affect CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZFSWbTaGMF1nUnfKybgkQ)_