### PR TITLE
fix(deps): bump dompurify to ^3.4.13 and js-yaml to ^4.3.1 (dependabot alerts 70, 71)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "react-popper>react": "^19.2.0",
       "react-popper>react-dom": "^19.1.1",
       "glob": "^10.5.0",
-      "js-yaml": "^4.3.0",
+      "js-yaml": "^4.3.1",
       "@codemirror/state": "^6.5.4",
       "lodash": ">=4.17.23",
       "seroval": ">=1.4.1",
@@ -49,7 +49,7 @@
       "esbuild": "^0.28.1",
       "@babel/core": "^7.29.6",
       "undici": "^7.28.0",
-      "dompurify": "^3.4.11"
+      "dompurify": "^3.4.13"
     }
   },
   "manypkg": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,7 @@
     "ansi-output": "^0.0.9",
     "asciinema-player": "^3.17.0",
     "clsx": "^2.1.1",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "lodash-es": "^4.18.1",
     "markdown-it": "^14.3.0",
     "markdown-it-mathjax3": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   react-popper>react: ^19.2.0
   react-popper>react-dom: ^19.1.1
   glob: ^10.5.0
-  js-yaml: ^4.3.0
+  js-yaml: ^4.3.1
   '@codemirror/state': ^6.5.4
   lodash: '>=4.17.23'
   seroval: '>=1.4.1'
@@ -25,7 +25,7 @@ overrides:
   esbuild: ^0.28.1
   '@babel/core': ^7.29.6
   undici: ^7.28.0
-  dompurify: ^3.4.11
+  dompurify: ^3.4.13
 
 importers:
 
@@ -615,8 +615,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.12
+        specifier: ^3.4.13
+        version: 3.4.13
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -3396,8 +3396,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -4023,8 +4023,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.0:
@@ -5959,7 +5959,7 @@ snapshots:
   '@manypkg/tools@2.1.1':
     dependencies:
       jju: 1.4.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       tinyglobby: 0.2.17
 
   '@marijn/find-cluster-break@1.0.3': {}
@@ -6285,7 +6285,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -7629,7 +7629,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8378,7 +8378,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Clears both currently open dependabot security alerts by raising the existing `pnpm.overrides` pins in the root `package.json`:

- [dependabot alert 70](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/70) — **js-yaml** (high, GHSA-5p4m-2wfm-xmqj): quadratic CPU consumption in `!!omap` resolution. Override raised `^4.3.0` → `^4.3.1`.
- [dependabot alert 71](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/71) — **dompurify** (medium, GHSA-55q2-fjhq-7xh7): `IN_PLACE` hook removal leaves a detached subtree executable (XSS). Override raised `^3.4.11` → `^3.4.13`, and the direct dependency in `@tsmono/react` bumped `^3.4.12` → `^3.4.13`. dompurify is already listed in `minimumReleaseAgeExclude`, so the 5-day-old patch installs despite the 7-day soak window; no config change needed.

No alerts deferred. Verified with `pnpm install`, lockfile inspection (only 3.4.13 / 4.3.1 resolve), `pnpm audit` (neither advisory reported anymore), and `pnpm check && pnpm build && pnpm test` (all green, 1129 tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)