### PR TITLE
Avoid type casts in tests

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/timeline/timelineData.test.ts
+++ b/apps/inspect/src/app/log-view/tabs/timeline/timelineData.test.ts
@@ -148,12 +148,11 @@ describe("rowCategory", () => {
 });
 
 describe("withConfigOrdinals", () => {
-  const configUpdate = (timestamp: string): ConfigUpdate =>
-    ({
-      scope: "task",
-      changes: [],
-      provenance: { timestamp, author: "a", metadata: {} },
-    }) as unknown as ConfigUpdate;
+  const configUpdate = (timestamp: string): ConfigUpdate => ({
+    scope: "task",
+    changes: [],
+    provenance: { timestamp, author: "a", metadata: {} },
+  });
 
   it("numbers config markers chronologically, skipping tag edits", () => {
     const config = configMarkers(
@@ -453,11 +452,11 @@ describe("historyRows", () => {
         },
       ],
     } as EvalStats;
-    const configUpdate = {
-      scope: "eval",
+    const configUpdate: ConfigUpdate = {
+      scope: "task",
       changes: [],
-      provenance: { timestamp: when, author: "cteague" },
-    } as unknown as ConfigUpdate;
+      provenance: { timestamp: when, author: "cteague", metadata: {} },
+    };
     const rows = historyRows({
       status: "success",
       stats,

--- a/apps/inspect/src/app/routing/loaders/LogLoadController.test.tsx
+++ b/apps/inspect/src/app/routing/loaders/LogLoadController.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
 import { data, loading } from "@tsmono/util";
 
 import { LogDetails } from "../../../client/api/types";
@@ -37,13 +38,17 @@ vi.mock("../../../state/store", () => ({
     }),
 }));
 
-const makeDetails = (n: number): LogDetails =>
-  ({
-    version: 2,
-    status: "started",
-    eval: { eval_id: `e${n}`, run_id: `r${n}`, task: "t", model: "m" },
-    sampleSummaries: [],
-  }) as unknown as LogDetails;
+const makeDetails = (n: number): LogDetails => ({
+  version: 2,
+  status: "started",
+  eval: testEvalSpec({
+    eval_id: `e${n}`,
+    run_id: `r${n}`,
+    task: "t",
+    model: "m",
+  }),
+  sampleSummaries: [],
+});
 
 beforeEach(() => {
   setLoadedLog.mockReset();

--- a/apps/inspect/src/app/routing/urlLinking.test.tsx
+++ b/apps/inspect/src/app/routing/urlLinking.test.tsx
@@ -29,12 +29,15 @@ const mockStore = vi.hoisted(() => ({
 
 vi.mock("../../state/store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../state/store")>();
+  const { testStoreState } = await import("../../state/testStore");
+  const base = testStoreState();
   return {
     ...actual,
     useStore: (selector: (s: StoreState) => unknown) =>
       selector({
-        logs: { selectedLogFile: mockStore.selectedLogFile },
-      } as unknown as StoreState),
+        ...base,
+        logs: { ...base.logs, selectedLogFile: mockStore.selectedLogFile },
+      }),
   };
 });
 

--- a/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
+++ b/apps/inspect/src/app/samples/SampleRetriedErrors.test.tsx
@@ -4,6 +4,7 @@ import { createRef, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
+import { testErrorEvent } from "@tsmono/inspect-common/testing";
 
 import { SampleRetriedErrors } from "./SampleRetriedErrors";
 
@@ -98,7 +99,7 @@ describe("SampleRetriedErrors", () => {
     const scrollRef = createRef<HTMLDivElement>();
     const withEvents = (n: number): EvalRetryError => ({
       ...makeRetry(n),
-      events: [{ event: "error" }] as unknown as EvalRetryError["events"],
+      events: [testErrorEvent()],
     });
     render(
       <SampleRetriedErrors

--- a/apps/inspect/src/app/samples/descriptor/testDescriptors.ts
+++ b/apps/inspect/src/app/samples/descriptor/testDescriptors.ts
@@ -1,0 +1,54 @@
+/**
+ * Cast-free descriptor fixtures: complete typed values with every member
+ * stubbed to throw, spread-merged with per-test overrides.
+ */
+import type { SamplesDescriptor } from "./samplesDescriptor";
+import type { EvalDescriptor, MessageShape, ScoreDescriptor } from "./types";
+
+const notImplemented = (name: string) => (): never => {
+  throw new Error(`${name} not implemented in test`);
+};
+
+export const testScoreDescriptor = (
+  overrides: Partial<ScoreDescriptor> = {}
+): ScoreDescriptor => ({
+  scoreType: "other",
+  compare: notImplemented("compare"),
+  render: notImplemented("render"),
+  ...overrides,
+});
+
+export const testEvalDescriptor = (
+  overrides: Partial<EvalDescriptor> = {}
+): EvalDescriptor => ({
+  scores: [],
+  scoreDescriptor: notImplemented("scoreDescriptor"),
+  scorerDescriptor: notImplemented("scorerDescriptor"),
+  score: notImplemented("score"),
+  scoreAnswer: notImplemented("scoreAnswer"),
+  ...overrides,
+});
+
+export const testMessageShape = (
+  overrides: Partial<MessageShape> = {}
+): MessageShape => ({
+  idSize: 0,
+  inputSize: 0,
+  targetSize: 0,
+  answerSize: 0,
+  limitSize: 0,
+  retriesSize: 0,
+  fallbacksSize: 0,
+  errorSize: 0,
+  ...overrides,
+});
+
+export const testSamplesDescriptor = (
+  overrides: Partial<SamplesDescriptor> = {}
+): SamplesDescriptor => ({
+  evalDescriptor: testEvalDescriptor(),
+  messageShape: testMessageShape(),
+  selectedScore: notImplemented("selectedScore"),
+  selectedScorerDescriptor: notImplemented("selectedScorerDescriptor"),
+  ...overrides,
+});

--- a/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
+++ b/apps/inspect/src/app/samples/list/samplesView.converters.test.ts
@@ -85,7 +85,7 @@ describe("liftEvalView", () => {
       name: "Triage",
       score_labels: { audit_situational_awareness: "Situational Awareness" },
     };
-    const lifted = liftEvalView(wire) as unknown as Record<string, unknown>;
+    const lifted = liftEvalView(wire);
     expect("scoreLabels" in lifted).toBe(false);
     expect("score_labels" in lifted).toBe(false);
   });
@@ -102,7 +102,7 @@ describe("liftEvalView", () => {
         verdict: { yes: "bad", no: "good" },
       },
     };
-    const lifted = liftEvalView(wire) as unknown as Record<string, unknown>;
+    const lifted = liftEvalView(wire);
     expect("scoreColorScales" in lifted).toBe(false);
     expect("score_color_scales" in lifted).toBe(false);
   });

--- a/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
+++ b/apps/inspect/src/app/samples/retry-display/RetryAttemptCard.test.tsx
@@ -4,6 +4,7 @@ import { ComponentProps, createRef, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
+import { testErrorEvent } from "@tsmono/inspect-common/testing";
 
 import { RetryAttemptCard } from "./RetryAttemptCard";
 
@@ -39,7 +40,7 @@ const baseRetry: EvalRetryError = {
 
 const withEvents = (): EvalRetryError => ({
   ...baseRetry,
-  events: [{ event: "error" }] as unknown as EvalRetryError["events"],
+  events: [testErrorEvent()],
 });
 
 function renderCard(

--- a/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
+++ b/apps/inspect/src/app/samples/retry-display/retryAttempt.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { EvalRetryError } from "@tsmono/inspect-common";
+import {
+  testErrorEvent,
+  testSampleInitEvent,
+} from "@tsmono/inspect-common/testing";
 
 import { attemptStartTime, deriveErrorType } from "./retryAttempt";
 
@@ -48,19 +52,19 @@ describe("deriveErrorType", () => {
 
 describe("attemptStartTime", () => {
   it("returns the earliest event timestamp regardless of event order", () => {
-    const events = [
-      { event: "error", timestamp: "2024-01-01T00:00:04.200Z" },
-      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
-    ] as unknown as EvalRetryError["events"];
+    const events: EvalRetryError["events"] = [
+      testErrorEvent({ timestamp: "2024-01-01T00:00:04.200Z" }),
+      testSampleInitEvent({ timestamp: "2024-01-01T00:00:00.000Z" }),
+    ];
     expect(attemptStartTime(retry({ events }))?.toISOString()).toBe(
       "2024-01-01T00:00:00.000Z"
     );
   });
 
   it("returns a start time from a single timestamped event", () => {
-    const events = [
-      { event: "sample_init", timestamp: "2024-01-01T00:00:00.000Z" },
-    ] as unknown as EvalRetryError["events"];
+    const events: EvalRetryError["events"] = [
+      testSampleInitEvent({ timestamp: "2024-01-01T00:00:00.000Z" }),
+    ];
     expect(attemptStartTime(retry({ events }))?.toISOString()).toBe(
       "2024-01-01T00:00:00.000Z"
     );

--- a/apps/inspect/src/app/samples/sample-tools/astToSpecs.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/astToSpecs.test.ts
@@ -6,7 +6,11 @@ import type {
 } from "@tsmono/inspect-components/columnFilter";
 
 import type { ScoreLabel } from "../../types";
-import type { EvalDescriptor, ScoreDescriptor } from "../descriptor/types";
+import {
+  testEvalDescriptor,
+  testScoreDescriptor,
+} from "../descriptor/testDescriptors";
+import type { EvalDescriptor } from "../descriptor/types";
 
 import { astToSpecs, parseFilterSpecs } from "./astToSpecs";
 import { parseFilter } from "./filterAst";
@@ -18,13 +22,13 @@ const registry = buildSampleFilterSpecRegistry(undefined);
 const descriptorWith = (
   scores: Array<{ name: string; scorer: string; scoreType: string }>
 ): EvalDescriptor =>
-  ({
+  testEvalDescriptor({
     scores: scores.map(({ name, scorer }) => ({ name, scorer })),
     scoreDescriptor: ({ name, scorer }: ScoreLabel) => {
       const match = scores.find((s) => s.name === name && s.scorer === scorer);
-      return { scoreType: match?.scoreType ?? "other" } as ScoreDescriptor;
+      return testScoreDescriptor({ scoreType: match?.scoreType ?? "other" });
     },
-  }) as unknown as EvalDescriptor;
+  });
 
 const toSpecs = (text: string): Record<string, ColumnFilter> | null =>
   parseFilterSpecs(text, registry);

--- a/apps/inspect/src/app/samples/sample-tools/filterSpecRegistry.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filterSpecRegistry.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { ScoreLabel } from "../../../app/types";
-import type { EvalDescriptor, ScoreDescriptor } from "../descriptor/types";
+import {
+  testEvalDescriptor,
+  testScoreDescriptor,
+} from "../descriptor/testDescriptors";
+import type { EvalDescriptor } from "../descriptor/types";
 
 import {
   buildSampleFilterSpecRegistry,
@@ -11,13 +15,13 @@ import {
 const descriptorWith = (
   scores: Array<{ name: string; scorer: string; scoreType: string }>
 ): EvalDescriptor =>
-  ({
+  testEvalDescriptor({
     scores: scores.map(({ name, scorer }) => ({ name, scorer })),
     scoreDescriptor: ({ name, scorer }: ScoreLabel) => {
       const match = scores.find((s) => s.name === name && s.scorer === scorer);
-      return { scoreType: match?.scoreType ?? "other" } as ScoreDescriptor;
+      return testScoreDescriptor({ scoreType: match?.scoreType ?? "other" });
     },
-  }) as unknown as EvalDescriptor;
+  });
 
 describe("buildSampleFilterSpecRegistry", () => {
   it("registers the static columns", () => {

--- a/apps/inspect/src/app/samples/sample-tools/filters.test.ts
+++ b/apps/inspect/src/app/samples/sample-tools/filters.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { testScore } from "@tsmono/inspect-common/testing";
+
 import { SampleSummary } from "../../../client/api/types";
 import type { ScoreLabel } from "../../types";
 import type { SamplesDescriptor } from "../descriptor/samplesDescriptor";
-import type { EvalDescriptor, ScoreDescriptor } from "../descriptor/types";
+import {
+  testEvalDescriptor,
+  testSamplesDescriptor,
+  testScoreDescriptor,
+} from "../descriptor/testDescriptors";
+import type { EvalDescriptor } from "../descriptor/types";
 
 import {
   bannedShortScoreNames,
@@ -16,21 +23,21 @@ import {
 const descriptorWith = (
   scores: Array<{ name: string; scorer: string; scoreType: string }>
 ): EvalDescriptor =>
-  ({
+  testEvalDescriptor({
     scores: scores.map(({ name, scorer }) => ({ name, scorer })),
     scoreDescriptor: ({ name, scorer }: ScoreLabel) => {
       const match = scores.find((s) => s.name === name && s.scorer === scorer);
-      return { scoreType: match?.scoreType ?? "other" } as ScoreDescriptor;
+      return testScoreDescriptor({ scoreType: match?.scoreType ?? "other" });
     },
-  }) as unknown as EvalDescriptor;
+  });
 
 const samplesDescriptorWith = (
   scores: Array<{ name: string; scorer: string; scoreType: string }>
 ): SamplesDescriptor =>
-  ({
+  testSamplesDescriptor({
     evalDescriptor: descriptorWith(scores),
     selectedScorerDescriptor: () => undefined,
-  }) as unknown as SamplesDescriptor;
+  });
 
 const sample = (overrides: Partial<SampleSummary> = {}): SampleSummary => ({
   id: "s1",
@@ -81,8 +88,8 @@ describe("filterExpression built-in shadowing", () => {
   ]);
   const s = sample({
     scores: {
-      grader: { value: { epoch: 99 } },
-    } as unknown as SampleSummary["scores"],
+      grader: testScore({ value: { epoch: 99 } }),
+    },
   });
 
   it("a bare built-in name reads the sample, not a score named after it", () => {

--- a/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
+++ b/apps/inspect/src/app/samples/transcript/TranscriptPanel.test.tsx
@@ -27,28 +27,23 @@ const kEventRoute = `${kSampleRoute}?event=event-1`;
 
 vi.mock("../../../state/store", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../state/store")>();
-  const state = {
+  const { testStoreState } = await import("../../../state/testStore");
+  const base = testStoreState();
+  const state: StoreState = {
+    ...base,
     sample: {
+      ...base.sample,
       eventFilter: { filteredTypes: [] },
       timelineSelected: null,
       activeTimelineIndex: 0,
       collapsedEvents: null,
       collapsedMode: null,
-      selectedOutlineId: null,
+      selectedOutlineId: undefined,
     },
-    sampleActions: {
-      setTimelineSelected: () => undefined,
-      setActiveTimelineIndex: () => undefined,
-      setCollapsedEvents: () => undefined,
-      collapseEvent: () => undefined,
-      setSelectedOutlineId: () => undefined,
-      setFilteredEventTypes: () => undefined,
-    },
-    app: { propertyBags: {} },
-    appActions: { setPropertyValue: () => undefined },
-    logs: { selectedLogFile: undefined, logDir: undefined },
-    log: { selectedSampleHandle: undefined },
-  } as unknown as StoreState;
+    app: { ...base.app, propertyBags: {} },
+    logs: { ...base.logs, selectedLogFile: undefined },
+    log: { ...base.log, selectedSampleHandle: undefined },
+  };
   return {
     ...actual,
     useStore: (selector: (s: StoreState) => unknown) => selector(state),

--- a/apps/inspect/src/app/samples/transcript/chunked/mainViewOutline.test.ts
+++ b/apps/inspect/src/app/samples/transcript/chunked/mainViewOutline.test.ts
@@ -13,6 +13,14 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  testModelEvent,
+  testScore,
+  testScoreEvent,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testSubtaskEvent,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 import {
   buildOutlineNodeList,
@@ -114,48 +122,43 @@ describe("chunked outline twin (real pipeline: real events vs synthetic)", () =>
   });
 
   // Hand-built streams for skeleton shapes absent from the eval corpus.
-  // Events double as SkeletonEvent (producer input) and Event (pipeline
-  // input) — the single cast below mirrors the corpus loader's JSON cast.
+  // Full `Event` values double as SkeletonEvent (producer input) and Event
+  // (pipeline input) — the union satisfies SkeletonEvent structurally.
   const ts = (i: number) =>
     `2026-01-01T00:00:${String(i).padStart(2, "0")}+00:00`;
-  const modelAt = (i: number): SkeletonEvent & Record<string, unknown> => ({
-    event: "model",
-    span_id: "S1",
-    model: "mockllm/model",
-    input: [],
-    output: { model: "", choices: [], usage: null },
-    timestamp: ts(i),
-    working_start: i,
-  });
+  const modelAt = (i: number): Event =>
+    testModelEvent({
+      span_id: "S1",
+      model: "mockllm/model",
+      timestamp: ts(i),
+      working_start: i,
+    });
   const spanWrapped = (
-    inner: (SkeletonEvent & Record<string, unknown>)[]
+    inner: Event[]
   ): { events: Event[]; skeletonEvents: SkeletonEvent[] } => {
-    const all: (SkeletonEvent & Record<string, unknown>)[] = [
-      {
-        event: "span_begin",
+    const all: Event[] = [
+      testSpanBeginEvent({
         id: "S1",
         name: "agent1",
         type: "agent",
         timestamp: ts(0),
         working_start: 0,
-      },
+      }),
       ...inner,
-      {
-        event: "span_end",
+      testSpanEndEvent({
         id: "S1",
         span_id: "S1",
         timestamp: ts(inner.length + 1),
         working_start: inner.length + 1,
-      },
+      }),
     ];
-    return { events: all as unknown as Event[], skeletonEvents: all };
+    return { events: all, skeletonEvents: all };
   };
 
   it("subtask strays carry a labelable payload (no outline crash)", () => {
     const { skeletonEvents } = spanWrapped([
       modelAt(1),
-      {
-        event: "subtask",
+      testSubtaskEvent({
         span_id: "S1",
         name: "calc",
         input: {},
@@ -163,7 +166,7 @@ describe("chunked outline twin (real pipeline: real events vs synthetic)", () =>
         events: [],
         timestamp: ts(2),
         working_start: 2,
-      },
+      }),
     ]);
     const synth = syntheticEventsFromSkeleton(sampleSkeleton(skeletonEvents));
     // fully expanded (no collapse): every row the outline can ever render
@@ -185,14 +188,18 @@ describe("chunked outline twin (real pipeline: real events vs synthetic)", () =>
     const { events, skeletonEvents } = spanWrapped(
       [1, 2, 3, 4].flatMap((k) => [
         modelAt(k * 2 - 1),
-        {
-          event: "score",
+        testScoreEvent({
           span_id: "S1",
-          score: { value: 1, answer: null, explanation: null, metadata: null },
+          score: testScore({
+            value: 1,
+            answer: null,
+            explanation: null,
+            metadata: null,
+          }),
           intermediate: false,
           timestamp: ts(k * 2),
           working_start: k * 2,
-        } satisfies SkeletonEvent & Record<string, unknown>,
+        }),
       ])
     );
     const skeleton = sampleSkeleton(skeletonEvents, { notable_cap: 2 });

--- a/apps/inspect/src/app/server/useEvalSet.test.tsx
+++ b/apps/inspect/src/app/server/useEvalSet.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EvalSet } from "@tsmono/inspect-common/types";
 
 import { APP_CONFIG_KEY, AppConfig } from "../../app_config";
+import { testClientAPI } from "../../client/api/testClientApi";
 import { ClientAPI } from "../../client/api/types";
 
 import { useEvalSet } from "./useEvalSet";
@@ -25,7 +26,7 @@ const seedConfig = (
   get_eval_set: ClientAPI["get_eval_set"]
 ) => {
   const config = {
-    api: { get_eval_set } as unknown as ClientAPI,
+    api: testClientAPI({ get_eval_set }),
     singleFileMode: false,
     loader: "replicator",
     inspect_version: "1.0.0",
@@ -37,8 +38,7 @@ const seedConfig = (
   client.setQueryData(APP_CONFIG_KEY, config);
 };
 
-const evalSet = (id: string): EvalSet =>
-  ({ eval_set_id: id }) as unknown as EvalSet;
+const evalSet = (id: string): EvalSet => ({ eval_set_id: id, tasks: [] });
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/apps/inspect/src/app/shared/openInNewTab.test.ts
+++ b/apps/inspect/src/app/shared/openInNewTab.test.ts
@@ -10,10 +10,10 @@ describe("openInNewTab", () => {
   it.each(["/logs/example.eval", "#/logs/example.eval"])(
     "opens %s without granting opener access",
     (route) => {
-      const blur = vi.fn();
-      const open = vi
-        .spyOn(window, "open")
-        .mockReturnValue({ blur } as unknown as Window);
+      // Return the real jsdom window as the popup so no cast is needed; the
+      // spied `blur` is the popup's, the spied `focus` the opener's.
+      const blur = vi.spyOn(window, "blur").mockImplementation(() => {});
+      const open = vi.spyOn(window, "open").mockReturnValue(window);
       const focus = vi.spyOn(window, "focus").mockImplementation(() => {});
 
       openInNewTab(route);

--- a/apps/inspect/src/app/shared/samples-grid/colorScale.test.ts
+++ b/apps/inspect/src/app/shared/samples-grid/colorScale.test.ts
@@ -41,7 +41,10 @@ describe("resolveScale", () => {
   });
 
   test("unknown palette name returns null", () => {
-    const bogus = "rainbow" as unknown as WireScoreColorScale;
+    // Wire data is unvalidated — widen to string first so a single assertion
+    // models the bogus palette name arriving off the wire.
+    const bogusName: string = "rainbow";
+    const bogus = bogusName as WireScoreColorScale;
     expect(resolveScale(bogus, { min: 0, max: 1 })).toBeNull();
   });
 
@@ -85,9 +88,8 @@ describe("resolveScale", () => {
   });
 
   test("object form rejects unknown palette name", () => {
-    const bogus = {
-      palette: "rainbow",
-    } as unknown as WireScoreColorScale;
+    const bogusName: string = "rainbow";
+    const bogus = { palette: bogusName } as WireScoreColorScale;
     expect(resolveScale(bogus, { min: 0, max: 1 })).toBeNull();
   });
 });

--- a/apps/inspect/src/app/shared/samples-grid/columns.test.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import { testScore } from "@tsmono/inspect-common/testing";
+
 import type { SampleSummary } from "../../../client/api/types";
-import type { SamplesDescriptor } from "../../samples/descriptor/samplesDescriptor";
+import { testSamplesDescriptor } from "../../samples/descriptor/testDescriptors";
 import {
   buildSampleFilterSpecRegistry,
   samplesOperatorsForKind,
@@ -16,17 +18,20 @@ const kField = `${SCORE_FIELD_RAW_PREFIX}quality`;
 // exercise raw-mode score-column discovery + colour-scale wiring without a
 // full SamplesDescriptor.
 const samplesWith = (values: number[]): SampleSummary[] =>
-  values.map(
-    (v, i) =>
-      ({
-        id: i,
-        epoch: 1,
-        scores: { quality: { value: v } },
-      }) as unknown as SampleSummary
-  );
+  values.map((v, i): SampleSummary => ({
+    id: i,
+    epoch: 1,
+    input: "input",
+    target: "target",
+    scores: { quality: testScore({ value: v }) },
+  }));
 
-const rowWith = (value: number): SampleRow =>
-  ({ [kField]: value }) as unknown as SampleRow;
+const rowWith = (value: number): SampleRow => ({
+  logFile: "log.eval",
+  sampleId: 1,
+  epoch: 1,
+  [kField]: value,
+});
 
 describe("buildSampleColumns score colour scales", () => {
   it("attaches a heat-map cellStyle that interpolates across the observed range", () => {
@@ -116,7 +121,7 @@ describe("buildSampleColumns TaskSamplesColumnId wire contract", () => {
     const cols = buildSampleColumns({
       viewMode: "grid",
       multiLog: false,
-      descriptor: {} as unknown as SamplesDescriptor,
+      descriptor: testSamplesDescriptor(),
     });
     const ids = new Set(cols.map((c) => c.id));
     const missing = kTaskSamplesColumnIds.filter((id) => !ids.has(id));
@@ -129,7 +134,7 @@ describe("buildSampleColumns registry-gated filterable pass", () => {
     const cols = buildSampleColumns({
       viewMode: "grid",
       multiLog: false,
-      descriptor: {} as unknown as SamplesDescriptor,
+      descriptor: testSamplesDescriptor(),
       filterSpecRegistry: buildSampleFilterSpecRegistry(undefined),
     });
     // sampleId is intentionally unregistered (mixed number/string ids don't
@@ -149,7 +154,7 @@ describe("buildSampleColumns registry-gated filterable pass", () => {
     const cols = buildSampleColumns({
       viewMode: "grid",
       multiLog: false,
-      descriptor: {} as unknown as SamplesDescriptor,
+      descriptor: testSamplesDescriptor(),
     });
     const sampleId = cols.find((c) => c.id === "sampleId");
     expect(sampleId?.meta?.filterable).toBe(true);

--- a/apps/inspect/src/app_config/resolveBackend.test.ts
+++ b/apps/inspect/src/app_config/resolveBackend.test.ts
@@ -5,7 +5,7 @@ import { getVscodeApi } from "@tsmono/util";
 import staticHttpApi, {
   staticLogRoot,
 } from "../client/api/static-http/api-static-http";
-import { ClientAPI } from "../client/api/types";
+import { testClientAPI } from "../client/api/testClientApi";
 import {
   fetchViewServerLogDir,
   fetchViewServerLogRoot,
@@ -249,7 +249,7 @@ describe("resolveBackend selection", () => {
 });
 
 describe("embedder api factory (setApiFactory)", () => {
-  const factoryApi = { __backend: "embedder" } as unknown as ClientAPI;
+  const factoryApi = testClientAPI();
 
   it("wins over every ambient signal (vscode host present)", async () => {
     mockGetVscodeApi.mockReturnValue(

--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi } from "vitest";
 
-import { testEvalLog, testEvalSpec } from "@tsmono/inspect-common/testing";
+import { testEvalLog } from "@tsmono/inspect-common/testing";
 
 import { openRemoteLogFile, RemoteLogFile } from "../remote/remoteLogFile";
 import { DirectFetchError } from "../remote/remotePendingSampleData";
 
 import { clientApi } from "./client-api";
+import { notImplemented, testLogDetails } from "./testClientApi";
 import {
   EditLogResult,
   LogDetails,
@@ -35,10 +36,6 @@ const okResponse = (has_more = false): SampleDataResponse => ({
   has_more,
 });
 
-const notImplemented = (name: string) => () => {
-  throw new Error(`${name} not implemented in test`);
-};
-
 const remoteLogFileWith = (
   overrides: Partial<RemoteLogFile> = {}
 ): RemoteLogFile => ({
@@ -47,13 +44,6 @@ const remoteLogFileWith = (
   readSample: vi.fn(notImplemented("readSample")),
   zipAccess: vi.fn(notImplemented("zipAccess")),
   readCompleteLog: vi.fn(notImplemented("readCompleteLog")),
-  ...overrides,
-});
-
-const detailsWith = (overrides: Partial<LogDetails> = {}): LogDetails => ({
-  eval: testEvalSpec(),
-  tags: [],
-  sampleSummaries: [],
   ...overrides,
 });
 
@@ -216,7 +206,7 @@ describe("clientApi.edit_log cache invalidation", () => {
     const remoteLogFile = remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValue(detailsWith()),
+        .mockResolvedValue(testLogDetails()),
     });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
@@ -244,7 +234,7 @@ describe("clientApi.edit_log cache invalidation", () => {
     const remoteLogFile = remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValue(detailsWith()),
+        .mockResolvedValue(testLogDetails()),
     });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
@@ -270,7 +260,7 @@ describe("clientApi.edit_log cache invalidation", () => {
     const remoteLogFile = remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValue(detailsWith()),
+        .mockResolvedValue(testLogDetails()),
     });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
@@ -300,7 +290,7 @@ describe("clientApi.get_log_details running-log caching", () => {
     remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValue(detailsWith({ status })),
+        .mockResolvedValue(testLogDetails({ status })),
     });
 
   test("a running log is not re-served from the memoized remote file", async () => {
@@ -462,7 +452,7 @@ describe("clientApi.edit_log etag plumbing", () => {
     const remoteLogFile = remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValue(detailsWith({ etag: "initial-from-s3" })),
+        .mockResolvedValue(testLogDetails({ etag: "initial-from-s3" })),
     });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
@@ -490,8 +480,8 @@ describe("clientApi.edit_log etag plumbing", () => {
     const remoteLogFile = remoteLogFileWith({
       readLogSummary: vi
         .fn<RemoteLogFile["readLogSummary"]>()
-        .mockResolvedValueOnce(detailsWith({ etag: "v1" }))
-        .mockResolvedValueOnce(detailsWith({ etag: "v2" })),
+        .mockResolvedValueOnce(testLogDetails({ etag: "v1" }))
+        .mockResolvedValueOnce(testLogDetails({ etag: "v2" })),
     });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();

--- a/apps/inspect/src/client/api/client-api.test.ts
+++ b/apps/inspect/src/client/api/client-api.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test, vi } from "vitest";
 
-import { openRemoteLogFile } from "../remote/remoteLogFile";
+import { testEvalLog, testEvalSpec } from "@tsmono/inspect-common/testing";
+
+import { openRemoteLogFile, RemoteLogFile } from "../remote/remoteLogFile";
 import { DirectFetchError } from "../remote/remotePendingSampleData";
 
 import { clientApi } from "./client-api";
 import {
   EditLogResult,
+  LogDetails,
   LogPreview,
   LogViewAPI,
   SampleData,
@@ -30,6 +33,28 @@ const okResponse = (has_more = false): SampleDataResponse => ({
   status: "OK",
   sampleData: emptySampleData,
   has_more,
+});
+
+const notImplemented = (name: string) => () => {
+  throw new Error(`${name} not implemented in test`);
+};
+
+const remoteLogFileWith = (
+  overrides: Partial<RemoteLogFile> = {}
+): RemoteLogFile => ({
+  readEvalBasicInfo: vi.fn(notImplemented("readEvalBasicInfo")),
+  readLogSummary: vi.fn(notImplemented("readLogSummary")),
+  readSample: vi.fn(notImplemented("readSample")),
+  zipAccess: vi.fn(notImplemented("zipAccess")),
+  readCompleteLog: vi.fn(notImplemented("readCompleteLog")),
+  ...overrides,
+});
+
+const detailsWith = (overrides: Partial<LogDetails> = {}): LogDetails => ({
+  eval: testEvalSpec(),
+  tags: [],
+  sampleSummaries: [],
+  ...overrides,
 });
 
 const baseApi = (): LogViewAPI => ({
@@ -177,10 +202,7 @@ describe("clientApi.edit_log cache invalidation", () => {
   // shows the pre-edit tags. The JSON path uses no cache in
   // get_log_details, so we don't exercise it here.
 
-  const sampleSummary = { tags: [] as string[], sampleSummaries: [] };
-  const okEdit: EditLogResult = {
-    log: {} as unknown as EditLogResult["log"],
-  };
+  const okEdit: EditLogResult = { log: testEvalLog() };
   const okUpdate = {
     edits: [],
     provenance: {
@@ -191,10 +213,11 @@ describe("clientApi.edit_log cache invalidation", () => {
   };
 
   test("subsequent reads on the same .eval file re-open after an edit", async () => {
-    const readLogSummary = vi.fn().mockResolvedValue(sampleSummary);
-    const remoteLogFile = { readLogSummary } as unknown as Awaited<
-      ReturnType<typeof openRemoteLogFile>
-    >;
+    const remoteLogFile = remoteLogFileWith({
+      readLogSummary: vi
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValue(detailsWith()),
+    });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
     openMock.mockResolvedValue(remoteLogFile);
@@ -218,10 +241,11 @@ describe("clientApi.edit_log cache invalidation", () => {
   });
 
   test("an edit on a different log preserves the cached one", async () => {
-    const readLogSummary = vi.fn().mockResolvedValue(sampleSummary);
-    const remoteLogFile = { readLogSummary } as unknown as Awaited<
-      ReturnType<typeof openRemoteLogFile>
-    >;
+    const remoteLogFile = remoteLogFileWith({
+      readLogSummary: vi
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValue(detailsWith()),
+    });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
     openMock.mockResolvedValue(remoteLogFile);
@@ -243,10 +267,11 @@ describe("clientApi.edit_log cache invalidation", () => {
     // Cache is dropped only after the underlying call resolves; a
     // rejection propagates without disturbing the cached reader. This
     // matters so a 412 conflict doesn't trigger an unnecessary refetch.
-    const readLogSummary = vi.fn().mockResolvedValue(sampleSummary);
-    const remoteLogFile = { readLogSummary } as unknown as Awaited<
-      ReturnType<typeof openRemoteLogFile>
-    >;
+    const remoteLogFile = remoteLogFileWith({
+      readLogSummary: vi
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValue(detailsWith()),
+    });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
     openMock.mockResolvedValue(remoteLogFile);
@@ -271,12 +296,12 @@ describe("clientApi.get_log_details running-log caching", () => {
   // for cached reads leaves live views permanently stale (any consumer that
   // reads without an explicit cached=false lands on it).
 
-  const remoteFileWith = (status: string) =>
-    ({
+  const remoteFileWith = (status: LogDetails["status"]) =>
+    remoteLogFileWith({
       readLogSummary: vi
-        .fn()
-        .mockResolvedValue({ status, sampleSummaries: [] }),
-    }) as unknown as Awaited<ReturnType<typeof openRemoteLogFile>>;
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValue(detailsWith({ status })),
+    });
 
   test("a running log is not re-served from the memoized remote file", async () => {
     const openMock = vi.mocked(openRemoteLogFile);
@@ -329,7 +354,7 @@ describe("clientApi.edit_log etag plumbing", () => {
       timestamp: "2026-01-01T00:00:00Z",
     },
   };
-  const okLog = {} as unknown as EditLogResult["log"];
+  const okLog = testEvalLog();
 
   test("carries the etag from a successful edit forward to the next edit on the same log", async () => {
     const edit_log = vi
@@ -434,14 +459,11 @@ describe("clientApi.edit_log etag plumbing", () => {
     // `get_log_info` S3 head_object response), so the *first* save in
     // a session also carries `If-Match`. Without this seeding, only
     // chained edits would be protected.
-    const readLogSummary = vi.fn().mockResolvedValue({
-      tags: [] as string[],
-      sampleSummaries: [],
-      etag: "initial-from-s3",
+    const remoteLogFile = remoteLogFileWith({
+      readLogSummary: vi
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValue(detailsWith({ etag: "initial-from-s3" })),
     });
-    const remoteLogFile = { readLogSummary } as unknown as Awaited<
-      ReturnType<typeof openRemoteLogFile>
-    >;
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
     openMock.mockResolvedValue(remoteLogFile);
@@ -465,21 +487,12 @@ describe("clientApi.edit_log etag plumbing", () => {
     // cached etag must update to the new value — otherwise the next
     // edit would race using the stale etag and get a (correct but
     // confusing) 412 even though the user's local view is in sync.
-    const readLogSummary = vi
-      .fn()
-      .mockResolvedValueOnce({
-        tags: [],
-        sampleSummaries: [],
-        etag: "v1",
-      })
-      .mockResolvedValueOnce({
-        tags: [],
-        sampleSummaries: [],
-        etag: "v2",
-      });
-    const remoteLogFile = { readLogSummary } as unknown as Awaited<
-      ReturnType<typeof openRemoteLogFile>
-    >;
+    const remoteLogFile = remoteLogFileWith({
+      readLogSummary: vi
+        .fn<RemoteLogFile["readLogSummary"]>()
+        .mockResolvedValueOnce(detailsWith({ etag: "v1" }))
+        .mockResolvedValueOnce(detailsWith({ etag: "v2" })),
+    });
     const openMock = vi.mocked(openRemoteLogFile);
     openMock.mockReset();
     openMock.mockResolvedValue(remoteLogFile);
@@ -503,8 +516,14 @@ describe("clientApi.get_log_summaries_settled", () => {
   // /log-headers request must not fail every other file in that batch — see
   // the TODO in client-api.ts for the server-side fix this works around.
 
-  const previewFor = (id: string): LogPreview =>
-    ({ eval_id: id, run_id: `run-${id}` }) as unknown as LogPreview;
+  const previewFor = (id: string): LogPreview => ({
+    eval_id: id,
+    run_id: `run-${id}`,
+    task: "test_task",
+    task_id: `task-${id}`,
+    task_version: 0,
+    model: "test-model",
+  });
 
   test("wraps the batched endpoint's results as ok when it returns the full set", async () => {
     const previews = [previewFor("a"), previewFor("b")];

--- a/apps/inspect/src/client/api/testClientApi.ts
+++ b/apps/inspect/src/client/api/testClientApi.ts
@@ -1,0 +1,27 @@
+/**
+ * Cast-free ClientAPI fixture: every required member stubbed to throw,
+ * spread-merged with per-test overrides.
+ */
+import type { ClientAPI } from "./types";
+
+const notImplemented = (name: string) => (): never => {
+  throw new Error(`${name} not implemented in test`);
+};
+
+export const testClientAPI = (
+  overrides: Partial<ClientAPI> = {}
+): ClientAPI => ({
+  get_logs: notImplemented("get_logs"),
+  get_eval_set: notImplemented("get_eval_set"),
+  get_flow: notImplemented("get_flow"),
+  get_log_summaries: notImplemented("get_log_summaries"),
+  get_log_summaries_settled: notImplemented("get_log_summaries_settled"),
+  get_log_details: notImplemented("get_log_details"),
+  get_log_info: notImplemented("get_log_info"),
+  get_log_sample: notImplemented("get_log_sample"),
+  client_events: notImplemented("client_events"),
+  download_file: notImplemented("download_file"),
+  open_log_file: notImplemented("open_log_file"),
+  get_app_config: notImplemented("get_app_config"),
+  ...overrides,
+});

--- a/apps/inspect/src/client/api/testClientApi.ts
+++ b/apps/inspect/src/client/api/testClientApi.ts
@@ -1,13 +1,21 @@
 /**
- * Cast-free ClientAPI fixture: every required member stubbed to throw,
- * spread-merged with per-test overrides.
+ * Cast-free fixtures for the client/api types: a ClientAPI whose members
+ * throw unless overridden, and complete minimal values of the log data
+ * shapes, spread-merged with per-test overrides.
  */
-import type { ClientAPI } from "./types";
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
 
-const notImplemented = (name: string) => (): never => {
+import type { ClientAPI, LogDetails, LogHeader, SampleSummary } from "./types";
+
+export const notImplemented = (name: string) => (): never => {
   throw new Error(`${name} not implemented in test`);
 };
 
+/**
+ * A complete ClientAPI whose required methods throw unless overridden.
+ * Optional methods stay undefined so presence-probing code paths behave as
+ * they would against a backend that lacks them.
+ */
 export const testClientAPI = (
   overrides: Partial<ClientAPI> = {}
 ): ClientAPI => ({
@@ -23,5 +31,37 @@ export const testClientAPI = (
   download_file: notImplemented("download_file"),
   open_log_file: notImplemented("open_log_file"),
   get_app_config: notImplemented("get_app_config"),
+  ...overrides,
+});
+
+export const testSampleSummary = (
+  overrides: Partial<SampleSummary> = {}
+): SampleSummary => ({
+  id: "s1",
+  epoch: 1,
+  input: "input",
+  target: "",
+  scores: null,
+  ...overrides,
+});
+
+export const testLogDetails = (
+  overrides: Partial<LogDetails> = {}
+): LogDetails => ({
+  version: 2,
+  status: "success",
+  eval: testEvalSpec(),
+  sampleSummaries: [],
+  ...overrides,
+});
+
+/** The stored form of a details payload (LogHeader), with sample facts zeroed. */
+export const testLogHeader = (
+  overrides: Partial<LogHeader> = {}
+): LogHeader => ({
+  eval: testEvalSpec(),
+  sampleCount: 0,
+  sampleErrorCount: 0,
+  sampleLimits: [],
   ...overrides,
 });

--- a/apps/inspect/src/client/api/view-server/api-view-server.test.ts
+++ b/apps/inspect/src/client/api/view-server/api-view-server.test.ts
@@ -17,19 +17,16 @@ describe("viewServerApi.eval_log_sample_data_direct", () => {
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       const url = String(input);
       expect(url).toContain("/pending-sample-data-urls?");
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        text: () =>
-          Promise.resolve(
-            JSON.stringify({
-              segments: [],
-              complete: true,
-              has_more: false,
-            })
-          ),
-      } as unknown as Response);
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            segments: [],
+            complete: true,
+            has_more: false,
+          }),
+          { status: 200, statusText: "OK" }
+        )
+      );
     });
 
     const api = viewServerApi({
@@ -67,12 +64,9 @@ describe("viewServerApi mutation requests", () => {
 
   test("posts client messages with the viewer request header", async () => {
     const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
-      Promise.resolve({
-        ok: true,
-        status: 204,
-        statusText: "No Content",
-        text: () => Promise.resolve(""),
-      } as unknown as Response)
+      Promise.resolve(
+        new Response(null, { status: 204, statusText: "No Content" })
+      )
     );
     globalThis.fetch = fetchMock;
 
@@ -97,13 +91,7 @@ describe("viewServerApi mutation requests", () => {
 
   test("adds the viewer request header to log edits", async () => {
     const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        headers: new Headers(),
-        text: () => Promise.resolve("{}"),
-      } as unknown as Response)
+      Promise.resolve(new Response("{}", { status: 200, statusText: "OK" }))
     );
     globalThis.fetch = fetchMock;
 
@@ -142,13 +130,7 @@ describe("viewServerApi.get_eval_set", () => {
   });
 
   const okJson = () =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      text: () => Promise.resolve("{}"),
-    } as unknown as Response);
+    Promise.resolve(new Response("{}", { status: 200, statusText: "OK" }));
 
   test("sends the construction log_dir with no dir param at the listing root", async () => {
     const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
@@ -199,16 +181,9 @@ describe("viewServerApi dir independence", () => {
     vi.restoreAllMocks();
   });
 
+  // get_flow reads this as bytes rather than text; "{}" decodes fine either way.
   const okJson = () =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers(),
-      text: () => Promise.resolve("{}"),
-      // get_flow reads bytes rather than text.
-      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-    } as unknown as Response);
+    Promise.resolve(new Response("{}", { status: 200, statusText: "OK" }));
 
   test("two instances over the same transport answer for their own dirs", async () => {
     // The LogViewAPI contract: an instance is bound to its construction dir.

--- a/apps/inspect/src/client/api/view-server/request.test.ts
+++ b/apps/inspect/src/client/api/view-server/request.test.ts
@@ -5,15 +5,16 @@ import { serverRequestApi } from "./request";
 describe("serverRequestApi customFetch", () => {
   test("routes requests through the provided customFetch", async () => {
     const calls: Array<{ url: string; method?: string }> = [];
-    const customFetch = vi.fn((input: string, init?: RequestInit) => {
-      calls.push({ url: input, method: init?.method });
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        text: () => Promise.resolve("[]"),
-      } as unknown as Response);
-    }) as unknown as typeof fetch;
+    const customFetch = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        // The test only ever calls fetch with a string URL.
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        calls.push({ url: String(input), method: init?.method });
+        return Promise.resolve(
+          new Response("[]", { status: 200, statusText: "OK" })
+        );
+      }
+    );
 
     const api = serverRequestApi("/api", undefined, customFetch);
     await api.fetchString("GET", "/logs");
@@ -26,12 +27,7 @@ describe("serverRequestApi customFetch", () => {
   test("falls back to global fetch when no customFetch given", async () => {
     const realFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        text: () => Promise.resolve("[]"),
-      } as unknown as Response)
+      Promise.resolve(new Response("[]", { status: 200, statusText: "OK" }))
     );
     try {
       const api = serverRequestApi("/api");

--- a/apps/inspect/src/client/api/vscode/api-vscode.e2e.test.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.e2e.test.ts
@@ -28,7 +28,7 @@ function connectFakeExtension(handler: (req: ProxyRequest) => ProxyResponse): {
   received: Array<{ method: string; params: unknown }>;
 } {
   const received: Array<{ method: string; params: unknown }> = [];
-  const vscode = {
+  const vscode: VSCodeApi = {
     postMessage: (data: unknown) => {
       const req = data as {
         jsonrpc: string;
@@ -48,8 +48,8 @@ function connectFakeExtension(handler: (req: ProxyRequest) => ProxyResponse): {
       });
     },
     getState: () => undefined,
-    setState: (s: unknown) => s,
-  } as unknown as VSCodeApi;
+    setState: () => {},
+  };
   return { vscode, received };
 }
 

--- a/apps/inspect/src/client/api/vscode/api-vscode.test.ts
+++ b/apps/inspect/src/client/api/vscode/api-vscode.test.ts
@@ -13,11 +13,13 @@ const stubFetch: typeof fetch = () =>
 
 function fakeVscode() {
   const posted: unknown[] = [];
-  const api = {
-    postMessage: (msg: unknown) => posted.push(msg),
+  const api: VSCodeApi = {
+    postMessage: (msg: unknown) => {
+      posted.push(msg);
+    },
     getState: () => undefined,
-    setState: (s: unknown) => s,
-  } as unknown as VSCodeApi;
+    setState: () => {},
+  };
   return { api, posted };
 }
 

--- a/apps/inspect/src/client/api/vscode/host-capabilities.test.ts
+++ b/apps/inspect/src/client/api/vscode/host-capabilities.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import { readHostCapabilities } from "./host-capabilities";
 
-function docWith(textContent: string | null) {
+function docWith(textContent: string | null): Pick<Document, "getElementById"> {
+  const el = document.createElement("script");
+  el.textContent = textContent;
   return {
     getElementById: (id: string) =>
-      id === "inspect-host-capabilities" && textContent !== null
-        ? ({ textContent } as unknown as HTMLElement)
-        : null,
-  } as Pick<Document, "getElementById">;
+      id === "inspect-host-capabilities" && textContent !== null ? el : null,
+  };
 }
 
 describe("readHostCapabilities", () => {

--- a/apps/inspect/src/client/database/database.test.ts
+++ b/apps/inspect/src/client/database/database.test.ts
@@ -12,6 +12,7 @@ import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { LogHandle } from "@tsmono/inspect-common";
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
 
 import {
   LogDetails,
@@ -47,7 +48,7 @@ function createTestLogInfo(overrides: Partial<LogDetails> = {}): LogDetails {
   return {
     version: 1,
     status: "success",
-    eval: {
+    eval: testEvalSpec({
       eval_set_id: "set-1",
       eval_id: "eval-1",
       run_id: "run-1",
@@ -58,9 +59,6 @@ function createTestLogInfo(overrides: Partial<LogDetails> = {}): LogDetails {
       task_file: "test.py",
       task_display_name: "Test Task",
       task_registry_name: "test",
-      task_attribs: {},
-      task_args: {},
-      task_args_passed: {},
       solver: null,
       solver_args: {},
       tags: [],
@@ -73,9 +71,8 @@ function createTestLogInfo(overrides: Partial<LogDetails> = {}): LogDetails {
       },
       sandbox: null,
       model: "gpt-4",
-      model_generate_config: {},
       model_base_url: null,
-    } as unknown as LogDetails["eval"],
+    }),
     plan: undefined,
     results: null,
     stats: undefined,

--- a/apps/inspect/src/client/remote/remoteLogFile.test.ts
+++ b/apps/inspect/src/client/remote/remoteLogFile.test.ts
@@ -15,6 +15,9 @@
 
 import { describe, expect, test } from "vitest";
 
+import { testEvalPlan, testEvalSpec } from "@tsmono/inspect-common/testing";
+import type { EvalSpec } from "@tsmono/inspect-common/types";
+
 import { SampleSummary } from "../api/types";
 
 import {
@@ -24,19 +27,17 @@ import {
   readJournalConfigUpdatesFrom,
 } from "./remoteLogFile";
 
-const baseEval = {
-  // EvalSpec has more fields, but the helper only touches `tags` and
-  // `metadata`; we cast as needed to avoid building the full shape.
+const baseEval = testEvalSpec({
   task: "test_task",
   task_id: "task_id",
   created: "2026-05-20T00:00:00Z",
-};
+});
 
-function makeStart(eval_: Record<string, unknown>): LogStart {
+function makeStart(eval_: EvalSpec): LogStart {
   return {
     version: 2,
-    eval: eval_ as unknown as LogStart["eval"],
-    plan: {} as LogStart["plan"],
+    eval: eval_,
+    plan: testEvalPlan(),
   };
 }
 

--- a/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
+++ b/apps/inspect/src/client/remote/remotePendingSampleData.test.ts
@@ -55,12 +55,7 @@ describe("fetchPendingSampleDataDirect", () => {
             call_pool: [],
           })
         );
-        return {
-          ok: true,
-          status: 200,
-          statusText: "OK",
-          arrayBuffer: () => Promise.resolve(body.buffer),
-        } as unknown as Response;
+        return new Response(body, { status: 200, statusText: "OK" });
       });
     });
 

--- a/apps/inspect/src/client/utils/derive.test.ts
+++ b/apps/inspect/src/client/utils/derive.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "vitest";
 
+import {
+  testEvalMetric,
+  testEvalResults,
+  testEvalScore,
+  testEvalSpec,
+  testEvalStats,
+} from "@tsmono/inspect-common/testing";
+
 import { LogHeader, SampleSummary } from "../api/types";
 
 import { deriveLogFields, deriveSampleFields } from "./derive";
@@ -7,16 +15,14 @@ import { deriveLogFields, deriveSampleFields } from "./derive";
 const makeHeader = (overrides: Partial<LogHeader> = {}): LogHeader => ({
   version: 1,
   status: "success",
-  eval: {
+  eval: testEvalSpec({
     eval_id: "eval-1",
     run_id: "run-1",
     created: "2024-01-01T00:00:00Z",
     task: "test-task",
     task_id: "task-1",
-    task_args: {},
-    task_args_passed: {},
     model: "gpt-4",
-  } as unknown as LogHeader["eval"],
+  }),
   results: null,
   stats: undefined,
   error: null,
@@ -41,7 +47,7 @@ const makeSummary = (
 describe("deriveLogFields", () => {
   test("sums total tokens across models", () => {
     const header = makeHeader({
-      stats: {
+      stats: testEvalStats({
         started_at: "2024-01-01T00:00:00Z",
         completed_at: "2024-01-01T01:00:00Z",
         model_usage: {
@@ -56,7 +62,7 @@ describe("deriveLogFields", () => {
             total_tokens: 30,
           },
         },
-      } as unknown as LogHeader["stats"],
+      }),
     });
     const derived = deriveLogFields(header);
     expect(derived.total_tokens).toBe(45);
@@ -75,31 +81,30 @@ describe("deriveLogFields", () => {
 
   test("ignores a duration whose end precedes its start", () => {
     const header = makeHeader({
-      stats: {
+      stats: testEvalStats({
         started_at: "2024-01-01T02:00:00Z",
         completed_at: "2024-01-01T01:00:00Z",
-        model_usage: {},
-      } as unknown as LogHeader["stats"],
+      }),
     });
     expect(deriveLogFields(header).duration).toBeUndefined();
   });
 
   test("formats task args, preferring task_args_passed", () => {
     const header = makeHeader({
-      eval: {
+      eval: testEvalSpec({
         task_args: { a: 1, b: "two", defaulted: true },
         task_args_passed: { a: 1, b: "two" },
-      } as unknown as LogHeader["eval"],
+      }),
     });
     expect(deriveLogFields(header).task_args).toBe('a=1, b="two"');
   });
 
   test("computes percent completed and joins sample limits", () => {
     const header = makeHeader({
-      results: {
+      results: testEvalResults({
         total_samples: 8,
         completed_samples: 2,
-      } as unknown as LogHeader["results"],
+      }),
       sampleLimits: ["message", "time"],
     });
     const derived = deriveLogFields(header);
@@ -109,23 +114,25 @@ describe("deriveLogFields", () => {
 
   test("maps scores keyed scorer → metric", () => {
     const header = makeHeader({
-      results: {
+      results: testEvalResults({
         total_samples: 1,
         completed_samples: 1,
         scores: [
-          {
+          testEvalScore({
             name: "grader",
             metrics: {
-              accuracy: { name: "accuracy", value: 0.9 },
-              stderr: { name: "stderr", value: 0.01 },
+              accuracy: testEvalMetric({ name: "accuracy", value: 0.9 }),
+              stderr: testEvalMetric({ name: "stderr", value: 0.01 }),
             },
-          },
-          {
+          }),
+          testEvalScore({
             name: "other",
-            metrics: { accuracy: { name: "accuracy", value: 0.5 } },
-          },
+            metrics: {
+              accuracy: testEvalMetric({ name: "accuracy", value: 0.5 }),
+            },
+          }),
         ],
-      } as unknown as LogHeader["results"],
+      }),
     });
     expect(deriveLogFields(header).scores).toEqual({
       grader: { accuracy: 0.9, stderr: 0.01 },
@@ -145,10 +152,8 @@ describe("deriveSampleFields", () => {
           output_tokens: 5,
           total_tokens: 15,
         },
-      } as unknown as SampleSummary["model_usage"],
-      model_fallbacks: [
-        { model: "a", fallback_model: "b", count: 2 },
-      ] as unknown as SampleSummary["model_fallbacks"],
+      },
+      model_fallbacks: [{ model: "a", fallback_model: "b", count: 2 }],
       scores: {
         accuracy: {
           value: 1,

--- a/apps/inspect/src/log_data/fetchEngine.test.ts
+++ b/apps/inspect/src/log_data/fetchEngine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { LogFilesResponse, LogHandle } from "@tsmono/inspect-common";
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
 
 import {
   ClientAPI,
@@ -16,21 +17,29 @@ import { WorkResult } from "../utils/workQueue";
 
 import { FetchEngine, FetchEngineDeps, LogsContentSink } from "./fetchEngine";
 import { syncListing } from "./listingSync";
+import {
+  testClientAPI,
+  testDatabaseService,
+  testLogDetails,
+} from "./testFixtures";
 
 // --- fakes (no jsdom, no react-query) ---
 
 const makeDetails = (
   name: string,
   status: "success" | "started" | "error" = "success",
-  extra: Record<string, unknown> = {}
+  extra: Partial<LogDetails> = {}
 ): LogDetails =>
-  ({
-    version: 2,
+  testLogDetails({
     status,
-    eval: { eval_id: name, run_id: `run-${name}`, task: "task", model: "m" },
-    sampleSummaries: [],
+    eval: testEvalSpec({
+      eval_id: name,
+      run_id: `run-${name}`,
+      task: "task",
+      model: "m",
+    }),
     ...extra,
-  }) as unknown as LogDetails;
+  });
 
 // The stored/cached form of the same fixture (what a db row's header holds).
 const makeHeader = (
@@ -42,8 +51,15 @@ const makeHeader = (
 const makePreview = (
   name: string,
   status: "success" | "started" = "success"
-): LogPreview =>
-  ({ eval_id: name, run_id: `run-${name}`, status }) as unknown as LogPreview;
+): LogPreview => ({
+  eval_id: name,
+  run_id: `run-${name}`,
+  task: "task",
+  task_id: "task_1",
+  task_version: 0,
+  model: "m",
+  status,
+});
 
 const handle = (name: string, mtime?: number): LogHandle =>
   mtime === undefined ? { name } : { name, mtime };
@@ -175,7 +191,7 @@ const createFakeApi = (options: FakeApiOptions = {}) => {
   };
 
   return {
-    api: api as unknown as ClientAPI,
+    api: testClientAPI(api),
     detailCalls,
     summaryCalls,
     callOrder,
@@ -192,7 +208,7 @@ const createFakeDb = (initialRows: Log[] = []): DatabaseService => {
     initialRows.map((row) => [row.name, { ...row }])
   );
 
-  const fake = {
+  return testDatabaseService({
     opened: () => true,
     readLogs: () =>
       Promise.resolve(Object.values(rows).map((row) => ({ ...row }))),
@@ -238,10 +254,8 @@ const createFakeDb = (initialRows: Log[] = []): DatabaseService => {
         logSummaries: 0,
         logHeaders: 0,
         sampleSummaries: 0,
-        logHandle: null,
       }),
-  };
-  return fake as unknown as DatabaseService;
+  });
 };
 
 // `db`, when provided, is a realism relay — mirrors how the real sink
@@ -540,9 +554,7 @@ describe("FetchEngine.start", () => {
     // last — the superseded start bails instead of seeding the new session
     // with the old dir's rows.
     const rowsA = deferred<Log[]>();
-    const dbA = {
-      readLogs: () => rowsA.promise,
-    } as unknown as DatabaseService;
+    const dbA = testDatabaseService({ readLogs: () => rowsA.promise });
     const rowB = previewedRow(handle("b.eval", 1));
     const engine = new FetchEngine({ flushDelayMs: 0, statsDelayMs: 0 });
     const sinkA = createFakeSink();

--- a/apps/inspect/src/log_data/listingSync.test.ts
+++ b/apps/inspect/src/log_data/listingSync.test.ts
@@ -6,13 +6,14 @@ import { ClientAPI } from "../client/api/types";
 
 import { ListingUpdate } from "./fetchEngine";
 import { ListingTarget, syncListing } from "./listingSync";
+import { testClientAPI } from "./testFixtures";
 
 const handle = (name: string, mtime?: number): LogHandle => ({ name, mtime });
 
 const apiWith = (response: LogFilesResponse): ClientAPI =>
-  ({
+  testClientAPI({
     get_logs: vi.fn().mockResolvedValue(response),
-  }) as unknown as ClientAPI;
+  });
 
 const targetWith = (local: LogHandle[]) => {
   const applied: ListingUpdate[] = [];

--- a/apps/inspect/src/log_data/log.test.ts
+++ b/apps/inspect/src/log_data/log.test.ts
@@ -3,12 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
+
 import { Log, LogDetails } from "../client/api/types";
 import { toLogHeader } from "../client/utils/type-utils";
 import { queryClient } from "../state/queryClient";
 
 import { useLogHeader } from "./log";
 import { clearFile, logKey, logsKey, writeDetails } from "./logsContent";
+import { testLogDetails } from "./testFixtures";
 
 const fetchLog = vi.hoisted(() => vi.fn());
 vi.mock("./replicationControl", () => ({ fetchLog }));
@@ -25,12 +28,14 @@ const LOG_DIR = "/logs";
 const LOG_FILE = "log.eval";
 
 const makeDetails = (name: string): LogDetails =>
-  ({
-    version: 2,
-    status: "success",
-    eval: { eval_id: name, run_id: `run-${name}`, task: "task", model: "m" },
-    sampleSummaries: [],
-  }) as unknown as LogDetails;
+  testLogDetails({
+    eval: testEvalSpec({
+      eval_id: name,
+      run_id: `run-${name}`,
+      task: "task",
+      model: "m",
+    }),
+  });
 
 const detailedRow = (name: string): Log => ({
   name,

--- a/apps/inspect/src/log_data/messagesFromEvents.test.ts
+++ b/apps/inspect/src/log_data/messagesFromEvents.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testToolMessage,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { ChatMessage, Event } from "@tsmono/inspect-common/types";
 
 import {
@@ -15,44 +23,32 @@ const makeModelEvent = (opts: {
   inputId?: string;
   outputId?: string;
 }): Event =>
-  ({
-    event: "model",
+  testModelEvent({
     error: opts.error ?? null,
     input:
       opts.input ??
       (opts.inputId
-        ? [{ id: opts.inputId, role: "user", content: "hello", source: null }]
+        ? [testUserMessage({ id: opts.inputId, content: "hello" })]
         : []),
-    output: {
+    output: testModelOutput({
       choices: [
-        {
-          message: {
+        testChatCompletionChoice({
+          message: testAssistantMessage({
             id: opts.outputId ?? null,
-            role: "assistant",
             content: "response",
             source: "generate",
-          },
-        },
+          }),
+        }),
       ],
-    },
-  }) as unknown as Event;
+    }),
+  });
 
 const userMsg = (id: string): ChatMessage =>
-  ({ id, role: "user", content: "u", source: null }) as unknown as ChatMessage;
+  testUserMessage({ id, content: "u" });
 const assistantMsg = (id: string): ChatMessage =>
-  ({
-    id,
-    role: "assistant",
-    content: "a",
-    source: "generate",
-  }) as unknown as ChatMessage;
+  testAssistantMessage({ id, content: "a", source: "generate" });
 const toolMsg = (id: string): ChatMessage =>
-  ({
-    id,
-    role: "tool",
-    content: "t",
-    source: null,
-  }) as unknown as ChatMessage;
+  testToolMessage({ id, content: "t" });
 
 describe("messagesFromEvents", () => {
   it("returns messages from successful model events", () => {

--- a/apps/inspect/src/log_data/pendingSamples.test.ts
+++ b/apps/inspect/src/log_data/pendingSamples.test.ts
@@ -15,6 +15,7 @@ import {
   pendingSamplesKey,
   shouldPollPendingSamples,
 } from "./pendingSamples";
+import { testClientAPI } from "./testFixtures";
 
 const engineFetch = vi.hoisted(() => vi.fn());
 vi.mock("./fetchEngine", () => ({
@@ -106,10 +107,10 @@ describe("fetchPendingSamples", () => {
     const getPending = vi.fn().mockResolvedValue(response);
     let currentInfo = info;
     return {
-      api: {
+      api: testClientAPI({
         get_log_pending_samples: getPending,
         get_log_info: vi.fn(() => Promise.resolve(currentInfo)),
-      } as unknown as ClientAPI,
+      }),
       getPending,
       setSize: (size: number) => {
         currentInfo = { size };

--- a/apps/inspect/src/log_data/replicationControl.test.ts
+++ b/apps/inspect/src/log_data/replicationControl.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { AppConfig } from "../app_config";
 
+import { testClientAPI } from "./testFixtures";
+
 // The activation lifecycle under test is module state (the current
 // activation, waiters, pending sync), so every test re-imports a fresh module
 // via `control()` after `vi.resetModules()`. Collaborators are mocked at the
@@ -41,12 +43,14 @@ vi.mock("./logsContent", () => ({ createLogsContentSink: () => ({}) }));
 
 const control = () => import("./replicationControl");
 
-const configFor = (logDir: string): AppConfig =>
-  ({
-    logDir,
-    api: { __dir: logDir },
-    singleFileMode: false,
-  }) as unknown as AppConfig;
+const configFor = (logDir: string): AppConfig => ({
+  logDir,
+  api: testClientAPI(),
+  singleFileMode: false,
+  loader: "replicator",
+  inspect_version: "test",
+  scout_version: null,
+});
 
 beforeEach(() => {
   vi.resetModules();

--- a/apps/inspect/src/log_data/runningSampleQuery.test.ts
+++ b/apps/inspect/src/log_data/runningSampleQuery.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { testEvalSample } from "@tsmono/inspect-common/testing";
 import { EvalSample } from "@tsmono/inspect-common/types";
 
 import { initAppConfig } from "../app_config";
 import { SampleHandle } from "../app/types";
 import {
-  ClientAPI,
   SampleData,
   SampleDataResponse,
   SampleSummary,
@@ -23,6 +23,7 @@ import {
 import { SampleNotFoundError } from "./sampleFetch";
 import { sampleQueryKey } from "./sampleQuery";
 import { samplesListingKey, SamplesListingRow } from "./samplesListing";
+import { testClientAPI, testSampleSummary } from "./testFixtures";
 
 const LOG_DIR = "/logs";
 
@@ -31,7 +32,7 @@ const mockApi = {
   get_log_sample_data: vi.fn(),
   log_message: vi.fn(),
 };
-const api = mockApi as unknown as ClientAPI;
+const api = testClientAPI(mockApi);
 
 const emptySampleData: SampleData = {
   events: [],
@@ -77,15 +78,8 @@ const seedLogDetails = (logFile: string, summaries: SampleSummary[]) => {
   );
 };
 
-const rawSample = (overrides: Record<string, unknown> = {}) =>
-  ({
-    id: "sample-1",
-    epoch: 1,
-    events: [],
-    messages: [],
-    attachments: {},
-    ...overrides,
-  }) as unknown as EvalSample;
+const rawSample = (): EvalSample =>
+  testEvalSample({ id: "sample-1", epoch: 1 });
 
 beforeEach(() => {
   mockApi.get_log_sample.mockReset();
@@ -212,8 +206,8 @@ describe("streamRunningSampleTick", () => {
     seedLogDetails(handle.logFile, []);
     queryClient.setQueryData(pendingSamplesKey(LOG_DIR, handle.logFile), {
       samples: [
-        { id: "sample-1", epoch: 1, error: "boom", completed: true },
-      ] as unknown as SampleSummary[],
+        testSampleSummary({ id: "sample-1", error: "boom", completed: true }),
+      ],
       refresh: 2,
     });
     mockApi.get_log_sample_data.mockResolvedValueOnce({ status: "NotFound" });
@@ -239,7 +233,7 @@ describe("streamRunningSampleTick", () => {
   it("finalizes when the log summary reports the sample completed", async () => {
     const handle = makeHandle("summary-complete.eval");
     seedLogDetails(handle.logFile, [
-      { id: "sample-1", epoch: 1, completed: true } as unknown as SampleSummary,
+      testSampleSummary({ id: "sample-1", completed: true }),
     ]);
     mockApi.get_log_sample_data.mockResolvedValueOnce({
       status: "NotModified",

--- a/apps/inspect/src/log_data/sampleFetch.test.ts
+++ b/apps/inspect/src/log_data/sampleFetch.test.ts
@@ -12,6 +12,7 @@ import {
   SampleNotFoundError,
   synthesizeErroredSampleFromSummary,
 } from "./sampleFetch";
+import { testClientAPI } from "./testFixtures";
 
 const msg = (id: string, role: string, content: string) => ({
   id,
@@ -169,8 +170,8 @@ describe("resolveSample", () => {
 });
 
 describe("fetchSample", () => {
-  const makeApi = (get_log_sample: ReturnType<typeof vi.fn>) =>
-    ({ get_log_sample }) as unknown as ClientAPI;
+  const makeApi = (get_log_sample: ClientAPI["get_log_sample"]) =>
+    testClientAPI({ get_log_sample });
 
   it("fetches with the handle's coordinates and normalizes the EvalSample", async () => {
     const get_log_sample = vi.fn().mockResolvedValue(

--- a/apps/inspect/src/log_data/sampleMessages.test.ts
+++ b/apps/inspect/src/log_data/sampleMessages.test.ts
@@ -11,7 +11,7 @@ import {
   testHandle as handle,
   testMessages as makeMessages,
   makeWrapper,
-  testModelEvent as modelEvent,
+  testModelEventWithIds as modelEvent,
   sequenceReaderOver,
   settledData,
   testChunkedSample,

--- a/apps/inspect/src/log_data/sampleQuery.test.ts
+++ b/apps/inspect/src/log_data/sampleQuery.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 
+import { testEvalSample } from "@tsmono/inspect-common/testing";
 import { EvalSample } from "@tsmono/inspect-common/types";
 import { AsyncData, data, loading } from "@tsmono/util";
 
@@ -25,8 +26,7 @@ const makeSummary = (overrides: Partial<SampleSummary> = {}): SampleSummary =>
     ...overrides,
   }) as SampleSummary;
 
-const makeSample = (): EvalSample =>
-  ({ id: "s1", epoch: 1, events: [], messages: [] }) as unknown as EvalSample;
+const makeSample = (): EvalSample => testEvalSample({ id: "s1", epoch: 1 });
 
 const notFound = (): AsyncData<EvalSample> => ({
   loading: false,

--- a/apps/inspect/src/log_data/sampleStream.test.ts
+++ b/apps/inspect/src/log_data/sampleStream.test.ts
@@ -3,13 +3,14 @@
    assertions reach into their dynamically-shaped fields. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ClientAPI, SampleData, SampleDataResponse } from "../client/api/types";
+import { SampleData, SampleDataResponse } from "../client/api/types";
 
 import {
   createSampleStreamSession,
   hasSampleDataUpdates,
   shouldFinalizeStreamingSample,
 } from "./sampleStream";
+import { testClientAPI } from "./testFixtures";
 
 const emptySampleData: SampleData = {
   events: [],
@@ -73,7 +74,7 @@ const mockApi = {
   get_log_sample_data: vi.fn(),
   log_message: vi.fn(),
 };
-const api = mockApi as unknown as ClientAPI;
+const api = testClientAPI(mockApi);
 
 const makeSession = () =>
   createSampleStreamSession(api, "log.eval", "sample-1", 1);

--- a/apps/inspect/src/log_data/sampleSummaries.test.ts
+++ b/apps/inspect/src/log_data/sampleSummaries.test.ts
@@ -4,6 +4,8 @@ import Dexie from "dexie";
 import { createElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
+
 import {
   ClientAPI,
   LogDetails,
@@ -24,6 +26,7 @@ import {
   deactivateFetchEngine,
 } from "./replicationControl";
 import { mergeSampleSummaries, useSampleSummaries } from "./sampleSummaries";
+import { testClientAPI, testLogDetails } from "./testFixtures";
 
 const holder = vi.hoisted(() => ({
   service: null as DatabaseService | null,
@@ -117,10 +120,9 @@ describe("useSampleSummaries during a running eval", () => {
   let serverInfo: { size: number };
 
   const details = (sampleSummaries: SampleSummary[]): LogDetails =>
-    ({
-      version: 2,
+    testLogDetails({
       status: "started",
-      eval: {
+      eval: testEvalSpec({
         eval_id: "eval-run",
         run_id: "run-run",
         created: "2026-01-01T00:00:00Z",
@@ -128,11 +130,11 @@ describe("useSampleSummaries during a running eval", () => {
         task_id: "tid-run",
         task_version: 1,
         model: "mockllm/model",
-      },
+      }),
       sampleSummaries,
-    }) as unknown as LogDetails;
+    });
 
-  const api = {
+  const api = testClientAPI({
     get_log_details: vi.fn(() => Promise.resolve(serverDetails)),
     get_log_info: vi.fn(() => Promise.resolve(serverInfo)),
     get_log_pending_samples: vi.fn(
@@ -150,7 +152,7 @@ describe("useSampleSummaries during a running eval", () => {
               }
         )
     ),
-  } as unknown as ClientAPI;
+  });
 
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);

--- a/apps/inspect/src/log_data/samplesListing.test.ts
+++ b/apps/inspect/src/log_data/samplesListing.test.ts
@@ -4,6 +4,8 @@ import Dexie from "dexie";
 import { createElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
+
 import { LogDetails, SampleSummary } from "../client/api/types";
 import {
   createDatabaseService,
@@ -14,6 +16,7 @@ import { queryClient } from "../state/queryClient";
 
 import { clearFile, createLogsContentSink, writeDetails } from "./logsContent";
 import { useSamplesListing } from "./samplesListing";
+import { testLogDetails } from "./testFixtures";
 
 // The module-under-test reads Dexie through the shared instance; route it to
 // this test's real (fake-indexeddb-backed) service.
@@ -47,10 +50,9 @@ const payload = (
   status: LogDetails["status"],
   sampleSummaries: SampleSummary[]
 ): LogDetails =>
-  ({
-    version: 2,
+  testLogDetails({
     status,
-    eval: {
+    eval: testEvalSpec({
       eval_id: `eval-${file}`,
       run_id: `run-${file}`,
       created: "2026-01-01T00:00:00Z",
@@ -58,9 +60,9 @@ const payload = (
       task_id: `tid-${file}`,
       task_version: 1,
       model: "mockllm/model",
-    },
+    }),
     sampleSummaries,
-  }) as unknown as LogDetails;
+  });
 
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(QueryClientProvider, { client: queryClient }, children);

--- a/apps/inspect/src/log_data/scoreSchema.test.ts
+++ b/apps/inspect/src/log_data/scoreSchema.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testEvalMetric,
+  testEvalResults,
+  testEvalScore,
+} from "@tsmono/inspect-common/testing";
+
 import { Log, LogHeader } from "../client/api/types";
 
 import { computeScorerMap, scorerMapsEqual } from "./scoreSchema";
+import { testLogHeader } from "./testFixtures";
 
 // Wrap header fixtures as detailed-depth Log rows (the fn's input shape).
 const fromMap = (map: Record<string, LogHeader>): Log[] =>
@@ -18,16 +25,23 @@ const fromMap = (map: Record<string, LogHeader>): Log[] =>
 const details = (
   scores: Array<{ name: string; metrics: Record<string, number | string> }>
 ): LogHeader =>
-  ({
-    results: {
-      scores: scores.map((s) => ({
-        name: s.name,
-        metrics: Object.fromEntries(
-          Object.entries(s.metrics).map(([m, value]) => [m, { value }])
-        ),
-      })),
-    },
-  }) as unknown as LogHeader;
+  testLogHeader({
+    results: testEvalResults({
+      scores: scores.map((s) =>
+        testEvalScore({
+          name: s.name,
+          metrics: Object.fromEntries(
+            Object.entries(s.metrics).map(([m, value]) => [
+              m,
+              // `as number` widens past the schema: real logs carry string
+              // metric values, and computeScorerMap branches on typeof.
+              testEvalMetric({ name: m, value: value as number }),
+            ])
+          ),
+        })
+      ),
+    }),
+  });
 
 describe("computeScorerMap", () => {
   it("collects one entry per (scorer, metric) pair across logs", () => {
@@ -89,7 +103,7 @@ describe("computeScorerMap", () => {
   it("skips logs without score results", () => {
     const map = computeScorerMap(
       fromMap({
-        "/dir/a.eval": { sampleSummaries: [] } as unknown as LogHeader,
+        "/dir/a.eval": testLogHeader(),
       })
     );
     expect(map).toEqual({});

--- a/apps/inspect/src/log_data/testFixtures.ts
+++ b/apps/inspect/src/log_data/testFixtures.ts
@@ -6,9 +6,17 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, ReactNode } from "react";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
 import { ChatMessage, EvalSample, Event } from "@tsmono/inspect-common/types";
 
 import { SampleHandle } from "../app/types";
+import {
+  ClientAPI,
+  LogDetails,
+  LogHeader,
+  SampleSummary,
+} from "../client/api/types";
+import { DatabaseManager, DatabaseService } from "../client/database";
 
 import {
   ChunkByteStore,
@@ -65,6 +73,75 @@ export const testEvalSample = (messages: ChatMessage[]): EvalSample => ({
   role_usage: {},
   output: { model: "test", completion: "", choices: [] },
 });
+
+export const testSampleSummary = (
+  overrides: Partial<SampleSummary> = {}
+): SampleSummary => ({
+  id: "s1",
+  epoch: 1,
+  input: "input",
+  target: "",
+  scores: null,
+  ...overrides,
+});
+
+export const testLogDetails = (
+  overrides: Partial<LogDetails> = {}
+): LogDetails => ({
+  version: 2,
+  status: "success",
+  eval: testEvalSpec(),
+  sampleSummaries: [],
+  ...overrides,
+});
+
+/** The stored form of a details payload (LogHeader), with sample facts zeroed. */
+export const testLogHeader = (
+  overrides: Partial<LogHeader> = {}
+): LogHeader => ({
+  eval: testEvalSpec(),
+  sampleCount: 0,
+  sampleErrorCount: 0,
+  sampleLimits: [],
+  ...overrides,
+});
+
+const notImplemented = (name: string) => () => {
+  throw new Error(`${name} not implemented in test`);
+};
+
+/**
+ * A complete ClientAPI whose required methods throw unless overridden.
+ * Optional methods stay undefined so presence-probing code paths behave as
+ * they would against a backend that lacks them.
+ */
+export const testClientAPI = (
+  overrides: Partial<ClientAPI> = {}
+): ClientAPI => ({
+  get_logs: notImplemented("get_logs"),
+  get_eval_set: notImplemented("get_eval_set"),
+  get_flow: notImplemented("get_flow"),
+  get_log_summaries: notImplemented("get_log_summaries"),
+  get_log_summaries_settled: notImplemented("get_log_summaries_settled"),
+  get_log_details: notImplemented("get_log_details"),
+  get_log_info: notImplemented("get_log_info"),
+  get_log_sample: notImplemented("get_log_sample"),
+  client_events: notImplemented("client_events"),
+  download_file: notImplemented("download_file"),
+  open_log_file: notImplemented("open_log_file"),
+  get_app_config: notImplemented("get_app_config"),
+  ...overrides,
+});
+
+/**
+ * A real, never-opened DatabaseService with the given methods overridden —
+ * un-overridden calls fail loudly ("No database initialized") and `opened()`
+ * reports false unless a fake supplies its own.
+ */
+export const testDatabaseService = (
+  overrides: Partial<DatabaseService> = {}
+): DatabaseService =>
+  Object.assign(new DatabaseService(new DatabaseManager()), overrides);
 
 export const testModelEvent = (inputId: string, outputId: string): Event => ({
   event: "model",

--- a/apps/inspect/src/log_data/testFixtures.ts
+++ b/apps/inspect/src/log_data/testFixtures.ts
@@ -6,16 +6,17 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, ReactNode } from "react";
 
-import { testEvalSpec } from "@tsmono/inspect-common/testing";
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testEvalSample,
+  testModelEvent,
+  testModelOutput,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import { ChatMessage, EvalSample, Event } from "@tsmono/inspect-common/types";
 
 import { SampleHandle } from "../app/types";
-import {
-  ClientAPI,
-  LogDetails,
-  LogHeader,
-  SampleSummary,
-} from "../client/api/types";
 import { DatabaseManager, DatabaseService } from "../client/database";
 
 import {
@@ -38,7 +39,7 @@ export const testHandle: SampleHandle = {
 
 /** Sample data for a settled (fetched, non-streaming) monolith sample. */
 export const settledData = (messages: ChatMessage[]): EvalSampleData => ({
-  sample: testEvalSample(messages),
+  sample: testEvalSampleWithMessages(messages),
   status: "ok",
   error: undefined,
   running: [],
@@ -59,79 +60,23 @@ export const testMessages = (count: number): ChatMessage[] =>
     content: `message ${i}`,
   }));
 
-export const testEvalSample = (messages: ChatMessage[]): EvalSample => ({
-  id: "s1",
-  epoch: 1,
-  input: "input",
-  target: "",
-  messages,
-  events: [],
-  attachments: {},
-  metadata: {},
-  store: {},
-  model_usage: {},
-  role_usage: {},
-  output: { model: "test", completion: "", choices: [] },
-});
+export const testEvalSampleWithMessages = (
+  messages: ChatMessage[]
+): EvalSample =>
+  testEvalSample({
+    id: "s1",
+    input: "input",
+    target: "",
+    messages,
+    output: testModelOutput({ model: "test" }),
+  });
 
-export const testSampleSummary = (
-  overrides: Partial<SampleSummary> = {}
-): SampleSummary => ({
-  id: "s1",
-  epoch: 1,
-  input: "input",
-  target: "",
-  scores: null,
-  ...overrides,
-});
-
-export const testLogDetails = (
-  overrides: Partial<LogDetails> = {}
-): LogDetails => ({
-  version: 2,
-  status: "success",
-  eval: testEvalSpec(),
-  sampleSummaries: [],
-  ...overrides,
-});
-
-/** The stored form of a details payload (LogHeader), with sample facts zeroed. */
-export const testLogHeader = (
-  overrides: Partial<LogHeader> = {}
-): LogHeader => ({
-  eval: testEvalSpec(),
-  sampleCount: 0,
-  sampleErrorCount: 0,
-  sampleLimits: [],
-  ...overrides,
-});
-
-const notImplemented = (name: string) => () => {
-  throw new Error(`${name} not implemented in test`);
-};
-
-/**
- * A complete ClientAPI whose required methods throw unless overridden.
- * Optional methods stay undefined so presence-probing code paths behave as
- * they would against a backend that lacks them.
- */
-export const testClientAPI = (
-  overrides: Partial<ClientAPI> = {}
-): ClientAPI => ({
-  get_logs: notImplemented("get_logs"),
-  get_eval_set: notImplemented("get_eval_set"),
-  get_flow: notImplemented("get_flow"),
-  get_log_summaries: notImplemented("get_log_summaries"),
-  get_log_summaries_settled: notImplemented("get_log_summaries_settled"),
-  get_log_details: notImplemented("get_log_details"),
-  get_log_info: notImplemented("get_log_info"),
-  get_log_sample: notImplemented("get_log_sample"),
-  client_events: notImplemented("client_events"),
-  download_file: notImplemented("download_file"),
-  open_log_file: notImplemented("open_log_file"),
-  get_app_config: notImplemented("get_app_config"),
-  ...overrides,
-});
+export {
+  testClientAPI,
+  testLogDetails,
+  testLogHeader,
+  testSampleSummary,
+} from "../client/api/testClientApi";
 
 /**
  * A real, never-opened DatabaseService with the given methods overridden —
@@ -143,31 +88,28 @@ export const testDatabaseService = (
 ): DatabaseService =>
   Object.assign(new DatabaseService(new DatabaseManager()), overrides);
 
-export const testModelEvent = (inputId: string, outputId: string): Event => ({
-  event: "model",
-  model: "test",
-  timestamp: "2026-01-01T00:00:00+00:00",
-  working_start: 0,
-  config: {},
-  tools: [],
-  tool_choice: "auto",
-  input: [{ id: inputId, role: "user", content: "hello", source: null }],
-  output: {
+/** A model event whose input/output messages carry the given ids. */
+export const testModelEventWithIds = (
+  inputId: string,
+  outputId: string
+): Event =>
+  testModelEvent({
     model: "test",
-    completion: "",
-    choices: [
-      {
-        stop_reason: "stop",
-        message: {
-          id: outputId,
-          role: "assistant",
-          content: "response",
-          source: "generate",
-        },
-      },
-    ],
-  },
-});
+    timestamp: "2026-01-01T00:00:00+00:00",
+    input: [testUserMessage({ id: inputId, content: "hello", source: null })],
+    output: testModelOutput({
+      model: "test",
+      choices: [
+        testChatCompletionChoice({
+          message: testAssistantMessage({
+            id: outputId,
+            content: "response",
+            source: "generate",
+          }),
+        }),
+      ],
+    }),
+  });
 
 /** A real single-chunk reader over an in-memory item array. */
 export const sequenceReaderOver = <T>(items: T[]): SequenceReader<T> =>

--- a/apps/inspect/src/log_data/useLogsSync.test.ts
+++ b/apps/inspect/src/log_data/useLogsSync.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClientAPI } from "../client/api/types";
 import { queryClient } from "../state/queryClient";
 
+import { testClientAPI } from "./testFixtures";
 import { clientEventsTick, useLogsSync } from "./useLogsSync";
 
 const syncLogs = vi.hoisted(() => vi.fn());
@@ -30,9 +31,9 @@ const invalidateQueries = vi
   .mockResolvedValue();
 
 const apiWith = (events: string[]): ClientAPI =>
-  ({
+  testClientAPI({
     client_events: vi.fn().mockResolvedValue(events),
-  }) as unknown as ClientAPI;
+  });
 
 afterEach(() => {
   vi.useRealTimers();

--- a/apps/inspect/src/state/testStore.ts
+++ b/apps/inspect/src/state/testStore.ts
@@ -1,0 +1,26 @@
+/**
+ * Cast-free StoreState fixture: a real store built from the production slice
+ * creators (no persist/devtools), so tests get every slice's actual initial
+ * state and can spread in overrides.
+ */
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+
+import { createAppSlice } from "./appSlice";
+import { createLogSlice } from "./logSlice";
+import { createLogsSlice } from "./logsSlice";
+import { createSampleSlice } from "./sampleSlice";
+import { createSearchSlice } from "./searchSlice";
+import type { StoreState } from "./store";
+
+export const testStoreState = (): StoreState =>
+  create<StoreState>()(
+    immer((set, get, store) => ({
+      initialize: () => undefined,
+      ...createAppSlice(set, get, store),
+      ...createLogsSlice(set, get, store),
+      ...createLogSlice(set, get, store),
+      ...createSampleSlice(set, get, store),
+      ...createSearchSlice(set),
+    }))
+  ).getState();

--- a/apps/scout/src/app/scannerResult/result/ResultBody.test.tsx
+++ b/apps/scout/src/app/scannerResult/result/ResultBody.test.tsx
@@ -3,12 +3,12 @@ import { act, cleanup, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import { testModelEvent } from "@tsmono/inspect-common/testing";
 
 import { apiScoutServer } from "../../../api/api-scout-server";
 import { createStore, StoreProvider } from "../../../state/store";
+import { createScanResultData } from "../../../test/objectFactories";
 import type { ScannerInput } from "../../../types/api-types";
-import type { ScanResultData } from "../../types";
 
 import { ResultBody } from "./ResultBody";
 
@@ -27,14 +27,12 @@ afterEach(() => {
   capturedHeadroomHidden = undefined;
 });
 
-const eventsInput = {
+const eventsInput: ScannerInput = {
   input_type: "events",
-  input: [
-    { event: "model", uuid: "m1", timestamp: "2026-01-01T00:00:00Z" },
-  ] as unknown as Event[],
-} as unknown as ScannerInput;
+  input: [testModelEvent({ uuid: "m1", timestamp: "2026-01-01T00:00:00Z" })],
+};
 
-const resultData = { messageReferences: [] } as unknown as ScanResultData;
+const resultData = createScanResultData();
 
 const mountBody = (showFind: boolean) => {
   const store = createStore(apiScoutServer());

--- a/apps/scout/src/app/timeline/resolveMessageToEvent.test.ts
+++ b/apps/scout/src/app/timeline/resolveMessageToEvent.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testToolEvent,
+  testToolMessage,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 import {
   resolveMessageToEvent,
@@ -49,84 +58,36 @@ function makeModelEvent(opts: {
     role: "tool";
   }>;
 }): Event {
-  const input: Array<Record<string, unknown>> = [];
-  for (const id of opts.inputIds ?? []) {
-    input.push({
-      id,
-      role: "user",
-      content: "test",
-      source: null,
-      metadata: null,
-    });
-  }
-  for (const msg of opts.inputToolMessages ?? []) {
-    input.push({
-      id: msg.id,
-      role: "tool",
-      tool_call_id: msg.tool_call_id,
-      content: "tool result",
-      function: null,
-      error: null,
-      source: null,
-      metadata: null,
-    });
-  }
+  const input = [
+    ...(opts.inputIds ?? []).map((id) =>
+      testUserMessage({ id, content: "test" })
+    ),
+    ...(opts.inputToolMessages ?? []).map((msg) =>
+      testToolMessage({
+        id: msg.id,
+        tool_call_id: msg.tool_call_id,
+        content: "tool result",
+      })
+    ),
+  ];
 
-  const choices: Array<Record<string, unknown>> = [];
-  if (opts.outputId) {
-    choices.push({
-      message: {
-        id: opts.outputId,
-        role: "assistant",
-        content: "response",
-        source: null,
-        metadata: null,
-        tool_calls: null,
-        internal: null,
-      },
-      stop_reason: "stop",
-      logprobs: null,
-    });
-  }
+  const choices = opts.outputId
+    ? [
+        testChatCompletionChoice({
+          message: testAssistantMessage({
+            id: opts.outputId,
+            content: "response",
+          }),
+        }),
+      ]
+    : [];
 
-  return {
-    event: "model",
+  return testModelEvent({
     uuid: opts.uuid,
-    model: "test-model",
     input,
-    output: {
-      model: "test-model",
-      choices,
-      usage: {
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: 0,
-        input_tokens_cache_read: null,
-        input_tokens_cache_write: null,
-      },
-      error: null,
-      metadata: null,
-      time: null,
-      completion: "",
-    },
-    config: {} as Event & { event: "model" } extends { config: infer C }
-      ? C
-      : never,
-    tools: [],
-    tool_choice: "auto",
+    output: testModelOutput({ choices }),
     timestamp: kBaseDate.toISOString(),
-    span_id: null,
-    pending: null,
-    metadata: null,
-    role: null,
-    completed: null,
-    error: null,
-    cache: null,
-    call: null,
-    retries: null,
-    traceback: null,
-    working_start: 0,
-  } as unknown as Event;
+  });
 }
 
 function makeToolEvent(opts: {
@@ -134,26 +95,14 @@ function makeToolEvent(opts: {
   messageId?: string;
   agentSpanId?: string;
 }): Event {
-  return {
-    event: "tool",
+  return testToolEvent({
     uuid: opts.uuid,
     id: `tool-call-${opts.uuid}`,
-    function: "test_tool",
     message_id: opts.messageId ?? null,
     agent_span_id: opts.agentSpanId ?? null,
     result: "tool result text",
-    span_id: null,
-    pending: null,
-    metadata: null,
     timestamp: kBaseDate.toISOString(),
-    completed: null,
-    error: null,
-    events: [],
-    failed: null,
-    truncated: null,
-    view: null,
-    working_start: 0,
-  } as unknown as Event;
+  });
 }
 
 // =============================================================================

--- a/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.test.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { TranscriptColumn } from "../columns";
 
@@ -24,9 +24,7 @@ vi.mock("../../../state/store", () => ({
 describe("useColumnSizing", () => {
   // Dynamic imports ensure modules resolve against the vi.mock above
   const loadUseStore = async () =>
-    (await import("../../../state/store")).useStore as unknown as ReturnType<
-      typeof vi.fn
-    >;
+    (await import("../../../state/store")).useStore as Mock;
   const loadUseColumnSizing = async () =>
     (await import("./useColumnSizing")).useColumnSizing;
 

--- a/apps/scout/src/query/transcriptColumns.test.ts
+++ b/apps/scout/src/query/transcriptColumns.test.ts
@@ -5,9 +5,11 @@ import { Column } from "@tsmono/inspect-common/query";
 import { transcriptColumns } from "./index";
 import { TranscriptColumns } from "./transcriptColumns";
 
-// The proxy resolves arbitrary field names to Columns at runtime; the class
-// type only declares the predefined columns, so dynamic access needs a cast.
-const dynamic = transcriptColumns as unknown as Record<string, Column>;
+// The proxy resolves arbitrary field names to Columns at runtime (and blocks
+// underscore-prefixed ones); the class type only declares the predefined
+// columns, so widen with an index signature for dynamic access.
+const dynamic = transcriptColumns as TranscriptColumns &
+  Record<string, Column | undefined>;
 
 describe("transcriptColumns", () => {
   it("builds conditions from predefined columns", () => {
@@ -48,9 +50,7 @@ describe("transcriptColumns", () => {
   });
 
   it("blocks access to private members through the proxy", () => {
-    expect(
-      (transcriptColumns as unknown as Record<string, unknown>)._instance
-    ).toBeUndefined();
+    expect(dynamic._instance).toBeUndefined();
   });
 
   it("returns a shared singleton instance", () => {

--- a/apps/scout/src/test/objectFactories.ts
+++ b/apps/scout/src/test/objectFactories.ts
@@ -1,3 +1,4 @@
+import type { ScanResultData } from "../app/types";
 import type { ActiveScanInfo } from "../types/api-types";
 
 export function createActiveScanInfo(
@@ -24,6 +25,37 @@ export function createActiveScanInfo(
     summary: { complete: true, scanners: {} },
     title: overrides.scan_id,
     total_scans: 0,
+    ...overrides,
+  };
+}
+
+export function createScanResultData(
+  overrides: Partial<ScanResultData> = {}
+): ScanResultData {
+  return {
+    identifier: "result-1",
+    inputType: "events",
+    eventReferences: [],
+    messageReferences: [],
+    validationResult: true,
+    validationTarget: null,
+    value: null,
+    valueType: "null",
+    transcriptSourceId: "source-1",
+    transcriptMetadata: {},
+    inputIds: [],
+    metadata: {},
+    scanId: "scan-1",
+    scanMetadata: {},
+    scanModelUsage: {},
+    scanTags: [],
+    scanTotalTokens: 0,
+    scannerFile: "scanner.py",
+    scannerKey: "scanner",
+    scannerName: "scanner",
+    scannerParams: {},
+    transcriptId: "transcript-1",
+    transcriptSourceUri: "file:///transcript",
     ...overrides,
   };
 }

--- a/packages/inspect-common/package.json
+++ b/packages/inspect-common/package.json
@@ -9,6 +9,7 @@
     ".": "./src/types/index.ts",
     "./types": "./src/types/index.ts",
     "./utils": "./src/utils/index.ts",
+    "./testing": "./src/testing/index.ts",
     "./query": "./src/query/index.ts"
   },
   "scripts": {

--- a/packages/inspect-common/src/testing/index.ts
+++ b/packages/inspect-common/src/testing/index.ts
@@ -1,0 +1,356 @@
+/**
+ * Cast-free test fixtures for the generated log types.
+ *
+ * Each builder returns a fully-typed minimal value with every required field
+ * populated, spread-merged with the caller's overrides. Tests should use
+ * these instead of `as unknown as X` casts on partial literals — fixtures
+ * break loudly (at typecheck) when the generated types move, casts don't.
+ */
+import type {
+  ApprovalEvent,
+  ChatCompletionChoice,
+  ChatMessageAssistant,
+  ChatMessageSystem,
+  ChatMessageTool,
+  ChatMessageUser,
+  CompactionEvent,
+  ErrorEvent,
+  EvalError,
+  EvalSample,
+  InfoEvent,
+  InputEvent,
+  LoggerEvent,
+  ModelEvent,
+  ModelOutput,
+  ModelUsage,
+  SampleInitEvent,
+  SampleLimitEvent,
+  SandboxEvent,
+  Score,
+  ScoreEvent,
+  SpanBeginEvent,
+  SpanEndEvent,
+  StateEvent,
+  StepEvent,
+  SubtaskEvent,
+  ToolCall,
+  ToolEvent,
+} from "../types";
+
+/** Fixed timestamp so fixtures are deterministic; override where timing matters. */
+export const TEST_TIMESTAMP = "2025-01-15T10:00:00.000Z";
+
+// ---------------------------------------------------------------------------
+// Chat messages
+// ---------------------------------------------------------------------------
+
+export const testSystemMessage = (
+  overrides: Partial<ChatMessageSystem> = {}
+): ChatMessageSystem => ({
+  role: "system",
+  content: "You are a helpful assistant.",
+  ...overrides,
+});
+
+export const testUserMessage = (
+  overrides: Partial<ChatMessageUser> = {}
+): ChatMessageUser => ({
+  role: "user",
+  content: "Hello",
+  ...overrides,
+});
+
+export const testAssistantMessage = (
+  overrides: Partial<ChatMessageAssistant> = {}
+): ChatMessageAssistant => ({
+  role: "assistant",
+  content: "Hi there",
+  ...overrides,
+});
+
+export const testToolMessage = (
+  overrides: Partial<ChatMessageTool> = {}
+): ChatMessageTool => ({
+  role: "tool",
+  content: "tool result",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Model output
+// ---------------------------------------------------------------------------
+
+export const testModelUsage = (
+  overrides: Partial<ModelUsage> = {}
+): ModelUsage => ({
+  input_tokens: 0,
+  output_tokens: 0,
+  total_tokens: 0,
+  ...overrides,
+});
+
+export const testChatCompletionChoice = (
+  overrides: Partial<ChatCompletionChoice> = {}
+): ChatCompletionChoice => ({
+  message: testAssistantMessage(),
+  stop_reason: "stop",
+  ...overrides,
+});
+
+export const testModelOutput = (
+  overrides: Partial<ModelOutput> = {}
+): ModelOutput => ({
+  model: "test-model",
+  completion: "",
+  choices: [],
+  ...overrides,
+});
+
+export const testToolCall = (overrides: Partial<ToolCall> = {}): ToolCall => ({
+  id: "call_1",
+  function: "test_tool",
+  arguments: {},
+  type: "function",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+export const testModelEvent = (
+  overrides: Partial<ModelEvent> = {}
+): ModelEvent => ({
+  event: "model",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  model: "test-model",
+  input: [],
+  tools: [],
+  tool_choice: "auto",
+  config: {},
+  output: testModelOutput(),
+  ...overrides,
+});
+
+export const testToolEvent = (
+  overrides: Partial<ToolEvent> = {}
+): ToolEvent => ({
+  event: "tool",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  id: "call_1",
+  type: "function",
+  function: "test_tool",
+  arguments: {},
+  result: "",
+  events: [],
+  ...overrides,
+});
+
+export const testSpanBeginEvent = (
+  overrides: Partial<SpanBeginEvent> = {}
+): SpanBeginEvent => ({
+  event: "span_begin",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  id: "span_1",
+  name: "span",
+  ...overrides,
+});
+
+export const testSpanEndEvent = (
+  overrides: Partial<SpanEndEvent> = {}
+): SpanEndEvent => ({
+  event: "span_end",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  id: "span_1",
+  ...overrides,
+});
+
+export const testStateEvent = (
+  overrides: Partial<StateEvent> = {}
+): StateEvent => ({
+  event: "state",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  changes: [],
+  ...overrides,
+});
+
+export const testInfoEvent = (
+  overrides: Partial<InfoEvent> = {}
+): InfoEvent => ({
+  event: "info",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  data: {},
+  ...overrides,
+});
+
+export const testScore = (overrides: Partial<Score> = {}): Score => ({
+  value: 1,
+  history: [],
+  ...overrides,
+});
+
+export const testScoreEvent = (
+  overrides: Partial<ScoreEvent> = {}
+): ScoreEvent => ({
+  event: "score",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  intermediate: false,
+  score: testScore(),
+  ...overrides,
+});
+
+export const testEvalError = (
+  overrides: Partial<EvalError> = {}
+): EvalError => ({
+  message: "test error",
+  traceback: "",
+  traceback_ansi: "",
+  ...overrides,
+});
+
+export const testErrorEvent = (
+  overrides: Partial<ErrorEvent> = {}
+): ErrorEvent => ({
+  event: "error",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  error: testEvalError(),
+  ...overrides,
+});
+
+export const testSampleInitEvent = (
+  overrides: Partial<SampleInitEvent> = {}
+): SampleInitEvent => ({
+  event: "sample_init",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  sample: { input: "test input", target: "test target" },
+  state: {},
+  ...overrides,
+});
+
+export const testSampleLimitEvent = (
+  overrides: Partial<SampleLimitEvent> = {}
+): SampleLimitEvent => ({
+  event: "sample_limit",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  type: "token",
+  message: "limit reached",
+  ...overrides,
+});
+
+export const testCompactionEvent = (
+  overrides: Partial<CompactionEvent> = {}
+): CompactionEvent => ({
+  event: "compaction",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  type: "summary",
+  ...overrides,
+});
+
+export const testLoggerEvent = (
+  overrides: Partial<LoggerEvent> = {}
+): LoggerEvent => ({
+  event: "logger",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  message: {
+    name: "logger",
+    level: "info",
+    message: "log message",
+    created: 0,
+    filename: "test.py",
+    module: "test",
+    lineno: 1,
+  },
+  ...overrides,
+});
+
+export const testStepEvent = (
+  overrides: Partial<StepEvent> = {}
+): StepEvent => ({
+  event: "step",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  action: "begin",
+  name: "step",
+  ...overrides,
+});
+
+export const testSubtaskEvent = (
+  overrides: Partial<SubtaskEvent> = {}
+): SubtaskEvent => ({
+  event: "subtask",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  name: "subtask",
+  input: {},
+  result: null,
+  events: [],
+  ...overrides,
+});
+
+export const testApprovalEvent = (
+  overrides: Partial<ApprovalEvent> = {}
+): ApprovalEvent => ({
+  event: "approval",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  approver: "test-approver",
+  call: testToolCall(),
+  decision: "approve",
+  message: "",
+  ...overrides,
+});
+
+export const testSandboxEvent = (
+  overrides: Partial<SandboxEvent> = {}
+): SandboxEvent => ({
+  event: "sandbox",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  action: "exec",
+  ...overrides,
+});
+
+export const testInputEvent = (
+  overrides: Partial<InputEvent> = {}
+): InputEvent => ({
+  event: "input",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  input: "",
+  input_ansi: "",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Samples
+// ---------------------------------------------------------------------------
+
+export const testEvalSample = (
+  overrides: Partial<EvalSample> = {}
+): EvalSample => ({
+  id: "sample_1",
+  epoch: 1,
+  input: "test input",
+  target: "test target",
+  messages: [],
+  events: [],
+  output: testModelOutput(),
+  metadata: {},
+  store: {},
+  attachments: {},
+  model_usage: {},
+  role_usage: {},
+  ...overrides,
+});

--- a/packages/inspect-common/src/testing/index.ts
+++ b/packages/inspect-common/src/testing/index.ts
@@ -16,7 +16,14 @@ import type {
   CompactionEvent,
   ErrorEvent,
   EvalError,
+  EvalLog,
+  EvalMetric,
+  EvalPlan,
+  EvalResults,
   EvalSample,
+  EvalScore,
+  EvalSpec,
+  EvalStats,
   InfoEvent,
   InputEvent,
   LoggerEvent,
@@ -352,5 +359,86 @@ export const testEvalSample = (
   attachments: {},
   model_usage: {},
   role_usage: {},
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Eval log
+// ---------------------------------------------------------------------------
+
+export const testEvalSpec = (overrides: Partial<EvalSpec> = {}): EvalSpec => ({
+  eval_id: "eval_1",
+  run_id: "run_1",
+  created: TEST_TIMESTAMP,
+  task: "test_task",
+  task_id: "task_1",
+  task_version: 0,
+  task_args: {},
+  task_args_passed: {},
+  task_attribs: {},
+  dataset: {},
+  model: "test-model",
+  model_args: {},
+  model_generate_config: {},
+  config: {},
+  packages: {},
+  ...overrides,
+});
+
+export const testEvalPlan = (overrides: Partial<EvalPlan> = {}): EvalPlan => ({
+  name: "plan",
+  steps: [],
+  config: {},
+  ...overrides,
+});
+
+export const testEvalStats = (
+  overrides: Partial<EvalStats> = {}
+): EvalStats => ({
+  started_at: "",
+  completed_at: "",
+  model_usage: {},
+  role_usage: {},
+  connection_limit_history: [],
+  ...overrides,
+});
+
+export const testEvalMetric = (
+  overrides: Partial<EvalMetric> = {}
+): EvalMetric => ({
+  name: "accuracy",
+  value: 0,
+  params: {},
+  ...overrides,
+});
+
+export const testEvalScore = (
+  overrides: Partial<EvalScore> = {}
+): EvalScore => ({
+  name: "test-scorer",
+  scorer: "test-scorer",
+  metrics: {},
+  params: {},
+  ...overrides,
+});
+
+export const testEvalResults = (
+  overrides: Partial<EvalResults> = {}
+): EvalResults => ({
+  total_samples: 0,
+  completed_samples: 0,
+  scores: [],
+  ...overrides,
+});
+
+export const testEvalLog = (overrides: Partial<EvalLog> = {}): EvalLog => ({
+  version: 2,
+  status: "started",
+  eval: testEvalSpec(),
+  plan: testEvalPlan(),
+  stats: testEvalStats(),
+  tags: [],
+  metadata: {},
+  invalidated: false,
   ...overrides,
 });

--- a/packages/inspect-common/src/types/openapi-ts-behavior.test.ts
+++ b/packages/inspect-common/src/types/openapi-ts-behavior.test.ts
@@ -149,6 +149,9 @@ async function classifyField(
   schema: Record<string, unknown>,
   defaultNonNullable: boolean
 ): Promise<"required" | "optional"> {
+  // openapi-typescript's SchemaObject input type requires a `type` key, but
+  // the anyOf-only property schemas exercised here are valid OpenAPI without
+  // one — the document can't be constructed as OpenAPI3, so cast.
   const ast = await openapiTS(schema as unknown as OpenAPI3, {
     ...openapiTSOptions,
     defaultNonNullable,

--- a/packages/inspect-common/src/utils/effectiveConfig.test.ts
+++ b/packages/inspect-common/src/utils/effectiveConfig.test.ts
@@ -24,6 +24,10 @@ const update = (
   ...overrides,
 });
 
+/** Deliberately schema-invalid updates for the runtime-guard tests below. */
+const malformedUpdates = (updates: unknown[]): ConfigUpdate[] =>
+  updates as ConfigUpdate[];
+
 describe("effectiveEvalConfig", () => {
   it("returns the launch config unchanged when there are no updates", () => {
     const launch: EvalConfig = { epochs: 1, max_samples: 5 };
@@ -193,7 +197,7 @@ describe("effectiveEvalConfig", () => {
 
   it("skips updates whose changes is missing or not an array", () => {
     const launch: EvalConfig = { max_samples: 5 };
-    const malformed = [
+    const malformed = malformedUpdates([
       update([]),
       { ...update([]), changes: undefined },
       { ...update([]), changes: { config: "eval" } },
@@ -206,7 +210,7 @@ describe("effectiveEvalConfig", () => {
           cleared: false,
         },
       ]),
-    ] as unknown as ConfigUpdate[];
+    ]);
     expect(effectiveEvalConfig(launch, malformed).max_samples).toBe(10);
     expect(evalConfigChanges(malformed).get("max_samples")?.value).toBe(10);
     expect(concurrencyChanges(malformed)).toEqual([]);
@@ -214,7 +218,7 @@ describe("effectiveEvalConfig", () => {
 
   it("skips non-object elements inside changes", () => {
     const launch: EvalConfig = { max_samples: 5 };
-    const corrupt = [
+    const corrupt = malformedUpdates([
       {
         ...update([]),
         changes: [
@@ -230,14 +234,14 @@ describe("effectiveEvalConfig", () => {
           },
         ],
       },
-    ] as unknown as ConfigUpdate[];
+    ]);
     expect(effectiveEvalConfig(launch, corrupt).max_samples).toBe(10);
     expect(evalConfigChanges(corrupt).get("max_samples")?.value).toBe(10);
     expect(concurrencyChanges(corrupt)).toEqual([]);
   });
 
   it("tolerates a missing provenance", () => {
-    const bare = [
+    const bare = malformedUpdates([
       {
         ...update([
           {
@@ -257,7 +261,7 @@ describe("effectiveEvalConfig", () => {
         ]),
         provenance: undefined,
       },
-    ] as unknown as ConfigUpdate[];
+    ]);
     expect(evalConfigChanges(bare).get("max_samples")?.inherited).toBe(false);
     expect(concurrencyChanges(bare)[0]?.inherited).toBe(false);
   });

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -3,6 +3,7 @@ import { render } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { testAssistantMessage } from "@tsmono/inspect-common/testing";
 import type { ChatMessage } from "@tsmono/inspect-common/types";
 import { ExtendedFindProvider } from "@tsmono/react/components";
 import {
@@ -16,10 +17,10 @@ import {
 } from "./ChatViewVirtualList";
 import { buildMessageRows, messageRowOptions } from "./rowsModel";
 
-const messages = [
-  { id: "m-1", role: "assistant", content: "one" },
-  { id: "m-2", role: "assistant", content: "two" },
-] as unknown as ChatMessage[];
+const messages: ChatMessage[] = [
+  testAssistantMessage({ id: "m-1", content: "one" }),
+  testAssistantMessage({ id: "m-2", content: "two" }),
+];
 
 // jsdom has no scrollTo; VirtualList calls it during mount/follow.
 beforeEach(() => {

--- a/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
+++ b/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
@@ -2,31 +2,28 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { testSpanBeginEvent } from "@tsmono/inspect-common/testing";
 import type { SpanBeginEvent } from "@tsmono/inspect-common/types";
 
 import { EmptyBranchView } from "./EmptyBranchView";
-import type { EventNode } from "./types";
+import { EventNode } from "./types";
 
 function makeNode(
   metadata: Record<string, unknown> | null
 ): EventNode<SpanBeginEvent> {
-  return {
-    id: "node-1",
-    children: [],
-    event: {
-      event: "span_begin",
+  return new EventNode<SpanBeginEvent>(
+    "node-1",
+    testSpanBeginEvent({
       name: "Branch 2 (empty)",
       id: "emptybranch-empty",
       span_id: "emptybranch-empty",
       type: "empty_branch",
       timestamp: new Date(0).toISOString(),
-      parent_id: null,
-      pending: false,
-      working_start: 0,
       uuid: "emptybranch-empty",
       metadata,
-    },
-  } as unknown as EventNode<SpanBeginEvent>;
+    }),
+    0
+  );
 }
 
 describe("EmptyBranchView", () => {

--- a/packages/inspect-components/src/transcript/InfoEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/InfoEventView.test.tsx
@@ -2,7 +2,8 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { InfoEvent } from "@tsmono/inspect-common/types";
+import { testInfoEvent } from "@tsmono/inspect-common/testing";
+import type { InfoEvent, JsonValue } from "@tsmono/inspect-common/types";
 import { ComponentNavigationProvider } from "@tsmono/react/components";
 import {
   ComponentStateHooks,
@@ -10,7 +11,7 @@ import {
 } from "@tsmono/react/state";
 
 import { InfoEventView } from "./InfoEventView";
-import type { EventNode } from "./types";
+import { EventNode } from "./types";
 
 const stateHooks: ComponentStateHooks = {
   useValue: (_id, _prop, defaultValue) => defaultValue,
@@ -21,25 +22,20 @@ const stateHooks: ComponentStateHooks = {
   useRemoveByPrefix: () => () => {},
 };
 
-function makeNode(data: unknown): EventNode<InfoEvent> {
-  return {
-    id: "info-1",
-    children: [],
-    event: {
-      event: "info",
+function makeNode(data: JsonValue): EventNode<InfoEvent> {
+  return new EventNode<InfoEvent>(
+    "info-1",
+    testInfoEvent({
       source: "test-source",
       data,
       timestamp: new Date(0).toISOString(),
-      pending: false,
-      working_start: 0,
-      span_id: null,
       uuid: "info-1",
-      metadata: null,
-    },
-  } as unknown as EventNode<InfoEvent>;
+    }),
+    0
+  );
 }
 
-const renderView = (data: unknown) =>
+const renderView = (data: JsonValue) =>
   render(
     <ComponentStateProvider hooks={stateHooks}>
       <ComponentNavigationProvider navigation={{ navigate: () => {} }}>

--- a/packages/inspect-components/src/transcript/ToolEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.test.tsx
@@ -2,7 +2,8 @@
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ToolEvent } from "@tsmono/inspect-common/types";
+import { testToolEvent } from "@tsmono/inspect-common/testing";
+import type { JsonValue, ToolEvent } from "@tsmono/inspect-common/types";
 import { ComponentNavigationProvider } from "@tsmono/react/components";
 import {
   ComponentStateHooks,
@@ -10,7 +11,7 @@ import {
 } from "@tsmono/react/state";
 
 import { ToolEventView } from "./ToolEventView";
-import type { EventNode } from "./types";
+import { EventNode } from "./types";
 
 const stateHooks: ComponentStateHooks = {
   useValue: (_id, _prop, defaultValue) => defaultValue,
@@ -23,31 +24,23 @@ const stateHooks: ComponentStateHooks = {
 
 function makeNode(
   fn: string,
-  args: Record<string, unknown>
+  args: Record<string, JsonValue>
 ): EventNode<ToolEvent> {
-  return {
-    id: "tool-1",
-    children: [],
-    event: {
-      event: "tool",
+  return new EventNode<ToolEvent>(
+    "tool-1",
+    testToolEvent({
       id: "tool-call-1",
       function: fn,
       arguments: args,
       result: "done",
-      view: null,
-      error: null,
-      pending: false,
       timestamp: new Date(0).toISOString(),
-      working_start: 0,
-      span_id: null,
       uuid: "tool-1",
-      metadata: null,
-      events: [],
-    },
-  } as unknown as EventNode<ToolEvent>;
+    }),
+    0
+  );
 }
 
-const renderView = (fn: string, args: Record<string, unknown>) =>
+const renderView = (fn: string, args: Record<string, JsonValue>) =>
   render(
     <ComponentStateProvider hooks={stateHooks}>
       <ComponentNavigationProvider navigation={{ navigate: () => {} }}>

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
@@ -16,7 +16,10 @@ import {
 } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import {
+  testModelEvent,
+  testSpanBeginEvent,
+} from "@tsmono/inspect-common/testing";
 import {
   ComponentStateProvider,
   type ComponentStateHooks,
@@ -50,11 +53,14 @@ vi.mock("./TranscriptVirtualList", () => ({
     eventCallbacks?: EventPanelCallbacks;
   }) => {
     listHandle.current = {
-      scrollToIndex: ({ onDone }: { onDone?: () => void }) => {
+      scrollToIndex: ({ onDone }) => {
         onDone?.();
       },
       scrollTo: () => {},
-    } as unknown as VirtualListHandle;
+      getState: () => {},
+      jumpToStart: () => {},
+      jumpToEnd: () => {},
+    };
     capturedEventCallbacks = eventCallbacks;
     return (
       <div>
@@ -128,31 +134,21 @@ beforeEach(() => {
   Element.prototype.checkVisibility = function () {
     return true;
   };
-  vi.stubGlobal(
-    "requestAnimationFrame",
-    (cb: FrameRequestCallback) =>
-      setTimeout(() => cb(performance.now()), 0) as unknown as number
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 0)
   );
-  vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+  vi.stubGlobal("cancelAnimationFrame", (id: ReturnType<typeof setTimeout>) =>
+    clearTimeout(id)
+  );
 });
 
 const ts = "2026-01-01T00:00:00Z";
 const model = (id: string, depth = 0): EventNode =>
-  new EventNode(
-    id,
-    { event: "model", uuid: id, timestamp: ts } as unknown as Event,
-    depth
-  );
+  new EventNode(id, testModelEvent({ uuid: id, timestamp: ts }), depth);
 const agentSpan = (id: string, children: EventNode[]): EventNode => {
   const n = new EventNode(
     id,
-    {
-      event: "span_begin",
-      type: "agent",
-      name: "sub",
-      uuid: id,
-      timestamp: ts,
-    } as unknown as Event,
+    testSpanBeginEvent({ type: "agent", name: "sub", uuid: id, timestamp: ts }),
     0
   );
   n.children = children;

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { createRef, useSyncExternalStore } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import { testInfoEvent } from "@tsmono/inspect-common/testing";
 import { ExtendedFindProvider } from "@tsmono/react/components";
 import {
   ComponentStateProvider,
@@ -19,16 +19,16 @@ import { EventNode } from "./types";
 
 afterEach(cleanup);
 
-const node = (id: string, event: string, depth: number): EventNode =>
+const node = (id: string, depth: number): EventNode =>
   new EventNode(
     id,
-    { event, uuid: id, timestamp: "2026-01-01T00:00:00Z" } as unknown as Event,
+    testInfoEvent({ uuid: id, timestamp: "2026-01-01T00:00:00Z" }),
     depth
   );
 
 // A focus slice starting inside an agent span: rows keep their ABSOLUTE
 // transcript depths (2 and 3 here).
-const nestedSlice = [node("m1", "info", 2), node("t1", "info", 3)];
+const nestedSlice = [node("m1", 2), node("t1", 3)];
 
 const stateHooks: ComponentStateHooks = {
   useValue: () => undefined,
@@ -123,7 +123,7 @@ describe("TranscriptVirtualList finish scroll-to-top", () => {
   const mountLive = (scrollToTopOnFinish: boolean | undefined) => {
     const scrollRef = createRef<HTMLDivElement>();
     const hooks = makeReactiveStateHooks();
-    const nodes = [node("e1", "info", 0), node("e2", "info", 0)];
+    const nodes = [node("e1", 0), node("e2", 0)];
     const view = (running: boolean) => (
       <ComponentStateProvider hooks={hooks}>
         <ExtendedFindProvider>

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it, test } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testStateEvent,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
 import type {
   CompactionEvent,
   ContentImage,
   ContentReasoning,
   ContentToolUse,
+  JsonValue,
   ModelEvent,
+  StateEvent,
   ToolEvent,
 } from "@tsmono/inspect-common/types";
 
@@ -22,41 +32,19 @@ const reasoning = (r: Partial<ContentReasoning>): ContentReasoning => ({
 const modelEventWith = (
   content: ModelEvent["output"]["choices"][number]["message"]["content"]
 ): ModelEvent =>
-  ({
-    event: "model",
+  testModelEvent({
     uuid: "u",
-    span_id: null,
     timestamp: "2026-04-29T00:00:00Z",
-    working_start: 0,
-    pending: false,
     model: "test/model",
-    role: null,
-    input: [],
-    tools: [],
-    tool_choice: null,
-    config: {},
-    output: {
+    output: testModelOutput({
       model: "test/model",
       choices: [
-        {
-          message: {
-            role: "assistant",
-            content,
-            source: "generate",
-          },
-          stop_reason: "stop",
-        },
+        testChatCompletionChoice({
+          message: testAssistantMessage({ content, source: "generate" }),
+        }),
       ],
-      usage: null,
-    },
-    error: null,
-    cache: null,
-    call: null,
-    completed: null,
-    working_time: null,
-    style: null,
-    metadata: null,
-  }) as unknown as ModelEvent;
+    }),
+  });
 
 describe("eventsToStr — reasoning content", () => {
   it("uses summary when redacted (Anthropic ≥4, OpenAI encrypted)", () => {
@@ -130,13 +118,13 @@ describe("eventsToStr — tool_use content", () => {
   it("includes result and error text for tool_use blocks", () => {
     const toolUse: ContentToolUse = {
       type: "tool_use",
+      tool_type: "web_search",
       id: "tu-1",
       name: "search",
       arguments: '{"q":"hi"}',
       result: "Found 3 hits",
       error: "rate-limited",
-      caller: { type: "direct" },
-    } as unknown as ContentToolUse;
+    };
     const out = eventsToStr([modelEventWith([toolUse])]);
     expect(out).toContain("search");
     expect(out).toContain("Found 3 hits");
@@ -146,14 +134,15 @@ describe("eventsToStr — tool_use content", () => {
 
 describe("extractEventFields — model error / traceback", () => {
   it("includes the model event error and traceback in search text", () => {
-    const node = {
-      event: {
-        event: "model",
+    const node = new EventNode(
+      "model-1",
+      testModelEvent({
         model: "test/model",
         error: "API rate limit exceeded",
         traceback: "Traceback (most recent call last): ...",
-      },
-    } as unknown as EventNode;
+      }),
+      0
+    );
     const texts = eventSearchText(node);
     expect(texts).toContain("API rate limit exceeded");
     expect(texts).toContain("Traceback (most recent call last): ...");
@@ -165,8 +154,8 @@ describe("eventsToStr — multimodal content placeholders", () => {
   const image: ContentImage = {
     type: "image",
     image: data,
-    detail: null,
-  } as unknown as ContentImage;
+    detail: "auto",
+  };
 
   it("emits <image /> placeholder, no base64 leak", () => {
     const out = eventsToStr([modelEventWith([image])]);
@@ -197,15 +186,12 @@ describe("eventsToStr — multimodal content placeholders", () => {
 // sanitizeStringify isn't exported; exercised here via state events, whose
 // `value` field is routed through the helper.
 describe("eventsToStr — sanitizeStringify (via state events)", () => {
-  const stateEvent = (value: unknown) =>
-    ({
-      event: "state",
+  const stateEvent = (value: JsonValue): StateEvent =>
+    testStateEvent({
       uuid: "s",
-      span_id: null,
       timestamp: "2026-04-29T00:00:00Z",
-      working_start: 0,
-      changes: [{ op: "replace", path: "/x", value }],
-    }) as unknown as Parameters<typeof eventsToStr>[0][number];
+      changes: [{ op: "replace", path: "/x", value, replaced: null }],
+    });
 
   it("redacts ContentReasoning to summary when redacted", () => {
     const out = eventsToStr([
@@ -273,33 +259,24 @@ describe("eventsToStr — sanitizeStringify (via state events)", () => {
   });
 });
 
-const toolEvent = (result: unknown): ToolEvent =>
-  ({
-    event: "tool",
+const toolEvent = (result: ToolEvent["result"]): ToolEvent =>
+  testToolEvent({
     uuid: "t",
-    span_id: null,
     timestamp: "2026-04-29T00:00:00Z",
-    working_start: 0,
-    pending: false,
     function: "view_image",
     arguments: { path: "/foo.png" },
     result,
-    truncated: null,
-    view: null,
-    error: null,
-    events: [],
-    completed: null,
-    working_time: null,
-    agent: null,
-    failed: null,
-    metadata: null,
-  }) as unknown as ToolEvent;
+  });
 
 describe("eventsToStr — extractEventFields sanitization", () => {
   it("walks a tool result array: text renders, data: image drops (no placeholder, no leak)", () => {
     const out = eventsToStr([
       toolEvent([
-        { type: "image", image: "data:image/png;base64,_HUGE_PNG_" },
+        {
+          type: "image",
+          image: "data:image/png;base64,_HUGE_PNG_",
+          detail: "auto",
+        },
         { type: "text", text: "see image" },
       ]),
     ]);
@@ -311,24 +288,23 @@ describe("eventsToStr — extractEventFields sanitization", () => {
 
 const compactionEvent = (
   partial: Partial<CompactionEvent> = {}
-): CompactionEvent =>
-  ({
-    event: "compaction",
-    uuid: "VYVv8bWPCmD5fJYzrYq5MT",
-    span_id: "SPJ9XpwBYA3GuLzkGwmdwR",
-    timestamp: "2026-04-25T03:12:30.042596+00:00",
-    working_start: 4195.599,
-    source: "inspect",
-    type: "summary",
-    tokens_before: 263089,
-    tokens_after: 1923,
-    metadata: {
-      strategy: "CompactionSummary",
-      messages_before: 190,
-      messages_after: 3,
-    },
-    ...partial,
-  }) as unknown as CompactionEvent;
+): CompactionEvent => ({
+  event: "compaction",
+  uuid: "VYVv8bWPCmD5fJYzrYq5MT",
+  span_id: "SPJ9XpwBYA3GuLzkGwmdwR",
+  timestamp: "2026-04-25T03:12:30.042596+00:00",
+  working_start: 4195.599,
+  source: "inspect",
+  type: "summary",
+  tokens_before: 263089,
+  tokens_after: 1923,
+  metadata: {
+    strategy: "CompactionSummary",
+    messages_before: 190,
+    messages_after: 3,
+  },
+  ...partial,
+});
 
 describe("eventsToStr — compaction event", () => {
   it("renders only UI-visible fields (tokens + metadata), not full event JSON", () => {

--- a/packages/inspect-components/src/transcript/findTimelineForDeepLink.test.ts
+++ b/packages/inspect-components/src/transcript/findTimelineForDeepLink.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import {
@@ -9,29 +16,29 @@ import {
 } from "./findTimelineForDeepLink";
 import { TimelineEvent, TimelineSpan, type Timeline } from "./timeline/core";
 
-// Minimal model-event factory; mirrors the `as unknown as Event` pattern in
-// timeline/testHelpers.ts (only the fields the lookup reads are populated).
 function modelEvent(
   uuid: string,
   opts?: { inputId?: string; outputId?: string }
 ): Event {
-  return {
-    event: "model",
+  return testModelEvent({
     uuid,
     timestamp: "2025-01-01T00:00:00Z",
     input: opts?.inputId
-      ? [{ id: opts.inputId, role: "user", content: "hi" }]
+      ? [testUserMessage({ id: opts.inputId, content: "hi" })]
       : [],
-    output: {
+    output: testModelOutput({
       choices: opts?.outputId
         ? [
-            {
-              message: { id: opts.outputId, role: "assistant", content: "ok" },
-            },
+            testChatCompletionChoice({
+              message: testAssistantMessage({
+                id: opts.outputId,
+                content: "ok",
+              }),
+            }),
           ]
         : [],
-    },
-  } as unknown as Event;
+    }),
+  });
 }
 
 function span(

--- a/packages/inspect-components/src/transcript/hasToolEventsAtDepth.test.ts
+++ b/packages/inspect-components/src/transcript/hasToolEventsAtDepth.test.ts
@@ -1,20 +1,28 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testInfoEvent,
+  testModelEvent,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { computeHasToolEventsAtDepth } from "./hasToolEventsAtDepth";
 import { EventNode } from "./types";
 
 // Only `event.event` (the discriminant) and `depth` affect the lookup, so the
-// rest of the Event payload is stubbed. Mirrors transform/flatten.test.ts.
+// rest of the Event payload is defaulted. Mirrors transform/flatten.test.ts.
+const events: Record<"tool" | "model" | "info", () => Event> = {
+  tool: testToolEvent,
+  model: testModelEvent,
+  info: testInfoEvent,
+};
+
 const node = (
-  eventType: string,
+  eventType: "tool" | "model" | "info",
   depth: number,
   id = `${eventType}-${depth}-${Math.random()}`
-): EventNode => {
-  const event = { event: eventType } as unknown as Event;
-  return new EventNode(id, event, depth);
-};
+): EventNode => new EventNode(id, events[eventType](), depth);
 
 // Faithful O(n^2) reference for computeHasToolEventsAtDepth: a LITERAL
 // transcription of the original per-index backward scan. The tool check

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -3,6 +3,12 @@ import { renderHook } from "@testing-library/react";
 import { useMemo } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
 import type {
   Event,
   Timeline as ServerTimeline,
@@ -24,35 +30,26 @@ function makeModelEvent(
   startSec: number,
   outputMessageId?: string
 ): Event {
-  return {
-    event: "model",
+  return testModelEvent({
     uuid,
-    model: "test-model",
-    input: [],
-    output: {
+    output: testModelOutput({
       choices: [
-        {
-          message: {
+        testChatCompletionChoice({
+          message: testAssistantMessage({
             id: outputMessageId,
-            role: "assistant",
             content: "response",
-          },
-          stop_reason: "stop",
-        },
+          }),
+        }),
       ],
       completion: "response",
-      model: "test-model",
-    },
-    config: {},
-    tools: [],
-    tool_choice: "auto",
+    }),
     timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
     working_start: startSec,
     working_time: 1,
     error: null,
     pending: false,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 function makeServerEvent(uuid: string): ServerTimelineEvent {

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -2,6 +2,14 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testToolEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { useEventNodeData } from "./useEventNodeData";
@@ -11,41 +19,31 @@ import { useEventNodeData } from "./useEventNodeData";
 // =============================================================================
 
 function makeModelEvent(uuid: string, messageId: string): Event {
-  return {
-    event: "model",
+  return testModelEvent({
     uuid,
-    model: "test-model",
-    input: [{ id: messageId, role: "user", content: "hi" }],
-    output: {
+    input: [testUserMessage({ id: messageId, content: "hi" })],
+    output: testModelOutput({
       choices: [
-        {
-          message: { role: "assistant", content: "response" },
-          stop_reason: "stop",
-        },
+        testChatCompletionChoice({
+          message: testAssistantMessage({ content: "response" }),
+        }),
       ],
       completion: "response",
-      model: "test-model",
-    },
-    config: {},
-    tools: [],
-    tool_choice: "auto",
+    }),
     timestamp: "2024-01-01T00:00:00Z",
-    working_start: 0,
     working_time: 1,
     error: null,
     pending: false,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 function makeToolEvent(id: string, messageId: string): Event {
-  return {
-    event: "tool",
+  return testToolEvent({
     id,
     uuid: `uuid-${id}`,
     message_id: messageId,
     function: "search",
-    arguments: {},
     result: "ok",
     error: null,
     agent: null,
@@ -54,8 +52,7 @@ function makeToolEvent(id: string, messageId: string): Event {
     working_start: 1,
     pending: false,
     span_id: null,
-    events: [],
-  } as unknown as Event;
+  });
 }
 
 // =============================================================================

--- a/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
@@ -4,6 +4,18 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testErrorEvent,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testScoreEvent,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { InMemoryStateWrapper } from "../testHelpers";
@@ -25,12 +37,9 @@ import {
 // A model event carrying the uuid that computeLaneFirstAnchors keys turn
 // anchors by (the id the focus page parks `?event=` on).
 const model = (uuid: string): TimelineEvent =>
-  new TimelineEvent({
-    event: "model",
-    uuid,
-    timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
-  } as unknown as Event);
+  new TimelineEvent(
+    testModelEvent({ uuid, timestamp: "2026-01-01T00:00:00Z" })
+  );
 
 const span = (
   id: string,
@@ -221,7 +230,7 @@ describe("deriveFocusLanes — petri branch row keeps its main ancestry", () => 
   })();
   const targetRoot = (() => {
     const r = span("t-main", "main", "agent", [model("m-t")]);
-    (r as unknown as { branches: TimelineSpan[] }).branches = [branch];
+    r.branches = [branch];
     return r;
   })();
   const auditorRoot = span("a-main", "main", "agent", [model("m-a")]);
@@ -274,8 +283,23 @@ describe("deriveFocusLanes — timeline whose root is a branch span", () => {
 });
 
 describe("appendSampleTerminalEvents", () => {
-  const ev = (event: string, uuid: string): Event =>
-    ({ event, uuid, timestamp: "2026-01-01T00:00:00Z" }) as unknown as Event;
+  const ev = (
+    event: "span_begin" | "span_end" | "model" | "score" | "error",
+    uuid: string
+  ): Event => {
+    switch (event) {
+      case "span_begin":
+        return testSpanBeginEvent({ uuid });
+      case "span_end":
+        return testSpanEndEvent({ uuid });
+      case "model":
+        return testModelEvent({ uuid });
+      case "score":
+        return testScoreEvent({ uuid });
+      case "error":
+        return testErrorEvent({ uuid });
+    }
+  };
 
   it("appends trailing score/error events missing from a carved lane", () => {
     // Real logs nest turns in a solver span; the focus lane's events end at
@@ -327,30 +351,30 @@ describe("useFocusLaneScope — utility-agents toggle", () => {
   const iso = (secs: number) =>
     new Date(Date.UTC(2026, 0, 1, 0, 0, secs)).toISOString();
   const modelEvent = (uuid: string, warmup: boolean, secs: number): Event =>
-    ({
-      event: "model",
+    testModelEvent({
       uuid,
       timestamp: iso(secs),
       completed: iso(secs),
-      working_start: 0,
       pending: false,
       metadata: null,
       span_id: null,
       model: "mockllm/model",
       config: warmup ? { max_tokens: 1 } : {},
-      input: warmup
-        ? [{ role: "user", content: "warmup" }]
-        : [{ role: "user", content: "do the task please" }],
-      output: {
+      input: [
+        testUserMessage({
+          content: warmup ? "warmup" : "do the task please",
+        }),
+      ],
+      output: testModelOutput({
         choices: [
-          {
-            message: { role: "assistant", content: "ok" },
+          testChatCompletionChoice({
+            message: testAssistantMessage({ content: "ok" }),
             stop_reason: warmup ? "max_tokens" : "stop",
-          },
+          }),
         ],
-        usage: { input_tokens: 5, output_tokens: 1 },
-      },
-    }) as unknown as Event;
+        usage: testModelUsage({ input_tokens: 5, output_tokens: 1 }),
+      }),
+    });
 
   const events: Event[] = [
     modelEvent("m-main", false, 1),

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { TimelineSpan } from "../timeline/core";
 import type { TimelineState } from "../timeline/hooks";
 import type { SwimlaneRow } from "../timeline/swimlaneRows";
 
@@ -14,26 +15,41 @@ import { useSelectionActions } from "./useSelectionActions";
 
 /** Minimal single-agent-span swimlane row (the shape buildSpanSelectKeys reads). */
 function agentRow(key: string, spanId: string): SwimlaneRow {
+  const agent = new TimelineSpan({
+    id: spanId,
+    name: spanId,
+    spanType: "agent",
+  });
   return {
     key,
     name: spanId,
     depth: 1,
     branch: false,
-    spans: [{ agent: { id: spanId } }],
-  } as unknown as SwimlaneRow;
+    spans: [{ agent }],
+    totalTokens: 0,
+    startTime: new Date(0),
+    endTime: new Date(0),
+  };
 }
 
 function makeTimelineState(rows: SwimlaneRow[]) {
   const select = vi.fn<TimelineState["select"]>();
-  const state = { rows, selected: null, select } as unknown as TimelineState;
+  const state: TimelineState = {
+    node: new TimelineSpan({ id: "root", name: "root", spanType: "root" }),
+    rows,
+    selected: null,
+    select,
+    clearSelection: () => {},
+  };
   return { state, select };
 }
 
 function makeScrollRef(scrollTop = 0) {
-  const scrollTo = vi.fn<(opts: { top: number }) => void>();
-  const ref = {
-    current: { scrollTop, scrollTo },
-  } as unknown as RefObject<HTMLDivElement>;
+  const el = document.createElement("div");
+  el.scrollTop = scrollTop;
+  const scrollTo = vi.fn();
+  el.scrollTo = scrollTo;
+  const ref: RefObject<HTMLDivElement> = { current: el };
   return { ref, scrollTo };
 }
 

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
@@ -31,8 +31,8 @@ function makeScroller(options: ScrollerOptions = {}) {
     configurable: true,
   });
   el.scrollTop = options.scrollTop ?? 0;
-  const scrollBy = vi.fn<(opts: { top: number }) => void>();
-  (el as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy;
+  const scrollBy = vi.fn();
+  el.scrollBy = scrollBy;
   return { el, scrollBy };
 }
 

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -2,6 +2,13 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testInfoEvent,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { InMemoryStateWrapper } from "../testHelpers";
@@ -13,36 +20,27 @@ import { useTimelinePipeline } from "./useTimelinePipeline";
 // =============================================================================
 
 function makeModelEvent(uuid: string, startSec: number): Event {
-  return {
-    event: "model",
+  return testModelEvent({
     uuid,
-    model: "test-model",
-    input: [],
-    output: {
+    output: testModelOutput({
       choices: [
-        {
-          message: { role: "assistant", content: "response" },
-          stop_reason: "stop",
-        },
+        testChatCompletionChoice({
+          message: testAssistantMessage({ content: "response" }),
+        }),
       ],
       completion: "response",
-      model: "test-model",
-    },
-    config: {},
-    tools: [],
-    tool_choice: "auto",
+    }),
     timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
     working_start: startSec,
     working_time: 1,
     error: null,
     pending: false,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 function makeInfoEvent(uuid: string, startSec: number): Event {
-  return {
-    event: "info",
+  return testInfoEvent({
     uuid,
     source: "test",
     data: "",
@@ -50,7 +48,7 @@ function makeInfoEvent(uuid: string, startSec: number): Event {
     working_start: startSec,
     pending: false,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 // =============================================================================

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
@@ -31,10 +31,7 @@ function Harness({
   return (
     <div
       ref={(el) => {
-        if (el)
-          (
-            el as unknown as { checkVisibility: () => boolean }
-          ).checkVisibility = () => visible;
+        if (el) el.checkVisibility = () => visible;
         scrollRef.current = el;
       }}
     />

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import { testInfoEvent } from "@tsmono/inspect-common/testing";
 import {
   ComponentStateProvider,
   type ComponentStateHooks,
@@ -79,17 +79,15 @@ const makeReactiveStateHooks = () => {
 const node = (id: string): EventNode =>
   new EventNode(
     id,
-    {
-      event: "info",
+    testInfoEvent({
       uuid: id,
       timestamp: "2026-01-01T00:00:00Z",
       source: "",
       data: "",
       pending: false,
-      working_start: 0,
       span_id: null,
       metadata: null,
-    } as unknown as Event,
+    }),
     0
   );
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
@@ -103,9 +103,9 @@ describe("useOutlineScrollSync", () => {
   function renderSync() {
     const { allNodesList, outlineNodeList } = makeNodes();
     const setSelectedOutlineId = vi.fn<(id: string) => void>();
-    const scrollRef = {
-      current: { scrollTop: 100 },
-    } as unknown as RefObject<HTMLDivElement>;
+    const scrollEl = document.createElement("div");
+    scrollEl.scrollTop = 100;
+    const scrollRef: RefObject<HTMLDivElement> = { current: scrollEl };
     const view = renderHook(() =>
       useOutlineScrollSync({
         allNodesList,

--- a/packages/inspect-components/src/transcript/recentInputMessages.test.ts
+++ b/packages/inspect-components/src/transcript/recentInputMessages.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testSystemMessage,
+  testToolMessage,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { ChatMessage } from "@tsmono/inspect-common/types";
 
 import { recentInputMessages } from "./recentInputMessages";
@@ -12,17 +18,23 @@ import { recentInputMessages } from "./recentInputMessages";
 // ContentText.internal.
 
 let nextId = 0;
-const msg = (role: string, text = "content"): ChatMessage =>
-  ({
-    id: `m${nextId++}`,
-    role,
-    content: text,
-  }) as unknown as ChatMessage;
+const msg = (role: ChatMessage["role"], text = "content"): ChatMessage => {
+  const id = `m${nextId++}`;
+  switch (role) {
+    case "system":
+      return testSystemMessage({ id, content: text });
+    case "user":
+      return testUserMessage({ id, content: text });
+    case "assistant":
+      return testAssistantMessage({ id, content: text });
+    case "tool":
+      return testToolMessage({ id, content: text });
+  }
+};
 
 const handoffMsg = (text = "Agent message from /root:\ntask"): ChatMessage =>
-  ({
+  testUserMessage({
     id: `m${nextId++}`,
-    role: "user",
     content: [
       {
         type: "text",
@@ -36,15 +48,14 @@ const handoffMsg = (text = "Agent message from /root:\ntask"): ChatMessage =>
         },
       },
     ],
-  }) as unknown as ChatMessage;
+  });
 
 const toolCallUser = (): ChatMessage =>
-  ({
+  testUserMessage({
     id: `m${nextId++}`,
-    role: "user",
     content: "output",
-    tool_call_id: "call_1",
-  }) as unknown as ChatMessage;
+    tool_call_id: ["call_1"],
+  });
 
 const defaults = { agentResultsFiltered: false, hasToolEvents: undefined };
 
@@ -160,11 +171,10 @@ describe("recentInputMessages (Multi-Agent V2 fork boundary)", () => {
   });
 
   it("ignores agent_message payloads on non-user messages", () => {
-    const sys = {
+    const sys = testSystemMessage({
       id: `m${nextId++}`,
-      role: "system",
       content: [{ type: "text", text: "x", internal: { agent_message: {} } }],
-    } as unknown as ChatMessage;
+    });
     const input = [msg("system"), sys, msg("user")];
     expect(recentInputMessages(input, defaults)).toEqual(input);
   });

--- a/packages/inspect-components/src/transcript/resolveEventToSpan.test.ts
+++ b/packages/inspect-components/src/transcript/resolveEventToSpan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import { testInfoEvent } from "@tsmono/inspect-common/testing";
 
 import {
   resolveEventInBranches,
@@ -10,12 +10,7 @@ import { TimelineEvent, TimelineSpan } from "./timeline/core";
 import { computeFlatSwimlaneRows } from "./timeline/swimlaneRows";
 
 const event = (uuid: string): TimelineEvent =>
-  new TimelineEvent({
-    event: "info",
-    uuid,
-    timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
-  } as unknown as Event);
+  new TimelineEvent(testInfoEvent({ uuid, timestamp: "2026-01-01T00:00:00Z" }));
 
 const span = (
   id: string,

--- a/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
+++ b/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
-import type {
-  Event,
-  InfoEvent,
-  ModelEvent,
-} from "@tsmono/inspect-common/types";
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testInfoEvent,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
+import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
 
 import { TimelineEvent, TimelineSpan } from "../timeline/core";
 import type { SwimlaneRow } from "../timeline/swimlaneRows";
@@ -13,17 +16,17 @@ import type { SwimlaneRow } from "../timeline/swimlaneRows";
 import { buildEventToRowMap, findAllMatches } from "./sampleSearch";
 
 const ev = (uuid: string): TimelineEvent =>
-  new TimelineEvent({
-    event: "info",
-    uuid,
-    timestamp: "2026-04-29T00:00:00Z",
-    pending: false,
-    span_id: null,
-    working_start: 0,
-    source: null,
-    data: null,
-    metadata: null,
-  } as unknown as InfoEvent);
+  new TimelineEvent(
+    testInfoEvent({
+      uuid,
+      timestamp: "2026-04-29T00:00:00Z",
+      pending: false,
+      span_id: null,
+      source: null,
+      data: null,
+      metadata: null,
+    })
+  );
 
 const span = (
   id: string,
@@ -109,38 +112,32 @@ describe("buildEventToRowMap", () => {
 });
 
 const modelEv = (uuid: string, output: string): ModelEvent =>
-  ({
-    event: "model",
+  testModelEvent({
     uuid,
     span_id: null,
     timestamp: "2026-04-29T00:00:00Z",
-    working_start: 0,
     pending: false,
     model: "test/model",
     role: null,
-    input: [],
-    tools: [],
-    tool_choice: "auto",
-    config: {},
-    output: {
+    output: testModelOutput({
       model: "test/model",
-      completion: "",
       choices: [
-        {
-          message: { role: "assistant", content: output, source: "generate" },
-          stop_reason: "stop",
-        },
+        testChatCompletionChoice({
+          message: testAssistantMessage({
+            content: output,
+            source: "generate",
+          }),
+        }),
       ],
       usage: null,
-    },
+    }),
     error: null,
     cache: null,
     call: null,
     completed: null,
     working_time: null,
-    style: null,
     metadata: null,
-  }) as unknown as ModelEvent;
+  });
 
 describe("findAllMatches", () => {
   it("returns empty for empty term", () => {

--- a/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
+++ b/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
@@ -3,6 +3,12 @@ import { act, render } from "@testing-library/react";
 import { useRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
 import type { ModelEvent } from "@tsmono/inspect-common/types";
 import {
   ExtendedFindProvider,
@@ -23,38 +29,32 @@ import { useTranscriptSearchSource } from "./useTranscriptSearchSource";
 // =============================================================================
 
 const ev = (uuid: string, output: string): ModelEvent =>
-  ({
-    event: "model",
+  testModelEvent({
     uuid,
     span_id: null,
     timestamp: "2026-04-29T00:00:00Z",
-    working_start: 0,
     pending: false,
     model: "test/model",
     role: null,
-    input: [],
-    tools: [],
-    tool_choice: "auto",
-    config: {},
-    output: {
+    output: testModelOutput({
       model: "test/model",
-      completion: "",
       choices: [
-        {
-          message: { role: "assistant", content: output, source: "generate" },
-          stop_reason: "stop",
-        },
+        testChatCompletionChoice({
+          message: testAssistantMessage({
+            content: output,
+            source: "generate",
+          }),
+        }),
       ],
       usage: null,
-    },
+    }),
     error: null,
     cache: null,
     call: null,
     completed: null,
     working_time: null,
-    style: null,
     metadata: null,
-  }) as unknown as ModelEvent;
+  });
 
 function makeRow(key: string, agent: TimelineSpan, depth = 0): SwimlaneRow {
   return {

--- a/packages/inspect-components/src/transcript/timeline/core.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.test.ts
@@ -8,6 +8,16 @@
 
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type {
   Event,
   Timeline as ServerTimeline,
@@ -68,7 +78,7 @@ function makeEvent(
 }
 
 function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid } as unknown as ServerTimelineEvent;
+  return { type: "event", event: uuid };
 }
 
 function makeServerSpan(
@@ -709,48 +719,43 @@ describe("utility wrapper ids", () => {
     const ts = () =>
       new Date(Date.UTC(2026, 0, 1, 0, 0, ++clock)).toISOString();
     const warmup = () =>
-      ({
-        event: "model",
+      testModelEvent({
         uuid: null,
         timestamp: ts(),
         completed: ts(),
-        working_start: 0,
         pending: false,
         metadata: null,
         span_id: "monitor",
         model: "mockllm/model",
         config: { max_tokens: 1 },
-        input: [{ role: "user", content: "warmup" }],
-        output: {
+        input: [testUserMessage({ content: "warmup" })],
+        output: testModelOutput({
           choices: [
-            {
-              message: { role: "assistant", content: "w" },
+            testChatCompletionChoice({
+              message: testAssistantMessage({ content: "w" }),
               stop_reason: "max_tokens",
-            },
+            }),
           ],
-          usage: { input_tokens: 5, output_tokens: 1 },
-        },
-      }) as unknown as Event;
-    const spanEvt = (evt: object) =>
-      ({
-        timestamp: ts(),
-        working_start: 0,
-        pending: false,
-        metadata: null,
-        uuid: null,
-        ...evt,
-      }) as unknown as Event;
+          usage: testModelUsage({ input_tokens: 5, output_tokens: 1 }),
+        }),
+      });
+    const spanMeta = () => ({
+      timestamp: ts(),
+      pending: false,
+      metadata: null,
+      uuid: null,
+    });
 
     const timeline = buildTimeline([
-      spanEvt({
-        event: "span_begin",
+      testSpanBeginEvent({
+        ...spanMeta(),
         id: "solvers",
         name: "solvers",
         type: "solvers",
         parent_id: null,
       }),
-      spanEvt({
-        event: "span_begin",
+      testSpanBeginEvent({
+        ...spanMeta(),
         id: "monitor",
         name: "monitor",
         type: "agent",
@@ -758,8 +763,8 @@ describe("utility wrapper ids", () => {
       }),
       warmup(),
       warmup(),
-      spanEvt({ event: "span_end", id: "monitor" }),
-      spanEvt({ event: "span_end", id: "solvers" }),
+      testSpanEndEvent({ ...spanMeta(), id: "monitor" }),
+      testSpanEndEvent({ ...spanMeta(), id: "solvers" }),
     ]);
 
     const wrappers = timeline.root.content.filter(

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -2,7 +2,17 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+} from "@tsmono/inspect-common/testing";
 import type {
+  AnchorEvent,
   Event,
   Timeline as ServerTimeline,
   TimelineEvent as ServerTimelineEvent,
@@ -16,40 +26,32 @@ import { useTranscriptTimeline } from "./useTranscriptTimeline";
 // =============================================================================
 
 function makeModelEvent(uuid: string, startSec: number, endSec: number): Event {
-  return {
-    event: "model",
+  return testModelEvent({
     uuid,
-    model: "test-model",
-    input: [],
-    output: {
+    output: testModelOutput({
       choices: [
-        {
-          message: {
-            role: "assistant",
+        testChatCompletionChoice({
+          message: testAssistantMessage({
             content: "response",
             source: "generate",
-          },
+          }),
           stop_reason: "stop",
-        },
+        }),
       ],
       completion: "response",
-      model: "test-model",
-      usage: {
+      usage: testModelUsage({
         input_tokens: 60,
         output_tokens: 40,
         total_tokens: 100,
-      },
+      }),
       time: endSec - startSec,
-    },
-    config: {},
-    tools: [],
-    tool_choice: "auto",
+    }),
     timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
     working_start: startSec,
     working_time: endSec - startSec,
     error: null,
     traceback_ansi: null,
-  } as unknown as Event;
+  });
 }
 
 function spanBegin(
@@ -58,32 +60,28 @@ function spanBegin(
   type: string | null,
   parentId: string | null
 ): Event {
-  return {
-    event: "span_begin",
+  return testSpanBeginEvent({
     id,
     name,
     type,
     parent_id: parentId,
     span_id: null,
     timestamp: new Date(1705312800000).toISOString(),
-    working_start: 0,
     pending: null,
     uuid: null,
     metadata: null,
-  } as unknown as Event;
+  });
 }
 
 function spanEnd(id: string): Event {
-  return {
-    event: "span_end",
+  return testSpanEndEvent({
     id,
     span_id: null,
     timestamp: new Date(1705312800000).toISOString(),
-    working_start: 0,
     pending: null,
     uuid: null,
     metadata: null,
-  } as unknown as Event;
+  });
 }
 
 function makeServerEvent(uuid: string): ServerTimelineEvent {
@@ -310,7 +308,7 @@ function makeAnchorEvent(
     pending: null,
     metadata: null,
     source: null,
-  } as unknown as Event;
+  } satisfies AnchorEvent;
 }
 
 describe("useTranscriptTimeline punch-down views", () => {

--- a/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryGrouping.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testModelEvent,
+  testModelOutput,
+  testStateEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type {
   Event,
   ModelEvent,
@@ -8,14 +14,18 @@ import type {
 
 import { groupRetryAttempts, retryAttemptKey } from "./retryGrouping";
 
-const NULL_CONFIG = {} as ModelEvent["config"];
-const EMPTY_OUTPUT = {
-  choices: [],
+const EMPTY_OUTPUT = testModelOutput({
   usage: null,
   time: null,
   metadata: null,
   error: null,
-} as unknown as ModelEvent["output"];
+});
+
+const toolInfo = (name: string): ModelEvent["tools"][number] => ({
+  name,
+  description: "",
+  parameters: { type: "object", properties: {}, required: [] },
+});
 
 function model(
   timestamp: string,
@@ -30,34 +40,25 @@ function model(
   }
 ): ModelEvent {
   const inputLen = options?.inputLen ?? 0;
-  return {
-    event: "model",
+  return testModelEvent({
     model: options?.name ?? "test",
     role: null,
-    input: Array.from({ length: inputLen }, () => ({}) as never),
+    input: Array.from({ length: inputLen }, () => testUserMessage()),
     input_refs: null,
-    tools: (options?.tools ?? []).map((name) => ({ name }) as never),
+    tools: (options?.tools ?? []).map(toolInfo),
     tool_choice: options?.toolChoice ?? "auto",
-    config: NULL_CONFIG,
     output: EMPTY_OUTPUT,
     cache: null,
     call: null,
     error: options?.error ?? null,
     span_id: options?.spanId === undefined ? null : options.spanId,
     timestamp,
-    working_start: 0,
     uuid: options?.uuid ?? null,
-  } as unknown as ModelEvent;
+  });
 }
 
 function state(timestamp: string): StateEvent {
-  return {
-    event: "state",
-    changes: [],
-    span_id: null,
-    timestamp,
-    working_start: 0,
-  } as unknown as StateEvent;
+  return testStateEvent({ span_id: null, timestamp });
 }
 
 describe("groupRetryAttempts", () => {

--- a/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/retryOrdering.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testModelEvent,
+  testModelOutput,
+  testStateEvent,
+} from "@tsmono/inspect-common/testing";
 import type {
   Event,
   ModelEvent,
@@ -8,46 +13,32 @@ import type {
 
 import { correctRetryTimestamps } from "./retryOrdering";
 
-const NULL_CONFIG = {} as ModelEvent["config"];
-const EMPTY_OUTPUT = {
-  choices: [],
+const EMPTY_OUTPUT = testModelOutput({
   usage: null,
   time: null,
   metadata: null,
   error: null,
-} as unknown as ModelEvent["output"];
+});
 
 function model(
   timestamp: string,
   options?: { error?: string; spanId?: string | null }
 ): ModelEvent {
-  return {
-    event: "model",
+  return testModelEvent({
     model: "test",
     role: null,
-    input: [],
     input_refs: null,
-    tools: [],
-    tool_choice: "auto",
-    config: NULL_CONFIG,
     output: EMPTY_OUTPUT,
     cache: null,
     call: null,
     error: options?.error ?? null,
     span_id: options?.spanId === undefined ? null : options.spanId,
     timestamp,
-    working_start: 0,
-  } as unknown as ModelEvent;
+  });
 }
 
 function state(timestamp: string): StateEvent {
-  return {
-    event: "state",
-    changes: [],
-    span_id: null,
-    timestamp,
-    working_start: 0,
-  } as unknown as StateEvent;
+  return testStateEvent({ span_id: null, timestamp });
 }
 
 function timestamps(events: Event[]): string[] {

--- a/packages/inspect-components/src/transcript/timeline/sampleLifecycleEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/sampleLifecycleEvents.test.ts
@@ -10,6 +10,17 @@
 
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testSampleLimitEvent,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { buildTimeline, TimelineEvent, type TimelineSpan } from "./core";
@@ -34,52 +45,47 @@ function spanBegin(
   type: string | null,
   parentId: string | null
 ): Event {
-  return {
+  return testSpanBeginEvent({
     ...base(),
-    event: "span_begin",
     id,
     name,
     type,
     parent_id: parentId,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 function spanEnd(id: string): Event {
-  return {
-    ...base(),
-    event: "span_end",
-    id,
-    span_id: null,
-  } as unknown as Event;
+  return testSpanEndEvent({ ...base(), id, span_id: null });
 }
 
 function modelTurn(spanId: string): Event {
-  return {
+  return testModelEvent({
     ...base(),
-    event: "model",
     model: "mockllm/model",
     completed: ts(),
     span_id: spanId,
-    input: [{ role: "user", content: "go" }],
-    output: {
+    input: [testUserMessage({ content: "go" })],
+    output: testModelOutput({
       choices: [
-        { message: { role: "assistant", content: "ok" }, stop_reason: "stop" },
+        testChatCompletionChoice({
+          message: testAssistantMessage({ content: "ok" }),
+          stop_reason: "stop",
+        }),
       ],
-      usage: { input_tokens: 5, output_tokens: 1 },
-    },
-  } as unknown as Event;
+      usage: testModelUsage({ input_tokens: 5, output_tokens: 1 }),
+    }),
+  });
 }
 
 function sampleLimitEvent(): Event {
-  return {
+  return testSampleLimitEvent({
     ...base(),
-    event: "sample_limit",
     type: "operator",
     message: "Sample completed: interrupted by operator",
     limit: null,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 /** Recursively collect the underlying Events from a span's content tree. */

--- a/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/solverChildEvents.test.ts
@@ -6,6 +6,17 @@
  */
 import { describe, expect, it } from "vitest";
 
+import {
+  testInfoEvent,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testScore,
+  testScoreEvent,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testStateEvent,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { buildTimeline, TimelineSpan, type Timeline } from "./core";
@@ -26,63 +37,38 @@ const spanBegin = (
   name: string,
   type: string | null,
   sec: number
-) =>
-  ({
-    event: "span_begin",
-    id,
-    parent_id,
-    name,
-    type,
-    timestamp: at(sec),
-  }) as unknown as Event;
+) => testSpanBeginEvent({ id, parent_id, name, type, timestamp: at(sec) });
 
 const spanEnd = (id: string, sec: number) =>
-  ({ event: "span_end", id, timestamp: at(sec) }) as unknown as Event;
+  testSpanEndEvent({ id, timestamp: at(sec) });
 
 const modelEvent = (span_id: string, sec: number) =>
-  ({
-    event: "model",
+  testModelEvent({
     span_id,
-    model: "test-model",
     timestamp: at(sec),
     completed: at(sec + 1),
-    output: {
-      usage: {
+    output: testModelOutput({
+      usage: testModelUsage({
         input_tokens: 6,
         output_tokens: 4,
         total_tokens: 10,
-        input_tokens_cache_read: null,
-        input_tokens_cache_write: null,
-        reasoning_tokens: null,
-        total_cost: null,
-      },
-    },
-  }) as unknown as Event;
+      }),
+    }),
+  });
 
 const infoEvent = (span_id: string, sec: number) =>
-  ({
-    event: "info",
-    span_id,
-    data: "solver-level info",
-    timestamp: at(sec),
-  }) as unknown as Event;
+  testInfoEvent({ span_id, data: "solver-level info", timestamp: at(sec) });
 
 const scoreEvent = (span_id: string, sec: number, intermediate: boolean) =>
-  ({
-    event: "score",
+  testScoreEvent({
     span_id,
     intermediate,
-    score: { value: 1, answer: null, explanation: null, metadata: null },
+    score: testScore({ value: 1 }),
     timestamp: at(sec),
-  }) as unknown as Event;
+  });
 
 const stateEvent = (span_id: string, sec: number) =>
-  ({
-    event: "state",
-    span_id,
-    changes: [],
-    timestamp: at(sec),
-  }) as unknown as Event;
+  testStateEvent({ span_id, timestamp: at(sec) });
 
 // --- assertion helper: collect every leaf event type in the built tree ------
 function collectEventTypes(span: TimelineSpan): string[] {

--- a/packages/inspect-components/src/transcript/timeline/testHelpers.ts
+++ b/packages/inspect-components/src/transcript/timeline/testHelpers.ts
@@ -5,7 +5,11 @@
  * markers, and useTimeline test files.
  */
 
-import type { Event } from "@tsmono/inspect-common/types";
+import {
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+} from "@tsmono/inspect-common/testing";
 
 import { TimelineEvent, TimelineSpan, type Timeline } from "./core";
 import { timelineScenarios } from "./syntheticNodes";
@@ -42,24 +46,19 @@ export function makeSyntheticEvent(
   endSec: number,
   tokens: number
 ): TimelineEvent {
-  const event = {
-    event: "model",
+  const event = testModelEvent({
     timestamp: ts(startSec).toISOString(),
     completed: ts(endSec).toISOString(),
     working_start: startSec,
     working_time: endSec - startSec,
-    output: {
-      usage: {
+    output: testModelOutput({
+      usage: testModelUsage({
         input_tokens: Math.floor(tokens * 0.6),
         output_tokens: tokens - Math.floor(tokens * 0.6),
         total_tokens: tokens,
-        input_tokens_cache_read: null,
-        input_tokens_cache_write: null,
-        reasoning_tokens: null,
-        total_cost: null,
-      },
-    },
-  } as unknown as Event;
+      }),
+    }),
+  });
   return new TimelineEvent(event);
 }
 

--- a/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/timelineEventNodes.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import { testModelEvent } from "@tsmono/inspect-common/testing";
 import type {
   AnchorEvent,
   CompactionEvent,
   Event,
   InfoEvent,
-  ModelEvent,
   SpanBeginEvent,
   SpanEndEvent,
   ToolEvent,
@@ -85,30 +85,26 @@ function makeAnchor(
 }
 
 function makeModel(sec: number, label = "m"): TimelineEvent {
-  return new TimelineEvent({
-    event: "model",
-    timestamp: ts(sec).toISOString(),
-    working_start: sec,
-    pending: null,
-    span_id: null,
-    uuid: `model-${label}-${sec}`,
-    metadata: null,
-    model: "synthetic",
-    role: null,
-    input: [],
-    tools: [],
-    tool_choice: null,
-    config: {} as ModelEvent["config"],
-    output: {} as ModelEvent["output"],
-    error: null,
-    cache: null,
-    call: null,
-    completed: ts(sec).toISOString(),
-    working_time: 0,
-    retries: null,
-    traceback: null,
-    traceback_ansi: null,
-  } as unknown as ModelEvent);
+  return new TimelineEvent(
+    testModelEvent({
+      timestamp: ts(sec).toISOString(),
+      working_start: sec,
+      pending: null,
+      span_id: null,
+      uuid: `model-${label}-${sec}`,
+      metadata: null,
+      model: "synthetic",
+      role: null,
+      error: null,
+      cache: null,
+      call: null,
+      completed: ts(sec).toISOString(),
+      working_time: 0,
+      retries: null,
+      traceback: null,
+      traceback_ansi: null,
+    })
+  );
 }
 
 /** A branch span that forks from the given anchor. */

--- a/packages/inspect-components/src/transcript/timeline/toolInvokedClassification.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/toolInvokedClassification.test.ts
@@ -11,6 +11,19 @@
 
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testSpanBeginEvent,
+  testSpanEndEvent,
+  testSystemMessage,
+  testToolCall,
+  testToolEvent,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import { buildTimeline, TimelineSpan } from "./core";
@@ -37,24 +50,18 @@ function spanBegin(
   type: string | null,
   parentId: string | null
 ): Event {
-  return {
+  return testSpanBeginEvent({
     ...base(),
-    event: "span_begin",
     id,
     name,
     type,
     parent_id: parentId,
     span_id: null,
-  } as unknown as Event;
+  });
 }
 
 function spanEnd(id: string): Event {
-  return {
-    ...base(),
-    event: "span_end",
-    id,
-    span_id: null,
-  } as unknown as Event;
+  return testSpanEndEvent({ ...base(), id, span_id: null });
 }
 
 function modelTurn(
@@ -62,36 +69,36 @@ function modelTurn(
   systemPrompt: string,
   opts?: { toolCalls?: boolean }
 ): Event {
-  const message = opts?.toolCalls
-    ? {
-        role: "assistant",
-        content: "ok",
-        tool_calls: [{ id: "call_1", function: "agent", arguments: {} }],
-      }
-    : { role: "assistant", content: "ok" };
-  return {
+  const message = testAssistantMessage({
+    content: "ok",
+    ...(opts?.toolCalls
+      ? { tool_calls: [testToolCall({ id: "call_1", function: "agent" })] }
+      : {}),
+  });
+  return testModelEvent({
     ...base(),
-    event: "model",
     model: "mockllm/model",
     completed: ts(),
     span_id: spanId,
     input: [
-      { role: "system", content: systemPrompt },
-      { role: "user", content: "go" },
+      testSystemMessage({ content: systemPrompt }),
+      testUserMessage({ content: "go" }),
     ],
-    output: {
+    output: testModelOutput({
       choices: [
-        { message, stop_reason: opts?.toolCalls ? "tool_calls" : "stop" },
+        testChatCompletionChoice({
+          message,
+          stop_reason: opts?.toolCalls ? "tool_calls" : "stop",
+        }),
       ],
-      usage: { input_tokens: 5, output_tokens: 1 },
-    },
-  } as unknown as Event;
+      usage: testModelUsage({ input_tokens: 5, output_tokens: 1 }),
+    }),
+  });
 }
 
 function dispatchToolEvent(spanId: string): Event {
-  return {
+  return testToolEvent({
     ...base(),
-    event: "tool",
     id: "call_1",
     function: "agent",
     completed: ts(),
@@ -99,7 +106,7 @@ function dispatchToolEvent(spanId: string): Event {
     events: [],
     span_id: spanId,
     result: "Dispatched AGENT-1.",
-  } as unknown as Event;
+  });
 }
 
 function findSpan(span: TimelineSpan, name: string): TimelineSpan | null {

--- a/packages/inspect-components/src/transcript/transform/fixups.test.ts
+++ b/packages/inspect-components/src/transcript/transform/fixups.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { testToolEvent } from "@tsmono/inspect-common/testing";
 import type { Event, ToolEvent } from "@tsmono/inspect-common/types";
 
 import { fixupEventStream } from "./fixups";
@@ -9,20 +10,14 @@ const toolEvent = (
   uuid: string | null,
   pending: boolean
 ): ToolEvent =>
-  ({
-    event: "tool",
-    type: "function",
+  testToolEvent({
     id,
     uuid,
     pending,
     timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
     function: "noop",
-    arguments: {},
-    events: [],
-    result: "",
     span_id: null,
-  }) as unknown as ToolEvent;
+  });
 
 const eventIds = (events: Event[]) =>
   events.filter((e): e is ToolEvent => e.event === "tool").map((e) => e.id);

--- a/packages/inspect-components/src/transcript/transform/flatten.test.ts
+++ b/packages/inspect-components/src/transcript/transform/flatten.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import { testInfoEvent } from "@tsmono/inspect-common/testing";
 
 import { EventNode } from "../types";
 
 import { findCollapsedAncestors } from "./flatten";
 
 const node = (id: string, children: EventNode[] = []): EventNode => {
-  const event = {
-    event: "info",
+  const event = testInfoEvent({
     uuid: id,
     timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
-  } as unknown as Event;
+  });
   const n = new EventNode(id, event, 0);
   n.children = children;
   return n;

--- a/packages/inspect-components/src/transcript/transform/labels.test.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import type { Event } from "@tsmono/inspect-common/types";
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testToolEvent,
+  testToolMessage,
+  testUserMessage,
+} from "@tsmono/inspect-common/testing";
+import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
 
 import { buildToolLabels, scopeMessageLabels } from "./labels";
 
@@ -8,26 +17,24 @@ import { buildToolLabels, scopeMessageLabels } from "./labels";
 // Fixtures
 // =============================================================================
 
-interface FixtureMessage {
-  id?: string;
-  role: string;
-  tool_call_id?: string;
-}
-
-function modelEvent(input: FixtureMessage[], choiceIds: string[] = []): Event {
-  return {
-    event: "model",
+function modelEvent(
+  input: ModelEvent["input"],
+  choiceIds: string[] = []
+): Event {
+  return testModelEvent({
     input,
-    output: {
-      choices: choiceIds.map((id) => ({
-        message: { id, role: "assistant", content: "" },
-      })),
-    },
-  } as unknown as Event;
+    output: testModelOutput({
+      choices: choiceIds.map((id) =>
+        testChatCompletionChoice({
+          message: testAssistantMessage({ id, content: "" }),
+        })
+      ),
+    }),
+  });
 }
 
 function toolEvent(id: string, messageId: string | null): Event {
-  return { event: "tool", id, message_id: messageId } as unknown as Event;
+  return testToolEvent({ id, message_id: messageId });
 }
 
 // =============================================================================
@@ -42,7 +49,7 @@ describe("scopeMessageLabels", () => {
   it.each([
     {
       desc: "model input message",
-      events: [modelEvent([{ id: "m1", role: "user" }])],
+      events: [modelEvent([testUserMessage({ id: "m1" })])],
     },
     {
       desc: "model output choice",
@@ -59,7 +66,7 @@ describe("scopeMessageLabels", () => {
   });
 
   it("returns undefined when no labeled message is present", () => {
-    const events = [modelEvent([{ id: "m1", role: "user" }])];
+    const events = [modelEvent([testUserMessage({ id: "m1" })])];
     expect(scopeMessageLabels(events, { other: "X" })).toBeUndefined();
   });
 });
@@ -81,8 +88,8 @@ describe("buildToolLabels", () => {
   it("labels tool calls via tool-role input messages on model events", () => {
     const events = [
       modelEvent([
-        { id: "m1", role: "tool", tool_call_id: "call1" },
-        { id: "m2", role: "user", tool_call_id: "call2" },
+        testToolMessage({ id: "m1", tool_call_id: "call1" }),
+        testUserMessage({ id: "m2", tool_call_id: ["call2"] }),
       ]),
     ];
     // The user-role message must not produce a label even though m2 is labeled.

--- a/packages/inspect-components/src/transcript/transform/toolApprovals.test.ts
+++ b/packages/inspect-components/src/transcript/transform/toolApprovals.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import type { ApprovalEvent, ToolEvent } from "@tsmono/inspect-common/types";
+import {
+  testApprovalEvent,
+  testSpanBeginEvent,
+  testToolCall,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
+import type { ApprovalEvent } from "@tsmono/inspect-common/types";
 
 import { EventNode } from "../types";
 
 import { pairToolApprovals } from "./toolApprovals";
 
 const toolNode = (nodeId: string, callId: string, depth = 0): EventNode => {
-  const event = {
-    event: "tool",
+  const event = testToolEvent({
     id: callId,
     uuid: nodeId,
     timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
-  } as ToolEvent;
+  });
   return new EventNode(nodeId, event, depth);
 };
 
@@ -22,27 +26,22 @@ const approvalNode = (
   callId: string,
   opts?: { approver?: string; decision?: ApprovalEvent["decision"] }
 ): EventNode => {
-  const event = {
-    event: "approval",
+  const event = testApprovalEvent({
     uuid: nodeId,
     approver: opts?.approver ?? "human",
     decision: opts?.decision ?? "approve",
-    call: { id: callId, function: "bash", arguments: {} },
-    message: "",
+    call: testToolCall({ id: callId, function: "bash" }),
     timestamp: "2026-01-01T00:00:01Z",
-    working_start: 0,
-  } as unknown as ApprovalEvent;
+  });
   return new EventNode(nodeId, event, 0);
 };
 
 const parent = (nodeId: string, children: EventNode[]): EventNode => {
-  const event = {
-    event: "span_begin",
+  const event = testSpanBeginEvent({
     id: nodeId,
     name: nodeId,
     timestamp: "2026-01-01T00:00:00Z",
-    working_start: 0,
-  } as unknown as EventNode["event"];
+  });
   const node = new EventNode(nodeId, event, 0);
   node.children = children;
   return node;

--- a/packages/inspect-components/src/transcript/turnNavigation.test.ts
+++ b/packages/inspect-components/src/transcript/turnNavigation.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  testInfoEvent,
+  testModelEvent,
+  testSpanBeginEvent,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
 import type { Event } from "@tsmono/inspect-common/types";
 
 import type { TurnInfo } from "./outline/tree-visitors";
@@ -13,7 +19,8 @@ import {
 } from "./turnNavigation";
 import { EventNode } from "./types";
 
-const node = (id: string): EventNode => ({ id }) as unknown as EventNode;
+const node = (id: string): EventNode =>
+  new EventNode(id, testInfoEvent({ uuid: id }), 0);
 
 const treeNode = (
   id: string,
@@ -100,17 +107,14 @@ describe("anchorIndexForTurn", () => {
 });
 
 describe("resolveEventTurnAnchor", () => {
-  const flatNode = (
-    id: string,
-    event: Record<string, unknown>,
-    depth: number
-  ): EventNode => new EventNode(id, event as unknown as Event, depth);
+  const flatNode = (id: string, event: Event, depth: number): EventNode =>
+    new EventNode(id, event, depth);
   const agentSpan = (id: string, name: string, depth: number): EventNode =>
-    flatNode(id, { event: "span_begin", type: "agent", name }, depth);
+    flatNode(id, testSpanBeginEvent({ type: "agent", name }), depth);
   const model = (id: string, depth: number): EventNode =>
-    flatNode(id, { event: "model" }, depth);
+    flatNode(id, testModelEvent(), depth);
   const tool = (id: string, depth: number): EventNode =>
-    flatNode(id, { event: "tool" }, depth);
+    flatNode(id, testToolEvent(), depth);
 
   // main turn m1 spawns a subagent (with its own turns) and CONTINUES with a
   // tool afterwards — the regression case: a document-order back-scan from t1
@@ -150,11 +154,7 @@ describe("computeTranscriptTurns", () => {
   const agentSpan = (id: string, children: EventNode[]): EventNode => {
     const n = new EventNode(
       id,
-      {
-        event: "span_begin",
-        type: "agent",
-        name: "sub",
-      } as unknown as Event,
+      testSpanBeginEvent({ type: "agent", name: "sub" }),
       0
     );
     n.children = children;

--- a/packages/inspect-components/src/usage/connectionHistory.test.ts
+++ b/packages/inspect-components/src/usage/connectionHistory.test.ts
@@ -342,6 +342,8 @@ describe("poolRetunes", () => {
   });
 
   it("skips journal entries whose changes is missing or not an array", () => {
+    // Intentionally malformed: `changes` is absent, so a plain assertion from
+    // the (valid-subset) literal documents exactly what is missing.
     const malformed = {
       scope: "task",
       provenance: {
@@ -349,7 +351,7 @@ describe("poolRetunes", () => {
         timestamp: "2026-07-18T10:05:00Z",
         metadata: {},
       },
-    } as unknown as ConfigUpdate;
+    } as ConfigUpdate;
     expect(poolRetunes([malformed], "openai/gpt-4o")).toEqual({});
   });
 

--- a/packages/react/src/components/ExpandablePanel.test.tsx
+++ b/packages/react/src/components/ExpandablePanel.test.tsx
@@ -38,9 +38,7 @@ vi.spyOn(window, "getComputedStyle").mockImplementation((el, pseudo) => {
     return new Proxy(style, {
       get(target, prop) {
         if (prop === "fontSize") return "16px";
-        const val = (target as unknown as Record<string, unknown>)[
-          prop as string
-        ];
+        const val: unknown = Reflect.get(target, prop);
         return typeof val === "function"
           ? (val as () => unknown).bind(target)
           : val;

--- a/packages/react/src/components/findBandDom.test.ts
+++ b/packages/react/src/components/findBandDom.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { findScrollableParent, scrollRangeToCenter } from "./findBandDom";
 
+// DOMRectList is array-like with item(); an array plus item() satisfies it.
+const rectList = (...rects: DOMRect[]): DOMRectList =>
+  Object.assign(rects, { item: (i: number) => rects[i] ?? null });
+
 describe("findScrollableParent", () => {
   let container: HTMLDivElement;
 
@@ -158,7 +162,7 @@ describe("scrollRangeToCenter", () => {
     // Mock getClientRects to return empty
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([] as unknown as DOMRectList);
+      .mockReturnValue(rectList());
 
     // Should not throw
     expect(() => scrollRangeToCenter(range)).not.toThrow();
@@ -169,19 +173,15 @@ describe("scrollRangeToCenter", () => {
     range.selectNodeContents(content);
 
     // Mock the necessary methods
-    const mockRect = { top: 300, left: 0, width: 100, height: 20 };
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([mockRect] as unknown as DOMRectList);
+      .mockReturnValue(rectList(new DOMRect(0, 300, 100, 20)));
 
     const scrollToMock = vi.fn();
     scrollable.scrollTo = scrollToMock;
-    scrollable.getBoundingClientRect = vi.fn<() => DOMRect>().mockReturnValue({
-      top: 0,
-      left: 0,
-      width: 400,
-      height: 200,
-    } as DOMRect);
+    scrollable.getBoundingClientRect = vi
+      .fn<() => DOMRect>()
+      .mockReturnValue(new DOMRect(0, 0, 400, 200));
 
     scrollRangeToCenter(range);
 
@@ -195,19 +195,15 @@ describe("scrollRangeToCenter", () => {
     const range = document.createRange();
     range.selectNodeContents(content);
 
-    const mockRect = { top: 300, left: 0, width: 100, height: 20 };
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([mockRect] as unknown as DOMRectList);
+      .mockReturnValue(rectList(new DOMRect(0, 300, 100, 20)));
 
     const scrollToMock = vi.fn();
     scrollable.scrollTo = scrollToMock;
-    scrollable.getBoundingClientRect = vi.fn<() => DOMRect>().mockReturnValue({
-      top: 0,
-      left: 0,
-      width: 400,
-      height: 200,
-    } as DOMRect);
+    scrollable.getBoundingClientRect = vi
+      .fn<() => DOMRect>()
+      .mockReturnValue(new DOMRect(0, 0, 400, 200));
 
     scrollRangeToCenter(range, { behavior: "smooth" });
 
@@ -231,10 +227,9 @@ describe("scrollRangeToCenter", () => {
     const range = document.createRange();
     range.selectNode(textNode);
 
-    const mockRect = { top: 500, left: 0, width: 100, height: 20 };
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([mockRect] as unknown as DOMRectList);
+      .mockReturnValue(rectList(new DOMRect(0, 500, 100, 20)));
 
     scrollRangeToCenter(range, { fallbackToScrollIntoView: true });
 
@@ -253,10 +248,9 @@ describe("scrollRangeToCenter", () => {
     const range = document.createRange();
     range.selectNodeContents(standaloneDiv);
 
-    const mockRect = { top: 500, left: 0, width: 100, height: 20 };
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([mockRect] as unknown as DOMRectList);
+      .mockReturnValue(rectList(new DOMRect(0, 500, 100, 20)));
 
     const scrollIntoViewMock = vi.fn();
     standaloneDiv.scrollIntoView = scrollIntoViewMock;
@@ -271,19 +265,15 @@ describe("scrollRangeToCenter", () => {
     range.selectNodeContents(content);
 
     // Position the selection near the top so calculated scroll would be negative
-    const mockRect = { top: 10, left: 0, width: 100, height: 20 };
     range.getClientRects = vi
       .fn<() => DOMRectList>()
-      .mockReturnValue([mockRect] as unknown as DOMRectList);
+      .mockReturnValue(rectList(new DOMRect(0, 10, 100, 20)));
 
     const scrollToMock = vi.fn();
     scrollable.scrollTo = scrollToMock;
-    scrollable.getBoundingClientRect = vi.fn<() => DOMRect>().mockReturnValue({
-      top: 0,
-      left: 0,
-      width: 400,
-      height: 200,
-    } as DOMRect);
+    scrollable.getBoundingClientRect = vi
+      .fn<() => DOMRect>()
+      .mockReturnValue(new DOMRect(0, 0, 400, 200));
 
     scrollRangeToCenter(range);
 

--- a/packages/react/src/hooks/useListKeyboardNavigation.test.tsx
+++ b/packages/react/src/hooks/useListKeyboardNavigation.test.tsx
@@ -17,10 +17,7 @@ function Harness({ jumpToEnd }: { jumpToEnd: () => void }) {
   return (
     <div
       ref={(el) => {
-        if (el)
-          (
-            el as unknown as { checkVisibility: () => boolean }
-          ).checkVisibility = () => true;
+        if (el) el.checkVisibility = () => true;
         scrollRef.current = el;
       }}
     />

--- a/packages/scout-components/src/sentinels/viewerConfig.test.ts
+++ b/packages/scout-components/src/sentinels/viewerConfig.test.ts
@@ -240,18 +240,23 @@ describe("resolveScannerResultView", () => {
   });
 
   it("drops entries with unknown kind or invalid builtin names", () => {
-    const viewer = {
+    // Intentionally malformed entry — runtime validation must drop it.
+    const bogus: { kind: string; name: string } = {
+      kind: "bogus",
+      name: "value",
+    };
+    const viewer: ViewerConfig = {
       scanner_result_view: {
         "*": {
           fields: [
-            { kind: "bogus", name: "value" },
+            bogus as ScannerResultField,
             builtin("value"),
             "not_a_real_builtin",
           ],
           exclude_fields: [],
         },
       },
-    } as unknown as ViewerConfig;
+    };
     const resolved = resolveScannerResultView(viewer, "any");
     // Only the valid `builtin("value")` survives as user-pinned; defaults append.
     expect(resolved.fields).toEqual(withAppendedDefaults([builtin("value")]));

--- a/packages/util/src/jsonrpc-fetch.test.ts
+++ b/packages/util/src/jsonrpc-fetch.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 
-import type { JsonValue } from "./json-value";
+import type { JsonObject, JsonValue } from "./json-value";
 import type { JsonRpcParams } from "./jsonrpc";
 import type { HttpProxyRequest, HttpProxyResponse } from "./jsonrpc-fetch";
 import { createJsonRpcFetch, kMethodHttpRequest } from "./jsonrpc-fetch";
@@ -9,7 +9,15 @@ import { createJsonRpcFetch, kMethodHttpRequest } from "./jsonrpc-fetch";
 type RpcClient = (method: string, params?: JsonRpcParams) => Promise<JsonValue>;
 
 function mockRpcClient(response: HttpProxyResponse) {
-  return vi.fn<RpcClient>().mockResolvedValue(response as unknown as JsonValue);
+  const json: JsonObject = {
+    status: response.status,
+    headers: response.headers,
+    body: response.body,
+  };
+  if (response.bodyEncoding !== undefined) {
+    json.bodyEncoding = response.bodyEncoding;
+  }
+  return vi.fn<RpcClient>().mockResolvedValue(json);
 }
 
 // The proxy is always invoked as rpcClient(method, [request]); pull the first


### PR DESCRIPTION
We had a pattern across a lot of test files where we'd need some mocked data for the test, and the data would have an `as unknown as WhateverType` type cast on it. Type casts undermine our type safety, and I want static feedback if any type changes might impact our tests. The prevalence of this pattern would also lead models to copy it in new tests.

I let Claude loose on this. In many cases, it lifted out common test fixtures to support generating data for tests. At some point, we may invest more in these test fixtures, but I think this is a great step in the right direction.