### PR TITLE
fix(inspect): start single-file sessions with database: null

### DIFF
--- a/apps/inspect/src/log_data/replicationControl.test.ts
+++ b/apps/inspect/src/log_data/replicationControl.test.ts
@@ -89,6 +89,20 @@ describe("fetch engine activation lifecycle", () => {
     expect(h.start).toHaveBeenCalledTimes(1);
   });
 
+  test("a single-file activation starts the engine with no database", async () => {
+    // The engine's contract (FetchEngineDeps.database) spells "no
+    // persistence" as null; passing the unopened service instead made
+    // beginFetch probe a closed database on every fetch (#518).
+    const { activateFetchEngine, fetchLog } = await control();
+
+    activateFetchEngine({ ...configFor("dirA"), singleFileMode: true });
+    await fetchLog("dirA", "file.eval");
+
+    expect(h.openDatabase).not.toHaveBeenCalled();
+    expect(h.start).toHaveBeenCalledTimes(1);
+    expect(h.start.mock.calls[0]?.[0]).toMatchObject({ database: null });
+  });
+
   test("fetchLog rejects when a dir switch lands while its activation settles", async () => {
     // Hold dirA's activation open across the database open, switch to dirB,
     // then release: the resumed caller must not fetch into dirB's engine.

--- a/apps/inspect/src/log_data/replicationControl.ts
+++ b/apps/inspect/src/log_data/replicationControl.ts
@@ -27,8 +27,9 @@ export const openLogDirDatabase = async (
 
 // Start the engine for a config snapshot — the composition root: the
 // database, api, and per-dir cache sink are wired here. Dir mode also opens
-// the per-dir database; single-file mode starts the engine alone (the
-// database stays unopened, so reads miss and writes are cache-only).
+// the per-dir database; single-file mode starts the engine with no database
+// (`database: null` per FetchEngineDeps — reads miss without probing
+// IndexedDB, writes are cache-only).
 const startEngine = async (config: AppConfig, seq: number): Promise<void> => {
   const { api, logDir } = config;
   // Bump the engine epoch before re-scoping, so an in-flight listing sync
@@ -54,11 +55,10 @@ const startEngine = async (config: AppConfig, seq: number): Promise<void> => {
   // mechanism — it would be a third.
   const epoch = fetchEngine.epoch();
   if (config.singleFileMode) {
-    const database = getDatabaseService();
     await fetchEngine.start({
       api,
-      database,
-      sink: createLogsContentSink(database, logDir),
+      database: null,
+      sink: createLogsContentSink(null, logDir),
       logDir,
     });
     return;


### PR DESCRIPTION
Fixes #518.

## Problem

Booting the viewer in VS Code single-file mode logged recoverable console errors from `FetchEngine.beginFetch`:

```
[DatabaseService] Error retrieving log row for …: Error: No database initialized. Call openDatabase first.
```

`FetchEngineDeps.database` documents `null` as the "no persistence" sentinel — *"null when unavailable (e.g. single-file sessions), in which case every read misses and writes are cache-only"* — and the engine honors it everywhere (`start()` skips hydration, `beginFetch` skips the row-cache probe). But `startEngine`'s single-file branch passed the constructed-but-never-opened `DatabaseService` singleton instead. The truthy value defeated the engine's null checks, so every details fetch probed the closed database: `readLogRow` threw, logged at error level, and returned the same `null` a skipped probe yields. Console noise plus a dead async round trip per fetch; no user-visible breakage.

## Fix

Pass `database: null` (and `createLogsContentSink(null, logDir)`) in the single-file branch, matching the documented contract. Behavior is otherwise identical: `start()` returned early either way (`readLogs` soft-misses when closed), and every sink write already gates on `db?.opened()`. The only change is that `beginFetch` no longer issues the guaranteed-dead probe.

## Testing

- New test pins the contract: a single-file activation starts the engine with `database: null` and never calls `openDatabase`.
- `vitest run` on `replicationControl.test.ts` + `fetchEngine.test.ts` (62 passed), `tsc --noEmit`, eslint, and prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTw3NpuC1kpY7UbqrYz4B3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTw3NpuC1kpY7UbqrYz4B3)_