### PR TITLE
Remove dead rollup override and @parcel/watcher allowBuilds entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ overrides:
   brace-expansion@2: ^2.1.4
   brace-expansion@5: ^5.0.9
   '@microsoft/api-extractor': ^7.57.6
-  rollup: ^4.59.0
   fast-uri: ^3.1.5
   immutable: ^5.1.8
   ws: ^8.20.1
@@ -1820,7 +1819,7 @@ packages:
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -1934,7 +1933,7 @@ packages:
     resolution: {integrity: sha512-IaX8FlM0H36HNFhJ2+4L9bCldqfvHGqcLg841SJNyK/DhfMlM7JsvY/GDH2ZFuWrUf8FSOx96GRRnHq6XfRKag==}
     peerDependencies:
       esbuild: ^0.28.2
-      rollup: ^4.59.0
+      rollup: '*'
       storybook: ^10.5.7
       vite: '*'
       webpack: '*'
@@ -4532,7 +4531,7 @@ packages:
       '@vue/language-core': ^3.1.5
       esbuild: ^0.28.2
       rolldown: '*'
-      rollup: ^4.59.0
+      rollup: '>=3'
       typescript: '>=4'
       vite: '>=3'
       webpack: ^4 || ^5
@@ -4589,7 +4588,7 @@ packages:
     resolution: {integrity: sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==}
     peerDependencies:
       '@microsoft/api-extractor': ^7.57.6
-      rollup: ^4.59.0
+      rollup: '>=3'
       vite: '>=3'
     peerDependenciesMeta:
       '@microsoft/api-extractor':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,6 @@ overrides:
   "brace-expansion@2": ^2.1.4
   "brace-expansion@5": ^5.0.9
   "@microsoft/api-extractor": ^7.57.6
-  rollup: ^4.59.0
   fast-uri: ^3.1.5
   immutable: ^5.1.8
   ws: ^8.20.1
@@ -58,7 +57,6 @@ overrides:
 # demonstrably needs its postinstall (esbuild gets binaries via
 # optionalDependencies; unrs-resolver has a JS fallback).
 allowBuilds:
-  "@parcel/watcher": false
   esbuild: false
   msw: false
   unrs-resolver: false


### PR DESCRIPTION
Follow-up cleanup for the two post-merge review comments on #537 ([rollup](https://github.com/meridianlabs-ai/ts-mono/pull/537#discussion_r3804155216), [@parcel/watcher](https://github.com/meridianlabs-ai/ts-mono/pull/537#discussion_r3804155222)). I verified both against the current lockfile before removing anything:

- **`rollup: ^4.59.0` override** — no resolved `rollup@…` package exists in `pnpm-lock.yaml`; every remaining mention is optional-peer metadata or a `transitivePeerDependencies` list (vite 8 bundles via rolldown). This is the same situation #537 used to justify dropping the `less` override. Removing it only reverts peer-range annotations in the lockfile to the upstream ranges — no package resolutions change.
- **`"@parcel/watcher": false` in `allowBuilds`** — zero occurrences in the lockfile, so the entry no longer matches the comment framing that list as build scripts actually being ignored.

Left as-is, per the comment's own analysis: the `@microsoft/api-extractor` override, which remains an optional peer of vite-plugin-dts/unplugin-dts.

Validation: `pnpm install` (regenerated lockfile, 856 entries), `pnpm check` (27/27), `pnpm test` (9/9 projects) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191v4yWSTcfWStHUf6spwEz

---
_Generated by [Claude Code](https://claude.ai/code/session_0191v4yWSTcfWStHUf6spwEz)_