### PR TITLE
Enable React Compiler in inspect and scout

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -48,9 +48,11 @@
     "./styles/index.css": "./lib/styles/index.css"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@eslint/js": "^10.0.1",
     "@msw/playwright": "^0.6.7",
     "@playwright/test": "^1.62.0",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@tanstack/react-devtools": "^0.10.9",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/dom": "^10.4.1",
@@ -65,6 +67,7 @@
     "@tsmono/tsconfig": "workspace:*",
     "@tsmono/util": "workspace:*",
     "@tsmono/zustand-devtools": "workspace:*",
+    "@types/babel__core": "^7.20.5",
     "@types/bootstrap": "^5.2.11",
     "@types/clipboard": "^2.0.10",
     "@types/codemirror": "^5.60.15",
@@ -76,6 +79,7 @@
     "@types/react-dom": "^19.2.3",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitejs/plugin-react": "^6.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "cross-env": "^10.1.0",
     "eslint": "^10.7.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -1,7 +1,8 @@
 import { cpSync, rmSync } from "fs";
 import { join, resolve } from "path";
 
-import react from "@vitejs/plugin-react";
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import pc from "picocolors";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
@@ -43,6 +44,7 @@ export default defineConfig(({ mode }) => {
         jsxRuntime: "automatic",
         fastRefresh: !isLibrary,
       }),
