### PR TITLE
Bump nanoid override to ^3.3.18 (dependabot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       "@babel/core": "^7.29.6",
       "undici": "^7.28.0",
       "dompurify": "^3.4.13",
-      "nanoid@3": "^3.3.17"
+      "nanoid@3": "^3.3.18"
     }
   },
   "manypkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   '@babel/core': ^7.29.6
   undici: ^7.28.0
   dompurify: ^3.4.13
-  nanoid@3: ^3.3.17
+  nanoid@3: ^3.3.18
 
 importers:
 
@@ -4344,8 +4344,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8729,7 +8729,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8992,7 +8992,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Routine dependabot-alert cleanup via `pnpm.overrides` in the root package.json.

## Fixed

- [Dependabot alert 75](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/75) — **nanoid** (high, GHSA-2v37-7h3g-55p8): raised the existing `nanoid@3` override from `^3.3.17` to `^3.3.18`. Only the 3.x line resolves in the tree; 3.3.18 was released 2026-08-07, past the 7-day `minimumReleaseAge` soak window.

## Deferred

- [Dependabot alert 74](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/74) — **image-size** (high, GHSA-w3rx-r6r6-pgpr): no patched version exists (latest release 2.0.2 is itself in the vulnerable range `<= 2.0.2`). Transitive dev-only dep via `vite > less`.
- [Dependabot alert 73](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/73) — **image-size** (high, GHSA-5p2g-fcmc-qvqq): same package, same situation — no patched version to force. Will fix on a later run once upstream publishes a patch.

## Verification

- `pnpm-lock.yaml` resolves only `nanoid@3.3.18`
- `pnpm audit` no longer reports the nanoid advisory (only the two unfixable image-size advisories remain)
- `pnpm check` (27 tasks), `pnpm build`, and `pnpm test` (1139 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)