### PR TITLE
Add sandbox_unavailable tool call error type

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -3823,7 +3823,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "unknown" | "output_limit";
+            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "sandbox_unavailable" | "unknown" | "output_limit";
         };
         /**
          * ToolCallView

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -3771,7 +3771,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "unknown" | "output_limit";
+            type: "parsing" | "timeout" | "unicode_decode" | "permission" | "file_not_found" | "is_a_directory" | "limit" | "approval" | "cancelled" | "sandbox_unavailable" | "unknown" | "output_limit";
         };
         /**
          * ToolCallView


### PR DESCRIPTION
Regenerated types for the `ToolCallError.type` enum widening in UKGovernmentBEIS/inspect_ai#4740 (review feedback: record dead sandboxes as a dedicated `sandbox_unavailable` tool error type, filterable in logs).

- `packages/inspect-common`: `generated.ts` regenerated via inspect_ai's `schema.py`
- `apps/scout`: `generated.ts` synced via inspect_scout's `export_openapi_schema.py` (scout's typecheck breaks on the widened union otherwise)

Paired inspect_ai PR: UKGovernmentBEIS/inspect_ai#4740 — merge this PR first, then the gitlink there gets bumped/validated per the usual two-phase landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)