### PR TITLE
Settle the VirtualList scroll restore and re-take @tanstack/react-virtual 3.14.9

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -102,7 +102,7 @@
     "@popperjs/core": "^2.11.8",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "^3.14.8",
+    "@tanstack/react-virtual": "^3.14.9",
     "@vscode-elements/react-elements": "^2.4.0",
     "@vscode/codicons": "^0.0.45",
     "asciinema-player": "^3.17.0",

--- a/apps/scout/e2e/transcript-events.spec.ts
+++ b/apps/scout/e2e/transcript-events.spec.ts
@@ -848,23 +848,19 @@ test.describe("transcript event rendering", () => {
     // WITHIN-VISIT tab flips still restore — the deliberate counterpart of
     // the fresh-visit top landing above. Two regressions, on this same
     // (fresh) visit to A:
-    // 1) events -> messages -> events lands back where the user was (a
-    //    one-shot scrollTop write against a freshly remounted virtualized
-    //    list lands on interim row measurements and drifts by the re-measure
-    //    delta);
+    // 1) events -> messages -> events lands back where the user was;
     // 2) a flip INSIDE the recorder's debounce window must not lose the
     //    position — the pending record is flushed with the value captured at
     //    scroll time, not cancelled.
     //
-    // Tolerance: the restore is a single scrollTop write against a freshly
-    // remounted virtualizer (DEFAULT_ITEM_HEIGHT_PX estimate, no re-issue/
-    // settle loop — pixel accuracy is deliberately not guaranteed), so it
-    // lands within the straddling row's re-measure delta of the recorded
-    // offset — deterministic
-    // ~77/94px here on CI Linux font metrics (deeper scroll -> taller straddle
-    // row). 120px stays well under one 400px row, so it still fails a top reset
-    // (~1000px off) or a full-row miss; it only tolerates the sub-row drift.
-    const RESTORE_REMEASURE_TOLERANCE_PX = 120;
+    // Tolerance: the restore re-forces the recorded offset until re-measure
+    // compensation goes quiet (VirtualList.settleRestoreScroll, #519), so it
+    // converges on the recorded pixel regardless of when the remount
+    // measurement pass re-renders — locally exact (<=2px). The margin only
+    // covers a post-settle re-measure (late fonts/async content) nudging
+    // scrollTop to preserve viewport content; a single row's estimate error
+    // (~76-249px against the flat 400px estimate) must fail again.
+    const RESTORE_REMEASURE_TOLERANCE_PX = 20;
     const flipToMessagesAndBack = async () => {
       await page.getByRole("tab", { name: "Messages" }).first().click();
       await expect(page.getByText("flip message 0").first()).toBeVisible();

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "^3.14.8",
+    "@tanstack/react-virtual": "^3.14.9",
     "@uwdata/flechette": "^2.5.0",
     "@vscode-elements/react-elements": "^2.4.0",
     "@vscode/codicons": "^0.0.45",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@tanstack/react-virtual": "^3.14.8",
+    "@tanstack/react-virtual": "^3.14.9",
     "@vscode-elements/react-elements": "^2.4.0",
     "json5": "^2.2.3",
     "mathjax-full": "^3.2.2",
@@ -48,7 +48,7 @@
     "@storybook/react": "^10.5.6",
     "@storybook/react-vite": "^10.5.6",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-virtual": "^3.14.8",
+    "@tanstack/react-virtual": "^3.14.9",
     "@testing-library/react": "^16.3.1",
     "@tsmono/eslint-config": "workspace:*",
     "@tsmono/tsconfig": "workspace:*",

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -499,14 +499,14 @@ export function VirtualList<T>({
         // frames, and forcing first would hide it from the stability check.
         const preTop = el.scrollTop;
         el.scrollTop = getTargetSpacerTop();
+        const postTop = el.scrollTop;
         // Any movement since last frame — external compensation (preTop) or
         // our own re-force landing somewhere new (clamp released as content
-        // grew) — means the layout is still moving.
+        // grew, postTop) — means the layout is still moving.
         const moved =
-          Math.abs(preTop - lastTop) > 1 ||
-          Math.abs(el.scrollTop - lastTop) > 1;
+          Math.abs(preTop - lastTop) > 1 || Math.abs(postTop - lastTop) > 1;
         stable = moved ? 0 : stable + 1;
-        lastTop = el.scrollTop;
+        lastTop = postTop;
         if (stable < 3 && ++frames < 30) {
           settleFrameRef.current = requestAnimationFrame(settle);
         } else {
@@ -569,18 +569,19 @@ export function VirtualList<T>({
         hasInitialScrolledRef.current = true;
         if (!userScrolledRef.current) {
           // settleRestoreScroll releases the auto-scroll guard itself.
+          // Whether to clamp is decided once at restore time (one-shot
+          // semantics); only the clamp BOUNDS are re-read per frame.
+          const clampToMax = snapshot.totalCount !== data.length;
           settleRestoreScroll(() => {
-            // Clamp in content space: getTotalSize() is content-space while
-            // clientHeight is spacer-space (they differ when scale > 1).
-            const maxScroll = Math.max(
+            const target = toSpacerScroll(snapshot.scrollOffset);
+            if (!clampToMax) return target;
+            // Clamped fully in spacer space (dividing by the positive scale
+            // distributes over min/max, so this equals the content-space clamp).
+            const maxSpacerTop = Math.max(
               0,
-              virtualizer.getTotalSize() - toContentScroll(el.clientHeight)
+              toSpacerScroll(virtualizer.getTotalSize()) - el.clientHeight
             );
-            const offset =
-              snapshot.totalCount === data.length
-                ? snapshot.scrollOffset
-                : Math.min(snapshot.scrollOffset, maxScroll);
-            return toSpacerScroll(offset);
+            return Math.min(target, maxSpacerTop);
           });
         } else {
           release();
@@ -617,7 +618,6 @@ export function VirtualList<T>({
     live,
     getRestoreSnapshot,
     getScrollElement,
-    toContentScroll,
     toSpacerScroll,
     virtualizer,
   ]);

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -456,21 +456,29 @@ export function VirtualList<T>({
   // full row (#519). Re-forcing until quiet makes the landing independent of
   // when re-renders happen; it also absorbs the browser clamping an early
   // write against a not-yet-grown (estimate-sized) scrollHeight. The target
-  // is a callback so per-frame writes see fresh clamp bounds as totals grow.
+  // is a callback so per-frame writes see fresh clamp bounds — and, via the
+  // ref-backed converters, a fresh scale — as totals grow.
   const settleRestoreScroll = useCallback(
     (getTargetSpacerTop: () => number) => {
-      const el = getScrollElement();
-      if (!el) return;
+      // Guard bookkeeping mirrors settleScrollToIndex: every exit path —
+      // including a missing scroll element — must book the guard release, or
+      // the caller-taken auto-scroll guard leaks and persistence stays
+      // silently dead for the rest of the mount.
       isAutoScrollingRef.current = true;
       cancelAnimationFrame(releaseFrameRef.current);
       cancelAnimationFrame(settleFrameRef.current);
+      const el = getScrollElement();
       const keyAtStart = lastInitialKeyRef.current;
       const finish = () => {
-        lastAutoScrollTopRef.current = el.scrollTop;
+        if (el) lastAutoScrollTopRef.current = el.scrollTop;
         releaseFrameRef.current = requestAnimationFrame(() => {
           isAutoScrollingRef.current = false;
         });
       };
+      if (!el) {
+        finish();
+        return;
+      }
       el.scrollTop = getTargetSpacerTop();
       let frames = 0;
       let stable = 0;
@@ -562,9 +570,11 @@ export function VirtualList<T>({
         if (!userScrolledRef.current) {
           // settleRestoreScroll releases the auto-scroll guard itself.
           settleRestoreScroll(() => {
+            // Clamp in content space: getTotalSize() is content-space while
+            // clientHeight is spacer-space (they differ when scale > 1).
             const maxScroll = Math.max(
               0,
-              virtualizer.getTotalSize() - el.clientHeight
+              virtualizer.getTotalSize() - toContentScroll(el.clientHeight)
             );
             const offset =
               snapshot.totalCount === data.length
@@ -607,6 +617,7 @@ export function VirtualList<T>({
     live,
     getRestoreSnapshot,
     getScrollElement,
+    toContentScroll,
     toSpacerScroll,
     virtualizer,
   ]);

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -446,6 +446,69 @@ export function VirtualList<T>({
     []
   );
   const lastInitialKeyRef = useRef<string | null>(null);
+  // Restore a persisted pixel offset by RE-FORCING it until the virtualizer's
+  // re-measure compensation goes quiet. A one-shot write races the remount
+  // measurement pass: every row measured after the write that sits entirely
+  // above the fold shifts scrollTop by its estimate error (see
+  // shouldAdjustScrollPositionOnItemSizeChange), and which rows land after
+  // the write depends on re-render timing — virtual-core 3.17.7 moved that
+  // timing (notify(adjustedSync) -> flushSync) and drifted the restore by a
+  // full row (#519). Re-forcing until quiet makes the landing independent of
+  // when re-renders happen; it also absorbs the browser clamping an early
+  // write against a not-yet-grown (estimate-sized) scrollHeight. The target
+  // is a callback so per-frame writes see fresh clamp bounds as totals grow.
+  const settleRestoreScroll = useCallback(
+    (getTargetSpacerTop: () => number) => {
+      const el = getScrollElement();
+      if (!el) return;
+      isAutoScrollingRef.current = true;
+      cancelAnimationFrame(releaseFrameRef.current);
+      cancelAnimationFrame(settleFrameRef.current);
+      const keyAtStart = lastInitialKeyRef.current;
+      const finish = () => {
+        lastAutoScrollTopRef.current = el.scrollTop;
+        releaseFrameRef.current = requestAnimationFrame(() => {
+          isAutoScrollingRef.current = false;
+        });
+      };
+      el.scrollTop = getTargetSpacerTop();
+      let frames = 0;
+      let stable = 0;
+      let lastTop = el.scrollTop;
+      const settle = () => {
+        // A key change mid-settle means this restore belongs to the previous
+        // sample — stop before writing its offset into the new one's list.
+        // User input always wins over a pending restore.
+        if (
+          userInteractingRef.current ||
+          lastInitialKeyRef.current !== keyAtStart
+        ) {
+          finish();
+          return;
+        }
+        // Read BEFORE re-forcing: the drift being waited out (re-measure
+        // compensation nudging scrollTop after our write) happens between
+        // frames, and forcing first would hide it from the stability check.
+        const preTop = el.scrollTop;
+        el.scrollTop = getTargetSpacerTop();
+        // Any movement since last frame — external compensation (preTop) or
+        // our own re-force landing somewhere new (clamp released as content
+        // grew) — means the layout is still moving.
+        const moved =
+          Math.abs(preTop - lastTop) > 1 ||
+          Math.abs(el.scrollTop - lastTop) > 1;
+        stable = moved ? 0 : stable + 1;
+        lastTop = el.scrollTop;
+        if (stable < 3 && ++frames < 30) {
+          settleFrameRef.current = requestAnimationFrame(settle);
+        } else {
+          finish();
+        }
+      };
+      settleFrameRef.current = requestAnimationFrame(settle);
+    },
+    [getScrollElement]
+  );
   const lastInitialIndexRef = useRef<number | undefined>(undefined);
   // The no-snapshot "reset to top" is a one-shot per (re)key: re-firing on
   // every measurement would keep slamming scrollTop to 0 against an
@@ -497,17 +560,21 @@ export function VirtualList<T>({
         // wheel); a foreign scrollTop from a shared container doesn't block it.
         hasInitialScrolledRef.current = true;
         if (!userScrolledRef.current) {
-          const maxScroll = Math.max(
-            0,
-            virtualizer.getTotalSize() - el.clientHeight
-          );
-          const offset =
-            snapshot.totalCount === data.length
-              ? snapshot.scrollOffset
-              : Math.min(snapshot.scrollOffset, maxScroll);
-          el.scrollTop = toSpacerScroll(offset);
+          // settleRestoreScroll releases the auto-scroll guard itself.
+          settleRestoreScroll(() => {
+            const maxScroll = Math.max(
+              0,
+              virtualizer.getTotalSize() - el.clientHeight
+            );
+            const offset =
+              snapshot.totalCount === data.length
+                ? snapshot.scrollOffset
+                : Math.min(snapshot.scrollOffset, maxScroll);
+            return toSpacerScroll(offset);
+          });
+        } else {
+          release();
         }
-        release();
       } else if (!userScrolledRef.current && !hasResetTopRef.current) {
         // No snapshot: reset to top once WITHOUT committing the one-shot
         // guard (a snapshot may rehydrate later), but flag the reset so
@@ -533,6 +600,7 @@ export function VirtualList<T>({
     persistenceKey,
     initialIndex,
     settleScrollToIndex,
+    settleRestoreScroll,
     contentTotal,
     data.length,
     followOutput,

--- a/packages/react/src/virtual/use-scaled-virtualizer.ts
+++ b/packages/react/src/virtual/use-scaled-virtualizer.ts
@@ -5,7 +5,12 @@ import {
 } from "@tanstack/react-virtual";
 import { useCallback, useMemo, useRef } from "react";
 
-import { computeScale, SAFE_MAX_SPACER } from "./scale-coordinate-space";
+import {
+  computeScale,
+  SAFE_MAX_SPACER,
+  toContent,
+  toSpacer,
+} from "./scale-coordinate-space";
 
 export type ScaledVirtualizerOptions = {
   count: number;
@@ -121,11 +126,11 @@ export function useScaledVirtualizer(
   // change the scale — convert with the scale current at call time, not the
   // one captured when the closure was created.
   const toContentScroll = useCallback(
-    (spacerScroll: number) => spacerScroll * scaleRef.current,
+    (spacerScroll: number) => toContent(spacerScroll, scaleRef.current),
     []
   );
   const toSpacerScroll = useCallback(
-    (contentScroll: number) => contentScroll / scaleRef.current,
+    (contentScroll: number) => toSpacer(contentScroll, scaleRef.current),
     []
   );
 

--- a/packages/react/src/virtual/use-scaled-virtualizer.ts
+++ b/packages/react/src/virtual/use-scaled-virtualizer.ts
@@ -116,13 +116,17 @@ export function useScaledVirtualizer(
 
   const spacerHeight = scale === 1 ? contentTotal : SAFE_MAX_SPACER;
 
+  // Ref-backed (not closed over `scale`) so long-lived closures — the restore
+  // settle loop re-forces scrollTop across many frames while measurements
+  // change the scale — convert with the scale current at call time, not the
+  // one captured when the closure was created.
   const toContentScroll = useCallback(
-    (spacerScroll: number) => spacerScroll * scale,
-    [scale]
+    (spacerScroll: number) => spacerScroll * scaleRef.current,
+    []
   );
   const toSpacerScroll = useCallback(
-    (contentScroll: number) => contentScroll / scale,
-    [scale]
+    (contentScroll: number) => contentScroll / scaleRef.current,
+    []
   );
 
   return { virtualizer, scale, spacerHeight, toContentScroll, toSpacerScroll };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: ^3.14.8
-        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vscode-elements/react-elements':
         specifier: ^2.4.0
         version: 2.4.0(@types/react@19.2.18)(@vscode/codicons@0.0.45)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -295,8 +295,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: ^3.14.8
-        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@uwdata/flechette':
         specifier: ^2.5.0
         version: 2.5.0
@@ -635,8 +635,8 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: ^3.14.8
-        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@testing-library/react':
         specifier: ^16.3.1
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2419,8 +2419,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.14.8':
-    resolution: {integrity: sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==}
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2429,8 +2429,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.17.6':
-    resolution: {integrity: sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==}
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6737,15 +6737,15 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-virtual@3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/virtual-core': 3.17.6
+      '@tanstack/virtual-core': 3.17.7
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/virtual-core@3.17.6': {}
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Fixes #519 — option 2 (variant A: settle the pixel write), plus the `@tanstack/react-virtual` 3.14.8 → 3.14.9 bump that was reverted out of #509, to confirm the fix against the exact version that exposed the race.

## The race

`VirtualList`'s persisted-offset restore was a one-shot `scrollTop` write fired on the first quiet frame after remount (the restore effect depends on `getTotalSize()`, so each measurement batch cancelled and re-booked the pending rAF). Every row measured *after* the write that sits entirely above the fold shifts `scrollTop` by its estimate error via `shouldAdjustScrollPositionOnItemSizeChange` — so the final landing depended on which frame the write happened to hit. virtual-core 3.17.7 switched resize notifications to `flushSync` (TanStack/virtual#1239), moved that frame, and deterministically drifted the restore by one row's estimate error: 129px against the 120px e2e tolerance.

## The fix

Replace the one-shot write with a settle loop (`settleRestoreScroll`, same pattern as the existing `settleScrollToIndex`): re-force the recorded offset each frame until the layout holds still for 3 frames (bounded at 30), bailing on real user input or a persistence-key change. The landing no longer depends on when re-renders happen — it converges on the recorded pixel from wherever the measurement pass is. Re-forcing also absorbs the browser clamping an early write against a not-yet-grown, estimate-sized `scrollHeight`.

The persisted snapshot shape, `useVirtualListState`, and the `getState`/`scrollTo` imperative API are all unchanged.

## Test change

The e2e restore tolerance drops 120px → 20px (with the rationale comment rewritten): the settle converges on the recorded pixel — locally the test passes even at 2px — so the margin now only covers a post-settle re-measure nudging `scrollTop`, and any reintroduced sub-row drift (~76–249px per row against the flat 400px estimate) fails loudly instead of being tolerated.

## Validation

- `apps/scout` e2e `transcript-events.spec.ts` "within-visit tab flips restore the position" — the test that deterministically failed on CI with 3.14.9 — passes repeatedly with the bump in place, including probe runs at a 2px tolerance
- Full scout e2e suite: 65/65 passed with 3.14.9
- `turbo run check` (lint, typecheck, format) and `turbo run test` (all 9 workspace test tasks) pass

Note: with virtual-core 3.17.7, dev-mode console shows React's "flushSync was called from inside a lifecycle method" warning coming from the library's new resize notification path (upstream behavior from TanStack/virtual#1239, not specific to this change); React falls back to batched rendering in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuQHbV5oiGrKjAgFZd3LNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuQHbV5oiGrKjAgFZd3LNz)_