### PR TITLE
Stop transcripts beaconing to attacker-chosen hosts

### DIFF
--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -233,4 +233,63 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     expect(container.querySelector("style")).toBeNull();
     expect(container.querySelector("a[href]")).toBeNull();
   });
+
+  it("removes the background attribute", async () => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="text"
+        postProcess={(html) =>
+          `${html}<table><td background="https://evil.example/x.png"></td></table>`
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("text");
+    });
+
+    expect(container.querySelector("[background]")).toBeNull();
+    expect(container.innerHTML).not.toContain("evil.example");
+  });
+
+  // Each element needs its real parent namespace: mglyph is MathML, and inside
+  // <svg> it is dropped as unknown, which would pass for the wrong reason.
+  it.each([
+    ["mglyph", "math"],
+    ["feimage", "svg"],
+    ["animatecolor", "svg"],
+  ])("removes the %s element", async (tag, parent) => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="text"
+        postProcess={(html) =>
+          `${html}<${parent}><${tag} src="https://evil.example/x.png" href="https://evil.example/y.png"></${tag}></${parent}>`
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("text");
+    });
+
+    expect(container.querySelector(tag)).toBeNull();
+    expect(container.innerHTML).not.toContain("evil.example");
+  });
+
+  it("removes a src attribute from a non-img element", async () => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="text"
+        postProcess={(html) =>
+          `${html}<math><mtext src="https://evil.example/x.png">m</mtext></math>`
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("text");
+    });
+
+    expect(container.querySelector("[src]")).toBeNull();
+  });
 });

--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -221,4 +221,22 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     expect(container.querySelector("a")?.hasAttribute("href")).toBe(false);
     expect(container.querySelector("a")?.hasAttribute("onclick")).toBe(false);
   });
+
+  it("does not let math break out of an attribute into real markup", async () => {
+    const payload = `$\\href{x"><span id="mjx-aa"><style>#mjx-aa{}body{background-image:image-set('https://evil.example/b.png' 1x)}</style><b z="}{z}$`;
+    const { container } = render(<MarkdownDiv markdown={payload} />);
+
+    await waitFor(() => {
+      expect(container.querySelector("mjx-container")).not.toBeNull();
+    });
+
+    // Count only injected styles: every math render emits one legitimate
+    // MathJax stylesheet, so a bare querySelector("style") would pass here for
+    // the wrong reason.
+    const injected = Array.from(container.querySelectorAll("style")).filter(
+      (s) => s.textContent.includes("evil.example")
+    );
+    expect(injected).toHaveLength(0);
+    expect(container.querySelector("a[href]")).toBeNull();
+  });
 });

--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -276,6 +276,51 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
     expect(container.innerHTML).not.toContain("evil.example");
   });
 
+  it.each([
+    "fill",
+    "stroke",
+    "mask",
+    "filter",
+    "clip-path",
+    "marker-start",
+    "marker-mid",
+    "marker-end",
+  ])("removes an external url() from the %s attribute", async (attr) => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="text"
+        postProcess={(html) =>
+          `${html}<svg><rect ${attr}="url(https://evil.example/x.svg#p)"></rect></svg>`
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("text");
+    });
+
+    expect(container.innerHTML).not.toContain("evil.example");
+  });
+
+  it("keeps a same-document fragment reference", async () => {
+    const { container } = render(
+      <MarkdownDiv
+        markdown="text"
+        postProcess={(html) =>
+          `${html}<svg><rect fill="url(#paint)"></rect></svg>`
+        }
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("rect")).not.toBeNull();
+    });
+
+    expect(container.querySelector("rect")?.getAttribute("fill")).toBe(
+      "url(#paint)"
+    );
+  });
+
   it("removes a src attribute from a non-img element", async () => {
     const { container } = render(
       <MarkdownDiv

--- a/packages/react/src/components/MarkdownDiv.security.test.tsx
+++ b/packages/react/src/components/MarkdownDiv.security.test.tsx
@@ -20,7 +20,7 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
       expect(container.querySelector("mjx-container")).not.toBeNull();
     });
 
-    expect(container.querySelector('span[id^="mjx-"] > style')).not.toBeNull();
+    expect(container.querySelector("style")).toBeNull();
     expect(container.querySelector("animate")).toBeNull();
     expect(container.querySelector("[onbegin]")).toBeNull();
     expect(container.innerHTML).not.toContain("onbegin");
@@ -230,13 +230,7 @@ describe("MarkdownDiv rendered HTML sanitization", () => {
       expect(container.querySelector("mjx-container")).not.toBeNull();
     });
 
-    // Count only injected styles: every math render emits one legitimate
-    // MathJax stylesheet, so a bare querySelector("style") would pass here for
-    // the wrong reason.
-    const injected = Array.from(container.querySelectorAll("style")).filter(
-      (s) => s.textContent.includes("evil.example")
-    );
-    expect(injected).toHaveLength(0);
+    expect(container.querySelector("style")).toBeNull();
     expect(container.querySelector("a[href]")).toBeNull();
   });
 });

