### PR TITLE
Checkpoint config types: sample-layer strategy selection

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -865,6 +865,31 @@ export interface components {
             working_start: number;
         };
         /**
+         * ArchiveSnapshots
+         * @description One complete compressed tar archive per checkpoint.
+         *
+         *     Captures with tools already present in effectively every image
+         *     (tar, dd, sha256sum, zstd or gzip) — nothing is injected into the
+         *     sandbox. Each checkpoint's archive is self-contained, so restore
+         *     reads a single file. Best choice when restic injection is
+         *     impractical, or when the captured data is dominated by large,
+         *     high-entropy, frequently-rewritten files where incremental backup
+         *     stores roughly the full dataset again at every checkpoint anyway.
+         *
+         *     Unlike restic (which encrypts its repository with a per-sample
+         *     password), archives are written unencrypted: checkpoint data —
+         *     including any credentials or keys the agent wrote into captured
+         *     paths — lands in the checkpoint storage location (possibly S3) as
+         *     plaintext tar archives.
+         */
+        ArchiveSnapshots: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            name: "archive";
+        };
+        /**
          * BatchConfig
          * @description Batch processing configuration.
          */
@@ -1140,19 +1165,22 @@ export interface components {
          *
          *     These fields can be specified on ``Sample(checkpoint=...)`` and are
          *     also accepted at the task and eval layers (where they participate in
-         *     the per-field merge — precedence: eval > sample > task).
+         *     the per-field merge — precedence: eval > sample > task). Capture
+         *     configuration — what to snapshot and with which strategy — is a
+         *     property of the sample's workload, so it lives here.
          *
