### PR TITLE
fix: reconcile changed static log listings

### DIFF
--- a/apps/inspect/src/log_data/fetchEngine.ts
+++ b/apps/inspect/src/log_data/fetchEngine.ts
@@ -127,11 +127,11 @@ export interface FetchEngineStatus {
 
 /**
  * A replication discovery result. `listing` is the server's listing (a delta
- * or the full list — `persistListing` upserts it into the database and
- * re-reads the full list; otherwise it's activated cache-only, for static
- * listings that carry no mtimes to sync by). `invalidated` names files whose
- * cached content is stale (new/changed); `deleted` names files that no longer
- * exist.
+ * or the full list). `persistListing` upserts it into the database and re-reads
+ * the full list; otherwise it is activated cache-only. Static listings use the
+ * cache-only path when unchanged and persist when manifest membership changes.
+ * `invalidated` names files whose cached content is stale (new/changed);
+ * `deleted` names files that no longer exist.
  */
 export interface ListingUpdate {
   listing: LogHandle[];

--- a/apps/inspect/src/log_data/listingSync.test.ts
+++ b/apps/inspect/src/log_data/listingSync.test.ts
@@ -90,7 +90,7 @@ describe("syncListing", () => {
     expect(applied[0]?.invalidated).toEqual([]);
   });
 
-  it("static local list (no mtimes): a changed server list invalidates everything, cache-only", async () => {
+  it("static local list (no mtimes): a changed server list deletes ghosts and persists", async () => {
     const local = [handle("a.eval"), handle("b.eval")];
     const server = [handle("a.eval"), handle("c.eval")];
     const { target, applied } = targetWith(local);
@@ -103,9 +103,9 @@ describe("syncListing", () => {
     expect(applied).toEqual([
       {
         listing: server,
-        invalidated: ["a.eval", "b.eval"],
-        deleted: [],
-        persistListing: false,
+        invalidated: ["a.eval", "c.eval"],
+        deleted: ["b.eval"],
+        persistListing: true,
         epoch: 7,
       },
     ]);

--- a/apps/inspect/src/log_data/listingSync.ts
+++ b/apps/inspect/src/log_data/listingSync.ts
@@ -38,12 +38,18 @@ export const syncListing = async (
       serverLogs.files.some((file) => !localNames.has(file.name));
 
     if (changed) {
-      // Invalidate everything and activate the new list.
+      const serverNames = new Set(serverLogs.files.map((file) => file.name));
+      const deleted = localFiles
+        .filter((file) => !serverNames.has(file.name))
+        .map((file) => file.name);
+
+      // Static manifests have no mtimes, so changed surviving rows must be
+      // treated as changed and absent rows must be cleared from persisted state.
       return engine.applyListing({
         listing: serverLogs.files,
-        invalidated: localFiles.map((file) => file.name),
-        deleted: [],
-        persistListing: false,
+        invalidated: serverLogs.files.map((file) => file.name),
+        deleted,
+        persistListing: true,
         epoch,
       });
     }

--- a/apps/inspect/src/log_data/listingSync.ts
+++ b/apps/inspect/src/log_data/listingSync.ts
@@ -43,8 +43,8 @@ export const syncListing = async (
         .filter((file) => !serverNames.has(file.name))
         .map((file) => file.name);
 
-      // Static manifests have no mtimes, so changed surviving rows must be
-      // treated as changed and absent rows must be cleared from persisted state.
+      // Static manifests have no mtimes, so surviving rows must be treated as
+      // changed and absent rows must be cleared from persisted state.
       return engine.applyListing({
         listing: serverLogs.files,
         invalidated: serverLogs.files.map((file) => file.name),


### PR DESCRIPTION
## Summary

Static Inspect viewer deployments can keep removed log files in IndexedDB after a redeploy. The static listing path had no mtimes, so any changed server manifest invalidated the old local names cache-only, left `deleted` empty, and did not persist the replacement listing.

This changes changed static listings to:
- classify local names missing from the server manifest as deleted
- invalidate every file in the current server manifest, since static listings have no mtimes
- persist the replacement listing through the normal listing write path

Refs UKGovernmentBEIS/inspect_ai#4763.

Inspect AI follow-up: UKGovernmentBEIS/inspect_ai#4814 was closed in favor of a later Inspect AI-side submodule/dist bump after this source change lands.

## Validation

- `pnpm install --frozen-lockfile`
  - Passed after refreshing dependencies from the current lockfile.
- `pnpm --filter @meridianlabs/log-viewer test -- apps/inspect/src/log_data/listingSync.test.ts`
  - Passed: 106 files, 1,139 tests. The updated regression covers `a,b` cached locally and `a,c` on the server, expecting `b` to be deleted, `a,c` invalidated, and the new listing persisted.
- `pnpm --filter @meridianlabs/log-viewer typecheck`
  - Passed.
- `pnpm --filter @meridianlabs/log-viewer lint`
  - Passed.
- `pnpm --filter @meridianlabs/log-viewer format:check`
  - Passed.
- `pnpm --filter @meridianlabs/log-viewer build`
  - Passed.
