### PR TITLE
Configure jsdom for inspect-components tests

### DIFF
--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { beforeEach, describe, expect, it } from "vitest";

--- a/packages/inspect-components/src/chat/MessageContent.test.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/inspect-components/src/chat/tools/AnnotatedScreenshot.test.tsx
+++ b/packages/inspect-components/src/chat/tools/AnnotatedScreenshot.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/columnFilter/ColumnFilterEditor.test.tsx
+++ b/packages/inspect-components/src/columnFilter/ColumnFilterEditor.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/columnFilter/useColumnFilter.test.ts
+++ b/packages/inspect-components/src/columnFilter/useColumnFilter.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/content/MetaDataGrid.test.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,

--- a/packages/inspect-components/src/content/RecordTree.test.tsx
+++ b/packages/inspect-components/src/content/RecordTree.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,

--- a/packages/inspect-components/src/indicators/LoadingEventsIndicator.test.tsx
+++ b/packages/inspect-components/src/indicators/LoadingEventsIndicator.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/media/MediaReference.test.tsx
+++ b/packages/inspect-components/src/media/MediaReference.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/media/mediaRendering.test.tsx
+++ b/packages/inspect-components/src/media/mediaRendering.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript-search/useSearchQueries.test.ts
+++ b/packages/inspect-components/src/transcript-search/useSearchQueries.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";

--- a/packages/inspect-components/src/transcript/BranchPoint.test.tsx
+++ b/packages/inspect-components/src/transcript/BranchPoint.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
+++ b/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/GoToTurnBar.test.tsx
+++ b/packages/inspect-components/src/transcript/GoToTurnBar.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   act,
   cleanup,

--- a/packages/inspect-components/src/transcript/InfoEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/InfoEventView.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/ToolEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   act,
   cleanup,

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { createRef, useSyncExternalStore } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/event/StopReasonBadge.test.tsx
+++ b/packages/inspect-components/src/transcript/event/StopReasonBadge.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { useMemo } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 // jsdom: the timeline barrel transitively imports vscode-elements web
 // components, which touch CSSStyleSheet at module load.
 import { act, renderHook } from "@testing-library/react";

--- a/packages/inspect-components/src/transcript/hooks/useFocusTurnNavigation.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useFocusTurnNavigation.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 // jsdom: the hook mounts window key listeners via
 // useTranscriptKeyboardNavigation.
 import { renderHook } from "@testing-library/react";

--- a/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/outline/resolveOutlineSelection.test.ts
+++ b/packages/inspect-components/src/transcript/outline/resolveOutlineSelection.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import { eventNode } from "../testHelpers";

--- a/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
+++ b/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
+++ b/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, render } from "@testing-library/react";
 import { useRef } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useActiveTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useActiveTimeline.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/tsconfig.json
+++ b/packages/inspect-components/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["css-modules"]
   },
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/inspect-components/vitest.config.ts
+++ b/packages/inspect-components/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});


### PR DESCRIPTION
## Summary

- configure `jsdom` as the default Vitest environment for `@tsmono/inspect-components`
- remove redundant per-file `@vitest-environment jsdom` annotations from 43 tests
- include the Vitest config in the package TypeScript project for typed linting

## Why

`inspect-components` is a UI package whose tests broadly depend on DOM APIs. Keeping the environment in package-level configuration avoids boilerplate and ensures new tests inherit the expected environment automatically.

## Impact

Test behavior is unchanged; environment selection is now centralized. The full package suite also confirms that logic-only tests continue to pass under the package default.

## Validation

- `pnpm --filter @tsmono/inspect-components test` (86 files, 926 tests)
- `pnpm --filter @tsmono/inspect-components lint`
- `pnpm --filter @tsmono/inspect-components typecheck`
- `pnpm --filter @tsmono/inspect-components format:check`