### PR TITLE
Document why supersede fencing stays two-layer (#492)

### DIFF
--- a/apps/inspect/src/log_data/fetchEngine.ts
+++ b/apps/inspect/src/log_data/fetchEngine.ts
@@ -223,7 +223,10 @@ export class FetchEngine {
   // Engine generation, bumped on every stop() — a batch claimed under an
   // earlier generation that settles after a stop()/start() (dir switch) is
   // discarded rather than recorded/waited-on/coalesced into the new
-  // session's state.
+  // session's state. Engine-owned by design: the engine must be safe against
+  // its own stop()/start() races for any caller, so start() can't outsource
+  // this to an injected cancellation token (see the supersede-fence note in
+  // replicationControl's startEngine, #492).
   private _epoch = 0;
   // Monotonic claim counter (never reset — a post-restart collision would
   // let an old read's commit slip past the seq check below).

--- a/apps/inspect/src/log_data/replicationControl.ts
+++ b/apps/inspect/src/log_data/replicationControl.ts
@@ -40,6 +40,18 @@ const startEngine = async (config: AppConfig): Promise<void> => {
   // bumps it again (their `stop()`), and a superseded start must never touch
   // the engine — whichever continuation landed last would win, leaving the
   // engine wired for one dir while `activation.config` claims another.
+  //
+  // Deliberately NOT a per-activation AbortSignal (#492): the epoch exists
+  // regardless (the engine fences its own claimed batches, restarts, and
+  // listing syncs with it, for any caller — including same-dir restarts a
+  // dir-keyed token would miss), a signal's `throwIfAborted()` would be
+  // exactly as hand-placed as this re-check, and the dir matching below is
+  // the caller contract, not a fence — acquisition paths hold only a dir
+  // (waiters queue before any activation exists to hand them a token), and
+  // dir equality deliberately lets them span a same-dir re-activation
+  // (StrictMode remount, failed-start retry) where token identity would
+  // spuriously reject. A per-activation token would subsume neither
+  // mechanism — it would be a third.
   const epoch = fetchEngine.epoch();
   if (config.singleFileMode) {
     const database = getDatabaseService();


### PR DESCRIPTION
Fixes #492

Reviewed consolidating the log_data supersede fences onto one
per-activation cancellation token. It doesn't pay for itself: the engine
epoch must exist regardless (claimed-batch settles, listing syncs,
same-dir restarts), a signal's throwIfAborted() is exactly as hand-placed
as an epoch re-check, and dir matching is the caller contract rather than
a fence. Record the rationale where the two mechanisms meet.

Co-authored-by: Eric Patey <769548+epatey@users.noreply.github.com>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>