### PR TITLE
Enable React Compiler via SWC's Rust implementation

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -71,7 +71,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "@vitejs/plugin-react": "^6.0.5",
+    "@vitejs/plugin-react-swc": "^4.3.3",
     "cross-env": "^10.1.0",
     "eslint": "^10.7.0",
     "fake-indexeddb": "^6.2.2",

--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@msw/playwright": "^0.6.7",
     "@playwright/test": "^1.62.1",
+    "@swc/core": "^1.16.0",
     "@tanstack/react-devtools": "^0.10.9",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/dom": "^10.4.1",

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -1,7 +1,7 @@
 import { cpSync, rmSync } from "fs";
 import { join, resolve } from "path";
 
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 import pc from "picocolors";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
@@ -40,8 +40,16 @@ export default defineConfig(({ mode }) => {
   const baseConfig = {
     plugins: [
       react({
-        jsxRuntime: "automatic",
-        fastRefresh: !isLibrary,
+        // Rust React Compiler via SWC. The escape hatch is required — the
+        // plugin has no first-class reactCompiler option yet. Needs
+        // plugin-react-swc >= 4.2.0 (earlier versions kept production builds
+        // on the non-SWC path even when options are mutated) and
+        // @swc/core >= 1.16.0 (where jsc.transform.reactCompiler landed).
+        useAtYourOwnRisk_mutateSwcOptions(options) {
+          options.jsc ??= {};
+          options.jsc.transform ??= {};
+          options.jsc.transform.reactCompiler = true;
+        },
       }),
     ],
     resolve: {

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@msw/playwright": "^0.6.7",
     "@playwright/test": "^1.62.1",
+    "@swc/core": "^1.16.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
     "@testing-library/react": "^16.3.1",

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -73,7 +73,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "@vitejs/plugin-react": "^6.0.5",
+    "@vitejs/plugin-react-swc": "^4.3.3",
     "eslint": "^10.7.0",
     "eventsource": "^4.1.1",
     "jsdom": "^30.0.1",

--- a/apps/scout/src/state/store.ts
+++ b/apps/scout/src/state/store.ts
@@ -828,16 +828,19 @@ const ApiContext = createContext<ScoutApiV2 | null>(null);
 export const StoreProvider = StoreContext.Provider;
 export const ApiProvider = ApiContext.Provider;
 
+const selectWholeState = (state: StoreState) => state;
+
 export const useStore = <T>(selector?: (state: StoreState) => T) => {
-  const store = useContext(StoreContext);
-  if (!store) throw new Error("useStore must be used within StoreProvider");
+  // Named `use*` so React Compiler recognizes the call below as a hook. Under
+  // any other name it treats `store(selector)` as a plain call and memoizes it
+  // away, skipping zustand's useSyncExternalStore on later renders.
+  const useBoundStore = useContext(StoreContext);
+  if (!useBoundStore)
+    throw new Error("useStore must be used within StoreProvider");
 
-  // If no selector is provided, return the whole state
-  if (!selector) {
-    return store((state) => state) as T;
-  }
-
-  return store(selector);
+  return useBoundStore(
+    (selector ?? selectWholeState) as (state: StoreState) => T
+  );
 };
 
 export const useApi = (): ScoutApiV2 => {

--- a/apps/scout/src/state/store.ts
+++ b/apps/scout/src/state/store.ts
@@ -830,7 +830,9 @@ export const ApiProvider = ApiContext.Provider;
 
 const selectWholeState = (state: StoreState) => state;
 
-export const useStore = <T>(selector?: (state: StoreState) => T) => {
+export function useStore(): StoreState;
+export function useStore<T>(selector: (state: StoreState) => T): T;
+export function useStore<T>(selector?: (state: StoreState) => T) {
   // Named `use*` so React Compiler recognizes the call below as a hook. Under
   // any other name it treats `store(selector)` as a plain call and memoizes it
   // away, skipping zustand's useSyncExternalStore on later renders.
@@ -838,10 +840,8 @@ export const useStore = <T>(selector?: (state: StoreState) => T) => {
   if (!useBoundStore)
     throw new Error("useStore must be used within StoreProvider");
 
-  return useBoundStore(
-    (selector ?? selectWholeState) as (state: StoreState) => T
-  );
-};
+  return useBoundStore<T | StoreState>(selector ?? selectWholeState);
+}
 
 export const useApi = (): ScoutApiV2 => {
   const api = useContext(ApiContext);

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -1,7 +1,7 @@
 import { cpSync, rmSync } from "fs";
 import { join, resolve } from "path";
 
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 import pc from "picocolors";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
@@ -39,7 +39,16 @@ export default defineConfig(({ mode }) => {
   const baseConfig = {
     plugins: [
       react({
-        jsxRuntime: "automatic",
+        // Rust React Compiler via SWC. The escape hatch is required — the
+        // plugin has no first-class reactCompiler option yet. Needs
+        // plugin-react-swc >= 4.2.0 (earlier versions kept production builds
+        // on the non-SWC path even when options are mutated) and
+        // @swc/core >= 1.16.0 (where jsc.transform.reactCompiler landed).
+        useAtYourOwnRisk_mutateSwcOptions(options) {
+          options.jsc ??= {};
+          options.jsc.transform ??= {};
+          options.jsc.transform.reactCompiler = true;
+        },
       }),
     ],
     define: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,9 +221,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
-      '@vitejs/plugin-react':
-        specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -390,9 +390,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
-      '@vitejs/plugin-react':
-        specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))
       eslint:
         specifier: ^10.7.0
         version: 10.8.1(supports-color@10.2.2)
@@ -2026,6 +2026,99 @@ packages:
       typescript:
         optional: true
 
+  '@swc/core-darwin-arm64@1.16.0':
+    resolution: {integrity: sha512-SJQPl+xG/zB8bNjC/gTg3WOmOvz7EzlQD+VShfCKFYPNr2qvb+vATUY11vYEjnMWCn6wV8H8eAtjQrVflYyX5A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.16.0':
+    resolution: {integrity: sha512-ql2JVch8V5t1i+HxiiuD4oVDI1dOku4/e3QiCkplONrm3SLitqNAP+nztHN51fSG2IgGuOwpAi3hgA+ukT5yQg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.16.0':
+    resolution: {integrity: sha512-PcdDBaRbe39y37h1rXVkhNy7mEU7f8b34KD761C68R23EsfMsj5oDPVddRzGdSRAvwwSfH0WSNEHgYmc/AJipg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.16.0':
+    resolution: {integrity: sha512-t21IUztHQ/COucy7Kk9eIlehmq08H/hYq7aRA6fZox3S5ddi6TxWPK6e5S/+aTCf6+Od9qQ+LIpjHMiTy737vA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.16.0':
+    resolution: {integrity: sha512-d9+iajbMB87b0umgbP+Gy3yBDSDgty4Q6H5pZ8fgTb/dOoKIwwynP4L4kvWCOFg2i49kxmAAUs1uJZh9s0E+RQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.16.0':
+    resolution: {integrity: sha512-QRpeKGOg+B0qmo3BFU+6rL/gpoKYYJ7OFSMf5DNMafohYZ/iq2qvAH9Gcrf8NxROj3iooKOVewJ+YgahH1nSLw==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.16.0':
+    resolution: {integrity: sha512-q+Vr/hmHCcRXT/WFzOJC+T6GGEEtq2iaTtmyLfxO7yzu4ckgcqSNkg9m181wfNhuMwfNBoBhOfwQCnLsGZ5F4g==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.16.0':
+    resolution: {integrity: sha512-DWVBc3QnpsSgKoq8N4rmZeZa5r/XrHdLkITsExN/tvTdqPtAPDPt+Ysy33OfgBlyN8lNe4xwsXWe6DXlRkJeRQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.16.0':
+    resolution: {integrity: sha512-6XCgDSc1HPf/5dpjvABhKHICiBcsuZyW3hQMkn8sxel0TqprkJGp+H4iaBYIUTPixhrBub2hBPtfjcZLE6yL3w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.16.0':
+    resolution: {integrity: sha512-T/+9VVCZJ3AKEth9IP3U9AJ2YscQq+7LUqRTvfR4a2q36+Ri22oOwUizpAKOqQ42vb2Y/kOa4TOcJOfHoDIT/w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.16.0':
+    resolution: {integrity: sha512-Pr1lsR/PMs8ndL0UWMrW8nLZ7H7sspIxBRDdjL8f+YJ/FJNASgzfunbVVXAqj0csgIJYHPZy+OW9smjFmk1Rcg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.16.0':
+    resolution: {integrity: sha512-ktdeYLgOQdaonvsj5tJijqgpb0wk7gfF80wCFVA0kucI1hhSUIyfcGbjo5+9sdqv38OhMnTdLoA6xbqgOgPQjw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.16.0':
+    resolution: {integrity: sha512-zSdvEHxBg00WhUNtW/u58hhcdR33gjtMQvOBo8F7POWJDyjRCt/miKfhidT3hCc/118RUwNnlEAmxiihFMbK4Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
+
   '@tanstack/devtools-client@0.0.8':
     resolution: {integrity: sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA==}
     engines: {node: '>=18'}
@@ -2558,18 +2651,11 @@ packages:
   '@uwdata/flechette@2.5.0':
     resolution: {integrity: sha512-NSB9xIPVsxpEcnEvtLfbvH/tEqZWiD4bfdz/yBUAUBEe0Z0C3zmA/Y4GOCsLZe4ChxiHaedFBZzVdUxQ+NVcMA==}
 
-  '@vitejs/plugin-react@6.0.5':
-    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
+  '@vitejs/plugin-react-swc@4.3.3':
+    resolution: {integrity: sha512-bti8ZAcvz4Lh6/e4Uk2k3aa1TiUXbbMsahuqOHvd3MveFTkKDZOA6wQVkpj7J/+tepX/wGfe+lsGh/t24HTXMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
-      babel-plugin-react-compiler: ^1.0.0
-      vite: ^8.0.0
-    peerDependenciesMeta:
-      '@rolldown/plugin-babel':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
+      vite: ^4 || ^5 || ^6 || ^7 || ^8
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -5876,6 +5962,66 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/core-darwin-arm64@1.16.0':
+    optional: true
+
+  '@swc/core-darwin-x64@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.16.0':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.16.0':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.16.0':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.16.0':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.16.0':
+    optional: true
+
+  '@swc/core@1.16.0':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.0
+      '@swc/core-darwin-x64': 1.16.0
+      '@swc/core-linux-arm-gnueabihf': 1.16.0
+      '@swc/core-linux-arm64-gnu': 1.16.0
+      '@swc/core-linux-arm64-musl': 1.16.0
+      '@swc/core-linux-ppc64-gnu': 1.16.0
+      '@swc/core-linux-s390x-gnu': 1.16.0
+      '@swc/core-linux-x64-gnu': 1.16.0
+      '@swc/core-linux-x64-musl': 1.16.0
+      '@swc/core-win32-arm64-msvc': 1.16.0
+      '@swc/core-win32-ia32-msvc': 1.16.0
+      '@swc/core-win32-x64-msvc': 1.16.0
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@tanstack/devtools-client@0.0.8':
     dependencies:
       '@tanstack/devtools-event-client': 0.5.0
@@ -6343,10 +6489,13 @@ snapshots:
 
   '@uwdata/flechette@2.5.0': {}
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))':
+  '@vitejs/plugin-react-swc@4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
+      '@swc/core': 1.16.0
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@vitest/expect@3.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
+      '@swc/core':
+        specifier: ^1.16.0
+        version: 1.16.0
       '@tanstack/react-devtools':
         specifier: ^0.10.9
         version: 0.10.9(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.14)
@@ -339,6 +342,9 @@ importers:
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
+      '@swc/core':
+        specifier: ^1.16.0
+        version: 1.16.0
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,9 @@ overrides:
 # demonstrably needs its postinstall (esbuild gets binaries via
 # optionalDependencies; unrs-resolver has a JS fallback).
 allowBuilds:
+  # Same shape as esbuild: the native binding arrives via optionalDependencies
+  # (@swc/core-<platform>); the postinstall is only a fallback downloader.
+  "@swc/core": false
   esbuild: false
   msw: false
   unrs-resolver: false


### PR DESCRIPTION
Experiment: same React Compiler integration as #500, but through the **Rust implementation shipped in SWC** instead of the Babel plugin. #500 stalled on build-time cost (inspect 7.1s → 24.1s, scout 5.4s → 29.8s, dev cold-transform 3.3s → 29.1s); this tests whether the Rust port eliminates that cost. **It does** — details and caveats below. Left as draft deliberately: the human decision between this and #500 (or neither) is still open.

## How it's wired

- `@vitejs/plugin-react` → `@vitejs/plugin-react-swc@4.3.3` in both apps. Version matters: **≥ 4.2.0** is where the `useAtYourOwnRisk_mutateSwcOptions` hatch started opting *production builds* into the SWC path — below that the compiler would run in dev only.
- The compiler is enabled through that hatch: `options.jsc.transform.reactCompiler = true`. There's no first-class plugin option yet.
- `@swc/core` resolves to **1.16.0** — the release where the option landed (swc-project/swc#11917). ~~Initially this needed a pnpm override plus a `minimumReleaseAgeExclude` bypass~~ — no longer: 1.16.0 aged past the 7-day soak window on 2026-08-21 and now resolves naturally from the plugin's own `^1.15.46` range, so the branch carries **no override and no soak exclusion**. One wrinkle worth knowing: the platform bindings each have their own publish clock, and `@swc/core-linux-arm64-gnu@1.16.0` was published 38 minutes after the main package, so it aged out last (18:01 UTC).
- `@swc/core`'s postinstall is declared `false` in the new `allowBuilds` policy — same shape as esbuild: the native binding arrives via `optionalDependencies`, the postinstall is only a fallback downloader. Verified by building both apps with the script ignored.
- The scout `store.ts` fix from #500 is carried over verbatim (byte-for-byte output parity means the Rust compiler has the same hook-by-callee-name behavior; without the rename it would miscompile `store(selector)` the same way). It survived rebasing over main's store refactor (`ColumnFilter` extraction) intact.
- `plugin-react-swc` has no `jsxRuntime`/`fastRefresh` options — the automatic runtime is the only mode, and refresh is dev-only automatically (verified: the library build output contains no refresh code).

## Cost (the reason this branch exists)

Measured on a CCR container at the pre-rebase base (`66cdaf7`); absolute times aren't comparable to #500's machine — ratios are what matter. Three runs per build cell (range shown, median in bold); baseline re-measured on the same machine after a lockfile round-trip.

| metric | main (no compiler) | #500 (Babel, their machine) | this branch (Rust/SWC) |
|---|---|---|---|
| inspect `build` | 8.9–10.0s, **8.94s** | 7.1s → 24.1s (**+240%**) | 8.2–10.9s, **8.89s** (**±0%**) |
| scout `build` | 5.7–7.4s, **6.83s** | 5.4s → 29.8s (**+450%**) | 8.0–8.8s, **8.59s** (**+26%**, see below) |
| dev cold-transform, inspect (278 tsx) | 4.55–5.93s | 3.3s → 29.1s (145 tsx, **~9×**) | 3.79–4.21s (**faster than baseline**) |
| dev cold-transform, scout (162 tsx) | 3.54–3.65s | n/a | 2.93–3.27s (**faster than baseline**) |
| scout bundle (minified main chunk) | 2,871,233 B | +8.0% | 3,103,018 B (**+8.1%**) |
| inspect bundle (gzip) | 1,252,701 B | +9.3% | 1,388,842 B (**+10.9%**) |

- The scout +26% needed disentangling, so I A/B'd it: with plugin-react-swc but `reactCompiler = false`, scout builds in 7.8–9.7s — overlapping both the compiler-on range and the baseline's upper range. The delta is mostly plugin-swap + container noise (variance here is ±20%), not compiler time. Nothing like Babel's unambiguous 4–6×.
- Dev cold-transform being *faster with the compiler on* than plugin-react without it is the headline: the entire ~9× dev penalty from #500 is gone.
- Bundle growth matches #500 almost exactly — consistent with the claimed output parity.
- Compiled-function counts: **inspect 474, scout 429** at the measured base (app bundle and lib build agree exactly in both apps; 472/430 after rebasing onto `ee3a194`). #500 reported 712 total; the codebase has grown since its base, and these counts double-count shared packages (compiled once per consuming app), so they're sanity checks, not comparable totals.

## Verification checklist (per the #500 lesson: e2e is the gate, not lint)

Full suite at the measured base, re-verified after rebasing onto `ee3a194` where noted:

1. **Compiler proven running in BOTH modes** — not trusted from config:
   - Production: inspect's unminified bundle has 474 `(0, import_compiler_runtime.c)(N)` memo-cache initializations; scout's minified bundle has 429 `.c)(N)` calls and imports the runtime. (Re-confirmed post-rebase: 472/430.)
   - Dev: served transforms import `/node_modules/.vite/deps/react_compiler-runtime.js` and define `_c` from it, with HMR context wired.
   - Shared workspace packages compile through each app's pipeline as expected — spot-checked `packages/react` (`MarkdownDiv`, `AsyncGate` carry memo caches in the bundle) and `packages/inspect-components`/`scout-components` in dev transforms.
2. `turbo run lint typecheck format:check test` — **36/36 tasks green** (1139 unit tests). Post-rebase: lint/typecheck/format:check/test/build/manypkg:check re-run green for both apps, including main's new strict-unnecessary-condition lint.
3. Both app builds, both library builds succeed. `lib/index.js` (both apps) contains exactly one `import { c } from "react/compiler-runtime"` and no bundled `useMemoCache` — the existing `/^(react|react-dom)(\/|$)/` external regex covers the runtime, as #500 found.
4. **e2e: inspect 102/102, scout 65/65** — both suites fully green at the measured base (suites have grown since #500's 96/64). Not re-run post-rebase locally; CI's e2e job covers it.
5. Dev-mode sanity: both dev servers boot and serve index.html; editing a compiled component (including one in `packages/react`) triggers an HMR `js-update` (Fast Refresh), not a full reload.

The `apps/inspect/src/state/store.ts` latent hazard from #500 (same `store(selector)` pattern, hidden from the compiler by the `as UseBoundStore<…>` cast) is deliberately untouched and confirmed still inert — inspect dev transform of that file shows zero memo-cache slots and inspect e2e is green.

## Differences observed vs the Babel path

- **Cost**: eliminated. Dev transforms are faster than the no-compiler baseline; production builds are within noise (inspect) or near it (scout).
- **Output**: same runtime import, same memo-cache shape, near-identical bundle growth. The compiler still bails out of scout's `useStore` itself (0 memo slots in that file) while its callers compile — the same safe-decline #500 got after the rename.
- **Diagnostics**: this is the trade. The Babel path logged per-function CompileSuccess/CompileError/bail-out reasons; the SWC path is silent — no healthcheck, no bail-out visibility, and `useAtYourOwnRisk_mutateSwcOptions` is explicitly unsupported API surface. If a future edit reintroduces a `store(selector)`-class bug, nothing but e2e will say so (which was already true of the Babel path's static checks — but Babel at least offered logging when you went looking).
- **Version coupling**: the plugin hatch could change shape in any release; the SWC option is one release old.

## Recommendation

If we want the React Compiler, this is the way to ship it — the correctness work from #500 transfers wholesale (parity held everywhere I could measure it), and the cost objection is gone. The residual risks are governance, not performance: an unsupported config hatch and no compiler diagnostics. The soak-window concern from the first draft of this PR is resolved — the dependency graph is now clean of bypasses. #500's annotation-mode fallback remains available if incremental rollout is preferred.

Prior art: #500 (Babel path, same store.ts fix, same verification method).