### PR TITLE
fix(deps): bump nanoid to ^3.3.17 (dependabot alert 72)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
       "esbuild": "^0.28.1",
       "@babel/core": "^7.29.6",
       "undici": "^7.28.0",
-      "dompurify": "^3.4.13"
+      "dompurify": "^3.4.13",
+      "nanoid@3": "^3.3.17"
     }
   },
   "manypkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   '@babel/core': ^7.29.6
   undici: ^7.28.0
   dompurify: ^3.4.13
+  nanoid@3: ^3.3.17
 
 importers:
 
@@ -4332,8 +4333,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8695,7 +8696,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8958,7 +8959,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Clears the currently fixable dependabot security alert via a pnpm override in the root package.json.

## Fixed

- [Dependabot alert 72](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/72) — **nanoid** (high, GHSA-2v37-7h3g-55p8): custom generators can loop indefinitely when size is zero. Added a version-scoped override `"nanoid@3": "^3.3.17"` (only the 3.x line resolves in the tree, via postcss; the advisory's 4.x–5.x range doesn't apply here). Lockfile now resolves nanoid 3.3.17.

## Deferred (unfixable — no patched version exists)

- [Dependabot alert 74](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/74) — **image-size** (high, GHSA-w3rx-r6r6-pgpr): ICNS parser infinite-loop DoS. Vulnerable range is `<= 2.0.2` with no first patched version published yet.
- [Dependabot alert 73](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/73) — **image-size** (high, GHSA-5p2g-fcmc-qvqq): JXL/HEIF parser infinite-loop DoS. Same situation — no patched version exists. image-size enters the tree as a dev-only transitive dep (`vite > less > image-size@0.5.5`); both alerts should fix cleanly on a later run once a patched release ships.

## Verification

- `pnpm audit` no longer reports the nanoid advisory (only the two unfixable image-size ones remain)
- `pnpm check` — 27 tasks passed
- `pnpm build` — passed
- `pnpm test` — 106 files, 1137 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
