### PR TITLE
fix: ignore malformed sample route epochs

### DIFF
--- a/apps/inspect/src/app/routing/loaders/SampleRouteSelectionController.test.tsx
+++ b/apps/inspect/src/app/routing/loaders/SampleRouteSelectionController.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SampleRouteSelectionController } from "./SampleRouteSelectionController";
+
+const routeParams = vi.hoisted(() => ({
+  samplesPath: "run.eval",
+  sampleId: "sample-1",
+  epoch: "1",
+  tabId: undefined,
+}));
+
+vi.mock("../url", () => ({
+  useSamplesRouteParams: () => routeParams,
+}));
+
+const selectLogFile = vi.hoisted(() => vi.fn());
+const selectSample = vi.hoisted(() => vi.fn());
+vi.mock("../../../state/actions", () => ({ selectLogFile, selectSample }));
+
+vi.mock("../../../state/store", () => ({
+  useStore: (selector: (state: unknown) => unknown) =>
+    selector({ logs: { selectedLogFile: undefined } }),
+}));
+
+beforeEach(() => {
+  selectLogFile.mockReset();
+  selectSample.mockReset();
+  routeParams.epoch = "1";
+});
+
+describe("SampleRouteSelectionController", () => {
+  it("selects a sample when the route epoch is numeric", () => {
+    render(<SampleRouteSelectionController />);
+
+    expect(selectLogFile).toHaveBeenCalledWith("run.eval");
+    expect(selectSample).toHaveBeenCalledWith("sample-1", 1, "run.eval");
+  });
+
+  it("does not store a sample handle for a malformed route epoch", () => {
+    routeParams.epoch = "abc";
+
+    render(<SampleRouteSelectionController />);
+
+    expect(selectLogFile).toHaveBeenCalledWith("run.eval");
+    expect(selectSample).not.toHaveBeenCalled();
+  });
+});

--- a/apps/inspect/src/app/routing/loaders/SampleRouteSelectionController.tsx
+++ b/apps/inspect/src/app/routing/loaders/SampleRouteSelectionController.tsx
@@ -24,7 +24,11 @@ export const SampleRouteSelectionController: FC = () => {
       if (selectedLogFile !== routeLogPath) {
         selectLogFile(routeLogPath);
       }
-      selectSample(sampleId, parseInt(epoch, 10), routeLogPath);
+      const targetEpoch = parseInt(epoch, 10);
+      if (isNaN(targetEpoch)) {
+        return;
+      }
+      selectSample(sampleId, targetEpoch, routeLogPath);
     }
   }, [routeLogPath, sampleId, epoch, selectedLogFile]);
 


### PR DESCRIPTION
## Summary

- reject malformed sample-route epoch segments before selecting a sample
- preserve log selection while preventing a `NaN` sample handle
- add controller coverage for numeric and malformed route epochs

## Validation

- `pnpm --filter @meridianlabs/log-viewer test -- src/app/routing/loaders/SampleRouteSelectionController.test.tsx` — 107 files and 1,141 tests passed; the package script runs the complete Inspect unit suite
- `pnpm --filter @meridianlabs/log-viewer typecheck` — passed
- `pnpm --filter @meridianlabs/log-viewer lint` — passed
- `pnpm --filter @meridianlabs/log-viewer format:check` — passed
- repository pre-commit and pre-push lint, format, and check hooks — passed under Node 24 and pnpm 11.22.0

## Risk

- Limited to malformed epoch segments; valid numeric routes retain existing behavior.

Fixes #396
