### PR TITLE
Scout shows anchor events by default that inspect hides — unify the default event filter

### DIFF
--- a/apps/inspect/src/app/samples/transcript/hooks.ts
+++ b/apps/inspect/src/app/samples/transcript/hooks.ts
@@ -66,9 +66,7 @@ export const useTranscriptFilter = () => {
   const isDefaultFilter = useMemo(() => {
     return (
       filtered.length === kDefaultExcludeEvents.length &&
-      [...filtered].every((type) =>
-        kDefaultExcludeEvents.some((t) => t === type)
-      )
+      filtered.every((type) => kDefaultExcludeEvents.some((t) => t === type))
     );
   }, [filtered]);
 

--- a/apps/inspect/src/app/samples/transcript/hooks.ts
+++ b/apps/inspect/src/app/samples/transcript/hooks.ts
@@ -66,7 +66,9 @@ export const useTranscriptFilter = () => {
   const isDefaultFilter = useMemo(() => {
     return (
       filtered.length === kDefaultExcludeEvents.length &&
-      [...filtered].every((type) => kDefaultExcludeEvents.includes(type))
+      [...filtered].every((type) =>
+        kDefaultExcludeEvents.some((t) => t === type)
+      )
     );
   }, [filtered]);
 

--- a/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
+++ b/apps/scout/src/app/timeline/components/TimelineEventsView.tsx
@@ -28,6 +28,10 @@ import { useTimelineSearchParams } from "../hooks/useTimeline";
 interface TimelineEventsViewProps {
   /** Raw events to display. Runs the full timeline pipeline internally. */
   events: Event[];
+  /** Event types hidden from the rendered list. Applied inside the timeline
+   *  pipeline (not by pre-filtering `events`) so structural events like
+   *  anchors still resolve fork points. */
+  hiddenEventTypes?: readonly string[];
   /** Scroll container for StickyScroll and virtual list. */
   scrollRef: RefObject<HTMLDivElement | null>;
   /** Base offset for sticky positioning (e.g. tab bar height). Default: 0. */
@@ -91,6 +95,7 @@ interface TimelineEventsViewProps {
 
 export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
   events,
+  hiddenEventTypes,
   scrollRef,
   offsetTop = 0,
   initialEventId,
@@ -249,6 +254,7 @@ export const TimelineEventsView: FC<TimelineEventsViewProps> = ({
   return (
     <TranscriptLayout
       events={events}
+      hiddenEventTypes={hiddenEventTypes}
       scrollRef={scrollRef}
       offsetTop={offsetTop}
       timeline={{

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -220,14 +220,6 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
   const { excludedEventTypes, isDebugFilter, isDefaultFilter } =
     useTranscriptColumnFilter();
 
-  // Pre-filter events by excluded types before feeding into the timeline pipeline
-  const filteredEvents = useMemo(() => {
-    if (excludedEventTypes.length === 0) return transcript.events;
-    return transcript.events.filter(
-      (event) => !excludedEventTypes.includes(event.event)
-    );
-  }, [transcript.events, excludedEventTypes]);
-
   // Transcript collapse (toolbar button state)
   const eventsCollapsed = useStore((state) => state.transcriptState.collapsed);
   const setTranscriptState = useStore((state) => state.setTranscriptState);
@@ -476,7 +468,8 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
       scrollable={false}
     >
       <TimelineEventsView
-        events={filteredEvents}
+        events={transcript.events}
+        hiddenEventTypes={excludedEventTypes}
         scrollRef={scrollRef}
         offsetTop={contentOffsetTop}
         initialEventId={eventParam}

--- a/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
+++ b/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
@@ -2,24 +2,16 @@ import { useCallback, useMemo } from "react";
 
 import {
   eventTypeValues,
+  kDefaultExcludeEvents,
   type EventTypeValue,
 } from "@tsmono/inspect-components/transcript";
 
 import { useStore } from "../../../state/store";
 
-export const kDefaultExcludedEventTypes: EventTypeValue[] = [
-  "branch",
-  "checkpoint",
-  "sample_init",
-  "sandbox",
-  "state",
-  "store",
-];
-
 export const useTranscriptColumnFilter = () => {
   const excludedEventTypes =
     useStore((state) => state.transcriptState.excludedTypes) ||
-    kDefaultExcludedEventTypes;
+    kDefaultExcludeEvents;
 
   const setTranscriptState = useStore((state) => state.setTranscriptState);
 
@@ -54,14 +46,14 @@ export const useTranscriptColumnFilter = () => {
   }, [setExcludedEventTypes]);
 
   const setDefaultFilter = useCallback(() => {
-    setExcludedEventTypes([...kDefaultExcludedEventTypes]);
+    setExcludedEventTypes([...kDefaultExcludeEvents]);
   }, [setExcludedEventTypes]);
 
   const isDefaultFilter = useMemo(() => {
     return (
-      excludedEventTypes.length === kDefaultExcludedEventTypes.length &&
+      excludedEventTypes.length === kDefaultExcludeEvents.length &&
       excludedEventTypes.every((type) =>
-        kDefaultExcludedEventTypes.includes(type as EventTypeValue)
+        kDefaultExcludeEvents.includes(type as EventTypeValue)
       )
     );
   }, [excludedEventTypes]);
@@ -73,8 +65,8 @@ export const useTranscriptColumnFilter = () => {
   const arrangedEventTypes = useCallback((columns: number = 1) => {
     // Sort keys alphabetically with default disabled keys at the end
     const sortedKeys = [...eventTypeValues].sort((a, b) => {
-      const aIsDefault = kDefaultExcludedEventTypes.includes(a);
-      const bIsDefault = kDefaultExcludedEventTypes.includes(b);
+      const aIsDefault = kDefaultExcludeEvents.includes(a);
+      const bIsDefault = kDefaultExcludeEvents.includes(b);
 
       // If one is in default exclude set and the other isn't, default goes to end
       if (aIsDefault && !bIsDefault) return 1;

--- a/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
+++ b/apps/scout/src/app/transcript/hooks/useTranscriptColumnFilter.ts
@@ -53,7 +53,7 @@ export const useTranscriptColumnFilter = () => {
     return (
       excludedEventTypes.length === kDefaultExcludeEvents.length &&
       excludedEventTypes.every((type) =>
-        kDefaultExcludeEvents.includes(type as EventTypeValue)
+        kDefaultExcludeEvents.some((t) => t === type)
       )
     );
   }, [excludedEventTypes]);

--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -110,7 +110,7 @@ export const eventTypeValues = [
 ] as const;
 
 // Event types the transcript hides by default (the "Events: Default" filter).
-export const kDefaultExcludeEvents: EventTypeValue[] = [
+export const kDefaultExcludeEvents: readonly EventTypeValue[] = [
   "sample_init",
   "sandbox",
   "state",

--- a/packages/inspect-components/src/transcript/types.ts
+++ b/packages/inspect-components/src/transcript/types.ts
@@ -110,7 +110,7 @@ export const eventTypeValues = [
 ] as const;
 
 // Event types the transcript hides by default (the "Events: Default" filter).
-export const kDefaultExcludeEvents = [
+export const kDefaultExcludeEvents: EventTypeValue[] = [
   "sample_init",
   "sandbox",
   "state",


### PR DESCRIPTION
Scout's filter popover kept its own copy of the default-hidden event types (`kDefaultExcludedEventTypes`), which missed the `anchor` addition from #174. As a result, scout showed payload-free fork-marker cards by default while inspect hid them — and scout disagreed with its own focus mode, which builds its slice from the shared `kDefaultExcludeEvents` via `turnNavigation.ts`.

This drops scout's copy and imports the shared constant, now typed `EventTypeValue[]` (with one comparison in inspect's `hooks.ts` adjusted to stay cast-free against its `string[]` store state). Persisted user filter selections are unaffected — the default only applies when nothing is stored.

The change exposed a second wiring bug, fixed here too: scout pre-filtered the raw event array before the timeline pipeline, which stripped the (now default-hidden) anchor events that fork-point resolution needs — breaking branch punch-down (caught by `timeline.spec.ts` e2e). Scout now passes the exclusions as `TranscriptLayout`'s `hiddenEventTypes`, the same way inspect does: the pipeline keeps anchors for timeline construction and drops hidden types from the rendered rows.

`turbo typecheck`, `lint`, `format:check`, and `test` pass for scout, inspect, and inspect-components; scout's full Playwright e2e suite passes locally (one unrelated scroll-restore flake passed 3/3 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)