### PR TITLE
Resolve attachment refs in scan result inputs

### DIFF
--- a/apps/scout/src/api/expandInputEvents.test.ts
+++ b/apps/scout/src/api/expandInputEvents.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScannerInputResponse, Transcript } from "../types/api-types";
+
+import { expandInputEvents } from "./expandInputEvents";
+
+const HASH = "00000000000000000000000000000001";
+const NESTED_HASH = "00000000000000000000000000000002";
+
+type InputData = NonNullable<ScannerInputResponse["input_data"]>;
+
+function inputData(overrides: Partial<InputData> = {}): InputData {
+  return { messages: [], calls: [], ...overrides };
+}
+
+function transcript(overrides: Partial<Transcript> = {}): Transcript {
+  return {
+    transcript_id: "t1",
+    messages: [],
+    events: [],
+    timelines: [],
+    ...overrides,
+  } as Transcript;
+}
+
+describe("expandInputEvents", () => {
+  it("returns the input untouched when there is no input_data", () => {
+    const input = transcript();
+    expect(expandInputEvents(input, "transcript", null)).toBe(input);
+  });
+
+  it("resolves attachment refs in messages", () => {
+    const input = transcript({
+      messages: [
+        { id: "m1", role: "user", content: `attachment://${HASH}` },
+      ] as Transcript["messages"],
+    });
+
+    const result = expandInputEvents(
+      input,
+      "transcript",
+      inputData({ attachments: { [HASH]: "the system prompt" } })
+    ) as Transcript;
+
+    expect(result.messages[0]).toMatchObject({ content: "the system prompt" });
+  });
+
+  it("resolves refs that only appear after pool expansion", () => {
+    // The ref lives in a pooled message, so it is unreachable until
+    // expandEvents has substituted the pool entry into the event.
+    const input = transcript({
+      events: [
+        {
+          event: "model",
+          span_id: "s1",
+          timestamp: "2026-01-01T00:00:00+00:00",
+          working_start: 0,
+          model: "m",
+          input: [],
+          input_refs: [[0, 1]],
+          output: { model: "m", choices: [] },
+        },
+      ] as unknown as Transcript["events"],
+    });
+
+    const result = expandInputEvents(
+      input,
+      "transcript",
+      inputData({
+        messages: [
+          { id: "p1", role: "system", content: `attachment://${NESTED_HASH}` },
+        ] as InputData["messages"],
+        attachments: { [NESTED_HASH]: "pooled content" },
+      })
+    ) as Transcript;
+
+    expect(JSON.stringify(result.events)).toContain("pooled content");
+    expect(JSON.stringify(result.events)).not.toContain("attachment://");
+  });
+
+  it("resolves refs in sample metadata", () => {
+    const input = transcript({
+      metadata: { sample_metadata: { note: `attachment://${HASH}` } },
+    });
+
+    const result = expandInputEvents(
+      input,
+      "transcript",
+      inputData({ attachments: { [HASH]: "metadata value" } })
+    ) as Transcript;
+
+    expect(result.metadata).toMatchObject({
+      sample_metadata: { note: "metadata value" },
+    });
+  });
+
+  it("leaves refs alone when no attachments table is present", () => {
+    const literal = `attachment://${HASH}`;
+    const input = transcript({
+      messages: [
+        { id: "m1", role: "user", content: literal },
+      ] as Transcript["messages"],
+    });
+
+    const result = expandInputEvents(
+      input,
+      "transcript",
+      inputData()
+    ) as Transcript;
+
+    expect(result.messages[0]).toMatchObject({ content: literal });
+  });
+
+  it("resolves refs for the events input type", () => {
+    const events = [
+      {
+        event: "info",
+        span_id: "s1",
+        timestamp: "2026-01-01T00:00:00+00:00",
+        working_start: 0,
+        data: `attachment://${HASH}`,
+      },
+    ] as unknown as ScannerInputResponse["input"];
+
+    const result = expandInputEvents(
+      events,
+      "events",
+      inputData({ attachments: { [HASH]: "info payload" } })
+    );
+
+    expect(JSON.stringify(result)).toContain("info payload");
+  });
+});

--- a/apps/scout/src/api/expandInputEvents.ts
+++ b/apps/scout/src/api/expandInputEvents.ts
@@ -3,9 +3,36 @@ import { expandEvents } from "@tsmono/inspect-common/utils";
 
 import type { ScannerInputResponse, Transcript } from "../types/api-types";
 
+import { resolveAttachments } from "./attachmentsHelpers";
+
+type InputData = NonNullable<ScannerInputResponse["input_data"]>;
+
 /**
- * Expand condensed events in a scan result input.
- * Handles both "transcript" (events inside Transcript object) and "events" input types.
+ * The attachments table travelling alongside the event pools in `input_data`.
+ *
+ * `EventsData` is `additionalProperties: true`, so the generated type exposes
+ * this through an index signature of `unknown` -- hence the runtime check.
+ */
+function inputAttachments(inputData: InputData): Record<string, string> | null {
+  const attachments = inputData["attachments"];
+  if (typeof attachments !== "object" || attachments === null) return null;
+  const entries = Object.entries(attachments).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+/**
+ * Restore a scan result input to its readable form.
+ *
+ * Recorded inputs are stored compactly: events carry range-encoded pool refs,
+ * and repeated content is replaced by `attachment://<hash>` refs resolved
+ * against a table in `input_data`. Both have to be undone for display, in that
+ * order -- refs also occur inside pool entries, so they only become reachable
+ * once the pools are expanded.
+ *
+ * Attachment resolution covers the whole input rather than only the events,
+ * because messages and sample metadata carry refs too.
  */
 export function expandInputEvents(
   input: ScannerInputResponse["input"],
@@ -14,6 +41,20 @@ export function expandInputEvents(
 ): ScannerInputResponse["input"] {
   if (!inputData) return input;
 
+  const expanded = expandPooledEvents(input, inputType, inputData);
+  const attachments = inputAttachments(inputData);
+  return attachments ? resolveAttachments(expanded, attachments) : expanded;
+}
+
+/**
+ * Expand condensed events in a scan result input.
+ * Handles both "transcript" (events inside Transcript object) and "events" input types.
+ */
+function expandPooledEvents(
+  input: ScannerInputResponse["input"],
+  inputType: ScannerInputResponse["input_type"],
+  inputData: InputData
+): ScannerInputResponse["input"] {
   if (inputType === "transcript") {
     const transcript = input as Transcript;
     const expanded = expandEvents(transcript.events, inputData);


### PR DESCRIPTION
## Summary

Scan results render `attachment://<32-hex>` as literal text instead of the content it stands for. inspect_ai turns every text value over 100 characters into an attachment, so on a real transcript this is most system prompts, model outputs and tool results — the Input tab is largely unreadable.

Recorded inputs are stored compactly, with repeated content replaced by refs into a table carried in `input_data`. The transcripts endpoint already resolves those; the results path never did, because results used to arrive pre-resolved and no longer do (meridianlabs-ai/inspect_scout#491 records the compact form straight from the transcript spool).

## Notes for reviewers

Two ordering constraints are easy to get wrong and are what the tests pin down:

- Resolution happens **after** pool expansion, not before — refs also occur inside pool entries, so they are unreachable until `expandEvents` has substituted them in.
- Resolution covers the **whole input**, not just the events — messages and sample metadata carry refs too.

## Test plan

CI covers the rest. Verified manually that the tests fail without the fix: 4 of the 6 new cases fail when the source change is reverted (the other 2 are no-op guards that should pass either way).
