### PR TITLE
Give the Claude dev agent pnpm access and a provisioned environment

### DIFF
--- a/.github/actions/claude-setup/action.yml
+++ b/.github/actions/claude-setup/action.yml
@@ -1,0 +1,17 @@
+name: claude-setup
+description: Provision pnpm + deps for the Claude dev agent
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22
+        cache: pnpm
+    - uses: actions/cache@v6
+      with:
+        path: .turbo
+        key: turbo-${{ github.sha }}
+        restore-keys: turbo-
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/claude-settings.json
+++ b/.github/claude-settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Bash(pnpm:*)",
+      "Bash(npx turbo:*)",
+      "Bash(gh:*)",
+      "Bash(git fetch:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git branch:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git remote:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git config:*)"
+    ]
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -107,6 +107,21 @@ jobs:
       id-token: write
       actions: read
     with:
+      # The reusable workflow's default allowlist is Python-oriented (pytest,
+      # ruff, uv, ...) — useless here and it auto-denies every pnpm command in
+      # headless runs. A caller-supplied settings REPLACES the default
+      # entirely, so the git/gh/file-edit entries must be repeated alongside
+      # the pnpm/turbo swap-ins. Keep in sync with the claude-auto job below.
+      settings: >-
+        {"permissions":{"allow":["Read","Edit","Write",
+        "Bash(pnpm:*)","Bash(npx turbo:*)",
+        "Bash(gh:*)",
+        "Bash(git fetch:*)","Bash(git merge:*)","Bash(git rebase:*)",
+        "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
+        "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
+        "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
+        "Bash(git remote:*)",
+        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
       # trigger_phrase is single-valued, so resolve it from the SAME source the
       # action will check for this event (comment > review > issue), not from a
       # union of all sources — otherwise a stale @claude in an enclosing issue
@@ -167,5 +182,16 @@ jobs:
       id-token: write
       actions: read
     with:
+      # Same allowlist override as the claude job above — keep them in sync.
+      settings: >-
+        {"permissions":{"allow":["Read","Edit","Write",
+        "Bash(pnpm:*)","Bash(npx turbo:*)",
+        "Bash(gh:*)",
+        "Bash(git fetch:*)","Bash(git merge:*)","Bash(git rebase:*)",
+        "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
+        "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
+        "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
+        "Bash(git remote:*)",
+        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
       trigger_phrase: "@auto"
       label_trigger: "auto"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,19 +109,12 @@ jobs:
     with:
       # The reusable workflow's default allowlist is Python-oriented (pytest,
       # ruff, uv, ...) — useless here and it auto-denies every pnpm command in
-      # headless runs. A caller-supplied settings REPLACES the default
-      # entirely, so the git/gh/file-edit entries must be repeated alongside
-      # the pnpm/turbo swap-ins. Keep in sync with the claude-auto job below.
-      settings: >-
-        {"permissions":{"allow":["Read","Edit","Write",
-        "Bash(pnpm:*)","Bash(npx turbo:*)",
-        "Bash(gh:*)",
-        "Bash(git fetch:*)","Bash(git merge:*)","Bash(git rebase:*)",
-        "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
-        "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
-        "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
-        "Bash(git remote:*)",
-        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
+      # headless runs. The override lives in .github/claude-settings.json
+      # (claude-code-action accepts a path as well as inline JSON, resolved
+      # against this repo's checkout). It replaces the default entirely, so
+      # the file repeats the git/gh/file-edit entries alongside the pnpm/turbo
+      # swap-ins.
+      settings: .github/claude-settings.json
       # trigger_phrase is single-valued, so resolve it from the SAME source the
       # action will check for this event (comment > review > issue), not from a
       # union of all sources — otherwise a stale @claude in an enclosing issue
@@ -182,16 +175,7 @@ jobs:
       id-token: write
       actions: read
     with:
-      # Same allowlist override as the claude job above — keep them in sync.
-      settings: >-
-        {"permissions":{"allow":["Read","Edit","Write",
-        "Bash(pnpm:*)","Bash(npx turbo:*)",
-        "Bash(gh:*)",
-        "Bash(git fetch:*)","Bash(git merge:*)","Bash(git rebase:*)",
-        "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
-        "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
-        "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
-        "Bash(git remote:*)",
-        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
+      # Same allowlist override as the claude job above (see the comment there).
+      settings: .github/claude-settings.json
       trigger_phrase: "@auto"
       label_trigger: "auto"


### PR DESCRIPTION
Fixes the pnpm-access failure marvin reported in https://github.com/meridianlabs-ai/ts-mono/pull/509#issuecomment-5270196706.

## Problem

The agent runs go through the reusable workflow `meridianlabs-ai/agents/.github/workflows/claude.yml@main`, whose default `settings` permission allowlist is Python-oriented (pytest, ruff, mypy, pip, uv, python). This repo's caller doesn't pass `settings`, so the agent gets that default and every `pnpm` command is auto-denied (headless runs deny anything not allowlisted).

There's a second gap: the reusable workflow only provisions the project environment when the caller repo defines a `.github/actions/claude-setup` composite action. This repo had no `.github/actions` at all, so even with `Bash(pnpm:*)` allowed, the runner would have no pnpm binary and no installed dependencies.

## Changes

1. **`.github/workflows/claude.yml`** — pass a `settings` override in both the `claude` and `claude-auto` jobs. A caller-supplied value replaces the default entirely, so it repeats the git/gh/file-edit entries and swaps the Python tools for `Bash(pnpm:*)` and `Bash(npx turbo:*)`.

2. **`.github/actions/claude-setup/action.yml`** — new composite action (auto-detected by the reusable workflow) that provisions pnpm, Node 22, the turbo cache, and installed deps, mirroring `ci.yaml`'s cache-backed setup.

No agents-repo change needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfCTxA4seXsGYbjGZVDmY4)_