### PR TITLE
fix(deps): bump fast-uri override to ^3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "brace-expansion@5": "^5.0.9",
       "@microsoft/api-extractor": "^7.57.6",
       "rollup": "^4.59.0",
-      "fast-uri": "^3.1.4",
+      "fast-uri": "^3.1.5",
       "immutable": "^5.1.8",
       "ws": "^8.20.1",
       "esbuild": "^0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   brace-expansion@5: ^5.0.9
   '@microsoft/api-extractor': ^7.57.6
   rollup: ^4.59.0
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   immutable: ^5.1.8
   ws: ^8.20.1
   esbuild: ^0.28.1
@@ -3668,8 +3668,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6353,7 +6353,7 @@ snapshots:
   '@redocly/ajv@8.17.4':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7338,7 +7338,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -8114,7 +8114,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
Clears the open dependabot security alert batch (1 alert).

## Fixed
- [dependabot alert 69](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/69) — fast-uri, high, GHSA-7p8r-x3mc-p8w7 (host confusion via backslash authority introducer). Raised the existing `pnpm.overrides` entry from `^3.1.4` to `^3.1.5`; the lockfile now resolves only fast-uri 3.1.5.

## Deferred
- js-yaml GHSA-5p4m-2wfm-xmqj (high, patched 4.3.1) — surfaced by `pnpm audit` but not yet an open dependabot alert. js-yaml 4.3.1 was published 2026-07-31T17:39Z, still inside the 7-day `minimumReleaseAge` soak window at run time (2026-08-07T10:20Z). It clears the window later today; the existing `js-yaml` override can be raised to `^4.3.1` on the next run.

## Verification
- `pnpm install` — lockfile updated, no vulnerable fast-uri versions remain
- `pnpm audit` — no longer reports GHSA-7p8r-x3mc-p8w7
- `pnpm check` (27 tasks), `pnpm build`, `pnpm test` (1129 tests, 106 files) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
