### PR TITLE
fix: keep flat punch-down navigation visible

### DIFF
--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -8,7 +8,13 @@ import {
   testModelEvent,
   testModelOutput,
 } from "@tsmono/inspect-common/testing";
-import type { Event } from "@tsmono/inspect-common/types";
+import type {
+  AnchorEvent,
+  Event,
+  Timeline as ServerTimeline,
+  TimelineEvent as ServerTimelineEvent,
+  TimelineSpan as ServerTimelineSpan,
+} from "@tsmono/inspect-common/types";
 
 import { InMemoryStateWrapper } from "../testHelpers";
 
@@ -50,6 +56,46 @@ function makeInfoEvent(uuid: string, startSec: number): Event {
   });
 }
 
+function makeAnchorEvent(
+  uuid: string,
+  anchorId: string,
+  startSec: number
+): AnchorEvent {
+  return {
+    event: "anchor",
+    uuid,
+    anchor_id: anchorId,
+    timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
+    working_start: startSec,
+    span_id: null,
+    pending: null,
+    metadata: null,
+    source: null,
+  };
+}
+
+function makeServerEvent(uuid: string): ServerTimelineEvent {
+  return { type: "event", event: uuid };
+}
+
+function makeServerSpan(
+  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
+): ServerTimelineSpan {
+  return {
+    type: "span",
+    span_type: null,
+    content: [],
+    branches: [],
+    branched_from: null,
+    description: null,
+    utility: false,
+    tool_invoked: false,
+    agent_result: null,
+    outline: null,
+    ...overrides,
+  };
+}
+
 // =============================================================================
 // useTimelinePipeline
 // =============================================================================
@@ -78,6 +124,55 @@ describe("useTimelinePipeline", () => {
     expect(result.current.showSwimlanes).toBe(true);
     // With swimlanes on the feed carries the (empty) source-span map.
     expect(result.current.nodeFeed.sourceSpans).toBeInstanceOf(Map);
+  });
+
+  it("keeps swimlane navigation visible in a flat punched-down branch", () => {
+    const branchEvents = [
+      makeModelEvent("main", 0),
+      makeAnchorEvent("anchor", "fork-1", 1),
+      makeModelEvent("branch-event", 2),
+    ];
+    const serverTimelines: ServerTimeline[] = [
+      {
+        name: "default",
+        description: "Flat branch",
+        root: makeServerSpan({
+          id: "root",
+          name: "Transcript",
+          content: [makeServerEvent("main"), makeServerEvent("anchor")],
+          branches: [
+            makeServerSpan({
+              id: "branch-1",
+              name: "Branch 1",
+              span_type: "branch",
+              branched_from: "fork-1",
+              content: [makeServerEvent("branch-event")],
+            }),
+          ],
+        }),
+      },
+    ];
+    const { result } = renderHook(
+      () =>
+        useTimelinePipeline({
+          events: branchEvents,
+          serverTimelines,
+          agentConfig: { showBranches: true },
+        }),
+      { wrapper: InMemoryStateWrapper }
+    );
+    const branchRow = result.current.timeline.state.rows.find(
+      (row) => row.branch
+    );
+    expect(branchRow).toBeDefined();
+
+    act(() =>
+      result.current.timeline.views.pushByRowKey(branchRow!.key, "Branch 1")
+    );
+
+    expect(result.current.timeline.views.stack).toHaveLength(1);
+    expect(result.current.timeline.hasTimeline).toBe(false);
+    expect(result.current.showSwimlanes).toBe(true);
   });
 
   it("filters hidden event types from the node feed and search set", () => {

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.ts
@@ -138,10 +138,21 @@ export function useTimelinePipeline(
 
   const showSwimlanes = useMemo(() => {
     if (showSwimlanesOption === "auto") {
-      return hasTimeline || regionCounts.size > 0 || timelines.length > 1;
+      return (
+        hasTimeline ||
+        regionCounts.size > 0 ||
+        timelines.length > 1 ||
+        timeline.views.stack.length > 0
+      );
     }
     return showSwimlanesOption;
-  }, [showSwimlanesOption, hasTimeline, regionCounts, timelines.length]);
+  }, [
+    showSwimlanesOption,
+    hasTimeline,
+    regionCounts,
+    timelines.length,
+    timeline.views.stack.length,
+  ]);
 
   const swimlanesDefaultCollapsed = useMemo(() => {
     if (


### PR DESCRIPTION
## Summary

- keep the timeline swimlane section mounted while a punch-down view is active
- preserve the header containing the back-navigation control for flat branches
- add a regression fixture proving a flat punched-down branch still exposes swimlane navigation

## Validation

- `pnpm --filter @tsmono/inspect-components test -- src/transcript/hooks/useTimelinePipeline.test.ts` — 85 files and 917 tests passed; 1 file and 2 tests skipped; the package script runs the complete workspace suite
- `pnpm --filter @tsmono/inspect-components typecheck` — passed
- `pnpm --filter @tsmono/inspect-components lint` — passed
- `pnpm --filter @tsmono/inspect-components format:check` — passed
- `pnpm --filter ./apps/scout e2e -- timeline.spec.ts -g "punch-down opens"` — the package script ran the complete Scout Playwright suite; all 65 tests passed, including punch-down navigation
- repository pre-commit and pre-push lint, format, and check hooks — passed under Node 24 and pnpm 11.22.0

## Risk

- The automatic swimlane policy changes only while the punch-down view stack is non-empty. Explicit `showSwimlanes` overrides remain unchanged.

Fixes #437
