### PR TITLE
Messages UI pagination

### DIFF
--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -919,18 +919,20 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 panel={hasRail ? railPanel : undefined}
                 label={railLabel}
               >
-                {sampleMessages.error ? (
+                {sampleMessages.rows.error ? (
                   // inside the rail host: the activity rail is the sole
                   // search/scans entry point and must survive the error
                   <ErrorPanel
                     title="An error occurred while loading messages."
-                    error={sampleMessages.error}
+                    error={sampleMessages.rows.error}
                   />
                 ) : (
                   <ChatViewRowsVirtualList
                     key={chatListId}
                     id={chatListId}
-                    rows={sampleMessages.data ?? kNoMessageRows}
+                    rows={sampleMessages.rows.data ?? kNoMessageRows}
+                    hasMoreRows={sampleMessages.hasMore}
+                    onLoadMoreRows={sampleMessages.loadMore}
                     initialMessageId={sampleDetailNavigation.message}
                     followRequested={sampleDetailNavigation.follow}
                     display={chatDisplay}
@@ -940,7 +942,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                     scrollRef={scrollRef}
                     tools={chatTools}
                     running={running}
-                    backfilling={backfilling || sampleMessages.loading}
+                    backfilling={backfilling || sampleMessages.rows.loading}
                     scrollToTopOnFinish={scrollToTopOnFinish}
                     className={styles.fullWidth}
                   />

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -247,7 +247,10 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     sampleData,
     messagesTabOpen,
     running,
-    sampleDetailNavigation.message
+    // `?message=` is also set by transcript-bound links (scan refs, transcript
+    // search hits), and the settled read stays activated once this tab has been
+    // opened — without the gate those ids would drain pages for a hidden tab.
+    messagesTabOpen ? sampleDetailNavigation.message : null
   );
   const exportMessages = useMessagesExport(sampleData);
 

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -241,11 +241,13 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     (state) => state.log.selectedSampleHandle
   );
   const messagesTabOpen = effectiveSelectedTab === kSampleMessagesTabId;
+  const sampleDetailNavigation = useSampleDetailNavigation();
   const sampleMessages = useSampleMessages(
     selectedSampleHandle,
     sampleData,
     messagesTabOpen,
-    running
+    running,
+    sampleDetailNavigation.message
   );
   const exportMessages = useMessagesExport(sampleData);
 
@@ -658,8 +660,6 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
     !selectedSampleSummary?.error &&
     logDetails?.status !== "error" &&
     logDetails?.status !== "cancelled";
-
-  const sampleDetailNavigation = useSampleDetailNavigation();
 
   const displayModeContext = useMemo(
     () => ({ displayMode: displayMode ?? ("rendered" as const) }),

--- a/apps/inspect/src/log_data/index.ts
+++ b/apps/inspect/src/log_data/index.ts
@@ -146,6 +146,7 @@ export { resolvedEventsReader } from "./chunkedAttachments";
 export { kDefaultMessageRowOptions } from "./messageRows";
 export { useMessagesExport } from "./messagesExport";
 export { useSampleMessages } from "./sampleMessages";
+export type { MessageRowsFeed } from "./messageRowsQuery";
 export { useChunkedSample, type ChunkedSampleData } from "./chunkedSampleQuery";
 export { useSampleSummaries } from "./sampleSummaries";
 export { type ScorerMap, scorerMetricKey, useScoreSchema } from "./scoreSchema";

--- a/apps/inspect/src/log_data/messageRowsQuery.test.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.test.ts
@@ -52,9 +52,7 @@ describe("useMessageRows", () => {
     await waitFor(() =>
       expect(result.current?.rows.data).toHaveLength(2 * kMessageRowsPageSize)
     );
-    expect(result.current?.rows.data?.[199]?.resolved.message.id).toBe(
-      "m-199"
-    );
+    expect(result.current?.rows.data?.[199]?.resolved.message.id).toBe("m-199");
     expect(result.current?.hasMore).toBe(true);
   });
 

--- a/apps/inspect/src/log_data/messageRowsQuery.test.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.test.ts
@@ -104,6 +104,47 @@ describe("useMessageRows", () => {
     expect(result.current?.hasMore).toBe(false);
   });
 
+  it("drains pages until a deep-link target is resident before serving rows", async () => {
+    const servedLengths: number[] = [];
+    const { result } = renderHook(
+      () => {
+        const feed = useMessageRows(
+          handle,
+          settledData(makeMessages(300)),
+          true,
+          "m-150"
+        );
+        if (feed?.rows.data !== undefined) {
+          servedLengths.push(feed.rows.data.length);
+        }
+        return feed;
+      },
+      { wrapper: makeWrapper() }
+    );
+
+    // the drain stops at the covering page, not the conversation's end
+    await waitFor(() =>
+      expect(result.current?.rows.data).toHaveLength(2 * kMessageRowsPageSize)
+    );
+    expect(result.current?.hasMore).toBe(true);
+    // rows were never served without the target resident: the list mounts
+    // with its initial scroll index resolvable
+    expect(servedLengths.every((l) => l === 2 * kMessageRowsPageSize)).toBe(
+      true
+    );
+  });
+
+  it("a target the conversation never renders drains to exhaustion, then serves", async () => {
+    const { result } = renderHook(
+      () =>
+        useMessageRows(handle, settledData(makeMessages(250)), true, "nope"),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(250));
+    expect(result.current?.hasMore).toBe(false);
+  });
+
   it("surfaces a chunked read failure as error, not endless loading", async () => {
     const chunked = testChunkedSample(
       failingSequenceReader(new Error("boom")),

--- a/apps/inspect/src/log_data/messageRowsQuery.test.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.test.ts
@@ -1,6 +1,9 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { ChatMessage } from "@tsmono/inspect-common/types";
+
+import { ChunkByteStore, SequenceReader } from "./chunked";
 import { kMessageRowsPageSize, useMessageRows } from "./messageRowsQuery";
 import { type EvalSampleData } from "./sampleData";
 import {
@@ -153,6 +156,56 @@ describe("useMessageRows", () => {
 
     await waitFor(() => expect(result.current?.rows.data).toHaveLength(250));
     expect(result.current?.hasMore).toBe(false);
+  });
+
+  it("halts the deep-link drain when a page read fails", async () => {
+    // two chunks: the first covers the scan's whole first batch (512
+    // messages), the second rejects — the drain must settle on the error,
+    // not refetch the failing page in an unbounded loop
+    const messages = makeMessages(700);
+    const encoder = new TextEncoder();
+    let failingReads = 0;
+    const reader = new SequenceReader<ChatMessage>(
+      new ChunkByteStore({
+        readFile: (name) => {
+          if (name !== "chunk/0.json") {
+            failingReads++;
+            return Promise.reject(new Error("boom"));
+          }
+          return Promise.resolve(
+            encoder.encode(JSON.stringify(messages.slice(0, 512)))
+          );
+        },
+      }),
+      (start) => `chunk/${start}.json`,
+      [0, 512],
+      700
+    );
+    const data: EvalSampleData = {
+      ...streamingData,
+      status: "ok",
+      chunked: testChunkedSample(reader),
+    };
+    const { result } = renderHook(
+      () => useMessageRows(handle, data, true, "m-650"),
+      { wrapper: makeWrapper() }
+    );
+
+    await waitFor(() =>
+      expect(result.current?.rows.error).toBeInstanceOf(Error)
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
+    expect(failingReads).toBe(1);
+  });
+
+  it("keeps the served feed's identity stable across rerenders", async () => {
+    const data = settledData(makeMessages(3));
+    const { result, rerender } = renderRows(data);
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(3));
+
+    const served = result.current;
+    rerender({ data, activated: true });
+    expect(result.current).toBe(served);
   });
 
   it("surfaces a chunked read failure as error, not endless loading", async () => {

--- a/apps/inspect/src/log_data/messageRowsQuery.test.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.test.ts
@@ -1,7 +1,7 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { useMessageRows } from "./messageRowsQuery";
+import { kMessageRowsPageSize, useMessageRows } from "./messageRowsQuery";
 import { type EvalSampleData } from "./sampleData";
 import {
   failingSequenceReader,
@@ -30,21 +30,49 @@ const renderRows = (data: EvalSampleData, activated = true) =>
   );
 
 describe("useMessageRows", () => {
-  it("materializes a settled conversation in one read", async () => {
+  it("serves a settled conversation one page at a time", async () => {
     const { result } = renderRows(settledData(makeMessages(1200)));
 
-    expect(result.current?.loading).toBe(true);
-    await waitFor(() => expect(result.current?.data).toHaveLength(1200));
-    expect(result.current?.loading).toBe(false);
-    expect(result.current?.data?.[1199]?.resolved.message.id).toBe("m-1199");
-    // whole-conversation numbering survives the read
-    expect(result.current?.data?.[1199]?.startNumber).toBe(1200);
+    expect(result.current?.rows.loading).toBe(true);
+    await waitFor(() =>
+      expect(result.current?.rows.data).toHaveLength(kMessageRowsPageSize)
+    );
+    expect(result.current?.hasMore).toBe(true);
+    // whole-conversation numbering survives the paged read
+    expect(result.current?.rows.data?.[99]?.startNumber).toBe(100);
+
+    act(() => result.current?.loadMore());
+    await waitFor(() =>
+      expect(result.current?.rows.data).toHaveLength(2 * kMessageRowsPageSize)
+    );
+    expect(result.current?.rows.data?.[199]?.resolved.message.id).toBe(
+      "m-199"
+    );
+    expect(result.current?.hasMore).toBe(true);
+  });
+
+  it("reports exhaustion on the last page", async () => {
+    const { result } = renderRows(settledData(makeMessages(150)));
+    await waitFor(() =>
+      expect(result.current?.rows.data).toHaveLength(kMessageRowsPageSize)
+    );
+    expect(result.current?.hasMore).toBe(true);
+
+    act(() => result.current?.loadMore());
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(150));
+    expect(result.current?.hasMore).toBe(false);
+  });
+
+  it("handles an empty settled conversation", async () => {
+    const { result } = renderRows(settledData([]));
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(0));
+    expect(result.current?.hasMore).toBe(false);
   });
 
   it("is idle without activation, even over a warm cache", async () => {
     const data = settledData(makeMessages(3));
     const { result, rerender } = renderRows(data);
-    await waitFor(() => expect(result.current?.data).toHaveLength(3));
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(3));
 
     rerender({ data, activated: false });
     expect(result.current).toBeUndefined();
@@ -58,24 +86,25 @@ describe("useMessageRows", () => {
   it("serves cached rows synchronously when the read reactivates", async () => {
     const data = settledData(makeMessages(3));
     const { result, rerender } = renderRows(data);
-    await waitFor(() => expect(result.current?.data).toHaveLength(3));
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(3));
 
     rerender({ data, activated: false });
     expect(result.current).toBeUndefined();
     rerender({ data, activated: true });
-    expect(result.current?.data).toHaveLength(3);
+    expect(result.current?.rows.data).toHaveLength(3);
   });
 
-  it("reads a chunked sample through hydration", async () => {
+  it("reads a chunked sample through the windowed source", async () => {
     const chunked = testChunkedSample(sequenceReaderOver(makeMessages(4)));
     const data: EvalSampleData = { ...streamingData, status: "ok", chunked };
     const { result } = renderRows(data);
 
-    expect(result.current?.loading).toBe(true);
-    await waitFor(() => expect(result.current?.data).toHaveLength(4));
+    expect(result.current?.rows.loading).toBe(true);
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(4));
+    expect(result.current?.hasMore).toBe(false);
   });
 
-  it("surfaces a chunked hydration failure as error, not endless loading", async () => {
+  it("surfaces a chunked read failure as error, not endless loading", async () => {
     const chunked = testChunkedSample(
       failingSequenceReader(new Error("boom")),
       [[0, 2]]
@@ -83,8 +112,10 @@ describe("useMessageRows", () => {
     const data: EvalSampleData = { ...streamingData, status: "ok", chunked };
     const { result } = renderRows(data);
 
-    await waitFor(() => expect(result.current?.error).toBeInstanceOf(Error));
-    expect(result.current?.loading).toBe(false);
-    expect(result.current?.data).toBeUndefined();
+    await waitFor(() =>
+      expect(result.current?.rows.error).toBeInstanceOf(Error)
+    );
+    expect(result.current?.rows.loading).toBe(false);
+    expect(result.current?.rows.data).toBeUndefined();
   });
 });

--- a/apps/inspect/src/log_data/messageRowsQuery.test.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.test.ts
@@ -29,9 +29,16 @@ const renderRows = (data: EvalSampleData, activated = true) =>
     { wrapper: makeWrapper(), initialProps: { data, activated } }
   );
 
+/** Sample data settled behind the paged (windowed chunked) source. */
+const chunkedData = (count: number): EvalSampleData => ({
+  ...streamingData,
+  status: "ok",
+  chunked: testChunkedSample(sequenceReaderOver(makeMessages(count))),
+});
+
 describe("useMessageRows", () => {
-  it("serves a settled conversation one page at a time", async () => {
-    const { result } = renderRows(settledData(makeMessages(1200)));
+  it("serves a paged source's conversation one page at a time", async () => {
+    const { result } = renderRows(chunkedData(1200));
 
     expect(result.current?.rows.loading).toBe(true);
     await waitFor(() =>
@@ -51,8 +58,8 @@ describe("useMessageRows", () => {
     expect(result.current?.hasMore).toBe(true);
   });
 
-  it("reports exhaustion on the last page", async () => {
-    const { result } = renderRows(settledData(makeMessages(150)));
+  it("reports exhaustion on a paged source's last page", async () => {
+    const { result } = renderRows(chunkedData(150));
     await waitFor(() =>
       expect(result.current?.rows.data).toHaveLength(kMessageRowsPageSize)
     );
@@ -61,6 +68,17 @@ describe("useMessageRows", () => {
     act(() => result.current?.loadMore());
     await waitFor(() => expect(result.current?.rows.data).toHaveLength(150));
     expect(result.current?.hasMore).toBe(false);
+  });
+
+  it("serves a monolith conversation whole in one read", async () => {
+    // in-memory sources are unpaged: customers' non-chunked evals keep the
+    // pre-paging feed — every row loaded, nothing behind loadMore
+    const { result } = renderRows(settledData(makeMessages(1200)));
+
+    expect(result.current?.rows.loading).toBe(true);
+    await waitFor(() => expect(result.current?.rows.data).toHaveLength(1200));
+    expect(result.current?.hasMore).toBe(false);
+    expect(result.current?.rows.data?.[1199]?.startNumber).toBe(1200);
   });
 
   it("handles an empty settled conversation", async () => {
@@ -108,12 +126,7 @@ describe("useMessageRows", () => {
     const servedLengths: number[] = [];
     const { result } = renderHook(
       () => {
-        const feed = useMessageRows(
-          handle,
-          settledData(makeMessages(300)),
-          true,
-          "m-150"
-        );
+        const feed = useMessageRows(handle, chunkedData(300), true, "m-150");
         if (feed?.rows.data !== undefined) {
           servedLengths.push(feed.rows.data.length);
         }
@@ -136,8 +149,7 @@ describe("useMessageRows", () => {
 
   it("a target the conversation never renders drains to exhaustion, then serves", async () => {
     const { result } = renderHook(
-      () =>
-        useMessageRows(handle, settledData(makeMessages(250)), true, "nope"),
+      () => useMessageRows(handle, chunkedData(250), true, "nope"),
       { wrapper: makeWrapper() }
     );
 

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -32,7 +32,9 @@ export interface MessageRowsFeed {
 const kNoLoadMore = () => {};
 
 /** A feed over rows that are already everything there is. */
-export const unpagedFeed = (rows: AsyncData<MessageRow[]>): MessageRowsFeed => ({
+export const unpagedFeed = (
+  rows: AsyncData<MessageRow[]>
+): MessageRowsFeed => ({
   rows,
   hasMore: false,
   loadMore: kNoLoadMore,

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -13,7 +13,7 @@ import { type EvalSampleData } from "./sampleData";
 import { sampleMessagesSource } from "./sampleMessagesSource";
 import { kSampleGcTimeMs } from "./sampleQuery";
 
-/** Rows per page of the settled conversation read. */
+/** Rows per page of a chunked sample's settled conversation read. */
 export const kMessageRowsPageSize = 100;
 
 /**
@@ -39,15 +39,20 @@ export const unpagedFeed = (rows: AsyncData<MessageRow[]>): MessageRowsFeed => (
 });
 
 /**
- * The settled conversation's rows for a sample, paged through react-query's
+ * The settled conversation's rows for a sample, read through react-query's
  * infinite query. Which feed backs them — inline monolith messages or the
  * windowed source over a chunked sample's conversation — is selected behind
- * the SampleMessagesData seam (`sampleMessagesSource`); both serve
- * kMessageRowsPageSize rows per read, so the tab's first paint costs one
+ * the SampleMessagesData seam (`sampleMessagesSource`). Chunked samples
+ * read in kMessageRowsPageSize pages, so the tab's first paint costs one
  * page even on a huge conversation and scrolling extends the loaded prefix
- * page by page. Pages are forward-contiguous from row 0 (offset cursors);
- * there is deliberately no eviction — `maxPages` would punch holes in the
- * flattened prefix the list renders.
+ * page by page; monolith samples serve the whole row space in one read,
+ * exactly like the pre-paging feed — a TEMPORARY gate, because behaviors
+ * built on a fully loaded list (find scope, the live-finish row swap)
+ * aren't paging-aware yet and customers' non-chunked evals must not lose
+ * them. Once those work over a paged prefix, the gate can drop. Pages are
+ * forward-contiguous from row 0 (offset cursors); there is deliberately no
+ * eviction — `maxPages` would punch holes in the flattened prefix the list
+ * renders.
  *
  * Returns undefined while there is no settled conversation to read (a
  * live streaming sample, a sample still fetching, the Messages tab never
@@ -70,6 +75,7 @@ export const useMessageRows = (
   targetMessageId?: string | null
 ): MessageRowsFeed | undefined => {
   const source = sampleMessagesSource(sampleData);
+  const paged = sampleData.chunked !== undefined;
 
   const query = useInfiniteQuery({
     // CONTRACT: the key omits the source because every source is a pure
@@ -91,7 +97,7 @@ export const useMessageRows = (
             source.getRows({
               cursor: pageParam === 0 ? null : { offset: pageParam },
               direction: "forward",
-              limit: kMessageRowsPageSize,
+              limit: paged ? kMessageRowsPageSize : Number.MAX_SAFE_INTEGER,
             })
         : skipToken,
     initialPageParam: 0,

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -1,7 +1,10 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
-import type { MessageRow } from "@tsmono/inspect-components/chat";
+import {
+  rowContainsMessage,
+  type MessageRow,
+} from "@tsmono/inspect-components/chat";
 import { AsyncData, loading as asyncLoading } from "@tsmono/util";
 
 import { SampleHandle } from "../app/types";
@@ -51,11 +54,20 @@ export const unpagedFeed = (rows: AsyncData<MessageRow[]>): MessageRowsFeed => (
  * activated); a loading feed while the first page is materializing; the
  * caller owns what covers those states (streaming rows, waiting/loading
  * affordances).
+ *
+ * `targetMessageId` is a `?message=` deep link's target: pages drain in
+ * serially until a loaded row renders that message (or the conversation
+ * is exhausted), and the feed reports loading until then — the list
+ * honors its initial scroll index at mount, so it must mount with the
+ * target resident. The prefix cost is deliberate: pages are
+ * forward-contiguous, so the covering prefix is the minimum the list can
+ * render anyway.
  */
 export const useMessageRows = (
   handle: SampleHandle | undefined,
   sampleData: EvalSampleData,
-  activated: boolean
+  activated: boolean,
+  targetMessageId?: string | null
 ): MessageRowsFeed | undefined => {
   const source = sampleMessagesSource(sampleData);
 
@@ -105,6 +117,22 @@ export const useMessageRows = (
   const pages = data?.pages;
   const rows = useMemo(() => pages?.flatMap((page) => page.rows), [pages]);
 
+  const targetLoaded = useMemo(
+    () =>
+      targetMessageId == null ||
+      (rows?.some((row) => rowContainsMessage(row, targetMessageId)) ?? false),
+    [rows, targetMessageId]
+  );
+  useEffect(() => {
+    if (!targetLoaded && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage({ cancelRefetch: false }).catch(() => undefined);
+    }
+    // `rows` is the re-fire key: a page can start AND land within one
+    // committed render (in-memory sources resolve in a microtask), so
+    // isFetchingNextPage never visibly flips and the other deps are
+    // unchanged after each drained page.
+  }, [rows, targetLoaded, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
   return useMemo(() => {
     if (!activated || source === undefined) {
       // idle even over a warm cache: rows are served only once the caller
@@ -118,6 +146,12 @@ export const useMessageRows = (
       // a failed page read fails the tab, matching the one-shot read's
       // behavior; the next loadMore after remount retries the same page
       return unpagedFeed({ error, loading: false });
+    }
+    if (!targetLoaded && hasNextPage) {
+      // the deep-link target's covering prefix is still draining in; a
+      // target the conversation never renders (hasNextPage exhausts) falls
+      // through and mounts at the top, like any unresolved ?message=
+      return unpagedFeed(asyncLoading);
     }
     return {
       rows: { data: rows ?? [], loading: false },
@@ -138,6 +172,7 @@ export const useMessageRows = (
     isError,
     error,
     rows,
+    targetLoaded,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -40,6 +40,10 @@ export const unpagedFeed = (
   loadMore: kNoLoadMore,
 });
 
+// one identity for every pending render — the returned feed is memoized so
+// consumers' own memos (useSampleMessages) see a stable value
+const kLoadingFeed = unpagedFeed(asyncLoading);
+
 /**
  * The settled conversation's rows for a sample, read through react-query's
  * infinite query. Which feed backs them — inline monolith messages or the
@@ -141,37 +145,53 @@ export const useMessageRows = (
     [rows, targetMessageId]
   );
   useEffect(() => {
-    if (!targetLoaded) {
+    // isError halts the drain: a failed page settles the query with
+    // hasNextPage still true, and re-firing fetchNext would retry the same
+    // page in an unbounded loop behind the error panel
+    if (!targetLoaded && !isError) {
       fetchNext();
     }
     // `rows` is the re-fire key: a page can start AND land within one
     // committed render (in-memory sources resolve in a microtask), so
     // isFetchingNextPage never visibly flips and the other deps are
     // unchanged after each drained page.
-  }, [rows, targetLoaded, fetchNext]);
+  }, [rows, targetLoaded, isError, fetchNext]);
 
-  if (!activated || source === undefined) {
-    // idle even over a warm cache: rows are served only once the caller
-    // activates the read and a settled feed exists
-    return undefined;
-  }
-  if (isPending) {
-    return unpagedFeed(asyncLoading);
-  }
-  if (isError) {
-    // a failed page read fails the tab, matching the one-shot read's
-    // behavior; the next loadMore after remount retries the same page
-    return unpagedFeed({ error, loading: false });
-  }
-  if (!targetLoaded && hasNextPage) {
-    // the deep-link target's covering prefix is still draining in; a
-    // target the conversation never renders (hasNextPage exhausts) falls
-    // through and mounts at the top, like any unresolved ?message=
-    return unpagedFeed(asyncLoading);
-  }
-  return {
-    rows: { data: rows ?? [], loading: false },
-    hasMore: hasNextPage,
-    loadMore: fetchNext,
-  };
+  const hasSource = source !== undefined;
+  return useMemo(() => {
+    if (!activated || !hasSource) {
+      // idle even over a warm cache: rows are served only once the caller
+      // activates the read and a settled feed exists
+      return undefined;
+    }
+    if (isPending) {
+      return kLoadingFeed;
+    }
+    if (isError) {
+      // a failed page read fails the tab, matching the one-shot read's
+      // behavior; the next loadMore after remount retries the same page
+      return unpagedFeed({ error, loading: false });
+    }
+    if (!targetLoaded && hasNextPage) {
+      // the deep-link target's covering prefix is still draining in; a
+      // target the conversation never renders (hasNextPage exhausts) falls
+      // through and mounts at the top, like any unresolved ?message=
+      return kLoadingFeed;
+    }
+    return {
+      rows: { data: rows ?? [], loading: false },
+      hasMore: hasNextPage,
+      loadMore: fetchNext,
+    };
+  }, [
+    activated,
+    hasSource,
+    isPending,
+    isError,
+    error,
+    targetLoaded,
+    hasNextPage,
+    rows,
+    fetchNext,
+  ]);
 };

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -1,5 +1,5 @@
 import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import {
   rowContainsMessage,
@@ -117,6 +117,15 @@ export const useMessageRows = (
   const pages = data?.pages;
   const rows = useMemo(() => pages?.flatMap((page) => page.rows), [pages]);
 
+  const fetchNext = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      // cancelRefetch false: callers repeat freely (scroll handlers, the
+      // drain effect) and a re-entrant call must not restart the in-flight
+      // page; failures surface through the query's own error state
+      fetchNextPage({ cancelRefetch: false }).catch(() => undefined);
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
   const targetLoaded = useMemo(
     () =>
       targetMessageId == null ||
@@ -124,57 +133,37 @@ export const useMessageRows = (
     [rows, targetMessageId]
   );
   useEffect(() => {
-    if (!targetLoaded && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage({ cancelRefetch: false }).catch(() => undefined);
+    if (!targetLoaded) {
+      fetchNext();
     }
     // `rows` is the re-fire key: a page can start AND land within one
     // committed render (in-memory sources resolve in a microtask), so
     // isFetchingNextPage never visibly flips and the other deps are
     // unchanged after each drained page.
-  }, [rows, targetLoaded, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [rows, targetLoaded, fetchNext]);
 
-  return useMemo(() => {
-    if (!activated || source === undefined) {
-      // idle even over a warm cache: rows are served only once the caller
-      // activates the read and a settled feed exists
-      return undefined;
-    }
-    if (isPending) {
-      return unpagedFeed(asyncLoading);
-    }
-    if (isError) {
-      // a failed page read fails the tab, matching the one-shot read's
-      // behavior; the next loadMore after remount retries the same page
-      return unpagedFeed({ error, loading: false });
-    }
-    if (!targetLoaded && hasNextPage) {
-      // the deep-link target's covering prefix is still draining in; a
-      // target the conversation never renders (hasNextPage exhausts) falls
-      // through and mounts at the top, like any unresolved ?message=
-      return unpagedFeed(asyncLoading);
-    }
-    return {
-      rows: { data: rows ?? [], loading: false },
-      hasMore: hasNextPage,
-      loadMore: () => {
-        if (hasNextPage && !isFetchingNextPage) {
-          // cancelRefetch false: scroll handlers call this repeatedly and a
-          // re-entrant call must not restart the in-flight page; failures
-          // surface through the query's own error state
-          fetchNextPage({ cancelRefetch: false }).catch(() => undefined);
-        }
-      },
-    };
-  }, [
-    activated,
-    source,
-    isPending,
-    isError,
-    error,
-    rows,
-    targetLoaded,
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-  ]);
+  if (!activated || source === undefined) {
+    // idle even over a warm cache: rows are served only once the caller
+    // activates the read and a settled feed exists
+    return undefined;
+  }
+  if (isPending) {
+    return unpagedFeed(asyncLoading);
+  }
+  if (isError) {
+    // a failed page read fails the tab, matching the one-shot read's
+    // behavior; the next loadMore after remount retries the same page
+    return unpagedFeed({ error, loading: false });
+  }
+  if (!targetLoaded && hasNextPage) {
+    // the deep-link target's covering prefix is still draining in; a
+    // target the conversation never renders (hasNextPage exhausts) falls
+    // through and mounts at the top, like any unresolved ?message=
+    return unpagedFeed(asyncLoading);
+  }
+  return {
+    rows: { data: rows ?? [], loading: false },
+    hasMore: hasNextPage,
+    loadMore: fetchNext,
+  };
 };

--- a/apps/inspect/src/log_data/messageRowsQuery.ts
+++ b/apps/inspect/src/log_data/messageRowsQuery.ts
@@ -1,9 +1,8 @@
-import { skipToken } from "@tanstack/react-query";
+import { skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import type { MessageRow } from "@tsmono/inspect-components/chat";
-import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
-import { AsyncData } from "@tsmono/util";
+import { AsyncData, loading as asyncLoading } from "@tsmono/util";
 
 import { SampleHandle } from "../app/types";
 
@@ -11,34 +10,62 @@ import { type EvalSampleData } from "./sampleData";
 import { sampleMessagesSource } from "./sampleMessagesSource";
 import { kSampleGcTimeMs } from "./sampleQuery";
 
+/** Rows per page of the settled conversation read. */
+export const kMessageRowsPageSize = 100;
+
 /**
- * The settled conversation's rows for a sample, held in react-query.
- * Which feed backs them — inline monolith messages or the windowed source
- * over a chunked sample's conversation — is selected behind the
- * SampleMessagesData seam (`sampleMessagesSource`). This stage reads the
- * whole row space in one getRows call (the chat list renders prebuilt
- * rows); everything below the seam — scanning, chunk fetches, folding —
- * serves that request the same way it will serve real pages when the
- * list virtualizes over them.
+ * The settled conversation as a loaded prefix of rows plus the controls to
+ * extend it — what the Messages tab consumes. `rows.data` is every row
+ * loaded so far (pages flattened); `hasMore` marks it a prefix; `loadMore`
+ * requests the next page and no-ops while one is in flight, so scroll
+ * handlers may call it freely.
+ */
+export interface MessageRowsFeed {
+  rows: AsyncData<MessageRow[]>;
+  hasMore: boolean;
+  loadMore: () => void;
+}
+
+const kNoLoadMore = () => {};
+
+/** A feed over rows that are already everything there is. */
+export const unpagedFeed = (rows: AsyncData<MessageRow[]>): MessageRowsFeed => ({
+  rows,
+  hasMore: false,
+  loadMore: kNoLoadMore,
+});
+
+/**
+ * The settled conversation's rows for a sample, paged through react-query's
+ * infinite query. Which feed backs them — inline monolith messages or the
+ * windowed source over a chunked sample's conversation — is selected behind
+ * the SampleMessagesData seam (`sampleMessagesSource`); both serve
+ * kMessageRowsPageSize rows per read, so the tab's first paint costs one
+ * page even on a huge conversation and scrolling extends the loaded prefix
+ * page by page. Pages are forward-contiguous from row 0 (offset cursors);
+ * there is deliberately no eviction — `maxPages` would punch holes in the
+ * flattened prefix the list renders.
  *
  * Returns undefined while there is no settled conversation to read (a
  * live streaming sample, a sample still fetching, the Messages tab never
- * activated); loading while one is materializing; the caller owns what
- * covers those states (streaming rows, waiting/loading affordances).
+ * activated); a loading feed while the first page is materializing; the
+ * caller owns what covers those states (streaming rows, waiting/loading
+ * affordances).
  */
 export const useMessageRows = (
   handle: SampleHandle | undefined,
   sampleData: EvalSampleData,
   activated: boolean
-): AsyncData<MessageRow[]> | undefined => {
+): MessageRowsFeed | undefined => {
   const source = sampleMessagesSource(sampleData);
 
-  const rows = useAsyncDataFromQuery<MessageRow[]>({
+  const query = useInfiniteQuery({
     // CONTRACT: the key omits the source because every source is a pure
     // function of the handle (logs are append-only; fold options are a
     // module constant) — that is what lets staleTime Infinity serve the
-    // cached read forever. A source that breaks the rule (per-user fold
-    // options) must add its distinguishing inputs here.
+    // cached read forever, and why these pages are NEVER invalidated (a
+    // refetch would re-read every loaded page). A source that breaks the
+    // rule (per-user fold options) must add its distinguishing inputs here.
     queryKey: [
       "log_data",
       "message-rows",
@@ -48,15 +75,15 @@ export const useMessageRows = (
     ],
     queryFn:
       activated && source && handle
-        ? async () => {
-            const page = await source.getRows({
-              cursor: null,
+        ? ({ pageParam }) =>
+            source.getRows({
+              cursor: pageParam === 0 ? null : { offset: pageParam },
               direction: "forward",
-              limit: Number.MAX_SAFE_INTEGER,
-            });
-            return page.rows;
-          }
+              limit: kMessageRowsPageSize,
+            })
         : skipToken,
+    initialPageParam: 0,
+    getNextPageParam: (last) => last.nextCursor?.offset,
     gcTime: kSampleGcTimeMs,
     staleTime: Infinity,
     retry: false,
@@ -66,12 +93,53 @@ export const useMessageRows = (
     structuralSharing: false,
   });
 
+  const {
+    data,
+    isPending,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = query;
+  const pages = data?.pages;
+  const rows = useMemo(() => pages?.flatMap((page) => page.rows), [pages]);
+
   return useMemo(() => {
     if (!activated || source === undefined) {
       // idle even over a warm cache: rows are served only once the caller
       // activates the read and a settled feed exists
       return undefined;
     }
-    return rows;
-  }, [activated, source, rows]);
+    if (isPending) {
+      return unpagedFeed(asyncLoading);
+    }
+    if (isError) {
+      // a failed page read fails the tab, matching the one-shot read's
+      // behavior; the next loadMore after remount retries the same page
+      return unpagedFeed({ error, loading: false });
+    }
+    return {
+      rows: { data: rows ?? [], loading: false },
+      hasMore: hasNextPage,
+      loadMore: () => {
+        if (hasNextPage && !isFetchingNextPage) {
+          // cancelRefetch false: scroll handlers call this repeatedly and a
+          // re-entrant call must not restart the in-flight page; failures
+          // surface through the query's own error state
+          fetchNextPage({ cancelRefetch: false }).catch(() => undefined);
+        }
+      },
+    };
+  }, [
+    activated,
+    source,
+    isPending,
+    isError,
+    error,
+    rows,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  ]);
 };

--- a/apps/inspect/src/log_data/sampleMessages.test.ts
+++ b/apps/inspect/src/log_data/sampleMessages.test.ts
@@ -92,10 +92,9 @@ describe("useSampleMessages", () => {
     );
 
     expect(result.current.rows.loading).toBe(false);
-    expect(result.current.rows.data?.map((r) => r.resolved.message.id)).toEqual([
-      "m-in",
-      "m-out",
-    ]);
+    expect(result.current.rows.data?.map((r) => r.resolved.message.id)).toEqual(
+      ["m-in", "m-out"]
+    );
   });
 
   it("keeps a pre-first-poll live sample on the waiting affordance", () => {

--- a/apps/inspect/src/log_data/sampleMessages.test.ts
+++ b/apps/inspect/src/log_data/sampleMessages.test.ts
@@ -12,12 +12,13 @@ import {
   testMessages as makeMessages,
   makeWrapper,
   testModelEvent as modelEvent,
+  sequenceReaderOver,
   settledData,
   testChunkedSample,
 } from "./testFixtures";
 
 describe("useSampleMessages", () => {
-  it("reads a settled sample's rows through the seam, one page at a time", async () => {
+  it("reads a settled monolith sample's rows through the seam in one read", async () => {
     const sampleData = settledData(makeMessages(1200));
     const { result } = renderHook(
       () => useSampleMessages(handle, sampleData, true, false),
@@ -28,12 +29,28 @@ describe("useSampleMessages", () => {
     expect(result.current.rows.loading).toBe(true);
     expect(result.current.rows.data).toBeUndefined();
 
-    // the settled feed is a paged prefix, not the whole conversation
+    // monolith samples are unpaged: the settled feed is the whole
+    // conversation, exactly as before paging existed
+    await waitFor(() => expect(result.current.rows.data).toHaveLength(1200));
+    expect(result.current.rows.loading).toBe(false);
+    expect(result.current.rows.data?.[0]?.startNumber).toBe(1);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it("reads a chunked sample's rows through the seam one page at a time", async () => {
+    const sampleData: EvalSampleData = {
+      ...settledData([]),
+      sample: undefined,
+      chunked: testChunkedSample(sequenceReaderOver(makeMessages(1200))),
+    };
+    const { result } = renderHook(
+      () => useSampleMessages(handle, sampleData, true, false),
+      { wrapper: makeWrapper() }
+    );
+
     await waitFor(() =>
       expect(result.current.rows.data).toHaveLength(kMessageRowsPageSize)
     );
-    expect(result.current.rows.loading).toBe(false);
-    expect(result.current.rows.data?.[0]?.startNumber).toBe(1);
     expect(result.current.hasMore).toBe(true);
 
     act(() => result.current.loadMore());

--- a/apps/inspect/src/log_data/sampleMessages.test.ts
+++ b/apps/inspect/src/log_data/sampleMessages.test.ts
@@ -1,8 +1,9 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { SampleHandle } from "../app/types";
 
+import { kMessageRowsPageSize } from "./messageRowsQuery";
 import { type EvalSampleData } from "./sampleData";
 import { useSampleMessages } from "./sampleMessages";
 import {
@@ -16,7 +17,7 @@ import {
 } from "./testFixtures";
 
 describe("useSampleMessages", () => {
-  it("reads a settled sample's rows through the seam", async () => {
+  it("reads a settled sample's rows through the seam, one page at a time", async () => {
     const sampleData = settledData(makeMessages(1200));
     const { result } = renderHook(
       () => useSampleMessages(handle, sampleData, true, false),
@@ -24,12 +25,21 @@ describe("useSampleMessages", () => {
     );
 
     // the read is asynchronous: a loading affordance covers the gap
-    expect(result.current.loading).toBe(true);
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.rows.loading).toBe(true);
+    expect(result.current.rows.data).toBeUndefined();
 
-    await waitFor(() => expect(result.current.data).toHaveLength(1200));
-    expect(result.current.loading).toBe(false);
-    expect(result.current.data?.[0]?.startNumber).toBe(1);
+    // the settled feed is a paged prefix, not the whole conversation
+    await waitFor(() =>
+      expect(result.current.rows.data).toHaveLength(kMessageRowsPageSize)
+    );
+    expect(result.current.rows.loading).toBe(false);
+    expect(result.current.rows.data?.[0]?.startNumber).toBe(1);
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.rows.data).toHaveLength(2 * kMessageRowsPageSize)
+    );
   });
 
   it("reports loading during a monolith sample fetch, never 'No messages'", () => {
@@ -46,8 +56,8 @@ describe("useSampleMessages", () => {
       { wrapper: makeWrapper() }
     );
 
-    expect(result.current.loading).toBe(true);
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.rows.loading).toBe(true);
+    expect(result.current.rows.data).toBeUndefined();
   });
 
   it("derives streaming rows from the event feed with no source", () => {
@@ -64,8 +74,8 @@ describe("useSampleMessages", () => {
       { wrapper: makeWrapper() }
     );
 
-    expect(result.current.loading).toBe(false);
-    expect(result.current.data?.map((r) => r.resolved.message.id)).toEqual([
+    expect(result.current.rows.loading).toBe(false);
+    expect(result.current.rows.data?.map((r) => r.resolved.message.id)).toEqual([
       "m-in",
       "m-out",
     ]);
@@ -86,8 +96,8 @@ describe("useSampleMessages", () => {
     );
 
     // running gates loading off: the view renders "Waiting for messages"
-    expect(result.current.loading).toBe(false);
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.loading).toBe(false);
+    expect(result.current.rows.data).toHaveLength(0);
   });
 
   it("swaps the streaming feed for settled rows without an empty frame", async () => {
@@ -111,15 +121,15 @@ describe("useSampleMessages", () => {
         initialProps: { data: streamingData, running: true },
       }
     );
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.rows.data).toHaveLength(2);
 
     rerender({ data: settledData(makeMessages(50)), running: false });
     // the bridge: streaming rows hold while the read is in flight
-    expect(result.current.data).toHaveLength(2);
-    expect(result.current.loading).toBe(false);
+    expect(result.current.rows.data).toHaveLength(2);
+    expect(result.current.rows.loading).toBe(false);
 
-    await waitFor(() => expect(result.current.data).toHaveLength(50));
-    expect(result.current.loading).toBe(false);
+    await waitFor(() => expect(result.current.rows.data).toHaveLength(50));
+    expect(result.current.rows.loading).toBe(false);
   });
 
   it("never bridges streaming rows across samples", async () => {
@@ -147,15 +157,15 @@ describe("useSampleMessages", () => {
         initialProps: { h: handle, data: streamingData, running: true },
       }
     );
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.rows.data).toHaveLength(2);
 
     // navigating mid-stream to a settled sample: the previous sample's
     // streaming rows must not cover the new sample's read
     rerender({ h: other, data: settledData(makeMessages(5)), running: false });
-    expect(result.current.data).toBeUndefined();
-    expect(result.current.loading).toBe(true);
+    expect(result.current.rows.data).toBeUndefined();
+    expect(result.current.rows.loading).toBe(true);
 
-    await waitFor(() => expect(result.current.data).toHaveLength(5));
+    await waitFor(() => expect(result.current.rows.data).toHaveLength(5));
   });
 
   it("defers all folding until the Messages tab first opens, then latches", async () => {
@@ -167,14 +177,14 @@ describe("useSampleMessages", () => {
     );
 
     // inactive: no read
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.data).toHaveLength(0);
 
     rerender({ active: true });
-    await waitFor(() => expect(result.current.data).toHaveLength(10));
+    await waitFor(() => expect(result.current.rows.data).toHaveLength(10));
 
     // latched: switching away keeps the rows resident
     rerender({ active: false });
-    expect(result.current.data).toHaveLength(10);
+    expect(result.current.rows.data).toHaveLength(10);
   });
 
   it("keeps the streaming fold off while the tab has never been open", () => {
@@ -192,10 +202,10 @@ describe("useSampleMessages", () => {
       { wrapper: makeWrapper(), initialProps: { active: false } }
     );
 
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.data).toHaveLength(0);
 
     rerender({ active: true });
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.rows.data).toHaveLength(2);
   });
 
   it("stops the streaming fold when the tab is hidden, latch or not", () => {
@@ -212,15 +222,15 @@ describe("useSampleMessages", () => {
         useSampleMessages(handle, streamingData, active, true),
       { wrapper: makeWrapper(), initialProps: { active: true } }
     );
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.rows.data).toHaveLength(2);
 
     // hidden mid-stream: the per-poll refold must not keep running (the
     // list is unmounted); returning rebuilds from the events
     rerender({ active: false });
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.data).toHaveLength(0);
 
     rerender({ active: true });
-    expect(result.current.data).toHaveLength(2);
+    expect(result.current.rows.data).toHaveLength(2);
   });
 
   it("resets the latch when the sample changes", async () => {
@@ -231,20 +241,20 @@ describe("useSampleMessages", () => {
         useSampleMessages(h, sampleData, active, false),
       { wrapper: makeWrapper(), initialProps: { h: handle, active: true } }
     );
-    await waitFor(() => expect(result.current.data).toHaveLength(4));
+    await waitFor(() => expect(result.current.rows.data).toHaveLength(4));
 
     // a different sample arrives with the tab closed: no read until opened
     rerender({ h: other, active: false });
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.data).toHaveLength(0);
 
     // returning to the previously-activated sample must NOT re-latch: the
     // hook mounts unkeyed, so a stale latch would read at sample open
     rerender({ h: handle, active: false });
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.rows.data).toHaveLength(0);
 
     // re-opening serves the cached rows synchronously
     rerender({ h: handle, active: true });
-    expect(result.current.data).toHaveLength(4);
+    expect(result.current.rows.data).toHaveLength(4);
   });
 
   it("surfaces a chunked hydration failure instead of 'No messages'", async () => {
@@ -267,10 +277,10 @@ describe("useSampleMessages", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.rows.error).toBeInstanceOf(Error);
     });
-    expect(result.current.loading).toBe(false);
-    expect(result.current.data).toBeUndefined();
+    expect(result.current.rows.loading).toBe(false);
+    expect(result.current.rows.data).toBeUndefined();
   });
 
   it("handles an empty settled conversation", async () => {
@@ -280,8 +290,8 @@ describe("useSampleMessages", () => {
       { wrapper: makeWrapper() }
     );
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.data).toHaveLength(0);
-    expect(result.current.error).toBeUndefined();
+    await waitFor(() => expect(result.current.rows.loading).toBe(false));
+    expect(result.current.rows.data).toHaveLength(0);
+    expect(result.current.rows.error).toBeUndefined();
   });
 });

--- a/apps/inspect/src/log_data/sampleMessages.ts
+++ b/apps/inspect/src/log_data/sampleMessages.ts
@@ -4,13 +4,17 @@ import {
   buildMessageRows,
   type MessageRow,
 } from "@tsmono/inspect-components/chat";
-import { AsyncData, loading as asyncLoading } from "@tsmono/util";
+import { loading as asyncLoading } from "@tsmono/util";
 
 import { Events } from "../@types/extraInspect";
 import { SampleHandle } from "../app/types";
 
 import { kDefaultMessageRowOptions } from "./messageRows";
-import { useMessageRows } from "./messageRowsQuery";
+import {
+  unpagedFeed,
+  useMessageRows,
+  type MessageRowsFeed,
+} from "./messageRowsQuery";
 import {
   messagesFromEvents,
   type MessagesFromEventsState,
@@ -74,25 +78,28 @@ const useStreamingRowsLatch = (
 
 /**
  * The Messages tab's one entry point: the settled conversation's rows read
- * through `useMessageRows`, with the live event stream serving rows until
+ * through `useMessageRows` — a paged feed whose loaded prefix the list
+ * extends by scrolling — with the live event stream serving rows until
  * a settled feed exists. The view consumes the result and reports two
  * gates it owns: `active` (the tab is open — the settled read and chunked
  * hydration are activation-latched on it, so neither is ever paid at
  * sample open) and `running` (live samples surface "waiting", not
  * "loading", before their first poll lands).
  *
- * `data` is the rows to render (settled, streaming, or an empty settled
- * conversation); `loading` means data that will produce messages is still
- * in flight (monolith fetch, chunked hydration, rows materialization);
- * `error` means the conversation failed to materialize. On loading and
- * error the view renders that affordance, never "No messages".
+ * `rows.data` is the rows to render (a settled prefix, streaming rows, or
+ * an empty settled conversation); `rows.loading` means data that will
+ * produce messages is still in flight (monolith fetch, chunked hydration,
+ * first-page materialization); `rows.error` means the conversation failed
+ * to materialize. On loading and error the view renders that affordance,
+ * never "No messages". Streaming rows are never paged (`hasMore` false):
+ * the event feed always renders whole.
  */
 export const useSampleMessages = (
   handle: SampleHandle | undefined,
   sampleData: EvalSampleData,
   active: boolean,
   running: boolean
-): AsyncData<MessageRow[]> => {
+): MessageRowsFeed => {
   // Activation latch: the first Messages-tab open turns the settled read
   // and chunked hydration on while the user stays on the sample. Ungated
   // they run at sample open (whole-conversation fold, hydration) while
@@ -119,28 +126,25 @@ export const useSampleMessages = (
   const settled = useMessageRows(handle, sampleData, activated);
   const streamingRows = useStreamingRowsLatch(
     active,
-    settled?.data !== undefined || settled?.error !== undefined,
+    settled?.rows.data !== undefined || settled?.rows.error !== undefined,
     sampleData.running,
     sampleKey
   );
 
   const status = sampleData.status;
   return useMemo(() => {
-    if (settled?.error !== undefined) {
-      return { error: settled.error, loading: false };
-    }
-    if (settled?.data !== undefined) {
-      return { data: settled.data, loading: false };
+    if (settled?.rows.error !== undefined || settled?.rows.data !== undefined) {
+      return settled;
     }
     if (streamingRows !== undefined) {
-      return { data: streamingRows, loading: false };
+      return unpagedFeed({ data: streamingRows, loading: false });
     }
     // the settled read/hydration in flight, or the monolith member
     // fetch/parse (`running` keeps the streaming path's pre-first-poll
     // state on its "waiting" affordance instead)
-    if (settled?.loading || (status === "loading" && !running)) {
-      return asyncLoading;
+    if (settled?.rows.loading || (status === "loading" && !running)) {
+      return unpagedFeed(asyncLoading);
     }
-    return { data: kNoRows, loading: false };
+    return unpagedFeed({ data: kNoRows, loading: false });
   }, [settled, streamingRows, status, running]);
 };

--- a/apps/inspect/src/log_data/sampleMessages.ts
+++ b/apps/inspect/src/log_data/sampleMessages.ts
@@ -93,12 +93,17 @@ const useStreamingRowsLatch = (
  * to materialize. On loading and error the view renders that affordance,
  * never "No messages". Streaming rows are never paged (`hasMore` false):
  * the event feed always renders whole.
+ *
+ * `targetMessageId` (a `?message=` deep link) keeps the settled feed on
+ * loading until the target's covering page prefix is resident — see
+ * `useMessageRows`.
  */
 export const useSampleMessages = (
   handle: SampleHandle | undefined,
   sampleData: EvalSampleData,
   active: boolean,
-  running: boolean
+  running: boolean,
+  targetMessageId?: string | null
 ): MessageRowsFeed => {
   // Activation latch: the first Messages-tab open turns the settled read
   // and chunked hydration on while the user stays on the sample. Ungated
@@ -123,7 +128,12 @@ export const useSampleMessages = (
   }
   const activated = active || (latch.key === sampleKey && latch.activated);
 
-  const settled = useMessageRows(handle, sampleData, activated);
+  const settled = useMessageRows(
+    handle,
+    sampleData,
+    activated,
+    targetMessageId
+  );
   const streamingRows = useStreamingRowsLatch(
     active,
     settled?.rows.data !== undefined || settled?.rows.error !== undefined,

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -87,14 +87,18 @@ describe("ChatViewRowsVirtualList paging", () => {
     rows: ReturnType<typeof rowsOf>;
     hasMoreRows?: boolean;
     onLoadMoreRows?: () => void;
-  }) =>
-    render(
-      <ComponentStateProvider hooks={makeStateStore().hooks}>
+  }) => {
+    const { hooks } = makeStateStore();
+    const ui = (p: typeof props) => (
+      <ComponentStateProvider hooks={hooks}>
         <ExtendedFindProvider>
-          <ChatViewRowsVirtualList id="chat" {...props} />
+          <ChatViewRowsVirtualList id="chat" {...p} />
         </ExtendedFindProvider>
       </ComponentStateProvider>
     );
+    const view = render(ui(props));
+    return { rerenderRows: (p: typeof props) => view.rerender(ui(p)) };
+  };
 
   it("requests the next page when the loaded end is within the margin", () => {
     // a loaded prefix shorter than the margin: the mount-time check alone
@@ -106,6 +110,21 @@ describe("ChatViewRowsVirtualList paging", () => {
       onLoadMoreRows: () => calls++,
     });
     expect(calls).toBeGreaterThan(0);
+  });
+
+  it("keeps paging when a page lands without the viewport moving", () => {
+    // the regrow re-check rides on VirtualList replaying the range to the
+    // new callback identity — no scroll event fires when rows are appended
+    let calls = 0;
+    const onLoadMoreRows = () => calls++;
+    const { rerenderRows } = mountRows({
+      rows: rowsOf(5),
+      hasMoreRows: true,
+      onLoadMoreRows,
+    });
+    const callsAfterMount = calls;
+    rerenderRows({ rows: rowsOf(10), hasMoreRows: true, onLoadMoreRows });
+    expect(calls).toBeGreaterThan(callsAfterMount);
   });
 
   it("never requests pages while the host reports no more rows", () => {

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -10,7 +10,11 @@ import {
   type ComponentStateHooks,
 } from "@tsmono/react/state";
 
-import { ChatViewVirtualList } from "./ChatViewVirtualList";
+import {
+  ChatViewRowsVirtualList,
+  ChatViewVirtualList,
+} from "./ChatViewVirtualList";
+import { buildMessageRows, messageRowOptions } from "./rowsModel";
 
 const messages = [
   { id: "m-1", role: "assistant", content: "one" },
@@ -22,12 +26,8 @@ beforeEach(() => {
   Element.prototype.scrollTo = function () {};
 });
 
-/** Mounts the list over an inspectable store and returns the persisted follow flag. */
-function mountFollow(props: {
-  running: boolean;
-  initialMessageId?: string;
-  followRequested?: boolean;
-}) {
+/** An inspectable in-memory ComponentStateHooks store. */
+function makeStateStore() {
   const store = new Map<string, unknown>();
   const listeners = new Set<() => void>();
   let version = 0;
@@ -51,6 +51,16 @@ function mountFollow(props: {
     useRemoveAll: () => () => {},
     useRemoveByPrefix: () => () => {},
   };
+  return { store, hooks };
+}
+
+/** Mounts the list over an inspectable store and returns the persisted follow flag. */
+function mountFollow(props: {
+  running: boolean;
+  initialMessageId?: string;
+  followRequested?: boolean;
+}) {
+  const { store, hooks } = makeStateStore();
 
   render(
     <ComponentStateProvider hooks={hooks}>
@@ -61,6 +71,53 @@ function mountFollow(props: {
   );
   return store.get("chat-chat::follow");
 }
+
+describe("ChatViewRowsVirtualList paging", () => {
+  const rowsOf = (count: number) =>
+    buildMessageRows(
+      Array.from({ length: count }, (_, i): ChatMessage => ({
+        id: `m-${i}`,
+        role: "user",
+        content: `message ${i}`,
+      })),
+      messageRowOptions()
+    );
+
+  const mountRows = (props: {
+    rows: ReturnType<typeof rowsOf>;
+    hasMoreRows?: boolean;
+    onLoadMoreRows?: () => void;
+  }) =>
+    render(
+      <ComponentStateProvider hooks={makeStateStore().hooks}>
+        <ExtendedFindProvider>
+          <ChatViewRowsVirtualList id="chat" {...props} />
+        </ExtendedFindProvider>
+      </ComponentStateProvider>
+    );
+
+  it("requests the next page when the loaded end is within the margin", () => {
+    // a loaded prefix shorter than the margin: the mount-time check alone
+    // must request more (there is no scroll event to re-trigger on)
+    let calls = 0;
+    mountRows({
+      rows: rowsOf(5),
+      hasMoreRows: true,
+      onLoadMoreRows: () => calls++,
+    });
+    expect(calls).toBeGreaterThan(0);
+  });
+
+  it("never requests pages while the host reports no more rows", () => {
+    let calls = 0;
+    mountRows({
+      rows: rowsOf(5),
+      hasMoreRows: false,
+      onLoadMoreRows: () => calls++,
+    });
+    expect(calls).toBe(0);
+  });
+});
 
 describe("ChatViewVirtualList live-follow ownership", () => {
   it("stands down on a ?message= landing into a live sample", () => {

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -66,9 +66,22 @@ const chatComponents = { Item: ChatItem };
 // Empirically tuned, sign-inverted vs naive TanStack math; don't "fix" without re-verifying against both chat and transcript surfaces.
 const kChatScrollPaddingStart = -15;
 
+// How close (in rows) the viewport gets to the loaded end before the next
+// page is requested — roughly a viewport of chat rows, so the fetch usually
+// lands before the user reaches the footer.
+const kLoadMoreMarginRows = 20;
+
 export interface ChatViewRowsVirtualListProps {
   id: string;
   rows: MessageRow[];
+  /** A paged host's signal that `rows` is a loaded prefix, not the whole
+   *  conversation: keeps a loading footer below the list and arms the
+   *  near-end trigger. */
+  hasMoreRows?: boolean;
+  /** Request the page after `rows`. Called whenever the viewport nears the
+   *  loaded end — possibly repeatedly, so the host owns the in-flight
+   *  guard. */
+  onLoadMoreRows?: () => void;
   className?: string | string[];
   initialMessageId?: string | null;
   /** Explicit `follow=1` URL param: arm live-tail at mount even on a
@@ -97,6 +110,8 @@ export const ChatViewRowsVirtualList: FC<ChatViewRowsVirtualListProps> = memo(
   function ChatViewRowsVirtualList({
     id,
     rows,
+    hasMoreRows,
+    onLoadMoreRows,
     initialMessageId,
     followRequested,
     className,
@@ -125,6 +140,31 @@ export const ChatViewRowsVirtualList: FC<ChatViewRowsVirtualListProps> = memo(
       scrollRef,
       itemCount: rows.length,
     });
+
+    // The near-end trigger re-checks on scroll (the range callback) AND when
+    // rows grow (the effect): a landing page doesn't move the viewport, so
+    // without the effect a user parked at the loaded end would stall after
+    // one page.
+    const visibleEndRef = useRef(0);
+    const maybeLoadMore = useCallback(() => {
+      if (
+        hasMoreRows &&
+        onLoadMoreRows &&
+        visibleEndRef.current >= rows.length - kLoadMoreMarginRows
+      ) {
+        onLoadMoreRows();
+      }
+    }, [hasMoreRows, onLoadMoreRows, rows.length]);
+    const handleVisibleRangeChange = useCallback(
+      (range: { startIndex: number; endIndex: number }) => {
+        visibleEndRef.current = range.endIndex;
+        maybeLoadMore();
+      },
+      [maybeLoadMore]
+    );
+    useEffect(() => {
+      maybeLoadMore();
+    }, [maybeLoadMore]);
 
     const initialMessageIndex = useMemo(() => {
       if (initialMessageId === null || initialMessageId === undefined) {
@@ -242,6 +282,8 @@ export const ChatViewRowsVirtualList: FC<ChatViewRowsVirtualListProps> = memo(
         components={chatComponents}
         smoothScroll={false}
         itemSearchText={rowSearchText}
+        showProgress={hasMoreRows}
+        onVisibleRangeChange={handleVisibleRangeChange}
       />
     );
   }

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -141,30 +141,23 @@ export const ChatViewRowsVirtualList: FC<ChatViewRowsVirtualListProps> = memo(
       itemCount: rows.length,
     });
 
-    // The near-end trigger re-checks on scroll (the range callback) AND when
-    // rows grow (the effect): a landing page doesn't move the viewport, so
-    // without the effect a user parked at the loaded end would stall after
-    // one page.
-    const visibleEndRef = useRef(0);
-    const maybeLoadMore = useCallback(() => {
-      if (
-        hasMoreRows &&
-        onLoadMoreRows &&
-        visibleEndRef.current >= rows.length - kLoadMoreMarginRows
-      ) {
-        onLoadMoreRows();
-      }
-    }, [hasMoreRows, onLoadMoreRows, rows.length]);
+    // The near-end trigger re-checks on scroll AND when rows grow: a landing
+    // page doesn't move the viewport, so the rows-grow case rides on
+    // VirtualList replaying the current range whenever this callback's
+    // identity (here, `rows.length`) changes — a user parked at the loaded
+    // end keeps paging without scrolling.
     const handleVisibleRangeChange = useCallback(
       (range: { startIndex: number; endIndex: number }) => {
-        visibleEndRef.current = range.endIndex;
-        maybeLoadMore();
+        if (
+          hasMoreRows &&
+          onLoadMoreRows &&
+          range.endIndex >= rows.length - kLoadMoreMarginRows
+        ) {
+          onLoadMoreRows();
+        }
       },
-      [maybeLoadMore]
+      [hasMoreRows, onLoadMoreRows, rows.length]
     );
-    useEffect(() => {
-      maybeLoadMore();
-    }, [maybeLoadMore]);
 
     const initialMessageIndex = useMemo(() => {
       if (initialMessageId === null || initialMessageId === undefined) {

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.tsx
@@ -34,6 +34,7 @@ import { messageSearchText } from "./messageSearchText";
 import {
   buildMessageRows,
   messageRowOptions,
+  rowContainsMessage,
   type MessageRow,
 } from "./rowsModel";
 import {
@@ -130,18 +131,9 @@ export const ChatViewRowsVirtualList: FC<ChatViewRowsVirtualListProps> = memo(
         return undefined;
       }
 
-      const index = rows.findIndex((row) => {
-        const messageId = row.resolved.message.id === initialMessageId;
-        if (messageId) {
-          return true;
-        }
-
-        if (
-          row.resolved.toolMessages.find((tm) => tm.id === initialMessageId)
-        ) {
-          return true;
-        }
-      });
+      const index = rows.findIndex((row) =>
+        rowContainsMessage(row, initialMessageId)
+      );
       return index !== -1 ? index : undefined;
     }, [initialMessageId, rows]);
 

--- a/packages/inspect-components/src/chat/index.ts
+++ b/packages/inspect-components/src/chat/index.ts
@@ -23,6 +23,7 @@ export {
   countRowBlocks,
   MessageRowScanner,
   messageRowOptions,
+  rowContainsMessage,
 } from "./rowsModel";
 
 export type { MessagesToStrOptions } from "./messagesToStr";

--- a/packages/inspect-components/src/chat/rowsModel.ts
+++ b/packages/inspect-components/src/chat/rowsModel.ts
@@ -25,6 +25,19 @@ export interface MessageRowOptions {
 }
 
 /**
+ * Whether a row renders the message with this id — as its head message or
+ * as one of its folded tool messages. The deep-link target scan and the
+ * data layer's target drain must agree on this, so it lives with the row
+ * type.
+ */
+export const rowContainsMessage = (
+  row: MessageRow,
+  messageId: string
+): boolean =>
+  row.resolved.message.id === messageId ||
+  row.resolved.toolMessages.some((tm) => tm.id === messageId);
+
+/**
  * Fold options from a view's tool options — the one place the fold
  * defaults ("complete", collapse on) are defined. Data-layer folds and
  * the chat components both derive from here, so pre-built rows and their

--- a/packages/react/src/virtual/types.ts
+++ b/packages/react/src/virtual/types.ts
@@ -67,6 +67,11 @@ export interface VirtualListProps<T> {
   itemSearchText?: (item: T) => string | string[];
   findScope?: "local" | "none";
   scrollToTopOnFinish?: boolean;
+  /** Called when the rendered range changes, AND replayed with the current
+   *  range whenever the callback's identity changes — callers rely on that
+   *  replay to re-check conditions that shift under a static viewport (e.g.
+   *  near-end paging when appended rows land). Keep the callback in the
+   *  notifying effect's deps. */
   onVisibleRangeChange?: (range: {
     startIndex: number;
     endIndex: number;


### PR DESCRIPTION
Building on #485, this PR introduces truly paginated data to the messages tab for chunked evals. We do this with `useInfiniteQuery` which allows us to load a single page initially and keep loading in more pages as you scroll. The messages tab loads quickly now even when the sample is huge!

Some features like `cmd+f` expect the full sample to be in the DOM, so these features aren't fully functional on chunked evals. For non-chunked evals that our customers currently use, we'll continue to load all of the data as one huge page with `limit: Number.MAX_SAFE_INTEGER` to prevent any problems like this.

When you deep-link to a specific message with `?message=MESSAGE_ID`, we stay in a loading state while fetching chunks of messages until we find that id. The worst scenario is linking to the last message of a large sample hosted on S3. I don't have any great ideas here yet. It seems like we need chunks `0..n` to satisfy our current UI, since row numbers do not directly align with message indices, and we also don't have any way to know which chunk holds the specified message ID. This is an open problem.

I learned that `useInfiniteQuery` actually does support `maxPages` where it can evict pages that have scrolled long out of view. This is a pretty easy change on the query side but a more involved change in the UI layer to prevent scroll position from getting janky when a page is evicted. Our virtualized list already has a bit of jank to it when you scroll on super long lists, so this will need quite a bit of attention.