### PR TITLE
fix: resolve attachment refs in scan results

### DIFF
--- a/apps/scout/src/api/expandInputEvents.test.ts
+++ b/apps/scout/src/api/expandInputEvents.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { expandInputEvents } from "./expandInputEvents";
+
+describe("expandInputEvents", () => {
+  it("resolves attachment refs carried in input_data", () => {
+    const id = "c".repeat(32);
+    const input = {
+      transcript_id: "t1",
+      messages: [{ id: "m1", role: "user", content: `attachment://${id}` }],
+      events: [],
+    };
+    const result = expandInputEvents(input as never, "transcript", {
+      messages: [],
+      calls: [],
+      attachments: { [id]: "hello" },
+    }) as unknown as typeof input;
+
+    expect(result.messages).toEqual([
+      { id: "m1", role: "user", content: "hello" },
+    ]);
+  });
+});

--- a/apps/scout/src/api/expandInputEvents.test.ts
+++ b/apps/scout/src/api/expandInputEvents.test.ts
@@ -1,23 +1,29 @@
 import { describe, expect, it } from "vitest";
 
+import type { Transcript } from "../types/api-types";
+
 import { expandInputEvents } from "./expandInputEvents";
 
 describe("expandInputEvents", () => {
   it("resolves attachment refs carried in input_data", () => {
     const id = "c".repeat(32);
-    const input = {
+    const input: Transcript = {
       transcript_id: "t1",
       messages: [{ id: "m1", role: "user", content: `attachment://${id}` }],
       events: [],
+      timelines: [],
+      metadata: {},
     };
-    const result = expandInputEvents(input as never, "transcript", {
+
+    const result = expandInputEvents(input, "transcript", {
       messages: [],
       calls: [],
       attachments: { [id]: "hello" },
-    }) as unknown as typeof input;
+    });
 
-    expect(result.messages).toEqual([
-      { id: "m1", role: "user", content: "hello" },
-    ]);
+    expect(result).toEqual({
+      ...input,
+      messages: [{ id: "m1", role: "user", content: "hello" }],
+    });
   });
 });

--- a/apps/scout/src/api/expandInputEvents.ts
+++ b/apps/scout/src/api/expandInputEvents.ts
@@ -3,6 +3,8 @@ import { expandEvents } from "@tsmono/inspect-common/utils";
 
 import type { ScannerInputResponse, Transcript } from "../types/api-types";
 
+import { resolveAttachments } from "./attachmentsHelpers";
+
 /**
  * Expand condensed events in a scan result input.
  * Handles both "transcript" (events inside Transcript object) and "events" input types.
@@ -14,17 +16,28 @@ export function expandInputEvents(
 ): ScannerInputResponse["input"] {
   if (!inputData) return input;
 
+  // EventsData is `additionalProperties: true`, so `attachments` isn't part
+  // of its generated type; narrow just enough to read it back out.
+  const attachments = (inputData as { attachments?: Record<string, string> })
+    .attachments;
+  const withAttachmentsResolved = (value: ScannerInputResponse["input"]) =>
+    attachments && Object.keys(attachments).length > 0
+      ? resolveAttachments(value, attachments)
+      : value;
+
   if (inputType === "transcript") {
     const transcript = input as Transcript;
     const expanded = expandEvents(transcript.events, inputData);
-    return expanded === transcript.events
-      ? input
-      : { ...transcript, events: expanded };
+    const result =
+      expanded === transcript.events
+        ? input
+        : { ...transcript, events: expanded };
+    return withAttachmentsResolved(result);
   }
 
   if (inputType === "events") {
-    return expandEvents(input as Event[], inputData);
+    return withAttachmentsResolved(expandEvents(input as Event[], inputData));
   }
 
-  return input;
+  return withAttachmentsResolved(input);
 }


### PR DESCRIPTION
#507 but with some type casts removed from the new test file. The type casts in the actual application changes seem harder to get rid of with the currently generated API types.

Thanks for the bug fix @rasmusfaber!