### PR TITLE
Derive LightboxCarousel id from event node id in HumanBaselineView

### DIFF
--- a/packages/inspect-components/src/transcript/state/StateEventRenderers.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventRenderers.tsx
@@ -20,7 +20,8 @@ interface ChangeType {
   match?: (changes: JsonChange[]) => boolean;
   render: (
     changes: JsonChange[],
-    state: Record<string, unknown>
+    state: Record<string, unknown>,
+    eventNodeId: string
   ) => JSX.Element;
 }
 
@@ -113,7 +114,7 @@ const human_baseline_session: ChangeType = {
     replace: [],
     remove: [],
   },
-  render: (_changes, state: Record<string, unknown>) => {
+  render: (_changes, state: Record<string, unknown>, eventNodeId) => {
     // Read the session values
     const started = state[humanAgentKey("started_running")] as number;
     const runtime = state[humanAgentKey("accumulated_time")] as number;
@@ -161,6 +162,7 @@ const human_baseline_session: ChangeType = {
     return (
       <HumanBaselineView
         key="human_baseline_view"
+        id={eventNodeId}
         started={startedDate}
         running={running}
         completed={completed}

--- a/packages/inspect-components/src/transcript/state/StateEventView.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventView.tsx
@@ -61,8 +61,8 @@ export const StateEventView: FC<StateEventViewProps> = ({
   const changePreview = useMemo(() => {
     const isStore = eventNode.event.event === "store";
     const afterClone = structuredClone(after) || {};
-    return generatePreview(event.changes, afterClone, isStore);
-  }, [event.changes, eventNode.event.event, after]);
+    return generatePreview(event.changes, afterClone, isStore, eventNode.id);
+  }, [event.changes, eventNode.event.event, after, eventNode.id]);
   // Compute the title
   const title = event.event === "state" ? "State Updated" : "Store Updated";
 
@@ -105,7 +105,8 @@ export const StateEventView: FC<StateEventViewProps> = ({
 const generatePreview = (
   changes: JsonChange[],
   resolvedState: Record<string, unknown>,
-  isStore: boolean
+  isStore: boolean,
+  eventNodeId: string
 ) => {
   const results: ReactNode[] = [];
   for (const changeType of [
@@ -163,14 +164,14 @@ const generatePreview = (
         }
       }
       if (matchingOps === requiredMatchCount) {
-        const el = changeType.render(changes, resolvedState);
+        const el = changeType.render(changes, resolvedState, eventNodeId);
         results.push(el);
         break;
       }
     } else if (changeType.match) {
       const matches = changeType.match(changes);
       if (matches) {
-        const el = changeType.render(changes, resolvedState);
+        const el = changeType.render(changes, resolvedState, eventNodeId);
         results.push(el);
         break;
       }

--- a/packages/react/src/components/HumanBaselineView.tsx
+++ b/packages/react/src/components/HumanBaselineView.tsx
@@ -19,6 +19,7 @@ export interface SessionLog {
 }
 
 interface HumanBaselineViewProps {
+  id: string;
   started?: Date;
   running: boolean;
   completed?: boolean;
@@ -31,6 +32,7 @@ interface HumanBaselineViewProps {
  * Renders the HumanBaselineView component.
  */
 export const HumanBaselineView: FC<HumanBaselineViewProps> = ({
+  id,
   started,
   runtime,
   answer,
@@ -60,7 +62,7 @@ export const HumanBaselineView: FC<HumanBaselineViewProps> = ({
       label: title,
       render: () => (
         <AsciinemaPlayer
-          id={`player-${currentCount}`}
+          id={`${id}-player-${currentCount}`}
           inputUrl={createRevokableUrl(sessionLog.input)}
           outputUrl={createRevokableUrl(sessionLog.output)}
           timingUrl={createRevokableUrl(sessionLog.timing)}
@@ -94,7 +96,7 @@ export const HumanBaselineView: FC<HumanBaselineViewProps> = ({
           />
         </div>
         <div className={"asciinema-body"}>
-          <LightboxCarousel id="ascii-cinema" slides={player_fns} />
+          <LightboxCarousel id={`${id}-ascii-cinema`} slides={player_fns} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Every HumanBaselineView rendered its LightboxCarousel with the same
hardcoded id "ascii-cinema". Lightbox open state is keyed by that id,
so clicking one Terminal Session thumbnail opened the lightbox in every
Store Updated panel at once, stacking duplicate asciinema players.

Thread the unique eventNode.id through ChangeType.render() so
HumanBaselineView can scope its carousel (and player DOM ids) per panel.

Fixes #517

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MRLJh7avtM7B7eLtfWrzxm