### PR TITLE
Static Scout bundles

### DIFF
--- a/apps/scout/src/AppRouter.tsx
+++ b/apps/scout/src/AppRouter.tsx
@@ -7,6 +7,7 @@ import {
   useFindBandShortcut,
 } from "@tsmono/react/components";
 
+import { useStaticBundle } from "./api/useStaticBundle";
 import { ActivityBarLayout } from "./app/components/ActivityBarLayout";
 import { useWindowMessaging } from "./app/hooks/useWindowMessaging";
 import { ProjectPanel } from "./app/project/ProjectPanel";
@@ -113,6 +114,19 @@ const ProjectPanelRoute = () => {
   return <ProjectPanel config={config} />;
 };
 
+const ValidationPanelRoute = () => {
+  const staticBundle = useStaticBundle();
+  return staticBundle ? (
+    <LoggingNavigate
+      to="/scans"
+      replace
+      reason="Validation unavailable in static bundle"
+    />
+  ) : (
+    <ValidationPanel />
+  );
+};
+
 export const createAppRouter = (config: AppRouterConfig) => {
   const AppLayout = createAppLayout(config);
   const transcriptsDir = config.config.transcripts;
@@ -153,7 +167,7 @@ export const createAppRouter = (config: AppRouterConfig) => {
           },
           {
             path: kValidationRouteUrlPattern,
-            element: <ValidationPanel />,
+            element: <ValidationPanelRoute />,
           },
           {
             path: kTranscriptEventDetailRoute,

--- a/apps/scout/src/AppRouter.tsx
+++ b/apps/scout/src/AppRouter.tsx
@@ -110,8 +110,30 @@ const ScanOrScanResultsRoute = () => {
 };
 
 const ProjectPanelRoute = () => {
+  const staticBundle = useStaticBundle();
   const config = useAppConfig();
-  return <ProjectPanel config={config} />;
+  return staticBundle ? (
+    <LoggingNavigate
+      to="/scans"
+      replace
+      reason="Project settings unavailable in static bundle"
+    />
+  ) : (
+    <ProjectPanel config={config} />
+  );
+};
+
+const RunScanPanelRoute = () => {
+  const staticBundle = useStaticBundle();
+  return staticBundle ? (
+    <LoggingNavigate
+      to="/scans"
+      replace
+      reason="Run Scan unavailable in static bundle"
+    />
+  ) : (
+    <RunScanPanel />
+  );
 };
 
 const ValidationPanelRoute = () => {
@@ -179,7 +201,7 @@ export const createAppRouter = (config: AppRouterConfig) => {
           },
           {
             path: "/run",
-            element: <RunScanPanel />,
+            element: <RunScanPanelRoute />,
           },
         ],
       },

--- a/apps/scout/src/api/api-scout-server.ts
+++ b/apps/scout/src/api/api-scout-server.ts
@@ -101,6 +101,7 @@ export const apiScoutServer = (
   const requestApi = serverRequestApi(apiBaseUrl, headerProvider, customFetch);
 
   return {
+    readOnly: false,
     capability: "workbench",
     getConfig: async (): Promise<AppConfig> => {
       const result = await requestApi.fetchString("GET", `/app-config`);

--- a/apps/scout/src/api/api.ts
+++ b/apps/scout/src/api/api.ts
@@ -132,6 +132,13 @@ export interface ScoutApiV2 {
 
   storage: ClientStorage;
   capability: "scans" | "workbench";
+
+  /**
+   * True when running against a static bundle (no backend). Mutation methods
+   * reject with StaticBundleError; live-update methods are no-ops. UI surfaces
+   * should disable scan/config/validation editing.
+   */
+  readOnly: boolean;
 }
 
 export const NoPersistence: ClientStorage = {

--- a/apps/scout/src/api/static-http/api-scout-static.test.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.test.ts
@@ -70,6 +70,28 @@ describe("apiScoutStatic", () => {
     );
   });
 
+  it("retries the manifest fetch after a transient failure", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${baseUrl}/manifest.json`, () => {
+        attempts++;
+        if (attempts === 1) {
+          return HttpResponse.text("boom", { status: 500 });
+        }
+        return HttpResponse.json(manifest);
+      }),
+      http.get(`${baseUrl}/transcripts/catalog/shard-0.json.zst`, () =>
+        HttpResponse.arrayBuffer(compress([info]).buffer as ArrayBuffer)
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    await expect(api.getTranscripts("/transcripts")).rejects.toThrow(/500/);
+    // rejection must not be cached: the retry refetches the manifest
+    const result = await api.getTranscripts("/transcripts");
+    expect(result.total_count).toBe(1);
+    expect(attempts).toBe(2);
+  });
+
   it("lists transcripts from catalog shards", async () => {
     useManifest(manifest);
     server.use(

--- a/apps/scout/src/api/static-http/api-scout-static.test.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.test.ts
@@ -172,6 +172,28 @@ describe("apiScoutStatic", () => {
     );
   });
 
+  it("emits one initial topic update to unblock app readiness", async () => {
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const updates: unknown[] = [];
+    api.connectTopicUpdates((topicVersions) => updates.push(topicVersions));
+    expect(updates).toEqual([]);
+    await Promise.resolve();
+    expect(updates).toEqual([
+      { "project-config": "static", scans: "static", transcripts: "static" },
+    ]);
+  });
+
+  it("does not emit the initial topic update after unsubscribing", async () => {
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const updates: unknown[] = [];
+    const unsubscribe = api.connectTopicUpdates((topicVersions) =>
+      updates.push(topicVersions)
+    );
+    unsubscribe();
+    await Promise.resolve();
+    expect(updates).toEqual([]);
+  });
+
   it("serves empty search and validation listings", async () => {
     const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
     await expect(api.getSearches("grep", 10)).resolves.toEqual({ items: [] });

--- a/apps/scout/src/api/static-http/api-scout-static.test.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { encodeBase64Url } from "@tsmono/util";
+
+import { server } from "../../test/setup-msw";
+import { setupZstdCompress } from "../../test/zstd";
+import type { TranscriptInfo } from "../../types/api-types";
+
+import { apiScoutStatic, StaticBundleError } from "./api-scout-static";
+import type { BundleManifest } from "./bundle-format";
+
+let compress: (data: unknown) => Uint8Array;
+
+beforeAll(async () => {
+  compress = await setupZstdCompress();
+});
+
+const baseUrl = "/bundle/api";
+
+const manifest: BundleManifest = {
+  format: "scout-static-bundle",
+  version: 1,
+  transcripts: {
+    dir: "/transcripts",
+    id_column: "transcript_id",
+    row_count: 1,
+    default_order: { column: "date", direction: "DESC" },
+    shards: [
+      {
+        path: "transcripts/catalog/shard-0.json.zst",
+        row_count: 1,
+        min: "2026-01-01",
+        max: "2026-01-01",
+      },
+    ],
+  },
+  scans: {
+    dir: "/scans",
+    id_column: "scan_id",
+    row_count: 0,
+    default_order: { column: "timestamp", direction: "DESC" },
+    shards: [],
+  },
+};
+
+const info: TranscriptInfo = {
+  transcript_id: "t1",
+  metadata: {},
+  model: "gpt-4",
+  date: "2026-01-01",
+};
+
+const useManifest = (m: BundleManifest) =>
+  server.use(http.get(`${baseUrl}/manifest.json`, () => HttpResponse.json(m)));
+
+describe("apiScoutStatic", () => {
+  it("reports readOnly and workbench capability", () => {
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    expect(api.readOnly).toBe(true);
+    expect(api.capability).toBe("workbench");
+  });
+
+  it("rejects manifests from a newer format version", async () => {
+    useManifest({ ...manifest, version: 99 });
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    await expect(api.getTranscripts("/transcripts")).rejects.toThrow(
+      /Unsupported bundle manifest/
+    );
+  });
+
+  it("lists transcripts from catalog shards", async () => {
+    useManifest(manifest);
+    server.use(
+      http.get(`${baseUrl}/transcripts/catalog/shard-0.json.zst`, () =>
+        HttpResponse.arrayBuffer(compress([info]).buffer as ArrayBuffer)
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const result = await api.getTranscripts("/transcripts");
+    expect(result.total_count).toBe(1);
+    expect(result.items[0]).toMatchObject({ transcript_id: "t1" });
+  });
+
+  it("reads a transcript from its combined .json.zst item file", async () => {
+    server.use(
+      http.get(`${baseUrl}/transcripts/items/t1.json.zst`, () =>
+        HttpResponse.arrayBuffer(
+          compress({
+            info,
+            messages: [
+              {
+                role: "user",
+                content: `attachment://${"a".repeat(32)}`,
+              },
+            ],
+            events: [],
+            timelines: [],
+            attachments: { ["a".repeat(32)]: "hello" },
+          }).buffer as ArrayBuffer
+        )
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const transcript = await api.getTranscript("/transcripts", "t1");
+    expect(transcript.transcript_id).toBe("t1");
+    expect(transcript.model).toBe("gpt-4");
+    expect(transcript.messages[0]).toMatchObject({ content: "hello" });
+  });
+
+  it("sanitizes path separators in transcript item ids", async () => {
+    server.use(
+      http.get(`${baseUrl}/transcripts/items/a_b_c.json.zst`, () =>
+        HttpResponse.arrayBuffer(
+          compress({
+            info: { ...info, transcript_id: "a/b\\c" },
+            messages: [],
+            events: [],
+            timelines: [],
+          }).buffer as ArrayBuffer
+        )
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const transcript = await api.getTranscript("/transcripts", "a/b\\c");
+    expect(transcript.transcript_id).toBe("a/b\\c");
+  });
+
+  it("answers hasTranscript with a HEAD probe", async () => {
+    server.use(
+      http.head(`${baseUrl}/transcripts/items/t1.json.zst`, () =>
+        HttpResponse.text("")
+      ),
+      http.head(`${baseUrl}/transcripts/items/nope.json.zst`, () =>
+        HttpResponse.text("", { status: 404 })
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    await expect(api.hasTranscript("/transcripts", "t1")).resolves.toBe(true);
+    await expect(api.hasTranscript("/transcripts", "nope")).resolves.toBe(
+      false
+    );
+  });
+
+  it("reads scan status from the base64url-encoded scan path", async () => {
+    const scanPath = "scans/2026-01-01T00-00-00/scan.json";
+    server.use(
+      http.get(
+        `${baseUrl}/scans/items/${encodeBase64Url(scanPath)}/status.json`,
+        () => HttpResponse.json({ complete: true })
+      )
+    );
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    const status = await api.getScan("/scans", scanPath);
+    expect(status).toMatchObject({ complete: true });
+  });
+
+  it("rejects mutations with StaticBundleError", async () => {
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    await expect(
+      api.startScan({} as Parameters<typeof api.startScan>[0])
+    ).rejects.toBeInstanceOf(StaticBundleError);
+    await expect(
+      api.updateProjectConfig(
+        {} as Parameters<typeof api.updateProjectConfig>[0],
+        null
+      )
+    ).rejects.toBeInstanceOf(StaticBundleError);
+    await expect(api.deleteValidationSet("uri")).rejects.toBeInstanceOf(
+      StaticBundleError
+    );
+  });
+
+  it("serves empty search and validation listings", async () => {
+    const api = apiScoutStatic({ bundleBaseUrl: baseUrl });
+    await expect(api.getSearches("grep", 10)).resolves.toEqual({ items: [] });
+    await expect(api.getValidationSets()).resolves.toEqual([]);
+  });
+});

--- a/apps/scout/src/api/static-http/api-scout-static.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.ts
@@ -90,19 +90,26 @@ export const apiScoutStatic = (
     if (!manifestPromise) {
       manifestPromise = fetchJson<BundleManifest>(
         joinUrl(baseUrl, "manifest.json")
-      ).then((manifest) => {
-        if (
-          manifest.format !== kBundleFormatName ||
-          manifest.version > kBundleFormatVersion
-        ) {
-          throw new Error(
-            `Unsupported bundle manifest (format=${manifest.format}, ` +
-              `version=${manifest.version}); this viewer supports ` +
-              `${kBundleFormatName} <= ${kBundleFormatVersion}.`
-          );
-        }
-        return manifest;
-      });
+      )
+        .then((manifest) => {
+          if (
+            manifest.format !== kBundleFormatName ||
+            manifest.version > kBundleFormatVersion
+          ) {
+            throw new Error(
+              `Unsupported bundle manifest (format=${manifest.format}, ` +
+                `version=${manifest.version}); this viewer supports ` +
+                `${kBundleFormatName} <= ${kBundleFormatVersion}.`
+            );
+          }
+          return manifest;
+        })
+        .catch((err: unknown) => {
+          // Evict on failure so a transient fetch error isn't cached forever;
+          // an unsupported-version rejection will simply recur on retry.
+          manifestPromise = undefined;
+          throw err;
+        });
     }
     return manifestPromise;
   };

--- a/apps/scout/src/api/static-http/api-scout-static.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.ts
@@ -1,0 +1,333 @@
+import type { Event } from "@tsmono/inspect-common/types";
+import { expandEvents } from "@tsmono/inspect-common/utils";
+import { encodeBase64Url } from "@tsmono/util";
+
+import type { Condition, OrderByModel } from "../../query";
+import {
+  ActiveScansResponse,
+  AppConfig,
+  CreateValidationSetRequest,
+  MessagesEventsResponse,
+  Pagination,
+  ProjectConfig,
+  ProjectConfigInput,
+  Result,
+  ScanJobConfig,
+  ScannerInputResponse,
+  ScannersResponse,
+  ScansResponse,
+  SearchInputListResponse,
+  SearchRequest,
+  SearchResponse,
+  Status,
+  Transcript,
+  TranscriptInfo,
+  TranscriptsResponse,
+  ValidationCase,
+  ValidationCaseRequest,
+} from "../../types/api-types";
+import {
+  NoPersistence,
+  ScalarValue,
+  ScanResultDetail,
+  ScoutApiV2,
+  SearchResultScope,
+  TopicVersions,
+} from "../api";
+import { resolveAttachments } from "../attachmentsHelpers";
+import { expandInputEvents } from "../expandInputEvents";
+
+import type { BundleManifest, CatalogManifest } from "./bundle-format";
+import { kBundleFormatName, kBundleFormatVersion } from "./bundle-format";
+import { StaticCatalog } from "./catalog";
+import {
+  fetchBytes,
+  fetchJson,
+  fetchJsonZst,
+  joinUrl,
+  urlExists,
+} from "./fetch";
+
+export class StaticBundleError extends Error {
+  constructor(operation: string) {
+    super(
+      `'${operation}' is not available in static bundle mode (read-only snapshot).`
+    );
+    this.name = "StaticBundleError";
+  }
+}
+
+export interface StaticBundleContext {
+  /** Base URL of the bundle's `api/` directory. Defaults to `./api`. */
+  bundleBaseUrl?: string;
+}
+
+/** Combined per-transcript file: listing info plus full content. */
+type TranscriptFile = MessagesEventsResponse & { info: TranscriptInfo };
+
+type ScanDetailFile = ScannerInputResponse & { scan_events?: Event[] };
+
+const unsupported = <T>(op: string): Promise<T> =>
+  Promise.reject(new StaticBundleError(op));
+
+/** Mirror the Python bundler's filesystem-safe transcript id encoding. */
+const sanitizeTranscriptId = (id: string): string => id.replace(/[/\\]/g, "_");
+
+export const apiScoutStatic = (
+  context: StaticBundleContext = {}
+): ScoutApiV2 => {
+  const baseUrl = context.bundleBaseUrl ?? "./api";
+
+  let manifestPromise: Promise<BundleManifest> | undefined;
+  const getManifest = (): Promise<BundleManifest> => {
+    if (!manifestPromise) {
+      manifestPromise = fetchJson<BundleManifest>(
+        joinUrl(baseUrl, "manifest.json")
+      ).then((manifest) => {
+        if (
+          manifest.format !== kBundleFormatName ||
+          manifest.version > kBundleFormatVersion
+        ) {
+          throw new Error(
+            `Unsupported bundle manifest (format=${manifest.format}, ` +
+              `version=${manifest.version}); this viewer supports ` +
+              `${kBundleFormatName} <= ${kBundleFormatVersion}.`
+          );
+        }
+        return manifest;
+      });
+    }
+    return manifestPromise;
+  };
+
+  const catalogs = new Map<string, StaticCatalog>();
+  const getCatalog = async (
+    kind: "transcripts" | "scans"
+  ): Promise<StaticCatalog> => {
+    let catalog = catalogs.get(kind);
+    if (!catalog) {
+      const manifest = await getManifest();
+      const section: CatalogManifest | undefined = manifest[kind];
+      if (!section) {
+        throw new Error(`Bundle contains no ${kind} catalog`);
+      }
+      catalog = catalogs.get(kind) ?? new StaticCatalog(baseUrl, section);
+      catalogs.set(kind, catalog);
+    }
+    return catalog;
+  };
+
+  const transcriptUrl = (id: string): string =>
+    joinUrl(
+      baseUrl,
+      "transcripts",
+      "items",
+      `${sanitizeTranscriptId(id)}.json.zst`
+    );
+
+  const scanUrl = (scanPath: string, ...parts: string[]): string =>
+    joinUrl(baseUrl, "scans", "items", encodeBase64Url(scanPath), ...parts);
+
+  return {
+    readOnly: true,
+    capability: "workbench",
+
+    getConfig: (): Promise<AppConfig> =>
+      fetchJson<AppConfig>(joinUrl(baseUrl, "config.json")),
+
+    getScanners: (): Promise<ScannersResponse> =>
+      fetchJson<ScannersResponse>(joinUrl(baseUrl, "scanners.json")).catch(
+        () => ({ items: [] })
+      ),
+
+    getProjectConfig: (): Promise<{ config: ProjectConfig; etag: string }> =>
+      fetchJson<ProjectConfig>(joinUrl(baseUrl, "project-config.json")).then(
+        (config) => ({ config, etag: "" })
+      ),
+
+    getActiveScans: (): Promise<ActiveScansResponse> =>
+      Promise.resolve({ items: {} }),
+
+    // Nothing changes in a static snapshot; never signal invalidations.
+    connectTopicUpdates: (
+      _onUpdate: (topVersions: TopicVersions) => void
+    ): (() => void) => {
+      return () => {};
+    },
+
+    // --- Listings (filter/sort/paginate applied client-side) ---
+
+    getTranscripts: async (
+      _transcriptsDir: string,
+      filter?: Condition,
+      orderBy?: OrderByModel | OrderByModel[],
+      pagination?: Pagination
+    ): Promise<TranscriptsResponse> => {
+      const catalog = await getCatalog("transcripts");
+      return (await catalog.query(
+        filter,
+        orderBy,
+        pagination
+      )) as TranscriptsResponse;
+    },
+
+    getScans: async (
+      _scansDir: string,
+      filter?: Condition,
+      orderBy?: OrderByModel | OrderByModel[],
+      pagination?: Pagination
+    ): Promise<ScansResponse> => {
+      const catalog = await getCatalog("scans");
+      return (await catalog.query(
+        filter,
+        orderBy,
+        pagination
+      )) as ScansResponse;
+    },
+
+    getTranscriptsColumnValues: async (
+      _transcriptsDir: string,
+      column: string,
+      filter: Condition | undefined
+    ): Promise<ScalarValue[]> =>
+      (await getCatalog("transcripts")).distinct(column, filter),
+
+    getScansColumnValues: async (
+      _scansDir: string,
+      column: string,
+      filter: Condition | undefined
+    ): Promise<ScalarValue[]> =>
+      (await getCatalog("scans")).distinct(column, filter),
+
+    // --- Single-item reads (O(1); no catalog load) ---
+
+    hasTranscript: (_transcriptsDir: string, id: string): Promise<boolean> =>
+      urlExists(transcriptUrl(id)),
+
+    getTranscript: async (
+      _transcriptsDir: string,
+      id: string
+    ): Promise<Transcript> => {
+      const parsed = await fetchJsonZst<TranscriptFile>(transcriptUrl(id));
+
+      const { info, messages, timelines, attachments } = parsed;
+      const events = expandEvents(parsed.events, parsed.events_data ?? null);
+
+      return {
+        ...info,
+        ...(attachments && Object.keys(attachments).length > 0
+          ? {
+              messages: resolveAttachments(messages, attachments),
+              events: resolveAttachments(events, attachments),
+              timelines,
+            }
+          : { messages, events, timelines }),
+      };
+    },
+
+    getScan: (_scansDir: string, scanPath: string): Promise<Status> =>
+      fetchJson<Status>(scanUrl(scanPath, "status.json")),
+
+    getScannerDataframe: (
+      _scansDir: string,
+      scanPath: string,
+      scanner: string,
+      _excludeColumns?: string[]
+    ): Promise<ArrayBuffer> =>
+      fetchBytes(
+        scanUrl(scanPath, "scanners", `${encodeURIComponent(scanner)}.arrow`)
+      ),
+
+    getScannerDataframeDetail: async (
+      _scansDir: string,
+      scanPath: string,
+      scanner: string,
+      uuid: string
+    ): Promise<ScanResultDetail> => {
+      const parsed = await fetchJsonZst<ScanDetailFile>(
+        scanUrl(
+          scanPath,
+          "details",
+          encodeURIComponent(scanner),
+          `${encodeURIComponent(uuid)}.json.zst`
+        )
+      );
+      return {
+        input: {
+          input_type: parsed.input_type,
+          input: expandInputEvents(
+            parsed.input,
+            parsed.input_type,
+            parsed.input_data
+          ),
+        },
+        scanEvents: parsed.scan_events ?? [],
+      };
+    },
+
+    // --- Search / validation: hidden in static bundles ---
+
+    getSearches: (
+      _searchType: SearchRequest["type"],
+      _count: number
+    ): Promise<SearchInputListResponse> => Promise.resolve({ items: [] }),
+
+    getSearchResult: (
+      _transcriptDir: string,
+      _transcriptId: string,
+      _searchId: string,
+      _scope: SearchResultScope
+    ): Promise<Result | null> => Promise.resolve(null),
+
+    getValidationSets: (): Promise<string[]> => Promise.resolve([]),
+
+    getValidationCases: (_uri: string): Promise<ValidationCase[]> =>
+      Promise.resolve([]),
+
+    getValidationCase: (
+      _uri: string,
+      _caseId: string
+    ): Promise<ValidationCase> => unsupported("getValidationCase"),
+
+    // --- Mutation methods: always throw in static mode ---
+
+    postCode: (_condition: Condition): Promise<Record<string, string>> =>
+      unsupported("postCode"),
+
+    updateProjectConfig: (
+      _config: ProjectConfigInput,
+      _etag: string | null
+    ): Promise<{ config: ProjectConfig; etag: string }> =>
+      unsupported("updateProjectConfig"),
+
+    startScan: (_config: ScanJobConfig): Promise<Status> =>
+      unsupported("startScan"),
+
+    createValidationSet: (
+      _request: CreateValidationSetRequest
+    ): Promise<string> => unsupported("createValidationSet"),
+
+    upsertValidationCase: (
+      _uri: string,
+      _caseId: string,
+      _data: ValidationCaseRequest
+    ): Promise<ValidationCase> => unsupported("upsertValidationCase"),
+
+    deleteValidationCase: (_uri: string, _caseId: string): Promise<void> =>
+      unsupported("deleteValidationCase"),
+
+    deleteValidationSet: (_uri: string): Promise<void> =>
+      unsupported("deleteValidationSet"),
+
+    renameValidationSet: (_uri: string, _newName: string): Promise<string> =>
+      unsupported("renameValidationSet"),
+
+    postSearch: (
+      _transcriptDir: string,
+      _transcriptId: string,
+      _request: SearchRequest
+    ): Promise<SearchResponse> => unsupported("postSearch"),
+
+    storage: NoPersistence,
+  };
+};

--- a/apps/scout/src/api/static-http/api-scout-static.ts
+++ b/apps/scout/src/api/static-http/api-scout-static.ts
@@ -73,6 +73,13 @@ const unsupported = <T>(op: string): Promise<T> =>
 /** Mirror the Python bundler's filesystem-safe transcript id encoding. */
 const sanitizeTranscriptId = (id: string): string => id.replace(/[/\\]/g, "_");
 
+/** Constant topic versions for the one-and-only static bundle "update". */
+const kStaticTopicVersions: TopicVersions = {
+  "project-config": "static",
+  scans: "static",
+  transcripts: "static",
+};
+
 export const apiScoutStatic = (
   context: StaticBundleContext = {}
 ): ScoutApiV2 => {
@@ -148,11 +155,21 @@ export const apiScoutStatic = (
     getActiveScans: (): Promise<ActiveScansResponse> =>
       Promise.resolve({ items: {} }),
 
-    // Nothing changes in a static snapshot; never signal invalidations.
+    // Nothing changes in a static snapshot, so no invalidations are ever
+    // signaled — but the app gates rendering on the first update, so emit
+    // one constant snapshot of versions to unblock it.
     connectTopicUpdates: (
-      _onUpdate: (topVersions: TopicVersions) => void
+      onUpdate: (topVersions: TopicVersions) => void
     ): (() => void) => {
-      return () => {};
+      let cancelled = false;
+      queueMicrotask(() => {
+        if (!cancelled) {
+          onUpdate(kStaticTopicVersions);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     },
 
     // --- Listings (filter/sort/paginate applied client-side) ---

--- a/apps/scout/src/api/static-http/bundle-format.ts
+++ b/apps/scout/src/api/static-http/bundle-format.ts
@@ -1,0 +1,62 @@
+/**
+ * Types describing the static bundle layout produced by `scout view bundle`.
+ *
+ * This is a cross-repo contract: the Python bundler in inspect_scout writes
+ * these files; this client reads them. See docs/static-bundle-format.md for
+ * the full specification. Bump `kBundleFormatVersion` in lockstep with the
+ * bundler when making incompatible changes.
+ */
+
+import type { ScalarValue } from "../../query";
+
+export const kBundleFormatName = "scout-static-bundle";
+export const kBundleFormatVersion = 1;
+
+export type OrderDirection = "ASC" | "DESC";
+
+export interface ShardEntry {
+  /** Path relative to the manifest's directory, e.g. `transcripts/catalog/shard-0000.json.zst`. */
+  path: string;
+  /** Number of rows in the shard. */
+  row_count: number;
+  /**
+   * Min/max of the catalog's `default_order.column` within this shard.
+   * Shards are written globally sorted ascending by that column (nulls
+   * first), so these ranges only overlap at boundary ties. Null when the
+   * shard contains only null values for the column.
+   */
+  min: ScalarValue;
+  max: ScalarValue;
+}
+
+export interface CatalogManifest {
+  /** Original directory URI this catalog snapshots (shown in the UI). */
+  dir: string;
+  /** Unique row id column: `transcript_id` for transcripts, `scan_id` for scans. */
+  id_column: string;
+  /** Total rows across all shards. */
+  row_count: number;
+  /**
+   * The sort order shards are written in. The client serves pages of the
+   * default listing view (and cursor pages on the same column) by fetching
+   * only the shards whose min/max range overlaps the page window.
+   */
+  default_order: { column: string; direction: OrderDirection };
+  shards: ShardEntry[];
+  /**
+   * Path (relative to the manifest) of a JSON file mapping column name to
+   * pre-computed sorted distinct values, used for filter autocomplete
+   * without a full catalog read.
+   */
+  column_values?: string;
+}
+
+export interface BundleManifest {
+  format: typeof kBundleFormatName;
+  version: number;
+  generated_at?: string;
+  transcripts?: CatalogManifest;
+  scans?: CatalogManifest;
+}
+
+export type ColumnValuesFile = Record<string, ScalarValue[]>;

--- a/apps/scout/src/api/static-http/catalog.test.ts
+++ b/apps/scout/src/api/static-http/catalog.test.ts
@@ -213,6 +213,45 @@ describe("StaticCatalog full-load path", () => {
   });
 });
 
+describe("StaticCatalog failure recovery", () => {
+  it("retries shard fetches after a transient failure", async () => {
+    let attempts = 0;
+    const flakyManifest: CatalogManifest = {
+      ...manifest,
+      row_count: 2,
+      shards: [
+        {
+          path: "flaky/shard-0.json.zst",
+          row_count: 2,
+          min: "2026-01-01",
+          max: "2026-01-02",
+        },
+      ],
+    };
+    server.use(
+      http.get(`${baseUrl}/flaky/shard-0.json.zst`, () => {
+        attempts++;
+        if (attempts === 1) {
+          return HttpResponse.arrayBuffer(new ArrayBuffer(0), { status: 500 });
+        }
+        return HttpResponse.arrayBuffer(
+          compress(shardRows[0]).buffer as ArrayBuffer
+        );
+      })
+    );
+
+    const catalog = new StaticCatalog(baseUrl, flakyManifest);
+    const query = () =>
+      catalog.query(undefined, undefined, { limit: 10, direction: "forward" });
+
+    await expect(query()).rejects.toThrow(/500/);
+    // rejection must not be cached: the retry gets a fresh fetch
+    const result = await query();
+    expect(result.items.map((r) => r["transcript_id"])).toEqual(["t1", "t2"]);
+    expect(attempts).toBe(2);
+  });
+});
+
 describe("StaticCatalog distinct", () => {
   it("serves unfiltered distincts from the precomputed file", async () => {
     const catalog = new StaticCatalog(baseUrl, manifest);

--- a/apps/scout/src/api/static-http/catalog.test.ts
+++ b/apps/scout/src/api/static-http/catalog.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { http, HttpResponse } from "msw";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { transcriptColumns as tc } from "../../query";
+import { server } from "../../test/setup-msw";
+import { setupZstdCompress } from "../../test/zstd";
+
+import type { CatalogManifest } from "./bundle-format";
+import { StaticCatalog } from "./catalog";
+
+let compress: (data: unknown) => Uint8Array;
+
+beforeAll(async () => {
+  compress = await setupZstdCompress();
+});
+
+const baseUrl = "/bundle/api";
+
+// Three shards globally sorted ascending by date (two rows each).
+const shardRows = [
+  [
+    { transcript_id: "t1", date: "2026-01-01", model: "gpt-4" },
+    { transcript_id: "t2", date: "2026-01-02", model: "claude-3" },
+  ],
+  [
+    { transcript_id: "t3", date: "2026-01-03", model: "gpt-4" },
+    { transcript_id: "t4", date: "2026-01-04", model: "claude-3" },
+  ],
+  [
+    { transcript_id: "t5", date: "2026-01-05", model: "gpt-4" },
+    { transcript_id: "t6", date: "2026-01-06", model: "gpt-4" },
+  ],
+];
+
+const manifest: CatalogManifest = {
+  dir: "/transcripts",
+  id_column: "transcript_id",
+  row_count: 6,
+  default_order: { column: "date", direction: "DESC" },
+  shards: shardRows.map((rows, i) => ({
+    path: `transcripts/catalog/shard-${i}.json.zst`,
+    row_count: rows.length,
+    min: rows[0]!.date,
+    max: rows[rows.length - 1]!.date,
+  })),
+  column_values: "transcripts/columns.json",
+};
+
+let shardFetches: number[];
+
+beforeEach(() => {
+  shardFetches = [0, 0, 0];
+  server.use(
+    ...shardRows.map((rows, i) =>
+      http.get(`${baseUrl}/transcripts/catalog/shard-${i}.json.zst`, () => {
+        shardFetches[i]!++;
+        return HttpResponse.arrayBuffer(compress(rows).buffer as ArrayBuffer);
+      })
+    ),
+    http.get(`${baseUrl}/transcripts/columns.json`, () =>
+      HttpResponse.json({ model: ["claude-3", "gpt-4"] })
+    )
+  );
+});
+
+describe("StaticCatalog shard-skip fast path", () => {
+  it("serves the first default-order page from the newest shard only", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const result = await catalog.query(
+      undefined,
+      { column: "date", direction: "DESC" },
+      { limit: 2, direction: "forward" }
+    );
+
+    expect(result.items.map((r) => r["transcript_id"])).toEqual(["t6", "t5"]);
+    expect(result.total_count).toBe(6);
+    expect(result.next_cursor).toEqual({
+      date: "2026-01-05",
+      transcript_id: "t5",
+    });
+    expect(shardFetches).toEqual([0, 0, 1]);
+  });
+
+  it("serves cursor pages, skipping shards past the cursor", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const page2 = await catalog.query(
+      undefined,
+      { column: "date", direction: "DESC" },
+      {
+        limit: 2,
+        direction: "forward",
+        cursor: { date: "2026-01-05", transcript_id: "t5" },
+      }
+    );
+
+    expect(page2.items.map((r) => r["transcript_id"])).toEqual(["t4", "t3"]);
+    // shard-2's min ties with the cursor value, so it must be checked for
+    // id-tiebreak rows; shard-0 is never touched.
+    expect(shardFetches).toEqual([0, 1, 1]);
+  });
+
+  it("spans shards when a page straddles a boundary", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const result = await catalog.query(
+      undefined,
+      { column: "date", direction: "DESC" },
+      { limit: 3, direction: "forward" }
+    );
+
+    expect(result.items.map((r) => r["transcript_id"])).toEqual([
+      "t6",
+      "t5",
+      "t4",
+    ]);
+    expect(shardFetches).toEqual([0, 1, 1]);
+  });
+
+  it("serves ascending pages from the oldest shard", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const result = await catalog.query(
+      undefined,
+      { column: "date", direction: "ASC" },
+      { limit: 2, direction: "forward" }
+    );
+
+    expect(result.items.map((r) => r["transcript_id"])).toEqual(["t1", "t2"]);
+    expect(shardFetches).toEqual([1, 0, 0]);
+  });
+
+  it("keeps loading through boundary ties", async () => {
+    const tiedRows = [
+      [
+        { transcript_id: "a", date: "2026-01-01" },
+        { transcript_id: "d", date: "2026-01-02" },
+      ],
+      [
+        { transcript_id: "b", date: "2026-01-02" },
+        { transcript_id: "c", date: "2026-01-02" },
+      ],
+    ];
+    const tiedManifest: CatalogManifest = {
+      ...manifest,
+      row_count: 4,
+      shards: tiedRows.map((rows, i) => ({
+        path: `tied/shard-${i}.json.zst`,
+        row_count: rows.length,
+        min: rows[0]!.date,
+        max: rows[rows.length - 1]!.date,
+      })),
+    };
+    server.use(
+      ...tiedRows.map((rows, i) =>
+        http.get(`${baseUrl}/tied/shard-${i}.json.zst`, () =>
+          HttpResponse.arrayBuffer(compress(rows).buffer as ArrayBuffer)
+        )
+      )
+    );
+
+    const catalog = new StaticCatalog(baseUrl, tiedManifest);
+    const result = await catalog.query(
+      undefined,
+      { column: "date", direction: "ASC" },
+      { limit: 2, direction: "forward" }
+    );
+
+    // The id tiebreak on 2026-01-02 pulls "b" from the second shard ahead
+    // of "d" from the first; stopping at shard 0 would return ["a", "d"].
+    expect(result.items.map((r) => r["transcript_id"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("StaticCatalog full-load path", () => {
+  it("filters across all shards with correct total_count", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const result = await catalog.query(
+      tc.model.eq("gpt-4"),
+      { column: "date", direction: "DESC" },
+      { limit: 2, direction: "forward" }
+    );
+
+    expect(result.items.map((r) => r["transcript_id"])).toEqual(["t6", "t5"]);
+    expect(result.total_count).toBe(4);
+    expect(result.next_cursor).toEqual({
+      date: "2026-01-05",
+      transcript_id: "t5",
+    });
+    expect(shardFetches).toEqual([1, 1, 1]);
+  });
+
+  it("caches shards across queries", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    await catalog.query(tc.model.eq("gpt-4"), undefined, undefined);
+    await catalog.query(tc.model.eq("claude-3"), undefined, undefined);
+    expect(shardFetches).toEqual([1, 1, 1]);
+  });
+
+  it("sorts by non-default columns via full load", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const result = await catalog.query(
+      undefined,
+      [
+        { column: "model", direction: "ASC" },
+        { column: "date", direction: "ASC" },
+      ],
+      { limit: 3, direction: "forward" }
+    );
+    expect(result.items.map((r) => r["transcript_id"])).toEqual([
+      "t2",
+      "t4",
+      "t1",
+    ]);
+  });
+});
+
+describe("StaticCatalog distinct", () => {
+  it("serves unfiltered distincts from the precomputed file", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const values = await catalog.distinct("model", undefined);
+    expect(values).toEqual(["claude-3", "gpt-4"]);
+    expect(shardFetches).toEqual([0, 0, 0]);
+  });
+
+  it("computes filtered distincts from shard rows", async () => {
+    const catalog = new StaticCatalog(baseUrl, manifest);
+    const values = await catalog.distinct("model", tc.date.gte("2026-01-05"));
+    expect(values).toEqual(["gpt-4"]);
+  });
+});

--- a/apps/scout/src/api/static-http/catalog.ts
+++ b/apps/scout/src/api/static-http/catalog.ts
@@ -1,0 +1,242 @@
+import type { Condition, OrderByModel, ScalarValue } from "../../query";
+import type { Pagination } from "../../types/api-types";
+
+import type {
+  CatalogManifest,
+  ColumnValuesFile,
+  ShardEntry,
+} from "./bundle-format";
+import {
+  applyOrderBy,
+  applyPagination,
+  cursorIncludes,
+  evaluateCondition,
+  scalarCompare,
+} from "./condition-eval";
+import { fetchJson, fetchJsonZst, joinUrl } from "./fetch";
+
+type Row = Record<string, unknown>;
+
+export interface ListingResult {
+  items: Row[];
+  total_count: number;
+  next_cursor: Record<string, ScalarValue> | null;
+}
+
+const normalizeOrderBy = (
+  orderBy: OrderByModel | OrderByModel[] | undefined
+): OrderByModel[] =>
+  orderBy ? (Array.isArray(orderBy) ? orderBy : [orderBy]) : [];
+
+/**
+ * A sharded catalog listing backed by `.json.zst` shard files.
+ *
+ * Rows load lazily and cache in memory: arbitrary filters/sorts trigger a
+ * one-time parallel load of all shards, while the default listing view
+ * (no filter, sorted by the manifest's default_order column) fetches only
+ * the shards whose min/max range overlaps the requested page.
+ */
+export class StaticCatalog {
+  private readonly shardRows = new Map<string, Promise<Row[]>>();
+  private allRowsPromise: Promise<Row[]> | undefined;
+  private columnValuesPromise: Promise<ColumnValuesFile> | undefined;
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly manifest: CatalogManifest
+  ) {}
+
+  get idColumn(): string {
+    return this.manifest.id_column;
+  }
+
+  async query(
+    filter: Condition | undefined,
+    orderBy: OrderByModel | OrderByModel[] | undefined,
+    pagination: Pagination | undefined
+  ): Promise<ListingResult> {
+    const orderColumns = normalizeOrderBy(orderBy);
+
+    if (!filter && pagination && this.canShardSkip(orderColumns)) {
+      return this.queryDefaultOrder(orderColumns[0]!, pagination);
+    }
+
+    const rows = await this.loadAll();
+    const filtered = filter
+      ? rows.filter((row) => evaluateCondition(row, filter))
+      : rows;
+    const ordered = applyOrderBy(filtered, orderColumns);
+    const { items, nextCursor } = applyPagination(
+      ordered,
+      orderColumns,
+      pagination,
+      this.manifest.id_column
+    );
+    return {
+      items,
+      total_count: filtered.length,
+      next_cursor: nextCursor,
+    };
+  }
+
+  async distinct(
+    column: string,
+    filter: Condition | undefined
+  ): Promise<ScalarValue[]> {
+    if (!filter && this.manifest.column_values) {
+      const values = await this.loadColumnValues();
+      const precomputed = values[column];
+      if (precomputed) return precomputed;
+    }
+    const rows = await this.loadAll();
+    const filtered = filter
+      ? rows.filter((row) => evaluateCondition(row, filter))
+      : rows;
+    return collectDistinct(filtered, column);
+  }
+
+  async hasRow(id: string): Promise<boolean> {
+    const rows = await this.loadAll();
+    return rows.some((row) => row[this.manifest.id_column] === id);
+  }
+
+  private loadShard(entry: ShardEntry): Promise<Row[]> {
+    let promise = this.shardRows.get(entry.path);
+    if (!promise) {
+      promise = fetchJsonZst<Row[]>(joinUrl(this.baseUrl, entry.path));
+      this.shardRows.set(entry.path, promise);
+    }
+    return promise;
+  }
+
+  private loadAll(): Promise<Row[]> {
+    if (!this.allRowsPromise) {
+      this.allRowsPromise = Promise.all(
+        this.manifest.shards.map((s) => this.loadShard(s))
+      ).then((chunks) => chunks.flat());
+    }
+    return this.allRowsPromise;
+  }
+
+  private loadColumnValues(): Promise<ColumnValuesFile> {
+    if (!this.columnValuesPromise) {
+      this.columnValuesPromise = fetchJson<ColumnValuesFile>(
+        joinUrl(this.baseUrl, this.manifest.column_values!)
+      );
+    }
+    return this.columnValuesPromise;
+  }
+
+  /**
+   * The shard-skip fast path applies only to pages of the default ordering:
+   * a single orderBy on the manifest's default_order column, no filter, and
+   * shard stats present.
+   */
+  private canShardSkip(orderColumns: OrderByModel[]): boolean {
+    return (
+      orderColumns.length === 1 &&
+      orderColumns[0]!.column === this.manifest.default_order.column &&
+      this.manifest.shards.length > 0 &&
+      this.manifest.shards.every(
+        (s) => s.min !== undefined && s.max !== undefined
+      )
+    );
+  }
+
+  /**
+   * Serve one page by loading shards in traversal order until the window is
+   * full. Shards are written globally sorted ascending by the stat column,
+   * so once `limit` qualifying rows are collected, later shards can only
+   * contribute on boundary ties (equal stat value, id tiebreak) — detected
+   * by comparing the next shard's leading edge against the window edge.
+   */
+  private async queryDefaultOrder(
+    orderBy: OrderByModel,
+    pagination: Pagination
+  ): Promise<ListingResult> {
+    const column = orderBy.column;
+    const idColumn = this.manifest.id_column;
+    const sortColumns: OrderByModel[] = [
+      orderBy,
+      { column: idColumn, direction: "ASC" },
+    ];
+
+    // Traversal over the ASC-sorted shard list: requested DESC reads from the
+    // end; backward pagination flips it again.
+    const reverse =
+      (orderBy.direction === "DESC") !== (pagination.direction === "backward");
+    const ordered = reverse
+      ? [...this.manifest.shards].reverse()
+      : this.manifest.shards;
+
+    const cursor = pagination.cursor ?? undefined;
+    const cursorVal = cursor?.[column];
+
+    const collected: Row[] = [];
+    for (let i = 0; i < ordered.length; i++) {
+      const shard = ordered[i]!;
+
+      // Shards entirely on the already-seen side of the cursor can't
+      // contribute; boundary ties (== cursor value) are kept for the id
+      // tiebreak.
+      if (cursor && cursorVal !== undefined) {
+        if (!reverse && scalarCompare(shard.max, cursorVal) < 0) continue;
+        if (reverse && scalarCompare(shard.min, cursorVal) > 0) continue;
+      }
+
+      collected.push(...(await this.loadShard(shard)));
+
+      const qualifying = cursor
+        ? collected.filter((row) =>
+            cursorIncludes(row, cursor, sortColumns, pagination.direction)
+          )
+        : collected;
+      if (qualifying.length < pagination.limit) continue;
+
+      const next = ordered[i + 1];
+      if (!next) break;
+
+      // Window edge value under the requested ordering: the limit-th
+      // qualifying row (mirroring applyPagination's backward flip). Later
+      // shards matter only if their leading edge ties with it.
+      const sorted = applyOrderBy(qualifying, sortColumns);
+      if (pagination.direction === "backward") sorted.reverse();
+      const windowEdge = sorted.slice(0, pagination.limit).at(-1)!;
+      const nextLeading = reverse ? next.max : next.min;
+      if (scalarCompare(nextLeading, windowEdge[column]) !== 0) break;
+    }
+
+    const { items, nextCursor } = applyPagination(
+      collected,
+      orderBy,
+      pagination,
+      idColumn
+    );
+    return {
+      items,
+      total_count: this.manifest.row_count,
+      next_cursor: nextCursor,
+    };
+  }
+}
+
+/** Compute distinct sorted scalar values for a column across a row collection. */
+const collectDistinct = (
+  rows: readonly Row[],
+  column: string
+): ScalarValue[] => {
+  const seen = new Set<string>();
+  const out: ScalarValue[] = [];
+  for (const row of rows) {
+    const raw = row[column];
+    if (raw === undefined) continue;
+    const value = raw as ScalarValue;
+    const key =
+      value === null ? "__null__" : `${typeof value}:${String(value)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(value);
+  }
+  out.sort(scalarCompare);
+  return out;
+};

--- a/apps/scout/src/api/static-http/catalog.ts
+++ b/apps/scout/src/api/static-http/catalog.ts
@@ -100,10 +100,18 @@ export class StaticCatalog {
     return rows.some((row) => row[this.manifest.id_column] === id);
   }
 
+  // Cached promises are evicted on rejection so a transient fetch failure
+  // doesn't poison the cache — react-query retries then get a fresh attempt.
+
   private loadShard(entry: ShardEntry): Promise<Row[]> {
     let promise = this.shardRows.get(entry.path);
     if (!promise) {
-      promise = fetchJsonZst<Row[]>(joinUrl(this.baseUrl, entry.path));
+      promise = fetchJsonZst<Row[]>(joinUrl(this.baseUrl, entry.path)).catch(
+        (err: unknown) => {
+          this.shardRows.delete(entry.path);
+          throw err;
+        }
+      );
       this.shardRows.set(entry.path, promise);
     }
     return promise;
@@ -113,7 +121,12 @@ export class StaticCatalog {
     if (!this.allRowsPromise) {
       this.allRowsPromise = Promise.all(
         this.manifest.shards.map((s) => this.loadShard(s))
-      ).then((chunks) => chunks.flat());
+      )
+        .then((chunks) => chunks.flat())
+        .catch((err: unknown) => {
+          this.allRowsPromise = undefined;
+          throw err;
+        });
     }
     return this.allRowsPromise;
   }
@@ -122,7 +135,10 @@ export class StaticCatalog {
     if (!this.columnValuesPromise) {
       this.columnValuesPromise = fetchJson<ColumnValuesFile>(
         joinUrl(this.baseUrl, this.manifest.column_values!)
-      );
+      ).catch((err: unknown) => {
+        this.columnValuesPromise = undefined;
+        throw err;
+      });
     }
     return this.columnValuesPromise;
   }

--- a/apps/scout/src/api/static-http/condition-eval.test.ts
+++ b/apps/scout/src/api/static-http/condition-eval.test.ts
@@ -51,6 +51,22 @@ describe("evaluateCondition", () => {
     expect(evaluateCondition(row({ model: "axb" }), tc.model.like("a.b"))).toBe(
       false
     );
+    // * and ? are SQL-literal too, not regex quantifiers
+    expect(evaluateCondition(row({ model: "a*b" }), tc.model.like("a*b"))).toBe(
+      true
+    );
+    expect(evaluateCondition(row({ model: "aab" }), tc.model.like("a*b"))).toBe(
+      false
+    );
+    expect(evaluateCondition(row({ model: "b" }), tc.model.like("a*b"))).toBe(
+      false
+    );
+    expect(evaluateCondition(row({ model: "a?" }), tc.model.like("a?"))).toBe(
+      true
+    );
+    expect(evaluateCondition(row({ model: "a" }), tc.model.like("a?"))).toBe(
+      false
+    );
   });
 
   it("handles NULL checks", () => {
@@ -75,6 +91,56 @@ describe("evaluateCondition", () => {
     expect(evaluateCondition(row({}), and)).toBe(true);
     expect(evaluateCondition(row({}), or)).toBe(true);
     expect(evaluateCondition(row({}), not)).toBe(false);
+  });
+
+  it("excludes NULL cells from comparisons and negations (SQL semantics)", () => {
+    const r = row({ score: null });
+    // a NULL operand makes the predicate unknown → row excluded
+    expect(evaluateCondition(r, tc.score.eq(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.ne(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.lt(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.lte(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.gt(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.gte(0.5))).toBe(false);
+    expect(evaluateCondition(r, tc.score.in([0.5]))).toBe(false);
+    expect(evaluateCondition(r, tc.score.notIn([0.5]))).toBe(false);
+    expect(evaluateCondition(r, tc.score.between(0, 1))).toBe(false);
+    expect(evaluateCondition(r, tc.score.notBetween(0, 1))).toBe(false);
+    expect(evaluateCondition(row({ model: null }), tc.model.like("g%"))).toBe(
+      false
+    );
+    expect(
+      evaluateCondition(row({ model: null }), tc.model.notLike("g%"))
+    ).toBe(false);
+  });
+
+  it("propagates unknown through NOT/AND/OR (Kleene logic)", () => {
+    const r = row({ score: null });
+    // NOT(unknown) is unknown → excluded, matching SQL
+    expect(evaluateCondition(r, tc.score.lt(0.5).not())).toBe(false);
+    // unknown AND true → unknown; unknown OR true → true
+    expect(
+      evaluateCondition(r, tc.score.lt(0.5).and(tc.model.eq("gpt-4")))
+    ).toBe(false);
+    expect(
+      evaluateCondition(r, tc.score.lt(0.5).or(tc.model.eq("gpt-4")))
+    ).toBe(true);
+    // false stays dominant over unknown for AND's negation
+    expect(
+      evaluateCondition(r, tc.score.lt(0.5).and(tc.model.eq("nope")).not())
+    ).toBe(true);
+  });
+
+  it("treats NULLs inside IN lists as SQL does", () => {
+    // match found → true regardless of NULLs in the list
+    expect(evaluateCondition(row({}), tc.model.in(["gpt-4", null]))).toBe(true);
+    // no match but list has NULL → unknown, so IN and NOT IN both exclude
+    expect(evaluateCondition(row({}), tc.model.in(["nope", null]))).toBe(false);
+    expect(evaluateCondition(row({}), tc.model.notIn(["nope", null]))).toBe(
+      false
+    );
+    // no match, no NULLs → NOT IN includes
+    expect(evaluateCondition(row({}), tc.model.notIn(["nope"]))).toBe(true);
   });
 
   it("resolves custom columns through the metadata object", () => {

--- a/apps/scout/src/api/static-http/condition-eval.test.ts
+++ b/apps/scout/src/api/static-http/condition-eval.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import { transcriptColumns as tc } from "../../query";
+import type { Pagination } from "../../types/api-types";
+
+import {
+  applyOrderBy,
+  applyPagination,
+  evaluateCondition,
+  resolveCell,
+} from "./condition-eval";
+
+const row = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  transcript_id: "t1",
+  model: "gpt-4",
+  score: 0.5,
+  error: null,
+  metadata: {},
+  ...overrides,
+});
+
+describe("evaluateCondition", () => {
+  it("handles comparison operators", () => {
+    expect(evaluateCondition(row({}), tc.model.eq("gpt-4"))).toBe(true);
+    expect(evaluateCondition(row({}), tc.model.ne("gpt-4"))).toBe(false);
+    expect(evaluateCondition(row({}), tc.score.gt(0.4))).toBe(true);
+    expect(evaluateCondition(row({}), tc.score.gt(0.5))).toBe(false);
+    expect(evaluateCondition(row({}), tc.score.gte(0.5))).toBe(true);
+    expect(evaluateCondition(row({}), tc.score.lt(0.5))).toBe(false);
+    expect(evaluateCondition(row({}), tc.score.lte(0.5))).toBe(true);
+  });
+
+  it("handles IN / NOT IN", () => {
+    expect(evaluateCondition(row({}), tc.model.in(["gpt-4", "claude-3"]))).toBe(
+      true
+    );
+    expect(evaluateCondition(row({}), tc.model.in(["claude-3"]))).toBe(false);
+    expect(evaluateCondition(row({}), tc.model.notIn(["claude-3"]))).toBe(true);
+  });
+
+  it("handles LIKE / ILIKE wildcards", () => {
+    expect(evaluateCondition(row({}), tc.model.like("gpt%"))).toBe(true);
+    expect(evaluateCondition(row({}), tc.model.like("GPT%"))).toBe(false);
+    expect(evaluateCondition(row({}), tc.model.ilike("GPT%"))).toBe(true);
+    expect(evaluateCondition(row({}), tc.model.like("gpt-_"))).toBe(true);
+    expect(evaluateCondition(row({}), tc.model.like("gpt-__"))).toBe(false);
+    // regex metacharacters in the pattern are literals
+    expect(evaluateCondition(row({ model: "a.b" }), tc.model.like("a.b"))).toBe(
+      true
+    );
+    expect(evaluateCondition(row({ model: "axb" }), tc.model.like("a.b"))).toBe(
+      false
+    );
+  });
+
+  it("handles NULL checks", () => {
+    expect(evaluateCondition(row({}), tc.error.isNull())).toBe(true);
+    expect(evaluateCondition(row({}), tc.error.isNotNull())).toBe(false);
+    // missing columns are null-like
+    expect(evaluateCondition(row({}), tc.field("absent").isNull())).toBe(true);
+  });
+
+  it("handles BETWEEN", () => {
+    expect(evaluateCondition(row({}), tc.score.between(0.1, 0.9))).toBe(true);
+    expect(evaluateCondition(row({}), tc.score.between(0.6, 0.9))).toBe(false);
+    expect(evaluateCondition(row({}), tc.score.notBetween(0.6, 0.9))).toBe(
+      true
+    );
+  });
+
+  it("handles AND / OR / NOT compounds", () => {
+    const and = tc.model.eq("gpt-4").and(tc.score.gt(0.4));
+    const or = tc.model.eq("nope").or(tc.score.gt(0.4));
+    const not = tc.model.eq("gpt-4").not();
+    expect(evaluateCondition(row({}), and)).toBe(true);
+    expect(evaluateCondition(row({}), or)).toBe(true);
+    expect(evaluateCondition(row({}), not)).toBe(false);
+  });
+
+  it("resolves custom columns through the metadata object", () => {
+    const r = row({ metadata: { difficulty: "hard" } });
+    expect(evaluateCondition(r, tc.field("difficulty").eq("hard"))).toBe(true);
+    expect(
+      evaluateCondition(r, tc.field("metadata.difficulty").eq("hard"))
+    ).toBe(true);
+  });
+});
+
+describe("resolveCell", () => {
+  it("prefers direct columns over metadata fallback", () => {
+    expect(resolveCell({ model: "a", metadata: { model: "b" } }, "model")).toBe(
+      "a"
+    );
+  });
+
+  it("traverses dotted paths", () => {
+    expect(resolveCell({ a: { b: { c: 1 } } }, "a.b.c")).toBe(1);
+    expect(resolveCell({ a: 2 }, "a.b.c")).toBeUndefined();
+  });
+});
+
+describe("applyOrderBy", () => {
+  it("sorts multi-column with direction and nulls first", () => {
+    const rows = [
+      { a: 2, b: "x" },
+      { a: 1, b: "y" },
+      { a: null, b: "z" },
+      { a: 1, b: "x" },
+    ];
+    const sorted = applyOrderBy(rows, [
+      { column: "a", direction: "ASC" },
+      { column: "b", direction: "DESC" },
+    ]);
+    expect(sorted).toEqual([
+      { a: null, b: "z" },
+      { a: 1, b: "y" },
+      { a: 1, b: "x" },
+      { a: 2, b: "x" },
+    ]);
+  });
+});
+
+describe("applyPagination", () => {
+  const rows = Array.from({ length: 5 }, (_, i) => ({
+    transcript_id: `t${i}`,
+    date: `2026-01-0${i + 1}`,
+  }));
+  const orderBy = { column: "date", direction: "DESC" as const };
+
+  it("windows forward and emits a cursor only when the page is full", () => {
+    const page1 = applyPagination(
+      rows,
+      orderBy,
+      { limit: 2, direction: "forward" },
+      "transcript_id"
+    );
+    expect(page1.items.map((r) => r.date)).toEqual([
+      "2026-01-05",
+      "2026-01-04",
+    ]);
+    expect(page1.nextCursor).toEqual({
+      date: "2026-01-04",
+      transcript_id: "t3",
+    });
+
+    const page2 = applyPagination(
+      rows,
+      orderBy,
+      { limit: 2, direction: "forward", cursor: page1.nextCursor },
+      "transcript_id"
+    );
+    expect(page2.items.map((r) => r.date)).toEqual([
+      "2026-01-03",
+      "2026-01-02",
+    ]);
+
+    const page3 = applyPagination(
+      rows,
+      orderBy,
+      { limit: 2, direction: "forward", cursor: page2.nextCursor },
+      "transcript_id"
+    );
+    expect(page3.items.map((r) => r.date)).toEqual(["2026-01-01"]);
+    // partial page: no further cursor
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("returns backward pages in forward order", () => {
+    const back: Pagination = {
+      limit: 2,
+      direction: "backward",
+      cursor: { date: "2026-01-02", transcript_id: "t1" },
+    };
+    const page = applyPagination(rows, orderBy, back, "transcript_id");
+    expect(page.items.map((r) => r.date)).toEqual(["2026-01-04", "2026-01-03"]);
+  });
+
+  it("breaks date ties by id ascending", () => {
+    const tied = [
+      { transcript_id: "b", date: "2026-01-01" },
+      { transcript_id: "a", date: "2026-01-01" },
+      { transcript_id: "c", date: "2026-01-01" },
+    ];
+    const page1 = applyPagination(
+      tied,
+      orderBy,
+      { limit: 2, direction: "forward" },
+      "transcript_id"
+    );
+    expect(page1.items.map((r) => r.transcript_id)).toEqual(["a", "b"]);
+    const page2 = applyPagination(
+      tied,
+      orderBy,
+      { limit: 2, direction: "forward", cursor: page1.nextCursor },
+      "transcript_id"
+    );
+    expect(page2.items.map((r) => r.transcript_id)).toEqual(["c"]);
+  });
+});

--- a/apps/scout/src/api/static-http/condition-eval.ts
+++ b/apps/scout/src/api/static-http/condition-eval.ts
@@ -29,23 +29,38 @@ export const resolveCell = (
   return undefined;
 };
 
+/**
+ * SQL three-valued truth: `null` is "unknown". Comparisons with a NULL
+ * operand are unknown (so the row is excluded), and unknown propagates
+ * through AND/OR/NOT per Kleene logic — matching how the server evaluates
+ * the same Condition in SQL.
+ */
+type Truth = boolean | null;
+
 /** Apply a Condition to a single row, returning whether it passes. */
 export const evaluateCondition = (
   row: Record<string, unknown>,
   condition: Condition
-): boolean => {
+): boolean => evaluateTruth(row, condition) === true;
+
+const evaluateTruth = (
+  row: Record<string, unknown>,
+  condition: Condition
+): Truth => {
   if (isCompoundCondition(condition)) {
+    const left = evaluateTruth(row, condition.left);
     if (condition.operator === "NOT") {
-      return !evaluateCondition(row, condition.left);
+      return left === null ? null : !left;
     }
-    const leftResult = evaluateCondition(row, condition.left);
-    const right = condition.right;
-    if (right === null) return leftResult;
+    if (condition.right === null) return left;
+    const right = evaluateTruth(row, condition.right);
     if (condition.operator === "AND") {
-      return leftResult && evaluateCondition(row, right);
+      if (left === false || right === false) return false;
+      return left === null || right === null ? null : true;
     }
     // OR
-    return leftResult || evaluateCondition(row, right);
+    if (left === true || right === true) return true;
+    return left === null || right === null ? null : false;
   }
 
   const cell = resolveCell(row, condition.left);
@@ -56,54 +71,64 @@ export const evaluateCondition = (
       return cell === null || cell === undefined;
     case "IS NOT NULL":
       return cell !== null && cell !== undefined;
+    default:
+      break;
+  }
+
+  // Every remaining operator is a comparison: a NULL cell makes it unknown.
+  if (cell === null || cell === undefined) return null;
+
+  switch (condition.operator) {
     case "=":
-      return cellEquals(cell, target);
+      return target === null ? null : cell === target;
     case "!=":
-      return !cellEquals(cell, target);
+      return target === null ? null : cell !== target;
     case "<":
-      return scalarCompare(cell, target) < 0;
+      return target === null ? null : scalarCompare(cell, target) < 0;
     case "<=":
-      return scalarCompare(cell, target) <= 0;
+      return target === null ? null : scalarCompare(cell, target) <= 0;
     case ">":
-      return scalarCompare(cell, target) > 0;
+      return target === null ? null : scalarCompare(cell, target) > 0;
     case ">=":
-      return scalarCompare(cell, target) >= 0;
+      return target === null ? null : scalarCompare(cell, target) >= 0;
     // Branch on the operator, not isScalarArray: isTuple claims any
     // 2-element array, which would misclassify a 2-value IN list.
     case "IN":
-      return Array.isArray(target) && target.some((v) => cellEquals(cell, v));
+      return inList(cell, target);
     case "NOT IN":
-      return Array.isArray(target) && !target.some((v) => cellEquals(cell, v));
+      return notTruth(inList(cell, target));
     case "LIKE":
       return likeMatch(cell, target, false);
     case "NOT LIKE":
-      return !likeMatch(cell, target, false);
+      return notTruth(likeMatch(cell, target, false));
     case "ILIKE":
       return likeMatch(cell, target, true);
     case "NOT ILIKE":
-      return !likeMatch(cell, target, true);
+      return notTruth(likeMatch(cell, target, true));
     case "BETWEEN":
-      return (
-        isTuple(target) &&
-        scalarCompare(cell, target[0]) >= 0 &&
-        scalarCompare(cell, target[1]) <= 0
-      );
+      return between(cell, target);
     case "NOT BETWEEN":
-      return (
-        isTuple(target) &&
-        (scalarCompare(cell, target[0]) < 0 ||
-          scalarCompare(cell, target[1]) > 0)
-      );
+      return notTruth(between(cell, target));
     default:
       return false;
   }
 };
 
-const cellEquals = (cell: unknown, target: unknown): boolean => {
-  if (cell === target) return true;
-  if (cell === null || target === null) return false;
-  if (cell === undefined || target === undefined) return false;
-  return cell === target;
+const notTruth = (t: Truth): Truth => (t === null ? null : !t);
+
+/** SQL IN: true on a match, unknown if no match but the list has NULLs. */
+const inList = (cell: unknown, target: unknown): Truth => {
+  if (!Array.isArray(target)) return false;
+  if (target.some((v) => v !== null && cell === v)) return true;
+  return target.includes(null) ? null : false;
+};
+
+const between = (cell: unknown, target: unknown): Truth => {
+  if (!isTuple(target)) return false;
+  if (target[0] === null || target[1] === null) return null;
+  return (
+    scalarCompare(cell, target[0]) >= 0 && scalarCompare(cell, target[1]) <= 0
+  );
 };
 
 const comparableString = (v: unknown): string => {
@@ -122,22 +147,37 @@ export const scalarCompare = (a: unknown, b: unknown): number => {
   return comparableString(a) < comparableString(b) ? -1 : 1;
 };
 
+// Compiled LIKE patterns are cached: the full-load path evaluates the same
+// condition against ~100k rows, and compiling a RegExp per row is wasteful.
+const likeRegexCache = new Map<string, RegExp>();
+
+const likeRegex = (pattern: string, caseInsensitive: boolean): RegExp => {
+  const key = (caseInsensitive ? "i:" : ":") + pattern;
+  let re = likeRegexCache.get(key);
+  if (!re) {
+    re = new RegExp(
+      "^" +
+        pattern
+          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+          .replace(/%/g, ".*")
+          .replace(/_/g, ".") +
+        "$",
+      caseInsensitive ? "i" : ""
+    );
+    if (likeRegexCache.size >= 500) likeRegexCache.clear();
+    likeRegexCache.set(key, re);
+  }
+  return re;
+};
+
 const likeMatch = (
   cell: unknown,
   pattern: unknown,
   caseInsensitive: boolean
-): boolean => {
+): Truth => {
+  if (pattern === null) return null;
   if (typeof cell !== "string" || typeof pattern !== "string") return false;
-  const re = new RegExp(
-    "^" +
-      pattern
-        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-        .replace(/%/g, ".*")
-        .replace(/_/g, ".") +
-      "$",
-    caseInsensitive ? "i" : ""
-  );
-  return re.test(cell);
+  return likeRegex(pattern, caseInsensitive).test(cell);
 };
 
 /** Stable, multi-column sort matching SQL semantics. */

--- a/apps/scout/src/api/static-http/condition-eval.ts
+++ b/apps/scout/src/api/static-http/condition-eval.ts
@@ -1,0 +1,241 @@
+import type { Condition, OrderByModel, ScalarValue } from "../../query";
+import { isCompoundCondition, isTuple } from "../../query";
+import type { Pagination } from "../../types/api-types";
+
+/**
+ * Resolve a condition column against a row. Falls back to dotted-path
+ * traversal (`metadata.foo`) and then to the row's `metadata` object, since
+ * the server exposes custom metadata fields as top-level filter columns.
+ */
+export const resolveCell = (
+  row: Record<string, unknown>,
+  column: string
+): unknown => {
+  if (column in row) return row[column];
+
+  if (column.includes(".")) {
+    let value: unknown = row;
+    for (const part of column.split(".")) {
+      if (value === null || typeof value !== "object") return undefined;
+      value = (value as Record<string, unknown>)[part];
+    }
+    return value;
+  }
+
+  const metadata = row["metadata"];
+  if (metadata && typeof metadata === "object") {
+    return (metadata as Record<string, unknown>)[column];
+  }
+  return undefined;
+};
+
+/** Apply a Condition to a single row, returning whether it passes. */
+export const evaluateCondition = (
+  row: Record<string, unknown>,
+  condition: Condition
+): boolean => {
+  if (isCompoundCondition(condition)) {
+    if (condition.operator === "NOT") {
+      return !evaluateCondition(row, condition.left);
+    }
+    const leftResult = evaluateCondition(row, condition.left);
+    const right = condition.right;
+    if (right === null) return leftResult;
+    if (condition.operator === "AND") {
+      return leftResult && evaluateCondition(row, right);
+    }
+    // OR
+    return leftResult || evaluateCondition(row, right);
+  }
+
+  const cell = resolveCell(row, condition.left);
+  const target = condition.right;
+
+  switch (condition.operator) {
+    case "IS NULL":
+      return cell === null || cell === undefined;
+    case "IS NOT NULL":
+      return cell !== null && cell !== undefined;
+    case "=":
+      return cellEquals(cell, target);
+    case "!=":
+      return !cellEquals(cell, target);
+    case "<":
+      return scalarCompare(cell, target) < 0;
+    case "<=":
+      return scalarCompare(cell, target) <= 0;
+    case ">":
+      return scalarCompare(cell, target) > 0;
+    case ">=":
+      return scalarCompare(cell, target) >= 0;
+    // Branch on the operator, not isScalarArray: isTuple claims any
+    // 2-element array, which would misclassify a 2-value IN list.
+    case "IN":
+      return Array.isArray(target) && target.some((v) => cellEquals(cell, v));
+    case "NOT IN":
+      return Array.isArray(target) && !target.some((v) => cellEquals(cell, v));
+    case "LIKE":
+      return likeMatch(cell, target, false);
+    case "NOT LIKE":
+      return !likeMatch(cell, target, false);
+    case "ILIKE":
+      return likeMatch(cell, target, true);
+    case "NOT ILIKE":
+      return !likeMatch(cell, target, true);
+    case "BETWEEN":
+      return (
+        isTuple(target) &&
+        scalarCompare(cell, target[0]) >= 0 &&
+        scalarCompare(cell, target[1]) <= 0
+      );
+    case "NOT BETWEEN":
+      return (
+        isTuple(target) &&
+        (scalarCompare(cell, target[0]) < 0 ||
+          scalarCompare(cell, target[1]) > 0)
+      );
+    default:
+      return false;
+  }
+};
+
+const cellEquals = (cell: unknown, target: unknown): boolean => {
+  if (cell === target) return true;
+  if (cell === null || target === null) return false;
+  if (cell === undefined || target === undefined) return false;
+  return cell === target;
+};
+
+const comparableString = (v: unknown): string => {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean" || typeof v === "bigint")
+    return v.toString();
+  return JSON.stringify(v) ?? "";
+};
+
+/** SQL-ish ordering: nulls sort first, numbers numerically, rest as strings. */
+export const scalarCompare = (a: unknown, b: unknown): number => {
+  if (a === b) return 0;
+  if (a === null || a === undefined) return -1;
+  if (b === null || b === undefined) return 1;
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  return comparableString(a) < comparableString(b) ? -1 : 1;
+};
+
+const likeMatch = (
+  cell: unknown,
+  pattern: unknown,
+  caseInsensitive: boolean
+): boolean => {
+  if (typeof cell !== "string" || typeof pattern !== "string") return false;
+  const re = new RegExp(
+    "^" +
+      pattern
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/%/g, ".*")
+        .replace(/_/g, ".") +
+      "$",
+    caseInsensitive ? "i" : ""
+  );
+  return re.test(cell);
+};
+
+/** Stable, multi-column sort matching SQL semantics. */
+export const applyOrderBy = <T extends Record<string, unknown>>(
+  rows: readonly T[],
+  orderBy: OrderByModel | OrderByModel[] | undefined
+): T[] => {
+  if (!orderBy) return [...rows];
+  const orderColumns = Array.isArray(orderBy) ? orderBy : [orderBy];
+  if (orderColumns.length === 0) return [...rows];
+  return [...rows].sort((a, b) => {
+    for (const ob of orderColumns) {
+      const cmp = scalarCompare(
+        resolveCell(a, ob.column),
+        resolveCell(b, ob.column)
+      );
+      if (cmp !== 0) return ob.direction === "DESC" ? -cmp : cmp;
+    }
+    return 0;
+  });
+};
+
+/** Apply cursor-based pagination matching the server's interpretation. */
+export const applyPagination = <T extends Record<string, unknown>>(
+  rows: readonly T[],
+  orderBy: OrderByModel | OrderByModel[] | undefined,
+  pagination: Pagination | undefined,
+  idColumn: string
+): { items: T[]; nextCursor: Record<string, ScalarValue> | null } => {
+  if (!pagination) return { items: [...rows], nextCursor: null };
+
+  const orderColumns = orderBy
+    ? Array.isArray(orderBy)
+      ? orderBy
+      : [orderBy]
+    : [];
+  // Server always appends a stable tiebreaker on the id column for cursoring.
+  const sortColumns: OrderByModel[] = [
+    ...orderColumns,
+    { column: idColumn, direction: "ASC" },
+  ];
+
+  let filtered: T[] = [...rows];
+  if (pagination.cursor) {
+    filtered = filtered.filter((row) =>
+      cursorIncludes(row, pagination.cursor!, sortColumns, pagination.direction)
+    );
+  }
+
+  const sorted = applyOrderBy(filtered, sortColumns);
+  if (pagination.direction === "backward") {
+    sorted.reverse();
+  }
+
+  const window = sorted.slice(0, pagination.limit);
+
+  let nextCursor: Record<string, ScalarValue> | null = null;
+  if (window.length === pagination.limit && window.length > 0) {
+    const edge: T =
+      pagination.direction === "forward"
+        ? window[window.length - 1]!
+        : window[0]!;
+    nextCursor = Object.fromEntries(
+      sortColumns.map((c) => [
+        c.column,
+        resolveCell(edge, c.column) as ScalarValue,
+      ])
+    );
+  }
+
+  // For backward pagination the server returns rows in original (forward)
+  // order, so flip back.
+  if (pagination.direction === "backward") {
+    window.reverse();
+  }
+
+  return { items: window, nextCursor };
+};
+
+/**
+ * Decide whether a row is on the correct side of the cursor given the sort
+ * columns and pagination direction. Used to skip already-seen rows.
+ */
+export const cursorIncludes = (
+  row: Record<string, unknown>,
+  cursor: { [key: string]: unknown },
+  sortColumns: OrderByModel[],
+  direction: "forward" | "backward"
+): boolean => {
+  for (const ob of sortColumns) {
+    const cell = resolveCell(row, ob.column);
+    const cursorVal = cursor[ob.column];
+    const cmp = scalarCompare(cell, cursorVal);
+    if (cmp === 0) continue;
+    // Forward + ASC: include rows strictly greater than cursor.
+    // Backward + ASC: include rows strictly less than cursor.
+    const effective = ob.direction === "DESC" ? -cmp : cmp;
+    return direction === "forward" ? effective > 0 : effective < 0;
+  }
+  return false;
+};

--- a/apps/scout/src/api/static-http/fetch.ts
+++ b/apps/scout/src/api/static-http/fetch.ts
@@ -1,0 +1,44 @@
+import { decompress as decompressZstd } from "fzstd";
+
+import { asyncJsonParseBytes } from "@tsmono/util";
+
+export const joinUrl = (base: string, ...parts: string[]): string => {
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const cleaned = parts
+    .map((p) => p.replace(/^\/+|\/+$/g, ""))
+    .filter((p) => p.length > 0);
+  return [trimmedBase, ...cleaned].join("/");
+};
+
+const fetchOk = async (url: string): Promise<Response> => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  return res;
+};
+
+export const fetchJson = async <T>(url: string): Promise<T> => {
+  const res = await fetchOk(url);
+  return (await res.json()) as T;
+};
+
+export const fetchBytes = async (url: string): Promise<ArrayBuffer> => {
+  const res = await fetchOk(url);
+  return res.arrayBuffer();
+};
+
+/**
+ * Fetch a `.json.zst` file: zstd-decompress (pure-JS fzstd, no wasm) then
+ * parse — off the main thread for large payloads.
+ */
+export const fetchJsonZst = async <T>(url: string): Promise<T> => {
+  const bytes = await fetchBytes(url);
+  return asyncJsonParseBytes<T>(decompressZstd(new Uint8Array(bytes)));
+};
+
+/** True when a resource exists (HEAD request; 404 → false). */
+export const urlExists = async (url: string): Promise<boolean> => {
+  const res = await fetch(url, { method: "HEAD" });
+  return res.ok;
+};

--- a/apps/scout/src/api/useStaticBundle.ts
+++ b/apps/scout/src/api/useStaticBundle.ts
@@ -1,0 +1,13 @@
+import { useApi } from "../state/store";
+
+/**
+ * Returns true when the app is running against a static bundle (no backend).
+ * UI surfaces that would require live server compute — search, validation
+ * editing, project config edits, scan launching — should hide themselves
+ * via this hook.
+ *
+ * For module-init code that runs before React (e.g. the router activities
+ * list), use `window.__SCOUT_STATIC_BUNDLE__` directly — it is set in
+ * main.tsx before any other module imports.
+ */
+export const useStaticBundle = (): boolean => useApi().readOnly;

--- a/apps/scout/src/api/useStaticBundle.ts
+++ b/apps/scout/src/api/useStaticBundle.ts
@@ -6,8 +6,8 @@ import { useApi } from "../state/store";
  * editing, project config edits, scan launching — should hide themselves
  * via this hook.
  *
- * For module-init code that runs before React (e.g. the router activities
- * list), use `window.__SCOUT_STATIC_BUNDLE__` directly — it is set in
- * main.tsx before any other module imports.
+ * This is the only static-bundle signal: it derives from the api object
+ * created in main.tsx, so it must be consulted at render time (module-eval
+ * code runs before the api exists).
  */
 export const useStaticBundle = (): boolean => useApi().readOnly;

--- a/apps/scout/src/app/components/ActivityBarLayout.tsx
+++ b/apps/scout/src/app/components/ActivityBarLayout.tsx
@@ -1,11 +1,12 @@
 import { FC, ReactNode } from "react";
 import { useLocation } from "react-router";
 
+import { useStaticBundle } from "../../api/useStaticBundle";
 import { useLoggingNavigate } from "../../debugging/navigationDebugging";
 import {
-  activities,
   getActivityById,
   getActivityByRoute,
+  visibleActivities,
 } from "../../router/activities";
 import { openRouteInNewTab } from "../../router/url";
 import { AppConfig } from "../../types/api-types";
@@ -28,6 +29,7 @@ export const ActivityBarLayout: FC<ActivityBarLayoutProps> = ({
 }) => {
   const location = useLocation();
   const navigate = useLoggingNavigate("ActivityBarLayout");
+  const staticBundle = useStaticBundle();
 
   // Determine the currently selected activity based on the current route
   const currentActivity = getActivityByRoute(location.pathname);
@@ -53,7 +55,7 @@ export const ActivityBarLayout: FC<ActivityBarLayoutProps> = ({
       <ProjectBar config={config} />
       <div className={styles.layout}>
         <ActivityBar
-          activities={activities.map((a) => ({
+          activities={visibleActivities(staticBundle).map((a) => ({
             id: a.id,
             label: a.label,
             icon: a.icon,

--- a/apps/scout/src/app/hooks/useTranscriptsFilterBarProps.ts
+++ b/apps/scout/src/app/hooks/useTranscriptsFilterBarProps.ts
@@ -2,6 +2,7 @@ import { skipToken } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 
 import { ScalarValue } from "../../api/api";
+import { useStaticBundle } from "../../api/useStaticBundle";
 import type { Condition } from "../../query";
 import { useCode } from "../server/useCode";
 import { useTranscriptsColumnValues } from "../server/useTranscriptsColumnValues";
@@ -26,12 +27,17 @@ interface TranscriptsFilterBarProps {
 export const useTranscriptsFilterBarProps = (
   transcriptsDir: string | undefined
 ): TranscriptsFilterBarProps => {
+  const staticBundle = useStaticBundle();
   const [editingColumnId, setEditingColumnId] = useState<string | null>(null);
 
   const condition = useFilterConditions();
   const otherColumnsFilter = useFilterConditions(editingColumnId ?? undefined);
 
-  const { data: filterCodeValues } = useCode(condition ?? skipToken);
+  // Filter-to-code generation requires the backend; skip it in static bundles
+  // so the Copy Filter button hides instead of erroring.
+  const { data: filterCodeValues } = useCode(
+    staticBundle ? skipToken : (condition ?? skipToken)
+  );
 
   const { data: filterSuggestions } = useTranscriptsColumnValues(
     editingColumnId && transcriptsDir

--- a/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
+++ b/apps/scout/src/app/scannerResult/ScannerResultPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "@tsmono/react/components";
 import { useDocumentTitle } from "@tsmono/react/hooks";
 
+import { useStaticBundle } from "../../api/useStaticBundle";
 import { ApplicationIcons } from "../../icons";
 import {
   getScannerParam,
@@ -157,7 +158,9 @@ export const ScannerResultPanel: FC = () => {
   const appConfig = useAppConfig();
 
   // Validation sidebar - URL is the source of truth
-  const validationSidebarCollapsed = !getValidationParam(searchParams);
+  const validationAvailable = !useStaticBundle();
+  const validationSidebarCollapsed =
+    !validationAvailable || !getValidationParam(searchParams);
 
   const toggleValidationSidebar = useCallback(() => {
     setSearchParams((prevParams) => {
@@ -317,7 +320,7 @@ export const ScannerResultPanel: FC = () => {
     }
 
     // Validation button - only show when transcriptId is available
-    if (selectedResult?.transcriptId) {
+    if (validationAvailable && selectedResult?.transcriptId) {
       toolButtons.push(
         <ToolButton
           key="validation-sidebar-toggle"
@@ -342,6 +345,7 @@ export const ScannerResultPanel: FC = () => {
     selectedResult,
     toggleValidationSidebar,
     validationSidebarCollapsed,
+    validationAvailable,
     handleNavigateToTranscript,
     hasTranscript,
     resolvedTranscriptsDir,

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -38,6 +38,7 @@ import {
 } from "@tsmono/react/hooks";
 import { formatDateTime, isHostedEnvironment } from "@tsmono/util";
 
+import { useStaticBundle } from "../../api/useStaticBundle";
 import { ApplicationIcons } from "../../icons";
 import {
   getRailParam,
@@ -155,6 +156,10 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
   const messagesReferenceLabels =
     searchScope === "messages" ? referenceLabels : undefined;
 
+  // Static bundle has no backend, so the Search (grep/LLM) and Validation
+  // (project-file writes) rail surfaces are hidden entirely.
+  const staticBundle = useStaticBundle();
+
   const handleTabChange = useCallback(
     (tabId: string) => {
       //  update both store and URL
@@ -242,8 +247,9 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
 
   // The rail (Search / Validation) is mutually exclusive; the URL is the
   // source of truth. The panel docks to the right of content on the Messages
-  // and Events tabs only.
-  const activeRail = getRailParam(searchParams) ?? null;
+  // and Events tabs only. In a static bundle the rail is suppressed, so a
+  // stale ?rail= param must not reopen a panel.
+  const activeRail = staticBundle ? null : (getRailParam(searchParams) ?? null);
 
   const onRailSelect = useCallback(
     (id: RailPanelId) => {
@@ -438,28 +444,40 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
             />
           </div>
         </div>
-        <RailDock
-          rail={railNode}
-          panel={buildRailPanel("messages")}
-          scrollRef={scrollRef}
-          offsetTop={contentOffsetTop}
-          panelWidth={railPanelWidth}
-          onPanelWidthChange={setRailPanelWidth}
-          label={railLabel}
-        />
+        {!staticBundle && (
+          <RailDock
+            rail={railNode}
+            panel={buildRailPanel("messages")}
+            scrollRef={scrollRef}
+            offsetTop={contentOffsetTop}
+            panelWidth={railPanelWidth}
+            onPanelWidthChange={setRailPanelWidth}
+            label={railLabel}
+          />
+        )}
       </div>
     </TabPanel>
   );
 
-  const eventsRightRail = useMemo<TranscriptLayoutRightRailProps>(
-    () => ({
-      rail: railNode,
-      panel: buildRailPanel("events"),
-      label: railLabel,
-      panelWidth: railPanelWidth,
-      onPanelWidthChange: setRailPanelWidth,
-    }),
-    [railNode, buildRailPanel, railLabel, railPanelWidth, setRailPanelWidth]
+  const eventsRightRail = useMemo<TranscriptLayoutRightRailProps | undefined>(
+    () =>
+      staticBundle
+        ? undefined
+        : {
+            rail: railNode,
+            panel: buildRailPanel("events"),
+            label: railLabel,
+            panelWidth: railPanelWidth,
+            onPanelWidthChange: setRailPanelWidth,
+          },
+    [
+      staticBundle,
+      railNode,
+      buildRailPanel,
+      railLabel,
+      railPanelWidth,
+      setRailPanelWidth,
+    ]
   );
 
   const eventsPanel = hasEvents ? (

--- a/apps/scout/src/app/transcripts/TranscriptFilterBar.tsx
+++ b/apps/scout/src/app/transcripts/TranscriptFilterBar.tsx
@@ -75,7 +75,7 @@ export const TranscriptFilterBar: FC<{
       filters={filters}
       onFilterChange={handleFilterChange}
       onRemoveFilter={removeFilter}
-      filterCodeValues={filterCodeValues ?? {}}
+      filterCodeValues={filterCodeValues}
       filterSuggestions={filterSuggestions}
       onFilterColumnChange={onFilterColumnChange}
       popoverIdPrefix="transcript"

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -22,7 +22,6 @@ declare global {
   interface Window {
     __SCOUT_BASE_PATH__?: string;
     __SCOUT_DISABLE_SSE__?: boolean;
-    __SCOUT_STATIC_BUNDLE__?: boolean;
   }
 }
 
@@ -54,11 +53,6 @@ const readBundleContext = (): StaticBundleContext | undefined => {
 };
 
 const bundleContext = readBundleContext();
-
-// Set the static-bundle flag before any module reads it (e.g. router activities).
-if (bundleContext) {
-  window.__SCOUT_STATIC_BUNDLE__ = true;
-}
 
 // Find the root element and render into it
 const containerId = "app";

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import JSON5 from "json5";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -9,6 +10,10 @@ import { getVscodeApi } from "@tsmono/util";
 import { ScoutApiV2 } from "./api/api";
 import { apiScoutServer } from "./api/api-scout-server";
 import { apiVscode } from "./api/api-vscode";
+import {
+  apiScoutStatic,
+  StaticBundleContext,
+} from "./api/static-http/api-scout-static";
 import { App } from "./App";
 import { getEmbeddedAppMessage } from "./app/hooks/useWindowMessaging";
 import { ApiProvider, createStore, StoreProvider } from "./state/store";
@@ -17,7 +22,42 @@ declare global {
   interface Window {
     __SCOUT_BASE_PATH__?: string;
     __SCOUT_DISABLE_SSE__?: boolean;
+    __SCOUT_STATIC_BUNDLE__?: boolean;
   }
+}
+
+const readBundleContext = (): StaticBundleContext | undefined => {
+  // Prefer an inline <script id="scout_context"> JSON blob (set by the bundler).
+  const scriptEl = document.getElementById("scout_context");
+  if (scriptEl?.textContent) {
+    try {
+      const data: StaticBundleContext & { bundle?: boolean } = JSON5.parse(
+        scriptEl.textContent
+      );
+      if (data.bundle) {
+        return data;
+      }
+    } catch (err) {
+      console.warn("Failed to parse scout_context script tag", err);
+    }
+  }
+
+  // Fall back to URL params for ad-hoc testing.
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get("bundle") === "true") {
+    return {
+      bundleBaseUrl: urlParams.get("bundle_base") ?? undefined,
+    };
+  }
+
+  return undefined;
+};
+
+const bundleContext = readBundleContext();
+
+// Set the static-bundle flag before any module reads it (e.g. router activities).
+if (bundleContext) {
+  window.__SCOUT_STATIC_BUNDLE__ = true;
 }
 
 // Find the root element and render into it
@@ -35,24 +75,27 @@ const root = createRoot(container);
 
 const selectApi = (): ScoutApiV2 => {
   const vscodeApi = getVscodeApi();
-  if (!vscodeApi) {
-    const basePath = window.__SCOUT_BASE_PATH__ ?? "";
-    return apiScoutServer({
-      apiBaseUrl: `${basePath}/api/v2`,
-      disableSSE: window.__SCOUT_DISABLE_SSE__,
-    });
+  if (vscodeApi) {
+    const protocolVersion =
+      getEmbeddedAppMessage()?.extensionProtocolVersion ?? 1;
+    if (protocolVersion < 2) {
+      throw new Error(
+        `VSCode extension protocol version ${protocolVersion} is no longer supported. ` +
+          "Please update your Inspect Scout VSCode extension to the latest version."
+      );
+    }
+    return apiVscode(vscodeApi);
   }
 
-  const protocolVersion =
-    getEmbeddedAppMessage()?.extensionProtocolVersion ?? 1;
-  if (protocolVersion < 2) {
-    throw new Error(
-      `VSCode extension protocol version ${protocolVersion} is no longer supported. ` +
-        "Please update your Inspect Scout VSCode extension to the latest version."
-    );
+  if (bundleContext) {
+    return apiScoutStatic(bundleContext);
   }
 
-  return apiVscode(vscodeApi);
+  const basePath = window.__SCOUT_BASE_PATH__ ?? "";
+  return apiScoutServer({
+    apiBaseUrl: `${basePath}/api/v2`,
+    disableSSE: window.__SCOUT_DISABLE_SSE__,
+  });
 };
 
 // Create the API, store, and query client

--- a/apps/scout/src/router/activities.test.ts
+++ b/apps/scout/src/router/activities.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { activities, visibleActivities } from "./activities";
+
+describe("visibleActivities", () => {
+  it("hides backend-dependent activities in static bundles", () => {
+    expect(visibleActivities(true).map((a) => a.id)).toEqual([
+      "transcripts",
+      "scans",
+    ]);
+  });
+
+  it("shows the full activity list outside static bundles", () => {
+    expect(visibleActivities(false)).toEqual(activities);
+    expect(visibleActivities(false).map((a) => a.id)).toEqual(
+      expect.arrayContaining(["project", "validation"])
+    );
+  });
+});

--- a/apps/scout/src/router/activities.tsx
+++ b/apps/scout/src/router/activities.tsx
@@ -2,6 +2,12 @@ import { ApplicationIcons } from "../icons";
 
 declare const __SCOUT_RUN_SCAN__: boolean;
 
+declare global {
+  interface Window {
+    __SCOUT_STATIC_BUNDLE__?: boolean;
+  }
+}
+
 export interface ActivityConfig {
   id: string;
   label: string;
@@ -52,8 +58,16 @@ const allActivities: ActivityConfig[] = [
   },
 ];
 
+const isStaticBundle = window.__SCOUT_STATIC_BUNDLE__ === true;
+
 export const activities = allActivities.filter((a) => {
   if (a.id === "runScan" && !__SCOUT_RUN_SCAN__) return false;
+  if (
+    isStaticBundle &&
+    (a.id === "runScan" || a.id === "project" || a.id === "validation")
+  ) {
+    return false;
+  }
   return true;
 });
 

--- a/apps/scout/src/router/activities.tsx
+++ b/apps/scout/src/router/activities.tsx
@@ -2,12 +2,6 @@ import { ApplicationIcons } from "../icons";
 
 declare const __SCOUT_RUN_SCAN__: boolean;
 
-declare global {
-  interface Window {
-    __SCOUT_STATIC_BUNDLE__?: boolean;
-  }
-}
-
 export interface ActivityConfig {
   id: string;
   label: string;
@@ -58,18 +52,25 @@ const allActivities: ActivityConfig[] = [
   },
 ];
 
-const isStaticBundle = window.__SCOUT_STATIC_BUNDLE__ === true;
+export const activities = allActivities.filter(
+  (a) => !(a.id === "runScan" && !__SCOUT_RUN_SCAN__)
+);
 
-export const activities = allActivities.filter((a) => {
-  if (a.id === "runScan" && !__SCOUT_RUN_SCAN__) return false;
-  if (
-    isStaticBundle &&
-    (a.id === "runScan" || a.id === "project" || a.id === "validation")
-  ) {
-    return false;
-  }
-  return true;
-});
+const kStaticBundleHiddenActivities = new Set([
+  "runScan",
+  "project",
+  "validation",
+]);
+
+/**
+ * Activities to render, hiding backend-dependent surfaces in static bundles.
+ * Must be applied at render time: the static-bundle signal comes from the api
+ * object created in main.tsx, which runs after all module bodies evaluate.
+ */
+export const visibleActivities = (staticBundle: boolean): ActivityConfig[] =>
+  staticBundle
+    ? activities.filter((a) => !kStaticBundleHiddenActivities.has(a.id))
+    : activities;
 
 export const getActivityByRoute = (
   path: string

--- a/apps/scout/src/test/zstd.ts
+++ b/apps/scout/src/test/zstd.ts
@@ -1,0 +1,38 @@
+import { http, passthrough } from "msw";
+import { ZstdCodec } from "zstd-codec";
+
+import { server } from "./setup-msw";
+
+// zstd-codec ships no type declarations; describe just the slice tests use.
+interface ZstdSimple {
+  compress(data: Uint8Array): Uint8Array;
+}
+interface ZstdModule {
+  Simple: new () => ZstdSimple;
+}
+
+/**
+ * Initialize a zstd compressor for building `.json.zst` test fixtures
+ * (fzstd, used by production code, is decompress-only). Call from
+ * `beforeAll`.
+ */
+export const setupZstdCompress = async (): Promise<
+  (data: unknown) => Uint8Array
+> => {
+  // zstd-codec loads WASM via a data URL that MSW intercepts. Passthrough
+  // prevents MSW from erroring on this unhandled request.
+  server.use(http.get(/octet-stream;base64,/, () => passthrough()));
+
+  const zstdCodec = ZstdCodec as {
+    run(cb: (zstd: ZstdModule) => void): void;
+  };
+
+  return new Promise((resolve) => {
+    zstdCodec.run((zstd) => {
+      const simple = new zstd.Simple();
+      resolve((data: unknown) =>
+        simple.compress(new TextEncoder().encode(JSON.stringify(data)))
+      );
+    });
+  });
+};

--- a/apps/scout/vitest.config.ts
+++ b/apps/scout/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  define: {
+    __SCOUT_RUN_SCAN__: "true",
+  },
   test: {
     include: ["src/**/*.test.{ts,tsx}"],
     setupFiles: ["src/test/setup-msw.ts"],

--- a/docs/static-bundle-format.md
+++ b/docs/static-bundle-format.md
@@ -1,0 +1,208 @@
+# Scout Static Bundle Format (v1)
+
+`scout view bundle` (inspect_scout, Python) produces a directory of static
+files that the scout viewer (apps/scout, this repo) can serve read-only from
+any static HTTP host — no backend, no wasm. This document is the contract
+between the two sides. The TypeScript types in
+`apps/scout/src/api/static-http/bundle-format.ts` mirror the manifest schema;
+change them in lockstep.
+
+## Design summary
+
+- **Everything is JSON**, compressed with **zstd** where payloads are large
+  (`.json.zst` extension, standard zstd frames). The viewer decompresses
+  in-app with pure-JS `fzstd`, so no reliance on `Content-Encoding`
+  negotiation, which static hosts handle inconsistently.
+- **Catalogs are sharded.** Listing metadata (never messages/events) is split
+  into shard files of a few thousand rows. The manifest records per-shard
+  min/max of the default sort column so the viewer can serve default-order
+  pages by fetching only the shards a page needs; the first arbitrary
+  filter/sort triggers a one-time parallel load of all shards, cached in
+  memory thereafter. Target scale: ~100k transcripts.
+- **Detail reads are O(1).** Each transcript (and scan detail) lives in its
+  own file addressed purely by id, so deep links never read a catalog.
+- **Scanner dataframes stay Arrow IPC** — the viewer already decodes Arrow
+  with pure-JS flechette/arquero, and columnar beats JSON for wide scan
+  results.
+
+## Directory layout
+
+```
+bundle/
+  index.html                 # built viewer; must embed the scout_context tag
+  assets/…                   # viewer js/css
+  api/
+    manifest.json            # entry point (uncompressed)
+    config.json              # AppConfig (uncompressed)
+    scanners.json            # ScannersResponse; optional
+    project-config.json      # ProjectConfig (no etag semantics); optional
+    transcripts/
+      catalog/
+        shard-0000.json.zst  # TranscriptInfo[] — listing columns only
+        shard-0001.json.zst
+        …
+      columns.json           # precomputed distinct values; optional
+      items/
+        <safe-id>.json.zst   # combined info + content per transcript
+    scans/
+      catalog/
+        shard-0000.json.zst  # ScanRow[]
+        …
+      columns.json
+      items/
+        <b64url(scan-path)>/
+          status.json                  # Status (uncompressed)
+          scanners/<scanner>.arrow     # Arrow IPC dataframe
+          details/<scanner>/<uuid>.json.zst
+```
+
+All paths inside `manifest.json` are relative to the `api/` directory. The
+viewer defaults to `./api` as the base URL, overridable via the
+`scout_context` boot tag.
+
+## Boot detection
+
+`index.html` must contain an inline JSON5 script tag; its presence (with
+`bundle: true`) switches the viewer into static mode:
+
+```html
+<script id="scout_context" type="application/json">
+  { "bundle": true, "bundleBaseUrl": "./api" }
+</script>
+```
+
+## manifest.json
+
+```jsonc
+{
+  "format": "scout-static-bundle",
+  "version": 1,
+  "generated_at": "2026-08-03T12:00:00Z", // optional, informational
+  "transcripts": { /* CatalogManifest */ },
+  "scans": { /* CatalogManifest */ }
+}
+```
+
+The viewer rejects manifests whose `format` differs or whose `version` is
+greater than it supports. Additive changes (new optional fields) do not bump
+the version; layout-breaking changes do.
+
+### CatalogManifest
+
+```jsonc
+{
+  "dir": "s3://bucket/transcripts",   // original dir URI (display only)
+  "id_column": "transcript_id",       // "scan_id" for the scans catalog
+  "row_count": 100000,
+  "default_order": { "column": "date", "direction": "DESC" },
+  "shards": [
+    {
+      "path": "transcripts/catalog/shard-0000.json.zst",
+      "row_count": 5000,
+      "min": "2026-01-01T00:00:00Z",  // min/max of default_order.column
+      "max": "2026-01-14T09:30:00Z"
+    }
+    // …
+  ],
+  "column_values": "transcripts/columns.json" // optional
+}
+```
+
+**Shard invariants the bundler MUST uphold:**
+
+1. Rows are **globally sorted ascending** by `default_order.column` across
+   the shard sequence (nulls first). Equal values may span shard boundaries;
+   the viewer handles boundary ties via the `id_column` tiebreak.
+2. `min`/`max` are the shard's actual bounds for that column (`null` if the
+   shard holds only nulls for it).
+3. `row_count` sums to the catalog's `row_count`.
+
+Recommended shard size: 2,000–5,000 rows (a few hundred KB compressed).
+`default_order` should match the viewer's default listing sort
+(`date DESC` for transcripts).
+
+Shard content is a JSON array of row objects — `TranscriptInfo` /
+`ScanRow` shapes from the server OpenAPI schema, **excluding** content
+columns (`messages`, `events`, `events_data`, `timelines`, `attachments`).
+Custom metadata stays nested under the row's `metadata` key; the viewer's
+filter evaluator resolves unknown filter columns through `metadata`
+automatically.
+
+### columns.json
+
+Optional map of column name → sorted distinct values, used for filter
+autocomplete without a catalog load:
+
+```json
+{ "model": ["claude-3", "gpt-4"], "task_set": ["swe-bench"] }
+```
+
+Only include columns whose distinct sets are reasonably small (say ≤1,000
+values); omit the file or a column to make the viewer compute distincts from
+shards instead.
+
+## Transcript items
+
+`transcripts/items/<safe-id>.json.zst` where `<safe-id>` is the
+`transcript_id` with `/` and `\` replaced by `_` (ids are expected to be
+UUID-like; the bundler must fail on collisions). Content is the server's
+`MessagesEventsResponse` plus the row's `TranscriptInfo` under `info`:
+
+```jsonc
+{
+  "info": { "transcript_id": "…", "date": "…", /* TranscriptInfo */ },
+  "messages": [ /* … */ ],
+  "events": [ /* … */ ],
+  "events_data": null,      // optional condensed events, as served live
+  "timelines": [ /* … */ ],
+  "attachments": { "<32-hex-id>": "…" } // optional, resolved client-side
+}
+```
+
+The viewer also issues `HEAD` requests against item files to answer
+"does this transcript exist" without a catalog read.
+
+## Scan items
+
+Directory name is the **base64url (unpadded) encoding of the scan path**
+string the catalog rows reference — the same encoding the live server uses in
+URLs (`encodeBase64Url`).
+
+- `status.json` — the scan `Status` object.
+- `scanners/<scanner>.arrow` — Arrow IPC stream for
+  `getScannerDataframe` (LZ4-compressed IPC is fine; the viewer registers an
+  LZ4 codec). `<scanner>` is percent-encoded by the viewer when requested;
+  bundlers should keep scanner names filesystem-safe.
+- `details/<scanner>/<uuid>.json.zst` — one file per result row:
+
+```jsonc
+{
+  "input": /* ScannerInput.input */,
+  "input_type": "transcript",
+  "input_data": null,       // optional condensed input events
+  "scan_events": [ /* Event[] */ ]
+}
+```
+
+## Top-level files
+
+- `config.json` — the `AppConfig` the live server would return from
+  `/app-config`, with `transcripts`/`scans` pointing at the bundled dirs.
+- `scanners.json` — `ScannersResponse`; optional (viewer falls back to
+  `{ "items": [] }`).
+- `project-config.json` — `ProjectConfig`; optional. Editing is disabled in
+  static mode regardless.
+
+## What static mode does NOT include
+
+No search, no validation sets, no scan launching, no filter-to-code
+generation, no live topic updates — the viewer hides these surfaces when it
+boots from a bundle (`api.readOnly === true`). Bundlers need not emit any
+files for them. `downloadScan` (zip archive) is also unavailable.
+
+## Hosting requirements
+
+Plain static file serving with `GET` and `HEAD`. No range requests, no
+custom headers, no `Content-Encoding` configuration. Files are fetched with
+same-origin relative URLs, so no CORS setup is needed when the bundle is
+served as one tree.

--- a/docs/static-bundle-format.md
+++ b/docs/static-bundle-format.md
@@ -171,8 +171,12 @@ URLs (`encodeBase64Url`).
 - `status.json` — the scan `Status` object.
 - `scanners/<scanner>.arrow` — Arrow IPC stream for
   `getScannerDataframe` (LZ4-compressed IPC is fine; the viewer registers an
-  LZ4 codec). `<scanner>` is percent-encoded by the viewer when requested;
-  bundlers should keep scanner names filesystem-safe.
+  LZ4 codec). Bake it with the heavy per-row columns the viewer always
+  excludes from grid fetches (`input`, `scan_events`) stripped — the static
+  client ignores its `excludeColumns` argument, and those columns are served
+  from the per-row detail files instead. `<scanner>` is percent-encoded by
+  the viewer when requested; bundlers should keep scanner names
+  filesystem-safe.
 - `details/<scanner>/<uuid>.json.zst` — one file per result row:
 
 ```jsonc


### PR DESCRIPTION
Previously we considered implementing static bundles on top of Parquet files, and shipping a WASM build of DuckDB to the client. Instead, we're going the other direction and leaning heavily into JSON. This allows us to very directly download a single transcript when you're viewing that transcript, and it prevents us from needing large WASM files.

[The details about the structure of the bundles can be found here.](https://github.com/meridianlabs-ai/ts-mono/blob/7eb9df738ed2efeaa39bfcd41b3ea08615456ca9/docs/static-bundle-format.md)

In regular `scout view` mode, Scout sends filter/sort options to the server where they're applied to the listings in the database on the server. In order to support the same UI, we need an implementation of this on the client.

Deployed it a few places:
https://brandly.github.io/static-scout-example/
https://scout-static-bundle.netlify.app/
https://d1f0ouq3gfwmsk.cloudfront.net/

Fixes #263