-         *     The fields excluded from this base class — ``checkpoints_location``
-         *     and ``retention`` — are eval-wide concerns that the sample layer must
-         *     not influence. They live only on the derived :class:`CheckpointConfig`,
-         *     which is the type used at the task and eval layers.
+         *     Excluded from the sample layer: ``checkpoints_location`` and
+         *     ``retention``. These are eval-wide storage-policy concerns that the
+         *     sample layer must not influence; they live only on
+         *     :class:`CheckpointConfig`, the subclass used at the task and eval
+         *     layers.
          */
         CheckpointSampleConfig: {
             /** Max Consecutive Failures */
             max_consecutive_failures?: number | null;
             /** Sandbox Paths */
             sandbox_paths?: {
-                [key: string]: string[];
+                [key: string]: string[] | components["schemas"]["SandboxSnapshotConfig"];
             } | null;
             /** Trigger */
             trigger?: components["schemas"]["Manual"] | components["schemas"]["TurnInterval"] | components["schemas"]["TimeInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | null;
@@ -2665,6 +2693,21 @@ export interface components {
             strict?: boolean | null;
         };
         /**
+         * ResticSnapshots
+         * @description Incremental restic-based sandbox snapshots (the default).
+         *
+         *     Each checkpoint stores only data changed since the previous one.
+         *     Best choice when most files are stable across checkpoints. Requires
+         *     injecting a restic binary into the sandbox.
+         */
+        ResticSnapshots: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            name: "restic-incremental";
+        };
+        /**
          * Result
          * @description Scan result.
          */
@@ -2832,6 +2875,22 @@ export interface components {
             uuid?: string | null;
             /** Working Start */
             working_start: number;
+        };
+        /**
+         * SandboxSnapshotConfig
+         * @description Per-sandbox snapshot configuration: what to capture and how.
+         *
+         *     Used as a ``sandbox_paths`` value in place of a bare path list when
+         *     a sandbox needs a non-default snapshot strategy. The ``paths``
+         *     field carries the same semantics as a bare path-list value
+         *     (``None`` = the sandbox default user's home directory; an empty
+         *     list opts the sandbox out entirely).
+         */
+        SandboxSnapshotConfig: {
+            /** Paths */
+            paths?: string[] | null;
+            /** Strategy */
+            strategy?: (components["schemas"]["ResticSnapshots"] | components["schemas"]["ArchiveSnapshots"]) | null;
         };
         /**
          * ScanJobConfig
@@ -3273,6 +3332,8 @@ export interface components {
             metadata?: {
                 [key: string]: unknown;
             } | null;
+            /** Reason */
+            reason?: ("invalid_response_format" | "refusal" | "no_response" | "grader_failed" | "scoring_failed") | string | null;
             /** Value */
             value: string | number | boolean | (string | number | boolean)[] | {
                 [key: string]: string | number | boolean | null;
@@ -3301,6 +3362,11 @@ export interface components {
                 [key: string]: unknown;
             } | "UNCHANGED";
             provenance?: components["schemas"]["ProvenanceData"] | null;
+            /**
+             * Reason
+             * @default UNCHANGED
+             */
+            reason?: ("invalid_response_format" | "refusal" | "no_response" | "grader_failed" | "scoring_failed") | string | "UNCHANGED" | null;
             /**
              * Value
              * @default UNCHANGED

--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -655,6 +655,31 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * ArchiveSnapshots
+         * @description One complete compressed tar archive per checkpoint.
+         *
+         *     Captures with tools already present in effectively every image
+         *     (tar, dd, sha256sum, zstd or gzip) — nothing is injected into the
+         *     sandbox. Each checkpoint's archive is self-contained, so restore
+         *     reads a single file. Best choice when restic injection is
+         *     impractical, or when the captured data is dominated by large,
+         *     high-entropy, frequently-rewritten files where incremental backup
+         *     stores roughly the full dataset again at every checkpoint anyway.
+         *
+         *     Unlike restic (which encrypts its repository with a per-sample
+         *     password), archives are written unencrypted: checkpoint data —
+         *     including any credentials or keys the agent wrote into captured
+         *     paths — lands in the checkpoint storage location (possibly S3) as
+         *     plaintext tar archives.
+         */
+        ArchiveSnapshots: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            name: "archive";
+        };
         /** AttachmentData */
         AttachmentData: {
             /** Content */
@@ -957,19 +982,22 @@ export interface components {
          *
          *     These fields can be specified on ``Sample(checkpoint=...)`` and are
          *     also accepted at the task and eval layers (where they participate in
-         *     the per-field merge — precedence: eval > sample > task).
+         *     the per-field merge — precedence: eval > sample > task). Capture
+         *     configuration — what to snapshot and with which strategy — is a
+         *     property of the sample's workload, so it lives here.
          *
-         *     The fields excluded from this base class — ``checkpoints_location``
-         *     and ``retention`` — are eval-wide concerns that the sample layer must
-         *     not influence. They live only on the derived :class:`CheckpointConfig`,
-         *     which is the type used at the task and eval layers.
+         *     Excluded from the sample layer: ``checkpoints_location`` and
+         *     ``retention``. These are eval-wide storage-policy concerns that the
+         *     sample layer must not influence; they live only on
+         *     :class:`CheckpointConfig`, the subclass used at the task and eval
+         *     layers.
          */
         CheckpointSampleConfig: {
             /** Max Consecutive Failures */
             max_consecutive_failures?: number | null;
             /** Sandbox Paths */
             sandbox_paths?: {
-                [key: string]: string[];
+                [key: string]: string[] | components["schemas"]["SandboxSnapshotConfig"];
             } | null;
             /** Trigger */
             trigger?: components["schemas"]["Manual"] | components["schemas"]["TurnInterval"] | components["schemas"]["TimeInterval"] | components["schemas"]["TokenInterval"] | components["schemas"]["CostInterval"] | components["schemas"]["BudgetPercent"] | null;
@@ -2913,6 +2941,21 @@ export interface components {
             strict?: boolean | null;
         };
         /**
+         * ResticSnapshots
+         * @description Incremental restic-based sandbox snapshots (the default).
+         *
+         *     Each checkpoint stores only data changed since the previous one.
+         *     Best choice when most files are stable across checkpoints. Requires
+         *     injecting a restic binary into the sandbox.
+         */
+        ResticSnapshots: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            name: "restic-incremental";
+        };
+        /**
          * Result
          * @description Scan result.
          */
@@ -3128,6 +3171,22 @@ export interface components {
             uuid?: string | null;
             /** Working Start */
             working_start: number;
+        };
+        /**
+         * SandboxSnapshotConfig
+         * @description Per-sandbox snapshot configuration: what to capture and how.
+         *
+         *     Used as a ``sandbox_paths`` value in place of a bare path list when
+         *     a sandbox needs a non-default snapshot strategy. The ``paths``
+         *     field carries the same semantics as a bare path-list value
+         *     (``None`` = the sandbox default user's home directory; an empty
+         *     list opts the sandbox out entirely).
+         */
+        SandboxSnapshotConfig: {
+            /** Paths */
+            paths?: string[] | null;
+            /** Strategy */
+            strategy?: (components["schemas"]["ResticSnapshots"] | components["schemas"]["ArchiveSnapshots"]) | null;
         };
         /**
          * ScannerResultField


### PR DESCRIPTION
Regenerated types for UKGovernmentBEIS/inspect_ai#4624: `CheckpointSampleConfig.sandbox_paths` values widen to `string[] | SandboxSnapshotConfig` (per-sample snapshot-strategy selection), adding the `ArchiveSnapshots`/`ResticSnapshots`/`SandboxSnapshotConfig` schemas. Includes the scout app's duplicated types, regenerated with inspect_scout's own tooling.

Pairs with UKGovernmentBEIS/inspect_ai#4624 (two-phase landing: merge this only when that PR is green except submodule-on-main and provisionally approved).
