### PR TITLE
Fix transcript rendering for Codex Multi-Agent V2: fork turn boundaries and Code Mode exec input

### DIFF
--- a/packages/inspect-components/src/chat/tools/ToolBlock.module.css
+++ b/packages/inspect-components/src/chat/tools/ToolBlock.module.css
@@ -22,6 +22,13 @@
   background-color: var(--inspect-tool-block-header-bg);
 }
 
+/* The zero bottom padding above assumes an input/output zone follows; a
+   header-only block (no input, no output yet) otherwise sits flush against
+   the container's bottom edge. */
+.header:last-child {
+  padding-bottom: 0.5rem;
+}
+
 .icon {
   flex: none;
   font-size: 13px;

--- a/packages/inspect-components/src/chat/tools/tool.test.ts
+++ b/packages/inspect-components/src/chat/tools/tool.test.ts
@@ -50,6 +50,24 @@ describe("resolveToolInput", () => {
     }
   });
 
+  it("renders codex Code Mode exec source as the body, typed javascript", () => {
+    // Code Mode `input` is JS source calling tools.* — often hundreds of chars
+    // with embedded string literals. It must become the input body (highlighted,
+    // expandable), not be inlined into the single-line header summary.
+    const source =
+      'const patch = "*** Begin Patch\\n*** End Patch";\ntext(await tools.apply_patch(patch));';
+    const result = resolveToolInput("exec", { input: source });
+    expect(result.input).toBe(source);
+    expect(result.contentType).toBe("javascript");
+    expect(result.functionCall).toBe("exec");
+  });
+
+  it("leaves non-Code-Mode exec tools on the default rendering", () => {
+    const result = resolveToolInput("exec", { cmd: "ls -la" });
+    expect(result.input).toBeUndefined();
+    expect(result.functionCall).toBe('exec(cmd: "ls -la")');
+  });
+
   it("leaves unknown tools without a markdown content type", () => {
     expect(resolveToolInput("some_other_tool", {}).contentType).not.toBe(
       "markdown"

--- a/packages/inspect-components/src/chat/tools/tool.ts
+++ b/packages/inspect-components/src/chat/tools/tool.ts
@@ -15,6 +15,7 @@ const kToolIcons: Record<string, string> = {
   // code
   python: "bi-code-square",
   code_execution: "bi-code-square",
+  exec: "bi-code-square",
   // web
   web_search: "bi-search",
   WebSearch: "bi-search",
@@ -259,6 +260,14 @@ const extractInputMetadata = (
     return {
       inputArg: "cmd",
       contentType: "bash",
+    };
+  } else if (toolName === "exec" && typeof toolArgs.input === "string") {
+    // Codex CLI Code Mode: `input` is JavaScript source calling `tools.*` —
+    // often hundreds of characters with embedded string literals. Keyed on the
+    // arg shape so an unrelated `exec` tool keeps the default rendering.
+    return {
+      inputArg: "input",
+      contentType: "javascript",
     };
   } else if (toolName === "spawn_agent") {
     return {

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -25,6 +25,7 @@ import { StopReasonBadge } from "./event/StopReasonBadge";
 import { formatTiming, formatTitle, isCancelError } from "./event/utils";
 import { TranscriptIcons } from "./icons";
 import styles from "./ModelEventView.module.css";
+import { recentInputMessages } from "./recentInputMessages";
 import { retryAttemptKey } from "./timeline/retryGrouping";
 import { EventNode, EventNodeContext, EventPanelCallbacks } from "./types";
 
@@ -86,40 +87,16 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
   // panel and display those user messages (exclude tool_call messages as they
   // are already shown in the tool call above)
   const userMessages = useMemo<ChatMessage[]>(() => {
-    const result: ChatMessage[] = [];
-
     // When agent tool results have been filtered from input (shown on AgentCard
     // instead), the trailing assistant message is the previous model call's output
     // — just show it without crawling backward through system/user messages.
     const agentResultsFiltered = !!(event as Record<string, unknown>)
       .agentResultsFiltered;
 
-    if (!agentResultsFiltered) {
-      // if there is an assistant message immediately before then include this
-      // (as it could be an assistant compaction message)
-      let offset: number | undefined = undefined;
-      const lastMessage = event.input.at(-1);
-      if (lastMessage?.role === "assistant") {
-        result.push(lastMessage);
-        offset = -1;
-      }
-
-      for (const msg of event.input.slice(offset).reverse()) {
-        if (
-          (msg.role === "user" && !msg.tool_call_id) ||
-          msg.role === "system" ||
-          // If the client doesn't support tool events, then tools messages are allowed to be displayed
-          // in this view, since no tool events will be shown.
-          (context?.hasToolEvents === false && msg.role === "tool")
-        ) {
-          result.unshift(msg);
-        } else {
-          break;
-        }
-      }
-    }
-
-    return result;
+    return recentInputMessages(event.input, {
+      agentResultsFiltered,
+      hasToolEvents: context?.hasToolEvents,
+    });
   }, [event, context?.hasToolEvents]);
 
   const hasHiddenMessages = event.input.length > userMessages.length;

--- a/packages/inspect-components/src/transcript/recentInputMessages.test.ts
+++ b/packages/inspect-components/src/transcript/recentInputMessages.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "@tsmono/inspect-common/types";
+
+import { recentInputMessages } from "./recentInputMessages";
+
+// Fixture shapes mirror a real codex 0.147.0 / gpt-5.6-sol eval log: a
+// Multi-Agent V2 spawn forks the parent's conversation into the child
+// (user/system messages only — the fork strips assistant turns), then appends
+// the fork-injected instructions and the agent_message task. The bridge marks
+// each agent_message-derived user message by stashing the raw item on
+// ContentText.internal.
+
+let nextId = 0;
+const msg = (role: string, text = "content"): ChatMessage =>
+  ({
+    id: `m${nextId++}`,
+    role,
+    content: text,
+  }) as unknown as ChatMessage;
+
+const handoffMsg = (text = "Agent message from /root:\ntask"): ChatMessage =>
+  ({
+    id: `m${nextId++}`,
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text,
+        internal: {
+          agent_message: {
+            type: "agent_message",
+            author: "/root",
+            recipient: "/root/write_fizzbuzz",
+          },
+        },
+      },
+    ],
+  }) as unknown as ChatMessage;
+
+const toolCallUser = (): ChatMessage =>
+  ({
+    id: `m${nextId++}`,
+    role: "user",
+    content: "output",
+    tool_call_id: "call_1",
+  }) as unknown as ChatMessage;
+
+const defaults = { agentResultsFiltered: false, hasToolEvents: undefined };
+
+// Characterization of the pre-existing walk-back (transcribed from
+// ModelEventView's userMessages memo). These pin current behavior — the
+// fork-boundary fix below must not change any of them.
+describe("recentInputMessages (existing behavior)", () => {
+  it("collects trailing user/system messages up to the last assistant/tool", () => {
+    const trailing = [msg("system"), msg("user"), msg("user")];
+    const input = [msg("system"), msg("user"), msg("assistant"), ...trailing];
+    expect(recentInputMessages(input, defaults)).toEqual(trailing);
+  });
+
+  it("shows the whole input when it is all user/system (e.g. first call)", () => {
+    const input = [msg("system"), msg("user"), msg("user")];
+    expect(recentInputMessages(input, defaults)).toEqual(input);
+  });
+
+  it("shows only the trailing assistant message when input ends with one", () => {
+    // NOTE: slice(-1) means the walk examines only the assistant message and
+    // stops — trailing-assistant events show just that message. Pinned as-is.
+    const assistant = msg("assistant");
+    const input = [msg("system"), msg("user"), assistant];
+    expect(recentInputMessages(input, defaults)).toEqual([assistant]);
+  });
+
+  it("stops at a user message that is a tool call result", () => {
+    const trailing = msg("user");
+    const input = [msg("user"), toolCallUser(), trailing];
+    expect(recentInputMessages(input, defaults)).toEqual([trailing]);
+  });
+
+  it("includes tool messages when the client has no tool events", () => {
+    const tool = msg("tool");
+    const user = msg("user");
+    const input = [msg("assistant"), tool, user];
+    expect(
+      recentInputMessages(input, { ...defaults, hasToolEvents: false })
+    ).toEqual([tool, user]);
+  });
+
+  it("hides tool messages when the client renders tool events", () => {
+    const user = msg("user");
+    const input = [msg("assistant"), msg("tool"), user];
+    expect(
+      recentInputMessages(input, { ...defaults, hasToolEvents: true })
+    ).toEqual([user]);
+  });
+
+  it("returns nothing when agent results were filtered", () => {
+    const input = [msg("user"), msg("assistant")];
+    expect(
+      recentInputMessages(input, { ...defaults, agentResultsFiltered: true })
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(recentInputMessages([], defaults)).toEqual([]);
+  });
+});
+
+// Multi-Agent V2 fork boundary: a forked child's first call contains the
+// parent's entire context as user/system messages (no assistant/tool message
+// to stop at), so the walk-back degenerates to "everything is recent". The
+// agent_message-derived user message is the real turn boundary.
+describe("recentInputMessages (Multi-Agent V2 fork boundary)", () => {
+  it("starts at the agent_message when the walk would consume the whole input", () => {
+    const handoff = handoffMsg();
+    const input = [
+      msg("system"),
+      msg("user", "parent task"),
+      msg("user", "parent context"),
+      msg("system", "fork-injected instructions"),
+      msg("system", "fork-injected instructions"),
+      handoff,
+    ];
+    expect(recentInputMessages(input, defaults)).toEqual([handoff]);
+  });
+
+  it("starts at the last agent_message when several are present", () => {
+    const latest = handoffMsg("Agent message from /root:\nfollowup");
+    const input = [
+      msg("system"),
+      handoffMsg("Agent message from /root:\nspawn task"),
+      msg("system"),
+      latest,
+    ];
+    expect(recentInputMessages(input, defaults)).toEqual([latest]);
+  });
+
+  it("keeps messages after the last agent_message", () => {
+    const handoff = handoffMsg();
+    const followup = msg("user", "notification");
+    const input = [msg("system"), msg("user"), handoff, followup];
+    expect(recentInputMessages(input, defaults)).toEqual([handoff, followup]);
+  });
+
+  it("does not trim when an assistant message bounded the walk", () => {
+    // parent-style input: the walk already stops at the assistant message, so
+    // the panel is unchanged even though an agent_message is present
+    const handoff = handoffMsg("Agent message from /root/write_primes:\ndone");
+    const notification = msg("user", "wait result");
+    const input = [msg("system"), msg("assistant"), handoff, notification];
+    expect(recentInputMessages(input, defaults)).toEqual([
+      handoff,
+      notification,
+    ]);
+  });
+
+  it("does not trim all-user/system input without agent_messages (V1 forks)", () => {
+    const input = [msg("system"), msg("user"), msg("user"), msg("user")];
+    expect(recentInputMessages(input, defaults)).toEqual(input);
+  });
+
+  it("ignores agent_message payloads on non-user messages", () => {
+    const sys = {
+      id: `m${nextId++}`,
+      role: "system",
+      content: [{ type: "text", text: "x", internal: { agent_message: {} } }],
+    } as unknown as ChatMessage;
+    const input = [msg("system"), sys, msg("user")];
+    expect(recentInputMessages(input, defaults)).toEqual(input);
+  });
+});

--- a/packages/inspect-components/src/transcript/recentInputMessages.ts
+++ b/packages/inspect-components/src/transcript/recentInputMessages.ts
@@ -1,0 +1,81 @@
+import type { ChatMessage } from "@tsmono/inspect-common/types";
+
+export interface RecentInputMessagesOptions {
+  /** Agent tool results were filtered from input (shown on AgentCard instead). */
+  agentResultsFiltered: boolean;
+  /** Whether the client renders tool events (tool messages hide here if so). */
+  hasToolEvents: boolean | undefined;
+}
+
+/**
+ * The user/system messages which immediately preceded a model call — the
+ * "recent messages" panel of ModelEventView. Walks backward from the end of
+ * the input, collecting trailing user/system messages (and tool messages when
+ * the client renders no tool events), stopping at the first assistant/tool
+ * message. Everything earlier is hidden behind "show all messages".
+ */
+export function recentInputMessages(
+  input: ChatMessage[],
+  options: RecentInputMessagesOptions
+): ChatMessage[] {
+  const result: ChatMessage[] = [];
+
+  if (!options.agentResultsFiltered) {
+    // if there is an assistant message immediately before then include this
+    // (as it could be an assistant compaction message)
+    let offset: number | undefined = undefined;
+    const lastMessage = input.at(-1);
+    if (lastMessage?.role === "assistant") {
+      result.push(lastMessage);
+      offset = -1;
+    }
+
+    for (const msg of input.slice(offset).reverse()) {
+      if (
+        (msg.role === "user" && !msg.tool_call_id) ||
+        msg.role === "system" ||
+        // If the client doesn't support tool events, then tools messages are allowed to be displayed
+        // in this view, since no tool events will be shown.
+        (options.hasToolEvents === false && msg.role === "tool")
+      ) {
+        result.unshift(msg);
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Multi-Agent V2 forks copy the parent's context into the child as
+  // user/system messages only, so the walk above finds no assistant/tool
+  // message to stop at and classifies the entire forked history as recent.
+  // Only in that degenerate case (whole input consumed), fall back to the
+  // real turn boundary: the last inter-agent handoff message.
+  if (result.length === input.length && result.length > 0) {
+    const lastHandoff = result.findLastIndex(isAgentHandoffMessage);
+    if (lastHandoff > 0) {
+      return result.slice(lastHandoff);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * A user message the agent bridge synthesized from a Codex Multi-Agent V2
+ * `agent_message` item (inter-agent handoff). The bridge preserves the raw
+ * item on ContentText.internal for native replay; its presence marks the
+ * message as the start of the receiving agent's turn.
+ */
+export function isAgentHandoffMessage(message: ChatMessage): boolean {
+  if (message.role !== "user" || typeof message.content === "string") {
+    return false;
+  }
+  return message.content.some(
+    (content) =>
+      content.type === "text" &&
+      typeof content.internal === "object" &&
+      content.internal !== null &&
+      !Array.isArray(content.internal) &&
+      "agent_message" in content.internal
+  );
+}


### PR DESCRIPTION
Two transcript-rendering fixes for Codex Multi-Agent V2 evals, found while verifying the `agent_message` bridge fix (UKGovernmentBEIS/inspect_ai#4787) end to end.

## 1. Forked model events showed the parent's entire context as "recent messages"

A V2 spawn forks the parent's conversation into the child as user/system messages only (assistant turns are stripped), so the recent-messages walk-back in `ModelEventView` found no assistant/tool message to stop at and classified the entire forked history as the new turn.

The walk-back is extracted into a pure `recentInputMessages()` helper. Only in the degenerate case (the walk consumed the whole input) does it fall back to the real turn boundary: the last `agent_message`-derived user message, identified by the raw item the agent bridge preserves on `ContentText.internal` (inspect_ai >= 0.3.253 / #4787). Inputs bounded by an assistant/tool message and forks without handoff messages render exactly as before.

**Regression protection:** 8 characterization tests pin the pre-existing behavior verbatim (including the `slice(-1)` trailing-assistant quirk, preserved as-is), and 3 guard tests prove the trim does not fire for parent-style inputs, V1 forks, or handoff payloads on non-user messages.

## 2. Code Mode `exec` calls truncated in the header with no body

Codex Code Mode's `exec` tool had no input descriptor, so its entire JavaScript source was inlined into the tool block's single-line (ellipsized) header summary, and the block rendered header-only — flush against its bottom edge, since the header's zero bottom padding assumes an input/output zone follows.

- `exec` with a string `input` arg now gets the bash/python treatment: the source renders as the input body, highlighted as javascript, expandable at 20 lines. Keyed on the arg shape so unrelated `exec` tools keep the default rendering. Adds the code icon.
- `.header:last-child` gains bottom padding, fixing every header-only block without touching blocks that have zones.

## Verification

- 926 package tests pass (13 + 2 new); typecheck, eslint, prettier clean.
- Verified against a real gpt-5.6-sol multi-agent eval log (codex 0.147.0): the child's first model event shows just its handoff task, and `exec` calls render as proper code blocks.

Merge note: needs the coordinated inspect_ai submodule pointer + dist bump after merge (per docs/submodule-guide.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
