### PR TITLE
Enable React StrictMode in both app entry points

### DIFF
--- a/apps/inspect/src/main.tsx
+++ b/apps/inspect/src/main.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { getVscodeApi } from "@tsmono/util";
@@ -56,7 +57,11 @@ if (!container) {
 
 // Render into the root
 const root = createRoot(container);
-root.render(<App />);
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
 
 function restoreHash() {
   // Check if we need to restore a route

--- a/apps/scout/src/main.tsx
+++ b/apps/scout/src/main.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { defaultRetry } from "@tsmono/react";
@@ -68,12 +69,14 @@ const scansMode =
 
 // Render the app
 root.render(
-  <QueryClientProvider client={queryClient}>
-    <ApiProvider value={api}>
-      <StoreProvider value={store}>
-        <App mode={scansMode ? "scans" : "workbench"} />
-      </StoreProvider>
-    </ApiProvider>
-    <ReactQueryDevtools initialIsOpen={false} />
-  </QueryClientProvider>
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ApiProvider value={api}>
+        <StoreProvider value={store}>
+          <App mode={scansMode ? "scans" : "workbench"} />
+        </StoreProvider>
+      </ApiProvider>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  </StrictMode>
 );


### PR DESCRIPTION
Wraps both roots in `<StrictMode>`. Double render / double effect mount surfaces the Rules-of-React violations React Compiler's memoization assumes cannot happen (#500).

Dev-only — both apps ship production React (verified: the built bundles contain `react-dom.production.js`, despite the `mode: "development"` in inspect's build config), so this changes nothing for users.

## Tested

Against merged main (`47c08d1`), with StrictMode on:

- inspect e2e **97/97**, scout e2e **65/65**
- exploratory driving of grids, CodeMirror, popovers, virtualized lists, tab/deep-link navigation: no duplicate listeners, no duplicate network requests, no `Maximum update depth exceeded`
- the one bug this found was fixed in #508

## Worth verifying before merge

None of these are known-broken — they're surfaces the e2e suites can't reach, so there's no evidence either way:

- **VS Code embedded mode** — `getVscodeApi()` is null in a browser, so it's entirely untested. Note the config-change **dir switch** is the production path analogous to the bug #508 fixed, so it's the one I'd click through by hand.
- **Asciinema player** — never driven (fixtures don't synthesize a log with recording URLs). Reads as safe: it disposes in cleanup.
- **Real backend** — no server on :7575/:7576, so streaming, SSE and byte-range `.eval` reads are unexercised.

## Known, not blocking

- react-popper's `flushSync was called from inside a lifecycle method` warning fires ~2× more often. Dev console noise, pre-existing, needs the popper-ref migration in #90.
- ~10 `useRef(false)` one-shot guards are unclassified (a ref survives a remount). Two measured benign, one correct by intent. Happy to triage the rest if preferred before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_011VaFgTNky8xT6xJBJg7ZZ4)_