### PR TITLE
Fix library builds emitting runtime require("react") that black-screens browser consumers

### DIFF
--- a/apps/inspect/package.json
+++ b/apps/inspect/package.json
@@ -117,6 +117,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router": "^8.3.0",
+    "use-sync-external-store": "^1.6.0",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {

--- a/apps/inspect/vite.config.ts
+++ b/apps/inspect/vite.config.ts
@@ -92,8 +92,14 @@ export default defineConfig(({ mode }) => {
           // mathjax is heavy and registers globals; keep it external so the
           // consumer installs/dedupes it once instead of each viewer
           // shipping its own copy.
+          //
+          // use-sync-external-store (via @tanstack/react-store) is CJS-only
+          // and `require`s react internally; bundling it alongside external
+          // react leaves a runtime `__require("react")` that throws in
+          // browsers. Externalize it (declared in dependencies) so the
+          // consumer's bundler does the CJS interop.
           external: (id: string) =>
-            /^(react|react-dom)(\/|$)/.test(id) ||
+            /^(react|react-dom|use-sync-external-store)(\/|$)/.test(id) ||
             id === "mathjax-full" ||
             id.startsWith("mathjax-full/") ||
             id === "markdown-it-mathjax3",

--- a/apps/scout/package.json
+++ b/apps/scout/package.json
@@ -110,6 +110,7 @@
     "lz4js": "^0.2.0",
     "prismjs": "^1.30.0",
     "react-router": "^8.3.0",
+    "use-sync-external-store": "^1.6.0",
     "zustand": "^5.0.14"
   }
 }

--- a/apps/scout/vite.config.ts
+++ b/apps/scout/vite.config.ts
@@ -78,8 +78,16 @@ export default defineConfig(({ mode }) => {
           // mathjax is heavy and registers globals; keep it external so the
           // consumer installs/dedupes it once instead of each viewer
           // shipping its own copy.
+          //
+          // use-sync-external-store (via @tanstack/react-store) is CJS-only
+          // and `require`s react internally; bundling it alongside external
+          // react leaves a runtime `__require("react")` that throws in
+          // browsers. Externalize it (declared in dependencies) so the
+          // consumer's bundler does the CJS interop.
           external: (id: string) =>
-            /^(react|react-dom|@tanstack\/react-query)(\/|$)/.test(id) ||
+            /^(react|react-dom|@tanstack\/react-query|use-sync-external-store)(\/|$)/.test(
+              id
+            ) ||
             id === "mathjax-full" ||
             id.startsWith("mathjax-full/") ||
             id === "markdown-it-mathjax3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@19.2.8)
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -317,6 +320,9 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@19.2.8)
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.18)(immer@11.1.16)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))


### PR DESCRIPTION
* by Fable, but used for testing hawk in #553

TanStack Table v9 pulls in @tanstack/react-store, which imports the CJS-only use-sync-external-store package. Library builds externalize react, so Rolldown kept that package's internal require("react") as a runtime __require that throws in browsers ("Calling 'require' for 'react' in an environment that doesn't expose the 'require' function"), breaking embedders that consume lib/index.js (e.g. hawk).

Externalize use-sync-external-store in the library builds and declare it as a direct dependency of both apps, so the emitted library is pure ESM and the consumer's bundler performs the CJS interop (the same way zustand/react-redux consumers get it).