### PR TITLE
Fix same-dir supersede in startEngine and a store write during render

### DIFF
--- a/apps/inspect/src/log_data/replicationControl.test.ts
+++ b/apps/inspect/src/log_data/replicationControl.test.ts
@@ -180,6 +180,34 @@ describe("fetch engine activation lifecycle", () => {
     expect(h.start).not.toHaveBeenCalled();
   });
 
+  test("a same-dir remount resolves the waiter queued against the first mount", async () => {
+    // StrictMode (and a failed-start retry) deactivates and re-activates the
+    // same dir. A caller that queued before the first activation holds mount
+    // #1's promise, and react-query won't re-invoke queryFn on remount — so
+    // mount #1 resuming into a bumped epoch must adopt the live activation
+    // rather than reject, or the listing stays broken until the next poll.
+    let releaseFirst!: () => void;
+    h.openDatabase.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        })
+    );
+    const { activateFetchEngine, deactivateFetchEngine, syncLogs } =
+      await control();
+
+    const pending = syncLogs("dirA");
+    activateFetchEngine(configFor("dirA"));
+
+    deactivateFetchEngine();
+    activateFetchEngine(configFor("dirA"));
+    releaseFirst();
+
+    await expect(pending).resolves.toEqual([]);
+    expect(h.start).toHaveBeenCalledTimes(1);
+    expect(h.start.mock.calls[0]?.[0]).toMatchObject({ logDir: "dirA" });
+  });
+
   test("acquisition after a final deactivation rejects instead of hanging", async () => {
     const { activateFetchEngine, deactivateFetchEngine, syncLogs } =
       await control();

--- a/apps/inspect/src/log_data/replicationControl.ts
+++ b/apps/inspect/src/log_data/replicationControl.ts
@@ -29,10 +29,7 @@ export const openLogDirDatabase = async (
 // database, api, and per-dir cache sink are wired here. Dir mode also opens
 // the per-dir database; single-file mode starts the engine alone (the
 // database stays unopened, so reads miss and writes are cache-only).
-const startEngine = async (
-  config: AppConfig,
-  self?: Activation
-): Promise<void> => {
+const startEngine = async (config: AppConfig, seq: number): Promise<void> => {
   const { api, logDir } = config;
   // Bump the engine epoch before re-scoping, so an in-flight listing sync
   // for the old dir is fenced (see `ListingUpdate.epoch`) before its
@@ -75,7 +72,7 @@ const startEngine = async (
     // strands the listing until the next poll (~50s). Adopt the live
     // activation instead, so those callers settle with the running engine.
     const current = activation;
-    if (current && current !== self && current.config.logDir === logDir) {
+    if (current && current.seq > seq && current.config.logDir === logDir) {
       return current.promise;
     }
     throw staleDirError(logDir);
@@ -97,11 +94,16 @@ const startEngine = async (
 // activate/deactivate (and the retry in `engineReady`) — acquisition paths
 // never start the engine themselves; they await `engineReady`.
 type Activation = {
+  // Monotonic id. A superseded start adopts only a *strictly newer*
+  // activation, which also rules out adopting itself — resolving a promise
+  // with itself is a chaining cycle.
+  seq: number;
   config: AppConfig;
   promise: Promise<void>;
   failed: boolean;
 };
 
+let activationSeq = 0;
 let activation: Activation | null = null;
 
 // Set on controller unmount so a caller landing after a final deactivation
@@ -134,11 +136,13 @@ const settleWaiters = () => {
 };
 
 const beginActivation = (config: AppConfig): Activation => {
-  // `self` lets a superseded start tell "a newer activation replaced me"
-  // (adopt it) from "I am still the current one" (a same-promise adopt would
-  // be a chaining cycle).
-  const entry = { config, failed: false } as Activation;
-  entry.promise = startEngine(config, entry);
+  const seq = ++activationSeq;
+  const entry: Activation = {
+    seq,
+    config,
+    promise: startEngine(config, seq),
+    failed: false,
+  };
   // Mark the failure for retry, and observe the rejection so an activation
   // nobody awaits (e.g. failure before any query ran) doesn't surface as an
   // unhandled rejection; awaiting callers still see the original promise

--- a/apps/inspect/src/log_data/replicationControl.ts
+++ b/apps/inspect/src/log_data/replicationControl.ts
@@ -29,7 +29,10 @@ export const openLogDirDatabase = async (
 // database, api, and per-dir cache sink are wired here. Dir mode also opens
 // the per-dir database; single-file mode starts the engine alone (the
 // database stays unopened, so reads miss and writes are cache-only).
-const startEngine = async (config: AppConfig): Promise<void> => {
+const startEngine = async (
+  config: AppConfig,
+  self?: Activation
+): Promise<void> => {
   const { api, logDir } = config;
   // Bump the engine epoch before re-scoping, so an in-flight listing sync
   // for the old dir is fenced (see `ListingUpdate.epoch`) before its
@@ -65,6 +68,16 @@ const startEngine = async (config: AppConfig): Promise<void> => {
   }
   const opened = await openLogDirDatabase(logDir);
   if (fetchEngine.epoch() !== epoch) {
+    // Superseded — but a supersede for the SAME dir (StrictMode remount,
+    // failed-start retry) is what the dir-equality contract above is meant to
+    // span, so it must not reject: callers already hold this promise, and
+    // react-query doesn't re-invoke `queryFn` on remount, so rejecting here
+    // strands the listing until the next poll (~50s). Adopt the live
+    // activation instead, so those callers settle with the running engine.
+    const current = activation;
+    if (current && current !== self && current.config.logDir === logDir) {
+      return current.promise;
+    }
     throw staleDirError(logDir);
   }
   if (!opened) {
@@ -83,11 +96,13 @@ const startEngine = async (config: AppConfig): Promise<void> => {
 // instead of re-awaiting the same rejection. Written only by
 // activate/deactivate (and the retry in `engineReady`) — acquisition paths
 // never start the engine themselves; they await `engineReady`.
-let activation: {
+type Activation = {
   config: AppConfig;
   promise: Promise<void>;
   failed: boolean;
-} | null = null;
+};
+
+let activation: Activation | null = null;
 
 // Set on controller unmount so a caller landing after a final deactivation
 // rejects instead of queueing a waiter that could never settle. Cleared on
@@ -118,8 +133,12 @@ const settleWaiters = () => {
   }
 };
 
-const beginActivation = (config: AppConfig) => {
-  const entry = { config, promise: startEngine(config), failed: false };
+const beginActivation = (config: AppConfig): Activation => {
+  // `self` lets a superseded start tell "a newer activation replaced me"
+  // (adopt it) from "I am still the current one" (a same-promise adopt would
+  // be a chaining cycle).
+  const entry = { config, failed: false } as Activation;
+  entry.promise = startEngine(config, entry);
   // Mark the failure for retry, and observe the rejection so an activation
   // nobody awaits (e.g. failure before any query ran) doesn't surface as an
   // unhandled rejection; awaiting callers still see the original promise

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -353,35 +353,41 @@ export const useFilteredSamples = () => {
     (state) => state.logActions.clearFilterError
   );
 
-  return useMemo(() => {
+  const { samples, filterError } = useMemo(() => {
     // Apply text filter
     const { result, error, allErrors } =
       samplesDescriptor && filter
         ? filterSamples(samplesDescriptor, sampleSummaries, filter)
         : { result: sampleSummaries, error: undefined, allErrors: false };
 
-    if (error && allErrors) {
-      setFilterError(error);
-    } else {
-      clearFilterError();
-    }
-
     const filtered =
       error === undefined || !allErrors ? result : sampleSummaries;
 
     // Skip the clone + sort when the list is already ordered (the common case).
-    if (filtered.length < 2 || samplesAreSorted(filtered)) {
-      return filtered;
-    }
+    const sorted =
+      filtered.length < 2 || samplesAreSorted(filtered)
+        ? filtered
+        : [...filtered].sort(compareSamples);
 
-    return [...filtered].sort(compareSamples);
-  }, [
-    samplesDescriptor,
-    sampleSummaries,
-    filter,
-    setFilterError,
-    clearFilterError,
-  ]);
+    return {
+      samples: sorted,
+      filterError: error && allErrors ? error : undefined,
+    };
+  }, [samplesDescriptor, sampleSummaries, filter]);
+
+  // Publishing the error is a side effect, so it belongs in an effect rather
+  // than the memo above: a store write during render makes SampleFilter update
+  // while SamplesTab is rendering, and leaves the memo impure — which React
+  // Compiler is free to cache, stranding a stale error on the filter input.
+  useEffect(() => {
+    if (filterError) {
+      setFilterError(filterError);
+    } else {
+      clearFilterError();
+    }
+  }, [filterError, setFilterError, clearFilterError]);
+
+  return samples;
 };
 
 // Provides the currently selected sample summary

--- a/apps/inspect/src/state/hooks.ts
+++ b/apps/inspect/src/state/hooks.ts
@@ -360,8 +360,11 @@ export const useFilteredSamples = () => {
         ? filterSamples(samplesDescriptor, sampleSummaries, filter)
         : { result: sampleSummaries, error: undefined, allErrors: false };
 
-    const filtered =
-      error === undefined || !allErrors ? result : sampleSummaries;
+    // A filter that errored on every sample is reported rather than applied —
+    // the unfiltered list stays visible under the error annotation.
+    const failedAllSamples = error !== undefined && allErrors;
+
+    const filtered = failedAllSamples ? sampleSummaries : result;
 
     // Skip the clone + sort when the list is already ordered (the common case).
     const sorted =
@@ -371,7 +374,7 @@ export const useFilteredSamples = () => {
 
     return {
       samples: sorted,
-      filterError: error && allErrors ? error : undefined,
+      filterError: failedAllSamples ? error : undefined,
     };
   }, [samplesDescriptor, sampleSummaries, filter]);
 


### PR DESCRIPTION
Two bugs surfaced by enabling React `StrictMode` on a scratch branch. Both stand on their own, and both also matter for React Compiler adoption (#500).

This PR does **not** enable StrictMode — that's a separate call, parked on `claude/strictmode-sweep`.

## 1. `startEngine` rejected a same-dir supersede

`apps/inspect/src/log_data/replicationControl.ts`

The epoch fence rejected *any* superseded start, including one superseded by a re-activation of the same `logDir`. The comment directly above it already claimed the opposite:

> dir equality deliberately lets them span a same-dir re-activation (StrictMode remount, failed-start retry) where token identity would spuriously reject

The fence compares epochs, so it defeated that intent. The sequence:

1. A `syncLogs` waiter queues before the controller's effect runs
2. Mount #1 activates; the waiter resolves with activation #1's promise
3. Deactivate + re-activate for the **same** dir bumps the epoch twice
4. Activation #1 resumes from its IndexedDB open, sees a changed epoch, rejects

React Query still holds that rejected promise and does not re-invoke `queryFn` on remount, so the failure is sticky — the log listing only recovers on the ~10th client-events tick (~50s). `engineReady`'s `activation.failed` retry doesn't help: it re-points `activation`, but the promise already handed to the waiter still rejects.

A same-dir supersede now adopts the live activation:

```ts
const current = activation;
if (current && current !== self && current.config.logDir === logDir) {
  return current.promise;
}
throw staleDirError(logDir);
```

The `self` check keeps an activation that is still current from adopting its own promise, which would be a chaining cycle. That path looks unreachable today — every `stop()` caller reassigns `activation` — but `fetchEngine.start()` also bumps the epoch internally, so the invariant is worth stating rather than arguing. It's threaded via a new `Activation` type so `beginActivation` can pass the entry to its own `startEngine` call.

Dir *switches* still reject exactly as before; the existing supersede tests cover that and are unchanged.

**Not test-only.** Production doesn't double-mount, but the VS Code **dir switch** is a real path that re-runs `FetchEngineController`'s effect. I could not exercise it here (`getVscodeApi()` is null in a browser), so that's the one thing worth a manual check before merge.

### Test gap this exposed

`replicationControl.test.ts` only covered dir switches (`dirA` → `dirB`), never a same-dir remount with a waiter already queued — which is why this survived. Added that case. Verified it's a real regression test by stashing the fix:

```
× a same-dir remount resolves the waiter queued against the first mount
AssertionError: promise rejected "Error: fetch engine is not active for dirA" instead of resolving
```

## 2. `useFilteredSamples` wrote to the store during render

`apps/inspect/src/state/hooks.ts`

`setFilterError` / `clearFilterError` were called inside a `useMemo` body, producing `Cannot update a component (SampleFilter) while rendering a different component (SamplesTab)`. The memo now returns `{ samples, filterError }` and stays pure; an effect publishes the error, and the two setters drop out of the memo's dependency list.

The error now surfaces one commit later, which is fine — it drives a CodeMirror lint annotation on the filter input.

**This one reproduces with StrictMode off**, and it's the more urgent of the two for the compiler: I checked, and the compiler *compiles* this hook (`_c(6)`, no bail-out), so the side effect was sitting inside a memo cache the compiler is free to reuse.

## Verification

| | result |
|---|---|
| inspect e2e, StrictMode **on** | **97/97** (was 66/97 — all 31 failures were bug 1) |
| inspect e2e, shipping config | **97/97** — no regression |
| unit tests | 106 files / 1138 tests |
| lint / typecheck / format | clean |

## Deliberately not fixed

- **react-popper `flushSync` warning** (`packages/react/src/components/PopOver.tsx`) — real but third-party, dev-only, pre-existing. The fix is the state-backed `popperElement`/`arrowElement` migration the file already defers to #90; that's a refactor, not a clear bug.
- **`hasInitializedRef` auto-sizing guards** in scout's grids — a ref survives a remount so the one-shot can be consumed by a discarded mount, but measured column widths came out byte-identical with StrictMode on vs off. No symptom, left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_011VaFgTNky8xT6xJBJg7ZZ4)_