+      babel({ presets: [reactCompilerPreset()] }),
     ],
     resolve: {
       dedupe: [

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -53,8 +53,10 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@msw/playwright": "^0.6.7",
     "@playwright/test": "^1.62.0",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/react": "^16.3.1",
@@ -66,6 +68,7 @@
     "@tsmono/theme": "workspace:*",
     "@tsmono/tsconfig": "workspace:*",
     "@tsmono/util": "workspace:*",
+    "@types/babel__core": "^7.20.5",
     "@types/bootstrap": "^5.2.11",
     "@types/css-modules": "^1.0.5",
     "@types/json5": "^2.2.0",
@@ -77,6 +80,7 @@
     "@types/react-dom": "^19.2.3",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitejs/plugin-react": "^6.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.7.0",
     "eventsource": "^4.1.0",
     "jsdom": "^30.0.0",

--- a/apps/scout/src/state/store.ts
+++ b/apps/scout/src/state/store.ts
@@ -840,16 +840,19 @@ const ApiContext = createContext<ScoutApiV2 | null>(null);
 export const StoreProvider = StoreContext.Provider;
 export const ApiProvider = ApiContext.Provider;
 
+const selectWholeState = (state: StoreState) => state;
+
 export const useStore = <T>(selector?: (state: StoreState) => T) => {
-  const store = useContext(StoreContext);
-  if (!store) throw new Error("useStore must be used within StoreProvider");
+  // Named `use*` so React Compiler recognizes the call below as a hook. Under
+  // any other name it treats `store(selector)` as a plain call and memoizes it
+  // away, skipping zustand's useSyncExternalStore on later renders.
+  const useBoundStore = useContext(StoreContext);
+  if (!useBoundStore)
+    throw new Error("useStore must be used within StoreProvider");
 
-  // If no selector is provided, return the whole state
-  if (!selector) {
-    return store((state) => state) as T;
-  }
-
-  return store(selector);
+  return useBoundStore(
+    (selector ?? selectWholeState) as (state: StoreState) => T
+  );
 };
 
 export const useApi = (): ScoutApiV2 => {

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -1,7 +1,8 @@
 import { cpSync, rmSync } from "fs";
 import { join, resolve } from "path";
 
-import react from "@vitejs/plugin-react";
+import babel from "@rolldown/plugin-babel";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import pc from "picocolors";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
@@ -41,6 +42,7 @@ export default defineConfig(({ mode }) => {
       react({
         jsxRuntime: "automatic",
       }),
+      babel({ presets: [reactCompilerPreset()] }),
     ],
     define: {
       __DEV_WATCH__: JSON.stringify(process.env.DEV_LOGGING === "true"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.6
+        version: 7.29.7
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0)
@@ -164,6 +167,9 @@ importers:
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
       '@tanstack/react-devtools':
         specifier: ^0.10.9
         version: 0.10.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.14)
@@ -206,6 +212,9 @@ importers:
       '@tsmono/zustand-devtools':
         specifier: workspace:*
         version: link:../../packages/zustand-devtools
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/bootstrap':
         specifier: ^5.2.11
         version: 5.2.11
@@ -238,7 +247,10 @@ importers:
         version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: ^6.0.4
-        version: 6.0.4(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+        version: 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -360,12 +372,18 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.6
+        version: 7.29.7
       '@msw/playwright':
         specifier: ^0.6.7
         version: 0.6.7(msw@2.15.0(@types/node@26.1.2)(@typescript/typescript6@6.0.2))
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.3
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -399,6 +417,9 @@ importers:
       '@tsmono/util':
         specifier: workspace:*
         version: link:../../packages/util
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
       '@types/bootstrap':
         specifier: ^5.2.11
         version: 5.2.11
@@ -431,7 +452,10 @@ importers:
         version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: ^6.0.4
-        version: 6.0.4(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+        version: 6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^10.7.0
         version: 10.7.0
@@ -1992,6 +2016,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.6
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
@@ -3122,6 +3163,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -6341,6 +6385,15 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.7
+      picomatch: 4.0.5
+      rolldown: 1.1.5
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3)
+
   '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.60.0)':
@@ -7110,10 +7163,13 @@ snapshots:
 
   '@uwdata/flechette@2.5.0': {}
 
-  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.4(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(yaml@2.8.3))
+      babel-plugin-react-compiler: 1.0.0
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7376,6 +7432,10 @@ snapshots:
   axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
 
   balanced-match@1.0.2: {}
 


### PR DESCRIPTION
Wires `babel-plugin-react-compiler` into both apps via `@vitejs/plugin-react`'s `reactCompilerPreset`, and fixes one real bug the compiler exposed.

Opening this for a decision on whether the build-time cost is worth it — the correctness work is done and verified either way. See **Cost** below for the number, and **If the cost isn't acceptable** for the cheaper landing.

## How it's wired

`plugin-react` v6 dropped Babel entirely (its only runtime dep is `@rolldown/pluginutils`; rolldown/oxc does JSX and Fast Refresh natively). The compiler is a Babel transform, so it needs Babel added back explicitly — `babel-plugin-react-compiler`, `@rolldown/plugin-babel`, `@babel/core`, `@types/babel__core`, all declared as optional peers of `plugin-react`:

```ts
plugins: [
  react({ jsxRuntime: "automatic" }),
  babel({ presets: [reactCompilerPreset()] }),
]
```

Because the shared packages are consumed as TS source (`"exports": "./src/index.ts"`), enabling this per-app also compiles `@tsmono/react`, `inspect-components` and `scout-components` through that app's pipeline. No per-package config needed.

React 19.2 provides `react/compiler-runtime`, so no runtime package and no `target` option. The lib build externalizes it correctly via the existing `/^(react|react-dom)(\/|$)/` rule — one `import { c as _c } from "react/compiler-runtime"` in `lib/index.js`.

## The bug this surfaced

Scout would not boot with the compiler on — 63 of 64 e2e tests failed, in dev **and** in the production build. Bisected to `AppRouter.tsx` + `state/store.ts` compiled together.

Scout builds its zustand store per-instance and injects it through context, so `useStore` pulled the bound store out under the name `store`. React Compiler identifies hook calls by callee name (`use[A-Z]…`), so `store(selector)` looked like an ordinary call and got memoized:

```js
if ($[0] !== store || $[1] !== t0) { t1 = store(t0); … } else { t1 = $[2]; }
```

On the second render with an unchanged store and selector, that call doesn't execute — zustand's `useSyncExternalStore` never registers, every subsequent hook in the fiber shifts a slot, and React's `areHookInputsEqual` reads `deps` off a hook state object that has none: `Cannot read properties of undefined (reading 'length')`.

Renaming the local to `useBoundStore` makes it recognizable, and the compiler switches from silently miscompiling to safely declining:

```
CompileError | Hooks must be the same function on every render, but this value
             | may change over time to a different function.
```

Also collapsed the two `store(...)` call sites into one (branching around two separate calls was itself a conditional hook call) and hoisted the whole-state selector to module scope, which stops allocating a fresh selector every render.

`useStore` losing memoization costs nothing measurable — it's a context read plus a subscription. Its callers still compile.

**Worth knowing:** no static check caught this. Lint was green on that file, `react-compiler-healthcheck` reported 711/711 components compiled with no incompatible libraries, and running the compiler directly logged `CompileSuccess`. Only the e2e suite caught it. Treat "e2e green on both apps" as the gate here, not lint.

## Verification

Rebased onto `b0f4d04` and re-verified from scratch, since main added a Timeline tab, pagination and the messages interface that the compiler now transforms:

- inspect e2e **96/96**, scout e2e **64/64**
- `turbo run lint typecheck format:check test` — **36/36 tasks**
- both app builds and the publishable lib build succeed
- scanned the 205 source files main added for the same dynamic-hook-callee pattern — none found

## Cost

| | before | after |
|---|---|---|
| inspect `build` | 7.1s | 24.1s |
| scout `build` | 5.4s | 29.8s |
| dev cold-transform, 145 tsx | 3.3s | 29.1s |
| scout bundle (minified) | 2,926 KB | 3,160 KB (+8.0%) |
| inspect bundle (gzip) | 1,246 KB | 1,362 KB (+9.3%) |

Babel is 46–51% of plugin time. This hit is steeper than most React Compiler adopters see, because moving to Vite 8 had removed Babel from the pipeline entirely — Next.js users and anyone on `plugin-react` v4/v5 were already paying for a Babel pass. The dev figure is a deliberate worst case (forcing every `.tsx` through at once); what a developer actually feels is the ~200ms per-file HMR re-transform. In CI the `build` job gains ~41s across both apps, against a check suite that already runs ~3m.

Output: 712 functions compiled, 13,608 memo cache slots, 88 bail-outs across 821 files. Bail-outs are the compiler safely declining, not errors.

## If the cost isn't acceptable

`compilationMode: "annotation"` is nearly free — **8.8s** for inspect vs 7.1s baseline — because the preset filters at the rolldown layer before Babel runs, so files without a `"use memo"` directive never reach it. That's a one-line change, and it's also React's documented incremental path: opt in per file, flip to `infer` later. Given the one real defect here was invisible to every static check, staging it that way makes rollout bisectable.

## Not included

Deliberately left for separate decisions:

- `apps/inspect/src/state/store.ts:51` has the same hazard (`storeImplementation(selector)`), inert only because the `as UseBoundStore<…>` cast hides `useStore` from the compiler. Any refactor dropping that cast re-arms it.
- 63 `eslint-disable react-hooks/*` comments cause the compiler to skip 16 whole components, including `PopOver` and both `DataGrid`s.
- Neither app uses `StrictMode`; both `main.tsx` files call bare `createRoot`.
- Vitest doesn't run the compiler (no plugin-react in either `vitest.config.ts`), so unit tests exercise uncompiled code. Same for Storybook in `packages/react`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011VaFgTNky8xT6xJBJg7ZZ4)_