### PR TITLE
fix: consume transcript scroll anchors

### DIFF
--- a/packages/inspect-components/src/transcript/hooks/useListPositionManager.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useListPositionManager.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useListPositionManager } from "./useListPositionManager";
+
+const stateHooks = vi.hoisted(() => ({
+  removeByPrefix: vi.fn(),
+  removeValue: vi.fn(),
+}));
+
+vi.mock("@tsmono/react/state", () => ({
+  useComponentStateHooks: () => ({
+    useRemoveByPrefix: () => stateHooks.removeByPrefix,
+    useRemoveValue: () => stateHooks.removeValue,
+  }),
+}));
+
+describe("useListPositionManager", () => {
+  it("does not reset scroll when a consumed target changes without a selection change", () => {
+    const scrollTo = vi.fn();
+    const scrollRef: RefObject<HTMLDivElement | null> = {
+      current: { scrollTo } as unknown as HTMLDivElement,
+    };
+
+    const { rerender } = renderHook(
+      ({ selected, hasScrollTarget }) =>
+        useListPositionManager("sample", selected, scrollRef, hasScrollTarget),
+      {
+        initialProps: {
+          selected: "root",
+          hasScrollTarget: false,
+        },
+      }
+    );
+
+    rerender({ selected: "root/branch-a", hasScrollTarget: true });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    rerender({ selected: "root/branch-a", hasScrollTarget: false });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    rerender({ selected: "root/branch-b", hasScrollTarget: false });
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+});

--- a/packages/inspect-components/src/transcript/hooks/useListPositionManager.ts
+++ b/packages/inspect-components/src/transcript/hooks/useListPositionManager.ts
@@ -43,6 +43,7 @@ export function useListPositionManager(
 
   // Track previous selected value to detect navigate-up
   const prevSelectedRef = useRef(selected);
+  const prevBaseListIdRef = useRef(baseListId);
   const isFirstRender = useRef(true);
 
   useEffect(() => {
@@ -50,11 +51,16 @@ export function useListPositionManager(
     if (isFirstRender.current) {
       isFirstRender.current = false;
       prevSelectedRef.current = selected;
+      prevBaseListIdRef.current = baseListId;
       return;
     }
 
     const prevSelected = prevSelectedRef.current;
+    if (prevSelected === selected && prevBaseListIdRef.current === baseListId) {
+      return;
+    }
     prevSelectedRef.current = selected;
+    prevBaseListIdRef.current = baseListId;
 
     // Clear saved Virtuoso state for the target agent
     const targetVirtuosoKey = `${kVirtuosoKeyPrefix}${effectiveListId}`;

--- a/packages/inspect-components/src/transcript/hooks/useListPositionManager.ts
+++ b/packages/inspect-components/src/transcript/hooks/useListPositionManager.ts
@@ -44,17 +44,8 @@ export function useListPositionManager(
   // Track previous selected value to detect navigate-up
   const prevSelectedRef = useRef(selected);
   const prevBaseListIdRef = useRef(baseListId);
-  const isFirstRender = useRef(true);
 
   useEffect(() => {
-    // Skip the first render -- don't clear positions on mount
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      prevSelectedRef.current = selected;
-      prevBaseListIdRef.current = baseListId;
-      return;
-    }
-
     const prevSelected = prevSelectedRef.current;
     if (prevSelected === selected && prevBaseListIdRef.current === baseListId) {
       return;

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
@@ -107,7 +107,7 @@ describe("useSelectionActions", () => {
     expect(result.current.hasScrollTarget).toBe(false);
   });
 
-  it("anchors and restores the scroll position for navigator clicks", () => {
+  it("anchors and restores the scroll position once for navigator clicks", () => {
     const { state } = makeTimelineState([]);
     const { ref, scrollTo } = makeScrollRef(123);
     const { result } = renderHook(() =>
@@ -120,8 +120,12 @@ describe("useSelectionActions", () => {
     expect(result.current.hasScrollTarget).toBe(true);
 
     // The restore runs in rAF after the selection lands.
-    flushFrames();
+    act(flushFrames);
     expect(scrollTo).toHaveBeenCalledWith({ top: 123 });
+    expect(result.current.hasScrollTarget).toBe(false);
+
+    act(() => result.current.selectByRowKey("root/c"));
+    expect(result.current.hasScrollTarget).toBe(false);
   });
 
   it("reports a pending scroll target for deep links", () => {

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.ts
@@ -57,11 +57,6 @@ export function useSelectionActions(
   // Scroll-anchor for inline fork-navigator clicks: the prefix above the
   // clicked navigator is unchanged across the selection, so capturing and
   // restoring scrollTop keeps the navigator at the same viewport position.
-  //
-  // Known issue: the anchor is never cleared after its restore runs, so the
-  // first anchored click latches hasScrollTarget true and suppresses the
-  // scroll-to-top for all later plain row selections. Pre-existing behavior,
-  // tracked in https://github.com/meridianlabs-ai/ts-mono/issues/440.
   const [scrollAnchor, setScrollAnchor] = useState<{
     scrollTop: number;
   } | null>(null);
@@ -103,6 +98,7 @@ export function useSelectionActions(
     if (!scrollAnchor) return;
     requestAnimationFrame(() => {
       scrollRef.current?.scrollTo({ top: scrollAnchor.scrollTop });
+      setScrollAnchor(null);
     });
   }, [scrollAnchor, scrollRef]);
 


### PR DESCRIPTION
Fixes #440

## Summary
- clear the inline fork-navigator scroll anchor after its one-shot restore
- ignore scroll-target-only rerenders in the list position manager
- cover the consumed-anchor transition and the next plain row selection

## Validation
- `pnpm --filter @tsmono/inspect-components test` (920 passed, 2 skipped)
- `pnpm --filter @tsmono/inspect-components typecheck`
- `pnpm --filter @tsmono/inspect-components lint`
- `pnpm --filter @tsmono/inspect-components format:check`
- `pnpm --filter scout e2e -- timeline.spec.ts` (65 passed)
- repository pre-commit and pre-push `lint --fix`, `format`, and `check` hooks

## Risk
Low. The change is confined to transcript selection/list-position hooks and preserves deep-link and anchored-selection behavior while restoring scroll-to-top for later unanchored selections.