--- a/packages/react/src/components/MarkdownDiv.tsx
+++ b/packages/react/src/components/MarkdownDiv.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import "./MarkdownDiv.css";
+import "./mathjaxStyles.css";
 
 import {
   defaultMarkdownRenderer,

--- a/packages/react/src/components/markdownRendering.ts
+++ b/packages/react/src/components/markdownRendering.ts
@@ -125,6 +125,12 @@ export const getMarkdownInstance = async (
     // entity-encoded by the pipeline for XSS safety, but MathJax needs
     // the raw characters (e.g. < for \lt comparisons). This is safe
     // because MathJax renders to SVG, not to injectable HTML.
+    // \href is the one TeX command whose attribute MathJax serializes without
+    // escaping quotes, letting content close it and inject real markup.
+    // \cssId escapes it; \text and undefined commands emit escaped entities.
+    const disableHref = (content: string): string =>
+      content.replace(/\\href(?![a-zA-Z])/g, "\\hrefdisabled");
+
     const origInline = md.renderer.rules.math_inline;
     const origBlock = md.renderer.rules.math_block;
 
@@ -132,7 +138,7 @@ export const getMarkdownInstance = async (
       md.renderer.rules.math_inline = (tokens, idx, options, env, self) => {
         const token = tokens[idx];
         if (token) {
-          token.content = unescapeHtmlForMath(token.content);
+          token.content = disableHref(unescapeHtmlForMath(token.content));
         }
         return origInline(tokens, idx, options, env, self);
       };
@@ -141,7 +147,7 @@ export const getMarkdownInstance = async (
       md.renderer.rules.math_block = (tokens, idx, options, env, self) => {
         const token = tokens[idx];
         if (token) {
-          token.content = unescapeHtmlForMath(token.content);
+          token.content = disableHref(unescapeHtmlForMath(token.content));
         }
         return origBlock(tokens, idx, options, env, self);
       };

--- a/packages/react/src/components/mathjaxStyles.css
+++ b/packages/react/src/components/mathjaxStyles.css
@@ -1,0 +1,164 @@
+/* MathJax's own SVG stylesheet, shipped as trusted app CSS because the
+   sanitizer forbids <style> outright: any carve-out admitting this one is
+   forgeable by content, and a surviving <style> is a fetch and exfiltration
+   vector.
+
+   Copied verbatim from MathJax's output via markdown-it-mathjax3@5.2.0, with
+   the per-instance `#mjx-<hash>` selector replaced by `span[id^="mjx-"]`. The
+   whole sheet is CSS-nested inside that one rule, so the substitution is the
+   only edit. Re-extract and diff on a MathJax upgrade. */
+span[id^="mjx-"] {
+        display:contents;
+        mjx-assistive-mml {
+          user-select: text !important;
+          clip: auto !important;
+          color: rgba(0,0,0,0);
+        }
+        
+mjx-container[jax="SVG"] {
+  direction: ltr;
+}
+
+mjx-container[jax="SVG"] > svg {
+  overflow: visible;
+  min-height: 1px;
+  min-width: 1px;
+}
+
+mjx-container[jax="SVG"] > svg a {
+  fill: blue;
+  stroke: blue;
+}
+
+mjx-assistive-mml {
+  position: absolute !important;
+  top: 0px;
+  left: 0px;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 1px 0px 0px 0px !important;
+  border: 0px !important;
+  display: block !important;
+  width: auto !important;
+  overflow: hidden !important;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+mjx-assistive-mml[display="block"] {
+  width: 100% !important;
+}
+
+mjx-container[jax="SVG"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+mjx-container[jax="SVG"][display="true"][width="full"] {
+  display: flex;
+}
+
+mjx-container[jax="SVG"][justify="left"] {
+  text-align: left;
+}
+
+mjx-container[jax="SVG"][justify="right"] {
+  text-align: right;
+}
+
+g[data-mml-node="merror"] > g {
+  fill: red;
+  stroke: red;
+}
+
+g[data-mml-node="merror"] > rect[data-background] {
+  fill: yellow;
+  stroke: none;
+}
+
+g[data-mml-node="mtable"] > line[data-line], svg[data-table] > g > line[data-line] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > rect[data-frame], svg[data-table] > g > rect[data-frame] {
+  stroke-width: 70px;
+  fill: none;
+}
+
+g[data-mml-node="mtable"] > .mjx-dashed, svg[data-table] > g > .mjx-dashed {
+  stroke-dasharray: 140;
+}
+
+g[data-mml-node="mtable"] > .mjx-dotted, svg[data-table] > g > .mjx-dotted {
+  stroke-linecap: round;
+  stroke-dasharray: 0,140;
+}
+
+g[data-mml-node="mtable"] > g > svg {
+  overflow: visible;
+}
+
+[jax="SVG"] mjx-tool {
+  display: inline-block;
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+[jax="SVG"] mjx-tool > mjx-tip {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+mjx-tool > mjx-tip {
+  display: inline-block;
+  padding: .2em;
+  border: 1px solid #888;
+  font-size: 70%;
+  background-color: #F8F8F8;
+  color: black;
+  box-shadow: 2px 2px 5px #AAAAAA;
+}
+
+g[data-mml-node="maction"][data-toggle] {
+  cursor: pointer;
+}
+
+mjx-status {
+  display: block;
+  position: fixed;
+  left: 1em;
+  bottom: 1em;
+  min-width: 25%;
+  padding: .2em .4em;
+  border: 1px solid #888;
+  font-size: 90%;
+  background-color: #F8F8F8;
+  color: black;
+}
+
+foreignObject[data-mjx-xml] {
+  font-family: initial;
+  line-height: normal;
+  overflow: visible;
+}
+
+mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
+  stroke-width: 3;
+}
+
+g[data-mml-node="xypic"] path {
+  stroke-width: inherit;
+}
+
+.MathJax g[data-mml-node="xypic"] path {
+  stroke-width: inherit;
+}
+
+      }

--- a/packages/react/src/components/mathjaxStyles.css
+++ b/packages/react/src/components/mathjaxStyles.css
@@ -8,157 +8,161 @@
    whole sheet is CSS-nested inside that one rule, so the substitution is the
    only edit. Re-extract and diff on a MathJax upgrade. */
 span[id^="mjx-"] {
-        display:contents;
-        mjx-assistive-mml {
-          user-select: text !important;
-          clip: auto !important;
-          color: rgba(0,0,0,0);
-        }
-        
-mjx-container[jax="SVG"] {
-  direction: ltr;
-}
+  display: contents;
+  mjx-assistive-mml {
+    user-select: text !important;
+    clip: auto !important;
+    color: rgba(0, 0, 0, 0);
+  }
 
-mjx-container[jax="SVG"] > svg {
-  overflow: visible;
-  min-height: 1px;
-  min-width: 1px;
-}
+  mjx-container[jax="SVG"] {
+    direction: ltr;
+  }
 
-mjx-container[jax="SVG"] > svg a {
-  fill: blue;
-  stroke: blue;
-}
+  mjx-container[jax="SVG"] > svg {
+    overflow: visible;
+    min-height: 1px;
+    min-width: 1px;
+  }
 
-mjx-assistive-mml {
-  position: absolute !important;
-  top: 0px;
-  left: 0px;
-  clip: rect(1px, 1px, 1px, 1px);
-  padding: 1px 0px 0px 0px !important;
-  border: 0px !important;
-  display: block !important;
-  width: auto !important;
-  overflow: hidden !important;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
+  mjx-container[jax="SVG"] > svg a {
+    fill: blue;
+    stroke: blue;
+  }
 
-mjx-assistive-mml[display="block"] {
-  width: 100% !important;
-}
+  mjx-assistive-mml {
+    position: absolute !important;
+    top: 0px;
+    left: 0px;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 1px 0px 0px 0px !important;
+    border: 0px !important;
+    display: block !important;
+    width: auto !important;
+    overflow: hidden !important;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
 
-mjx-container[jax="SVG"][display="true"] {
-  display: block;
-  text-align: center;
-  margin: 1em 0;
-}
+  mjx-assistive-mml[display="block"] {
+    width: 100% !important;
+  }
 
-mjx-container[jax="SVG"][display="true"][width="full"] {
-  display: flex;
-}
+  mjx-container[jax="SVG"][display="true"] {
+    display: block;
+    text-align: center;
+    margin: 1em 0;
+  }
 
-mjx-container[jax="SVG"][justify="left"] {
-  text-align: left;
-}
+  mjx-container[jax="SVG"][display="true"][width="full"] {
+    display: flex;
+  }
 
-mjx-container[jax="SVG"][justify="right"] {
-  text-align: right;
-}
+  mjx-container[jax="SVG"][justify="left"] {
+    text-align: left;
+  }
 
-g[data-mml-node="merror"] > g {
-  fill: red;
-  stroke: red;
-}
+  mjx-container[jax="SVG"][justify="right"] {
+    text-align: right;
+  }
 
-g[data-mml-node="merror"] > rect[data-background] {
-  fill: yellow;
-  stroke: none;
-}
+  g[data-mml-node="merror"] > g {
+    fill: red;
+    stroke: red;
+  }
 
-g[data-mml-node="mtable"] > line[data-line], svg[data-table] > g > line[data-line] {
-  stroke-width: 70px;
-  fill: none;
-}
+  g[data-mml-node="merror"] > rect[data-background] {
+    fill: yellow;
+    stroke: none;
+  }
 
-g[data-mml-node="mtable"] > rect[data-frame], svg[data-table] > g > rect[data-frame] {
-  stroke-width: 70px;
-  fill: none;
-}
+  g[data-mml-node="mtable"] > line[data-line],
+  svg[data-table] > g > line[data-line] {
+    stroke-width: 70px;
+    fill: none;
+  }
 
-g[data-mml-node="mtable"] > .mjx-dashed, svg[data-table] > g > .mjx-dashed {
-  stroke-dasharray: 140;
-}
+  g[data-mml-node="mtable"] > rect[data-frame],
+  svg[data-table] > g > rect[data-frame] {
+    stroke-width: 70px;
+    fill: none;
+  }
 
-g[data-mml-node="mtable"] > .mjx-dotted, svg[data-table] > g > .mjx-dotted {
-  stroke-linecap: round;
-  stroke-dasharray: 0,140;
-}
+  g[data-mml-node="mtable"] > .mjx-dashed,
+  svg[data-table] > g > .mjx-dashed {
+    stroke-dasharray: 140;
+  }
 
-g[data-mml-node="mtable"] > g > svg {
-  overflow: visible;
-}
+  g[data-mml-node="mtable"] > .mjx-dotted,
+  svg[data-table] > g > .mjx-dotted {
+    stroke-linecap: round;
+    stroke-dasharray: 0, 140;
+  }
 
-[jax="SVG"] mjx-tool {
-  display: inline-block;
-  position: relative;
-  width: 0;
-  height: 0;
-}
+  g[data-mml-node="mtable"] > g > svg {
+    overflow: visible;
+  }
 
-[jax="SVG"] mjx-tool > mjx-tip {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
+  [jax="SVG"] mjx-tool {
+    display: inline-block;
+    position: relative;
+    width: 0;
+    height: 0;
+  }
 
-mjx-tool > mjx-tip {
-  display: inline-block;
-  padding: .2em;
-  border: 1px solid #888;
-  font-size: 70%;
-  background-color: #F8F8F8;
-  color: black;
-  box-shadow: 2px 2px 5px #AAAAAA;
-}
+  [jax="SVG"] mjx-tool > mjx-tip {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 
-g[data-mml-node="maction"][data-toggle] {
-  cursor: pointer;
-}
+  mjx-tool > mjx-tip {
+    display: inline-block;
+    padding: 0.2em;
+    border: 1px solid #888;
+    font-size: 70%;
+    background-color: #f8f8f8;
+    color: black;
+    box-shadow: 2px 2px 5px #aaaaaa;
+  }
 
-mjx-status {
-  display: block;
-  position: fixed;
-  left: 1em;
-  bottom: 1em;
-  min-width: 25%;
-  padding: .2em .4em;
-  border: 1px solid #888;
-  font-size: 90%;
-  background-color: #F8F8F8;
-  color: black;
-}
+  g[data-mml-node="maction"][data-toggle] {
+    cursor: pointer;
+  }
 
-foreignObject[data-mjx-xml] {
-  font-family: initial;
-  line-height: normal;
-  overflow: visible;
-}
+  mjx-status {
+    display: block;
+    position: fixed;
+    left: 1em;
+    bottom: 1em;
+    min-width: 25%;
+    padding: 0.2em 0.4em;
+    border: 1px solid #888;
+    font-size: 90%;
+    background-color: #f8f8f8;
+    color: black;
+  }
 
-mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
-  stroke-width: 3;
-}
+  foreignObject[data-mjx-xml] {
+    font-family: initial;
+    line-height: normal;
+    overflow: visible;
+  }
 
-g[data-mml-node="xypic"] path {
-  stroke-width: inherit;
-}
+  mjx-container[jax="SVG"] path[data-c],
+  mjx-container[jax="SVG"] use[data-c] {
+    stroke-width: 3;
+  }
 
-.MathJax g[data-mml-node="xypic"] path {
-  stroke-width: inherit;
-}
+  g[data-mml-node="xypic"] path {
+    stroke-width: inherit;
+  }
 
-      }
+  .MathJax g[data-mml-node="xypic"] path {
+    stroke-width: inherit;
+  }
+}

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -6,8 +6,12 @@ import createDOMPurify, {
 
 import { canonicalImageSource } from "@tsmono/util";
 
+// Everything here either fetches a subresource or animates one in. feimage is
+// unreachable while USE_PROFILES omits DOMPurify's svgFilters profile; it is
+// listed so enabling that profile cannot silently open a fetch vector.
 const FORBIDDEN_TAGS = [
   "animate",
+  "animatecolor",
   "animatemotion",
   "animatetransform",
   "audio",
@@ -15,6 +19,7 @@ const FORBIDDEN_TAGS = [
   "button",
   "discard",
   "embed",
+  "feimage",
   "foreignobject",
   "form",
   "iframe",
@@ -22,6 +27,7 @@ const FORBIDDEN_TAGS = [
   "input",
   "link",
   "meta",
+  "mglyph",
   "mpath",
   "object",
   "picture",
@@ -59,10 +65,8 @@ const MATHJAX_ATTRS = [
 
 const URL_ATTRIBUTES = new Set([
   "action",
-  "background",
   "formaction",
   "href",
-  "poster",
   "src",
   "xlink:href",
 ]);
@@ -120,7 +124,11 @@ const PURIFY_CONFIG: Config = {
   ADD_TAGS: MATHJAX_TAGS,
   ALLOW_DATA_ATTR: true,
   ALLOW_UNKNOWN_PROTOCOLS: false,
-  FORBID_ATTR: ["srcdoc", "srcset"],
+  // background fetches on every table element per HTML §15.3.3, and no
+  // protocol check helps: the dangerous value is an ordinary https URL. Moving
+  // these to URL_ATTRIBUTES would un-check them, since isSafeUrlAttribute
+  // allows by default.
+  FORBID_ATTR: ["background", "poster", "srcdoc", "srcset"],
   FORBID_TAGS: FORBIDDEN_TAGS,
   USE_PROFILES: { html: true, mathMl: true, svg: true },
 };
@@ -184,8 +192,13 @@ const installHooks = (purify: DOMPurifyInstance): void => {
       return;
     }
 
-    if (hookEvent.attrName === "src" && isImgElement(node)) {
-      const canonical = safeImgSrc(hookEvent.attrValue);
+    if (hookEvent.attrName === "src") {
+      // img keeps a src only when safeImgSrc canonicalizes it to inline data;
+      // no other surviving element needs one. A protocol check would not help:
+      // the dangerous value is an ordinary https URL.
+      const canonical = isImgElement(node)
+        ? safeImgSrc(hookEvent.attrValue)
+        : undefined;
       if (canonical === undefined) {
         hookEvent.keepAttr = false;
         node.removeAttribute(hookEvent.attrName);

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -63,6 +63,17 @@ const MATHJAX_ATTRS = [
   "width",
 ];
 
+const PAINT_ATTRIBUTES = new Set([
+  "clip-path",
+  "fill",
+  "filter",
+  "marker-end",
+  "marker-mid",
+  "marker-start",
+  "mask",
+  "stroke",
+]);
+
 const URL_ATTRIBUTES = new Set([
   "action",
   "formaction",
@@ -209,6 +220,15 @@ const installHooks = (purify: DOMPurifyInstance): void => {
     }
 
     if (
+      PAINT_ATTRIBUTES.has(hookEvent.attrName) &&
+      !isSafePaintValue(hookEvent.attrValue)
+    ) {
+      hookEvent.keepAttr = false;
+      node.removeAttribute(hookEvent.attrName);
+      return;
+    }
+
+    if (
       URL_ATTRIBUTES.has(hookEvent.attrName) &&
       !isSafeUrlAttribute(hookEvent.attrValue)
     ) {
@@ -270,6 +290,11 @@ const safeImgSrc = (value: string): string | undefined => {
   }
   return canonicalImageSource(value);
 };
+
+// These are presentation attributes, not style, so sanitizeStyleAttribute never
+// sees them. MathJax only emits same-document references and plain colours.
+const isSafePaintValue = (value: string): boolean =>
+  !/url\(/i.test(value) || /^\s*url\(\s*['"]?#/.test(value);
 
 const isSafeUrlAttribute = (value: string): boolean => {
   const trimmed = value.trim();

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -29,6 +29,11 @@ const FORBIDDEN_TAGS = [
   "select",
   "set",
   "source",
+  // In DOMPurify's html profile by default, so it needs forbidding outright.
+  // MathJax's stylesheet ships as static app CSS (mathjaxStyles.css) instead:
+  // any rule for admitting a <style> from untrusted content is forgeable, and
+  // a surviving one is unscoped global CSS.
+  "style",
   "textarea",
   "track",
   "video",
@@ -40,7 +45,6 @@ const MATHJAX_TAGS = [
   "mjx-status",
   "mjx-tip",
   "mjx-tool",
-  "style",
 ];
 
 const MATHJAX_ATTRS = [
@@ -101,6 +105,9 @@ const SAFE_STYLE_PROPERTIES = new Set([
   "width",
 ]);
 
+// Only style attributes reach this, and sanitizeStyleAttribute round-trips
+// them through the CSSOM first, which normalizes escapes like `u\rl(` that a
+// raw-text check alone would miss.
 const UNSAFE_CSS_PATTERN =
   /@import|behavior\s*:|binding\s*:|expression\s*\(|javascript\s*:|vbscript\s*:|url\s*\(/i;
 
@@ -170,16 +177,6 @@ const installHooks = (purify: DOMPurifyInstance): void => {
     return;
   }
   hooksInstalled = true;
-
-  purify.addHook("uponSanitizeElement", (node, hookEvent) => {
-    if (
-      hookEvent.tagName === "style" &&
-      node instanceof Element &&
-      !isAllowedMathJaxStyleElement(node)
-    ) {
-      node.remove();
-    }
-  });
 
   purify.addHook("uponSanitizeAttribute", (node, hookEvent) => {
     if (hookEvent.attrName === "style") {
@@ -311,17 +308,4 @@ const sanitizeStyleAttribute = (style: string): string => {
   }
 
   return safeDeclarations.join(" ");
-};
-
-const isAllowedMathJaxStyleElement = (element: Element): boolean => {
-  const parent = element.parentElement;
-  const parentId = parent?.getAttribute("id") || "";
-  const css = element.textContent || "";
-
-  return (
-    parent?.tagName.toLowerCase() === "span" &&
-    /^mjx-[a-f0-9]+$/i.test(parentId) &&
-    css.includes(`#${parentId}`) &&
-    !UNSAFE_CSS_PATTERN.test(css)
-  );
 };


### PR DESCRIPTION
## Summary

(Found by Fable 5 during some other work, I can't take credit for discovering it, but I have validated it, and reviewed the fix):

PR #362 established that displaying transcript content must never trigger an automatic network request — loading a remote subresource leaks a read receipt, the viewer's IP, and timing to a host the content author chose. That invariant is currently violated. This markdown, in an ordinary transcript, beacons on display:

```
$\href{x"><span id="mjx-aa"><style>#mjx-aa{}body{background-image:
  image-set('https://evil.example/beacon.png' 1x)}</style><b z="}{z}$
```

Swap the payload for `input[value^="s"]{background-image:image-set("…")}` and it becomes a content-exfiltration channel instead of a beacon. There is no Content-Security-Policy anywhere in either app, so the sanitizer is the only control.

Three defects combine to allow it, and this PR fixes all three plus the class behind them.

## What was wrong

**The MathJax `<style>` carve-out was a shape heuristic, not a trust check.** It admitted a `<style>` element whenever the parent was a `<span>` with an `mjx-<hex>` id and the CSS mentioned that id — all attacker-supplyable, and the id check is satisfied by a comment. The only real gate was a substring denylist, which misses `image-set("URL")` (no `url(` token exists) and every CSS-escape spelling (`u\rl(`, `\75 rl(`, `@\69 mport`). A surviving `<style>` is unscoped global CSS.

**`\href` let content break out of an attribute.** MathJax's liteAdaptor doesn't escape `"` when serializing `href`, so the payload became real sibling elements. This is what made the carve-out reachable from plain markdown rather than only from `postProcess`.

**`isSafeUrlAttribute` allowed by default.** It asks "is this scheme dangerous?" when the invariant needs "can this fetch?" — so every `https://` URL was kept. That is why `<table background="https://…">` fetched on every table element (HTML §15.3.3 presentational hint, all engines), and why `<mglyph src>` and external SVG paint `url()` passed through.

## Approach

The carve-out can't be tightened into safety, because real MathJax CSS is itself global — a rule requiring it be scoped to `#mjx-<id>` would break rendering while still admitting attacker CSS. So the element is forbidden outright and MathJax's stylesheet ships as trusted app CSS (`mathjaxStyles.css`), extracted mechanically and with only its selector changed.

The URL policy flips to deny-by-default: `background` and `poster` forbidden, `src` dropped on every element, `mglyph`/`feimage`/`animatecolor` forbidden, SVG paint references restricted to `url(#fragment)`.

## Notes for reviewers

`feimage` is currently unreachable only because `USE_PROFILES` omits DOMPurify's `svgFilters` profile. It's forbidden explicitly, with a comment, so enabling that profile later can't silently open a first-class fetch vector.

Deliberately out of scope, each for a stated reason: the `SAFE_STYLE_PROPERTIES` shorthand-vs-longhand deadness (fails closed; fixing it would make currently-dropped styles start applying — a visible rendering change), `var()`/`env()` indirection (needs the `<style>` element this removes), and `injectReferenceLinks`' unescaped attribute interpolation (real, app-controlled, separate change).

## Test plan

Every vector above is a regression test driven through the real sanitizer.

CSS fetch behaviour was confirmed against **real Chrome 150** with a request-counting probe server during investigation — jsdom performs no resource loading, so no test here can observe a fetch, and every assertion is about what survives in the DOM instead. Two jsdom traps worth knowing: it retains CSS shorthands where browsers expand to longhands, and it drops `image-set(…)` outright, so tests can pass for the wrong reason.

Assertions count only `<style>` elements whose text references the attacker host — a bare `includes("<style>")` is invalid, because every math render legitimately emits one.

`\href` in math now renders a MathJax error — the one user-visible behaviour change.