### PR TITLE
Fix dependabot alert 65: force brace-expansion@2 to ^2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "seroval": ">=1.4.1",
       "seroval-plugins": ">=1.4.1",
       "minimatch@3": "^5.1.9",
+      "brace-expansion@2": "^2.1.3",
       "brace-expansion@5": "^5.0.8",
       "@microsoft/api-extractor": "^7.57.6",
       "rollup": "^4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   seroval: '>=1.4.1'
   seroval-plugins: '>=1.4.1'
   minimatch@3: ^5.1.9
+  brace-expansion@2: ^2.1.3
   brace-expansion@5: ^5.0.8
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
@@ -3163,8 +3164,8 @@ packages:
     peerDependencies:
       '@popperjs/core': ^2.11.8
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.3:
+    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -7488,7 +7489,7 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.3:
     dependencies:
       balanced-match: 1.0.2
 
@@ -8782,11 +8783,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.3
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Fixed

- [Dependabot alert 65](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/65) — brace-expansion (high, GHSA-mh99-v99m-4gvg): 2.x line vulnerable below 2.1.3. Added a version-scoped override `"brace-expansion@2": "^2.1.3"` so minimatch 5.x/9.x consumers resolve the patched version, without touching the existing `brace-expansion@5` pin.

Verified: `pnpm install`, lockfile no longer resolves 2.1.2, `pnpm check`, `pnpm build`, and `pnpm test` (1054 tests) all pass.

## Deferred (no dependabot alerts open yet; patched versions published 2026-08-03, inside the 7-day soak window)

`pnpm audit` also reports these advisories, but their fixes are too young for `minimumReleaseAge` — they will fix cleanly on a later run:

- brace-expansion GHSA-rgw5-rvv9-x895 (high) — mitigation bypass, patched 2.1.4 / 5.0.9; the caret overrides will pick these up once they clear the soak
- undici GHSA-4cwx-7wf7-3272 (high) + 4 moderate follow-ups — patched 7.29.0 (transitive via jsdom)
- fast-uri GHSA-7p8r-x3mc-p8w7 (high) — patched 3.1.5

postcss GHSA-6g55-p6wh-862q / GHSA-fxqj-rqcc-2cmp (direct dep of apps/inspect, patched 8.5.23) is already covered by dependabot's group bump PR 486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)