### PR TITLE
build: migrate TanStack Table to v9

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -95,7 +95,7 @@
     "@codemirror/view": "^6.43.8",
     "@lezer/highlight": "^1.2.2",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "@vscode-elements/react-elements": "^2.4.0",
     "@vscode/codicons": "^0.0.45",

--- a/apps/inspect/src/app/log-view/title-view/ScoreGrid.test.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreGrid.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { ScoreSummary } from "../../../scoring/types";
@@ -38,6 +44,19 @@ const groupedScores: ScoreSummary[] = [
     ],
   },
 ];
+
+const score = (scorer: string): ScoreSummary => ({
+  scorer,
+  scoredSamples: 1,
+  unscoredSamples: 0,
+  metrics: [{ name: "accuracy", value: 1 }],
+});
+
+const renderedScorers = () =>
+  screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => within(row).getAllByRole("cell")[0]?.textContent?.trim());
 
 describe("ScoreGrid", () => {
   // Auto-cleanup needs vitest `globals: true`, which this config doesn't set.
@@ -80,6 +99,26 @@ describe("ScoreGrid", () => {
     const scorerOrder = [cells[0]?.textContent, cells[3]?.textContent];
     expect(scorerOrder[0]).toContain("match");
     expect(scorerOrder[1]).toContain("model_graded");
+  });
+
+  test("sorts scorer names case-insensitively", () => {
+    render(
+      <ScoreGrid
+        scoreGroups={[[score("Zebra"), score("apple"), score("Banana")]]}
+      />
+    );
+    fireEvent.click(screen.getByRole("columnheader", { name: "Scorer" }));
+    expect(renderedScorers()).toEqual(["apple", "Banana", "Zebra"]);
+  });
+
+  test("sorts numbered scorer names naturally", () => {
+    render(
+      <ScoreGrid
+        scoreGroups={[[score("scorer10"), score("Scorer2"), score("scorer1")]]}
+      />
+    );
+    fireEvent.click(screen.getByRole("columnheader", { name: "Scorer" }));
+    expect(renderedScorers()).toEqual(["scorer1", "Scorer2", "scorer10"]);
   });
 
   test("compact card is not sortable", () => {

--- a/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
@@ -1,11 +1,13 @@
 import {
   ColumnDef,
+  columnVisibilityFeature,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
   Header,
+  rowSortingFeature,
   SortingState,
-  useReactTable,
+  tableFeatures,
+  useTable,
 } from "@tanstack/react-table";
 import clsx from "clsx";
 import { FC, ReactElement, useMemo, useState } from "react";
@@ -32,6 +34,14 @@ interface ScoreGridRow {
   unscoredSamples?: number;
   metrics: (number | undefined)[];
 }
+
+const scoreGridFeatures = tableFeatures({
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+});
+
+type ScoreGridFeatures = typeof scoreGridFeatures;
 
 const kScorerColWidth = 180;
 const kMetricColWidth = 120;
@@ -97,7 +107,10 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
       metrics: score.metrics.map((m) => m.value),
     }));
 
-    const leafCol = (name: string, i: number): ColumnDef<ScoreGridRow> => ({
+    const leafCol = (
+      name: string,
+      i: number
+    ): ColumnDef<ScoreGridFeatures, ScoreGridRow> => ({
       id: `metric_${i}`,
       header: name,
       accessorFn: (row) => row.metrics[i],
@@ -111,7 +124,7 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
     const runs = groupMetricRuns(metrics);
     const grouped = runs.some(isGroupRun);
 
-    const metricColumns: ColumnDef<ScoreGridRow>[] = [];
+    const metricColumns: ColumnDef<ScoreGridFeatures, ScoreGridRow>[] = [];
     let idx = 0;
     for (const [runIdx, run] of runs.entries()) {
       const children = run.metrics.map((m) => leafCol(m.name, idx++));
@@ -126,7 +139,7 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
       }
     }
 
-    const scorerCol: ColumnDef<ScoreGridRow> = {
+    const scorerCol: ColumnDef<ScoreGridFeatures, ScoreGridRow> = {
       id: "scorer",
       header: "Scorer",
       accessorFn: (row) => row.scorer,
@@ -142,7 +155,7 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
       ),
     };
 
-    const columns: ColumnDef<ScoreGridRow>[] = [
+    const columns: ColumnDef<ScoreGridFeatures, ScoreGridRow>[] = [
       grouped
         ? { id: "scorer_group", header: "", columns: [scorerCol] }
         : scorerCol,
@@ -156,17 +169,12 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
     };
   }, [scoreGroup, showReducer, sortable, scorerColWidth, metricColWidth]);
 
-  // useReactTable returns unmemoizable functions
-  // https://github.com/TanStack/table/issues/5567
-  // https://github.com/facebook/react/issues/33057
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
+    features: scoreGridFeatures,
     data: rows,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     enableMultiSort: false,
   });
 
@@ -255,7 +263,7 @@ const LeafHeader = ({
   header,
   isLast,
 }: {
-  header: Header<ScoreGridRow, unknown>;
+  header: Header<ScoreGridFeatures, ScoreGridRow, unknown>;
   isLast: boolean;
 }): ReactElement => {
   const sorted = header.column.getIsSorted();

--- a/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
@@ -5,6 +5,8 @@ import {
   flexRender,
   Header,
   rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
   SortingState,
   tableFeatures,
   useTable,
@@ -39,6 +41,7 @@ const scoreGridFeatures = tableFeatures({
   columnVisibilityFeature,
   rowSortingFeature,
   sortedRowModel: createSortedRowModel(),
+  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
 });
 
 type ScoreGridFeatures = typeof scoreGridFeatures;

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.pinning.test.tsx
@@ -30,7 +30,7 @@ const makeColumns = (pinnedIds: string[]): ExtendedColumnDef<Row>[] =>
     size: 100,
     accessorFn: (r: Row) => r[key],
     cell: ({ getValue }) => <div>{getValue<string>()}</div>,
-    ...(pinnedIds.includes(key) ? { pinned: "left" as const } : {}),
+    ...(pinnedIds.includes(key) ? { pinned: "start" as const } : {}),
   }));
 
 // jsdom has no DataTransfer; provide the bits the handlers touch.

--- a/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
+++ b/apps/inspect/src/app/shared/data-grid/DataGrid.tsx
@@ -1,15 +1,14 @@
 import {
   Column,
-  ColumnDef,
   ColumnSizingState,
+  ColumnVisibilityState,
   flexRender,
-  getCoreRowModel,
   Header,
   OnChangeFn,
   Row,
+  RowData,
   SortingState,
-  useReactTable,
-  VisibilityState,
+  useTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
@@ -44,6 +43,7 @@ import {
 import { ExtendedColumnDef } from "./columnTypes";
 import styles from "./DataGrid.module.css";
 import { resolveKeyboardNavTarget } from "./keyboardNav";
+import { dataGridFeatures, DataGridFeatures } from "./tableFeatures";
 
 const kRowHeight = 30;
 const kPageJump = 10;
@@ -55,7 +55,7 @@ const kRotatedHeaderHeight = 115;
 /** Full-text header tooltip (native `title`), shown on hover — useful when the
  *  header label is truncated (regular ellipsis or a narrow rotated label).
  *  Prefers an explicit `headerTitle`, else the string header text. */
-function resolveHeaderTitle<TRow>(
+function resolveHeaderTitle<TRow extends RowData>(
   columnDef: ExtendedColumnDef<TRow>
 ): string | undefined {
   if (columnDef.headerTitle) return columnDef.headerTitle;
@@ -66,7 +66,9 @@ function resolveHeaderTitle<TRow>(
  *  matching the pointer `onClick`. Stops propagation so the grid container's
  *  key handler doesn't also treat Enter/Space as "activate the selected row".
  *  Shift/Cmd/Ctrl carry through to the toggle handler for multi-sort. */
-function makeSortKeyDownHandler<TRow>(header: Header<TRow, unknown>) {
+function makeSortKeyDownHandler<TRow extends RowData>(
+  header: Header<DataGridFeatures, TRow, unknown>
+) {
   return (e: KeyboardEvent<HTMLElement>) => {
     if (e.key !== "Enter" && e.key !== " ") return;
     e.preventDefault();
@@ -92,15 +94,15 @@ function measureContentWidth(el: Element): number {
  *  sorted, this column's 1-based position in the sort order (the number is
  *  noise for a single sort, so it only appears for multi-sorts — matching
  *  the previous AG grid). */
-function SortIndicator<TRow>({
+function SortIndicator<TRow extends RowData>({
   header,
 }: {
-  header: Header<TRow, unknown>;
+  header: Header<DataGridFeatures, TRow, unknown>;
 }): ReactElement | null {
   const sorted = header.column.getIsSorted();
   if (!sorted) return null;
   const sortIndex = header.column.getSortIndex();
-  const multiSorted = header.getContext().table.getState().sorting.length > 1;
+  const multiSorted = header.getContext().table.store.state.sorting.length > 1;
   return (
     <span className={styles.sortIndicator}>
       {multiSorted && sortIndex >= 0 && (
@@ -130,12 +132,12 @@ const kAfterRotatedGap = 24;
 // invisible.
 const kFitSlack = 4;
 
-export interface DataGridProps<TRow> {
+export interface DataGridProps<TRow extends RowData> {
   data: TRow[];
   columns: ExtendedColumnDef<TRow>[];
   getRowId: (row: TRow) => string;
   /** Controlled column visibility (keyed by column id). Owned by the caller. */
-  columnVisibility?: VisibilityState;
+  columnVisibility?: ColumnVisibilityState;
   /** Controlled sort state. Rows arrive already sorted (manualSorting); this
    *  drives only the header indicators. */
   sorting?: SortingState;
@@ -204,7 +206,7 @@ export interface DataGridProps<TRow> {
  * double-click auto-size), pinning, reordering, and find are wired up —
  * see design/migration/archive/loglistgrid-tanstack.md.
  */
-export function DataGrid<TRow>({
+export function DataGrid<TRow extends RowData>({
   data,
   columns,
   getRowId,
@@ -336,14 +338,15 @@ export function DataGrid<TRow>({
   // drag-reorder as both source and target (matching the AG grid).
   const columnPinning = useMemo(
     () => ({
-      left: columns.flatMap((c) =>
-        c.pinned === "left" && c.id !== undefined ? [c.id] : []
+      start: columns.flatMap((c) =>
+        c.pinned === "start" && c.id !== undefined ? [c.id] : []
       ),
+      end: [],
     }),
     [columns]
   );
-  const pinnedLeft = useMemo(
-    () => new Set(columnPinning.left),
+  const pinnedStart = useMemo(
+    () => new Set(columnPinning.start),
     [columnPinning]
   );
 
@@ -398,7 +401,7 @@ export function DataGrid<TRow>({
     (e: DragEvent<HTMLElement>, colId: string) => {
       // Pinned columns are not drop targets: skipping preventDefault leaves
       // the cell an invalid target (browser shows no-drop).
-      if (!draggedColId || pinnedLeft.has(colId)) return;
+      if (!draggedColId || pinnedStart.has(colId)) return;
       // preventDefault marks the cell as a valid drop target.
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
@@ -415,7 +418,7 @@ export function DataGrid<TRow>({
           : { colId, side }
       );
     },
-    [draggedColId, effectiveColumnOrder, pinnedLeft]
+    [draggedColId, effectiveColumnOrder, pinnedStart]
   );
 
   const handleHeaderDragLeave = useCallback((e: DragEvent<HTMLElement>) => {
@@ -432,14 +435,14 @@ export function DataGrid<TRow>({
   const handleHeaderDrop = useCallback(
     (e: DragEvent<HTMLElement>, colId: string) => {
       e.preventDefault();
-      if (draggedColId && !pinnedLeft.has(colId)) {
+      if (draggedColId && !pinnedStart.has(colId)) {
         const next = moveColumn(effectiveColumnOrder, draggedColId, colId);
         if (next) commitColumnOrder(next);
       }
       setDraggedColId(null);
       setDropTarget(null);
     },
-    [draggedColId, effectiveColumnOrder, commitColumnOrder, pinnedLeft]
+    [draggedColId, effectiveColumnOrder, commitColumnOrder, pinnedStart]
   );
 
   // Fires on the drag source after a drop OR a cancelled drag (Escape /
@@ -459,8 +462,8 @@ export function DataGrid<TRow>({
     for (const c of columns) {
       if (c.id !== undefined) byId.set(c.id, c);
     }
-    const rest = effectiveColumnOrder.filter((id) => !pinnedLeft.has(id));
-    return [...columnPinning.left, ...rest]
+    const rest = effectiveColumnOrder.filter((id) => !pinnedStart.has(id));
+    return [...columnPinning.start, ...rest]
       .filter((id) => (columnVisibility?.[id] ?? true) && byId.has(id))
       .map((id) => byId.get(id)!);
   }, [
@@ -468,7 +471,7 @@ export function DataGrid<TRow>({
     columnVisibility,
     effectiveColumnOrder,
     columnPinning,
-    pinnedLeft,
+    pinnedStart,
   ]);
 
   // Rotated headers (compact score columns) need a taller header row and
@@ -546,7 +549,7 @@ export function DataGrid<TRow>({
   // correctly. The result commits through the normal sizing path, so it
   // persists exactly like a drag-resize.
   const autoSizeColumn = useCallback(
-    (column: Column<TRow, unknown>) => {
+    (column: Column<DataGridFeatures, TRow, unknown>) => {
       const container = containerRef.current;
       if (!container) return;
       const selector = `[role="gridcell"][data-col-id="${CSS.escape(column.id)}"]`;
@@ -568,14 +571,10 @@ export function DataGrid<TRow>({
     [handleColumnSizingChange]
   );
 
-  // useReactTable returns unmemoizable functions
-  // https://github.com/TanStack/table/issues/5567
-  // https://github.com/facebook/react/issues/33057
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data,
-    columns: columns as ColumnDef<TRow>[],
-    getCoreRowModel: getCoreRowModel(),
+    columns,
     getRowId,
     manualSorting: true,
     // TanStack defaults non-string columns to descending-first; the AG grid
@@ -621,6 +620,7 @@ export function DataGrid<TRow>({
   //  - scrollPaddingStart reserves the header's height when aligning to the
   //    top ("start"/"auto"), so a row scrolled in from above sits below the
   //    sticky header instead of behind it.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => containerRef.current,
@@ -819,7 +819,7 @@ export function DataGrid<TRow>({
 
                 const align = columnDef.meta?.align;
                 const filterType = columnDef.meta?.filterType;
-                const pinned = header.column.getIsPinned() === "left";
+                const pinned = header.column.getIsPinned() === "start";
                 const sorted = header.column.getIsSorted();
                 const sortCaret = <SortIndicator header={header} />;
                 const headerLabel = header.isPlaceholder
@@ -874,7 +874,7 @@ export function DataGrid<TRow>({
                           : 0),
                       ...(pinned && {
                         position: "sticky" as const,
-                        left: header.column.getStart("left"),
+                        left: header.column.getStart("start"),
                         zIndex: 3,
                       }),
                     }}
@@ -1013,13 +1013,13 @@ export function DataGrid<TRow>({
   );
 }
 
-interface GridRowProps<TRow> {
-  row: Row<TRow>;
+interface GridRowProps<TRow extends RowData> {
+  row: Row<DataGridFeatures, TRow>;
   ariaRowIndex: number;
   /** Not read directly (`row.getVisibleCells()` re-derives the cells) — a
    *  memo cache key so the row re-renders on visibility/order changes that
    *  don't move `width` (e.g. reordering columns keeps the total size). */
-  visibleColumns: Column<TRow, unknown>[];
+  visibleColumns: Column<DataGridFeatures, TRow, unknown>[];
   isSelected: boolean;
   rowHeight: number;
   width: number;
@@ -1028,7 +1028,7 @@ interface GridRowProps<TRow> {
   onRowClick: (e: MouseEvent<HTMLDivElement>, rowId: string, row: TRow) => void;
 }
 
-function GridRowInner<TRow>({
+function GridRowInner<TRow extends RowData>({
   row,
   ariaRowIndex,
   isSelected,
@@ -1058,7 +1058,7 @@ function GridRowInner<TRow>({
         const cellDef = cell.column.columnDef as ExtendedColumnDef<TRow>;
         const align = cellDef.meta?.align;
         const cellStyle = cellDef.meta?.cellStyle?.(row.original);
-        const pinned = cell.column.getIsPinned() === "left";
+        const pinned = cell.column.getIsPinned() === "start";
         return (
           <div
             key={cell.id}
@@ -1073,7 +1073,7 @@ function GridRowInner<TRow>({
                 (afterRotatedIds.has(cell.column.id) ? kAfterRotatedGap : 0),
               ...(pinned && {
                 position: "sticky" as const,
-                left: cell.column.getStart("left"),
+                left: cell.column.getStart("start"),
                 zIndex: 1,
               }),
               ...cellStyle,
@@ -1105,7 +1105,7 @@ const GridRow = memo(GridRowInner) as typeof GridRowInner;
  * non-rotated element at the cell's bottom so it opens below the header
  * (under the column) instead of over the headers next to the funnel.
  */
-function RotatedHeaderCell<TRow>({
+function RotatedHeaderCell<TRow extends RowData>({
   header,
   ariaColIndex,
   filterSpec,
@@ -1120,7 +1120,7 @@ function RotatedHeaderCell<TRow>({
   onHeaderDrop,
   onAutoSize,
 }: {
-  header: Header<TRow, unknown>;
+  header: Header<DataGridFeatures, TRow, unknown>;
   ariaColIndex: number;
   filterSpec: FilterSpec | null;
   onColumnFilterChange?: (

--- a/apps/inspect/src/app/shared/data-grid/columnTypes.ts
+++ b/apps/inspect/src/app/shared/data-grid/columnTypes.ts
@@ -1,10 +1,12 @@
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 import type { CSSProperties } from "react";
 
 import type {
   FilterType,
   UiOperator,
 } from "@tsmono/inspect-components/columnFilter";
+
+import type { DataGridFeatures } from "./tableFeatures";
 
 /**
  * Value comparator carried on a column for client-side sorting. Sorts
@@ -50,14 +52,17 @@ export interface BaseColumnMeta<TRow = unknown> {
  * plus a few rendering helpers. `size` / `minSize` / `maxSize` come from
  * TanStack's own `ColumnDef`.
  */
-export type ExtendedColumnDef<TRow> = ColumnDef<TRow> & {
+export type ExtendedColumnDef<TRow extends RowData> = ColumnDef<
+  DataGridFeatures,
+  TRow
+> & {
   meta?: BaseColumnMeta<TRow>;
   /**
    * Pin the column to the left edge: it orders before unpinned columns,
    * stays visible under horizontal scroll (sticky), and is excluded from
    * drag-reorder.
    */
-  pinned?: "left";
+  pinned?: "start";
   /**
    * Flex weight (AG `initialFlex`): the column absorbs leftover grid width
    * proportionally to its weight, floored at `minSize`. `size` serves as

--- a/apps/inspect/src/app/shared/data-grid/findMatches.ts
+++ b/apps/inspect/src/app/shared/data-grid/findMatches.ts
@@ -1,3 +1,5 @@
+import type { RowData } from "@tanstack/react-table";
+
 import type { ExtendedColumnDef } from "./columnTypes";
 
 /** Objects/arrays are skipped rather than stringified ("[object Object]"
@@ -19,7 +21,7 @@ function primitiveText(value: unknown): string | null {
  * One row's searchable text: lowercased plain-text built from the visible
  * columns' `textValue` (display formatting) or raw accessor value.
  */
-export function rowSearchText<TRow>(
+export function rowSearchText<TRow extends RowData>(
   row: TRow,
   columns: ExtendedColumnDef<TRow>[]
 ): string {
@@ -43,7 +45,7 @@ export function rowSearchText<TRow>(
  * Data-level — searches all rows, not just the virtualized window.
  * Insertion order follows `rows`, so match order is row order.
  */
-export function buildSearchIndex<TRow>(
+export function buildSearchIndex<TRow extends RowData>(
   rows: TRow[],
   columns: ExtendedColumnDef<TRow>[],
   getRowId: (row: TRow) => string

--- a/apps/inspect/src/app/shared/data-grid/tableFeatures.ts
+++ b/apps/inspect/src/app/shared/data-grid/tableFeatures.ts
@@ -1,0 +1,20 @@
+import {
+  columnOrderingFeature,
+  columnPinningFeature,
+  columnResizingFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  rowSortingFeature,
+  tableFeatures,
+} from "@tanstack/react-table";
+
+export const dataGridFeatures = tableFeatures({
+  columnOrderingFeature,
+  columnPinningFeature,
+  columnSizingFeature,
+  columnResizingFeature,
+  columnVisibilityFeature,
+  rowSortingFeature,
+});
+
+export type DataGridFeatures = typeof dataGridFeatures;

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -143,7 +143,7 @@ export function buildSampleColumns(
       maxSize: 80,
       enableSorting: false,
       enableResizing: false,
-      pinned: "left",
+      pinned: "start",
       accessorFn: (row) => row.displayIndex,
       cell: ({ row }) => {
         const value = row.original.displayIndex;

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -92,7 +92,7 @@
     "zstd-codec": "^0.1.5"
   },
   "dependencies": {
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "@uwdata/flechette": "^2.5.0",
     "@vscode-elements/react-elements": "^2.4.0",

--- a/apps/scout/src/app/components/columnSizing/types.ts
+++ b/apps/scout/src/app/components/columnSizing/types.ts
@@ -3,7 +3,7 @@
  * These types are used by the column sizing strategies and hooks.
  */
 
-import { ColumnSizingState } from "@tanstack/react-table";
+import { ColumnSizingState, RowData } from "@tanstack/react-table";
 
 import { BaseColumnMeta, ExtendedColumnDef } from "../columnTypes";
 
@@ -32,7 +32,7 @@ export const DEFAULT_SIZE = 150;
  * Context provided to sizing strategies for computing column sizes.
  * Generic over TData (row data type).
  */
-export interface SizingStrategyContext<TData> {
+export interface SizingStrategyContext<TData extends RowData> {
   /** The table element for DOM measurements (may be null) */
   tableElement: HTMLTableElement | null;
   /** Column definitions */
@@ -48,9 +48,11 @@ export interface SizingStrategyContext<TData> {
  * Each strategy computes column sizes differently.
  * Generic over TData (row data type).
  */
-export interface SizingStrategy<TData = unknown> {
+export interface SizingStrategy {
   /** Compute sizes for all columns */
-  computeSizes(context: SizingStrategyContext<TData>): ColumnSizingState;
+  computeSizes<TData extends RowData>(
+    context: SizingStrategyContext<TData>
+  ): ColumnSizingState;
 }
 
 /**
@@ -73,7 +75,7 @@ export function clampSize(
 /**
  * Get the column ID from a column definition.
  */
-export function getColumnId<TData>(
+export function getColumnId<TData extends RowData>(
   column: ExtendedColumnDef<TData, BaseColumnMeta>
 ): string {
   return column.id || (column as { accessorKey?: string }).accessorKey || "";
@@ -82,7 +84,7 @@ export function getColumnId<TData>(
 /**
  * Extract size constraints from column definitions.
  */
-export function getColumnConstraints<TData>(
+export function getColumnConstraints<TData extends RowData>(
   columns: ExtendedColumnDef<TData, BaseColumnMeta>[]
 ): Map<string, ColumnSizeConstraints> {
   const constraints = new Map<string, ColumnSizeConstraints>();

--- a/apps/scout/src/app/components/columnTypes.ts
+++ b/apps/scout/src/app/components/columnTypes.ts
@@ -1,7 +1,9 @@
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 
 import type { FilterType } from "../../state/store";
 import { valueAsString } from "../utils/format";
+
+import type { DataGridFeatures } from "./dataGrid/tableFeatures";
 
 /**
  * Common column metadata properties shared across all data grids.
@@ -20,9 +22,9 @@ export interface BaseColumnMeta {
  * Extends TanStack Table's ColumnDef with additional rendering helpers.
  */
 export type ExtendedColumnDef<
-  TData,
+  TData extends RowData,
   TMeta extends BaseColumnMeta = BaseColumnMeta,
-> = ColumnDef<TData> & {
+> = ColumnDef<DataGridFeatures, TData> & {
   meta?: TMeta;
   /** Returns string for tooltip display */
   titleValue?: (value: unknown) => string;
@@ -52,7 +54,7 @@ export interface ColumnInfo {
  * Extract title value for tooltip from a cell.
  * Uses custom titleValue function if provided, otherwise falls back to default formatting.
  */
-export function getCellTitleValue<TData>(
+export function getCellTitleValue<TData extends RowData>(
   value: unknown,
   columnDef: ExtendedColumnDef<TData>
 ): string {

--- a/apps/scout/src/app/components/dataGrid/DataGrid.tsx
+++ b/apps/scout/src/app/components/dataGrid/DataGrid.tsx
@@ -1,11 +1,11 @@
 import {
   ColumnSizingState,
   flexRender,
-  getCoreRowModel,
   OnChangeFn,
+  RowData,
   RowSelectionState,
   SortingState,
-  useReactTable,
+  useTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
@@ -34,6 +34,7 @@ import {
 } from "../columnTypes";
 
 import styles from "./DataGrid.module.css";
+import { dataGridFeatures } from "./tableFeatures";
 import type { DataGridProps, DataGridTableState } from "./types";
 
 /**
@@ -41,7 +42,7 @@ import type { DataGridProps, DataGridTableState } from "./types";
  * row selection, keyboard navigation, and column reordering.
  */
 export function DataGrid<
-  TData,
+  TData extends RowData,
   TColumn extends ExtendedColumnDef<TData, BaseColumnMeta>,
   TState extends DataGridTableState = DataGridTableState,
 >({
@@ -297,15 +298,10 @@ export function DataGrid<
     resetDragState();
   }, [resetDragState]);
 
-  // Create table instance
-  // useReactTable returns unmemoizable functions
-  // https://github.com/TanStack/table/issues/5567
-  // https://github.com/facebook/react/issues/33057
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
+    features: dataGridFeatures,
     data,
     columns,
-    getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
     columnResizeMode: "onChange",
     enableColumnResizing: true,
@@ -543,6 +539,7 @@ export function DataGrid<
   );
 
   // Create virtualizer
+  // eslint-disable-next-line react-hooks/incompatible-library
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => containerRef.current,

--- a/apps/scout/src/app/components/dataGrid/tableFeatures.ts
+++ b/apps/scout/src/app/components/dataGrid/tableFeatures.ts
@@ -1,0 +1,20 @@
+import {
+  columnOrderingFeature,
+  columnResizingFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  tableFeatures,
+} from "@tanstack/react-table";
+
+export const dataGridFeatures = tableFeatures({
+  columnOrderingFeature,
+  columnSizingFeature,
+  columnResizingFeature,
+  columnVisibilityFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+});
+
+export type DataGridFeatures = typeof dataGridFeatures;

--- a/apps/scout/src/app/components/dataGrid/types.ts
+++ b/apps/scout/src/app/components/dataGrid/types.ts
@@ -1,5 +1,6 @@
 import {
   ColumnSizingState,
+  RowData,
   RowSelectionState,
   SortingState,
 } from "@tanstack/react-table";
@@ -18,7 +19,7 @@ import type { BaseColumnMeta, ExtendedColumnDef } from "../columnTypes";
  * @template TState - The table state type (must extend DataGridTableState)
  */
 export interface DataGridProps<
-  TData,
+  TData extends RowData,
   TColumn extends ExtendedColumnDef<TData>,
   TState extends DataGridTableState = DataGridTableState,
 > {

--- a/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
@@ -7,7 +7,6 @@ import {
   ColumnSizingStrategyKey,
   getColumnConstraints,
   getSizingStrategy,
-  SizingStrategy,
 } from "../../components/columnSizing";
 import { ScanColumn, ScanRow } from "../columns";
 
@@ -162,9 +161,7 @@ export function useColumnSizing({
         columnSizing: currentSizing,
       } = latestRef.current;
 
-      const strategy = getSizingStrategy(
-        strategyKey
-      ) as SizingStrategy<ScanRow>;
+      const strategy = getSizingStrategy(strategyKey);
       const calculatedSizing = strategy.computeSizes({
         tableElement: tableRef.current,
         columns: cols,
@@ -207,9 +204,7 @@ export function useColumnSizing({
           columnConstraints: constraints,
         } = latestRef.current;
 
-        const strategy = getSizingStrategy(
-          strategyKey
-        ) as SizingStrategy<ScanRow>;
+        const strategy = getSizingStrategy(strategyKey);
         const allSizes = strategy.computeSizes({
           tableElement: tableRef.current,
           columns: cols,

--- a/apps/scout/src/app/transcripts/columnSizing/strategies.test.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/strategies.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { TranscriptInfo } from "../../../types/api-types";
 import {
   getSizingStrategy,
   sizingStrategies,
-  SizingStrategy,
 } from "../../components/columnSizing";
 import { TranscriptColumn } from "../columns";
 
 describe("sizingStrategies", () => {
   describe("default strategy", () => {
-    const strategy = sizingStrategies.default as SizingStrategy<TranscriptInfo>;
+    const strategy = sizingStrategies.default;
 
     it("extracts sizes from columns", () => {
       const columns: TranscriptColumn[] = [
@@ -77,9 +75,7 @@ describe("sizingStrategies", () => {
   });
 
   describe("fit-content strategy", () => {
-    const strategy = sizingStrategies[
-      "fit-content"
-    ] as SizingStrategy<TranscriptInfo>;
+    const strategy = sizingStrategies["fit-content"];
 
     it("falls back to default sizes when no table element", () => {
       const columns: TranscriptColumn[] = [

--- a/apps/scout/src/app/transcripts/columnSizing/types.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/types.ts
@@ -39,4 +39,4 @@ export interface SizingStrategyContext extends Omit<
  * Interface for column sizing strategies.
  * Each strategy computes column sizes differently.
  */
-export type SizingStrategy = GenericSizingStrategy<TranscriptInfo>;
+export type SizingStrategy = GenericSizingStrategy;

--- a/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
@@ -8,7 +8,6 @@ import {
   ColumnSizingStrategyKey,
   getColumnConstraints,
   getSizingStrategy,
-  SizingStrategy,
 } from "../../components/columnSizing";
 import { TranscriptColumn } from "../columns";
 
@@ -165,9 +164,7 @@ export function useColumnSizing({
         columnSizing: currentSizing,
       } = latestRef.current;
 
-      const strategy = getSizingStrategy(
-        strategyKey
-      ) as SizingStrategy<TranscriptInfo>;
+      const strategy = getSizingStrategy(strategyKey);
       const calculatedSizing = strategy.computeSizes({
         tableElement: tableRef.current,
         columns: cols,
@@ -210,9 +207,7 @@ export function useColumnSizing({
           columnConstraints: constraints,
         } = latestRef.current;
 
-        const strategy = getSizingStrategy(
-          strategyKey
-        ) as SizingStrategy<TranscriptInfo>;
+        const strategy = getSizingStrategy(strategyKey);
         const allSizes = strategy.computeSizes({
           tableElement: tableRef.current,
           columns: cols,

--- a/apps/scout/src/app/transcripts/columns.tsx
+++ b/apps/scout/src/app/transcripts/columns.tsx
@@ -1,4 +1,3 @@
-import { ColumnDef } from "@tanstack/react-table";
 import clsx from "clsx";
 
 import {
@@ -13,6 +12,7 @@ import { ApplicationIcons } from "../../icons";
 import { FilterType } from "../../state/store";
 import { TranscriptInfo } from "../../types/api-types";
 import type { AvailableColumn } from "../components/columnFilter";
+import type { ExtendedColumnDef } from "../components/columnTypes";
 import { valueAsString } from "../utils/format";
 
 import styles from "./columns.module.css";
@@ -71,7 +71,7 @@ export const COLUMN_HEADER_TITLES: Record<keyof TranscriptInfo, string> = {
   error: "Error message that terminated the task.",
 };
 
-export type TranscriptColumn = ColumnDef<TranscriptInfo> & {
+export type TranscriptColumn = ExtendedColumnDef<TranscriptInfo> & {
   meta?: {
     align?: "left" | "center" | "right";
     filterable?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -267,8 +267,8 @@ importers:
   apps/scout:
     dependencies:
       '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2050,12 +2050,17 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
 
   '@tanstack/react-virtual@3.14.9':
     resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
@@ -2063,9 +2068,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
+
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -5842,11 +5850,20 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-store@0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/store': 0.11.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
+      react: 19.2.8
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -5854,7 +5871,11 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/store@0.11.1': {}
+
+  '@tanstack/table-core@9.1.2':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@tanstack/virtual-core@3.17.7': {}
 


### PR DESCRIPTION
## Summary

- upgrade `@tanstack/react-table` from 8.21.3 to 9.1.2 in Inspect and Scout
- migrate both data-grid implementations to the native v9 feature and state APIs
- update sorting, column visibility, sizing, and logical start/end pinning integrations
- retain strict typing without using the v9 legacy compatibility hook

This replaces Dependabot PR #535, which could not be merged as a dependency-only update because TanStack Table v9 requires an application migration.

## Impact

Inspect and Scout continue to expose the same table behavior while running against TanStack Table v9. The migration is internal and does not intentionally change user-facing behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- Inspect unit tests: 1,139 passed
- Scout unit tests: 210 passed
- Inspect and Scout lint and format checks
- `pnpm build`
- Scout Playwright: 65 passed
- Inspect Playwright: 101 passed in the full serialized run; the single timing failure passed immediately in isolation
- Inspect migration-focused Playwright tests: 32 passed
- live Inspect browser session against real logs: grid loading, sorting, log details, and score grid
- live Scout browser session against real transcripts: 704-row grid, sorting, and transcript timeline
