### PR TITLE
ci: refresh agent workflow stubs from agents/examples

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,9 @@
 # Copy to .github/workflows/claude-review.yml in any Meridian repo to add the
-# read-only reviewer. Auto-reviews PRs when they open and on demand via an
-# @review comment. Independent of the dev agent (claude.yml) — different
-# trigger, different (lower) permissions.
+# read-only reviewer. Auto-reviews PRs when they open (drafts are skipped
+# until marked ready for review; release-please PRs are skipped too, gated in
+# the reusable workflow) and on demand via an @review comment.
+# Independent of the dev agent (claude.yml) — different trigger, different
+# (lower) permissions.
 #
 # Caveat: auto-review-on-open (the pull_request trigger) only fires where this
 # file exists on the PR's BASE branch — GitHub resolves pull_request-family
@@ -9,6 +11,12 @@
 # mirror like the inspect_ai fork, PRs target a base that lacks this workflow,
 # so pull_request never fires; only the @review comment path works there, and
 # auto-review is instead driven by the dev agent posting @review on PR open.
+#
+# Caveat: PRs from forks are skipped by auto-review. GitHub issues no OIDC
+# token and only a read-only GITHUB_TOKEN to pull_request runs from forks, so
+# the job — which requests id-token: write for WIF auth — fails at startup.
+# A maintainer can still review a fork PR with an @review comment, which runs
+# as issue_comment in the base-repo context with full token access.
 
 name: Review
 
@@ -20,23 +28,22 @@ on:
 
 jobs:
   review:
-    # Run on PR events, or on a PR comment containing @review. `@review` does
-    # not collide with the dev agent's `@claude` trigger.
-    #
-    # Auto-review is skipped for PRs from forks and from Dependabot: GitHub
-    # withholds the OIDC id-token (and secrets) from `pull_request` runs in
-    # those contexts for security, so the reviewer's WIF auth can't mint a
-    # token and the job would only fail. The `permissions:` block can't override
-    # this. Those PRs are instead reviewed on demand via an `@review` comment,
-    # which runs as `issue_comment` in the base-repo context (full token access).
-    # Skip draft PRs (auto-reviewed when marked Ready for review; an explicit
-    # `@review` comment still works on a draft).
+    # Run on PR events (skipping drafts — they get reviewed via
+    # ready_for_review when marked ready — and fork PRs, which get no OIDC
+    # token so the run would die at startup on id-token: write; the full_name
+    # check, not head.repo.fork, keeps same-repo PRs working on repos that are
+    # themselves forks), or on a PR comment containing @review. An explicit
+    # @review still works on a draft and on a fork PR. `@review` does not
+    # collide with the dev agent's `@claude` trigger.
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.draft != true &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.actor != 'dependabot[bot]') ||
       (github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@review')) ||
+      (github.event.issue.pull_request == null &&
+       contains(github.event.issue.labels.*.name, 'External') &&
        contains(github.event.comment.body, '@review'))
     uses: meridianlabs-ai/agents/.github/workflows/claude-review.yml@main
     # Machine-account PAT for the deterministic ack/stage steps only (eyes

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,7 +67,7 @@ jobs:
     # blocks the edit path. Acceptable for a cheap gate (no regex in workflow
     # expressions); the action remains the authoritative check on what fires.
     if: |
-      github.actor != 'i-am-marvin' && (
+      github.actor != 'i-am-marvin' && !endsWith(github.actor, '[bot]') && (
         ( github.event.action == 'edited'
           && ( contains(github.event.comment.body, '@claude')
             || contains(github.event.comment.body, '@i-am-marvin') )
@@ -152,8 +152,18 @@ jobs:
     # otherwise open a duplicate PR). Same machine-account guard too: @auto is
     # the loop-prone trigger, so keep the machine account from kicking it off
     # (nothing in the designed loop relies on marvin posting @auto).
+    # Machine-account EXCEPTION — the auto-LABEL path: automation (e.g. a
+    # triage pipeline) may add the `auto` label as the machine account, and a
+    # label event's actor is whoever added it. The hoisted marvin guard ate
+    # that trigger (observed: inspect_ai#236). Labeling is safe to exempt:
+    # the gate reads the label NAME (no quoted-token hazard), labeling needs
+    # triage access, and the action separately verifies the actor has write
+    # access before running. Comment/body paths keep the full guard.
     if: |
-      github.actor != 'i-am-marvin' && (
+      ( github.event_name == 'issues' && github.event.action == 'labeled'
+        && github.event.label.name == 'auto'
+        && !endsWith(github.actor, '[bot]') ) ||
+      ( github.actor != 'i-am-marvin' && !endsWith(github.actor, '[bot]') && (
         ( github.event.action == 'edited'
           && contains(github.event.comment.body, '@auto')
           && !contains(github.event.changes.body.from, '@auto') ) ||
@@ -164,7 +174,7 @@ jobs:
             contains(github.event.issue.title, '@auto') ||
             github.event.label.name == 'auto'
         ) )
-      )
+      ) )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
@@ -175,7 +185,13 @@ jobs:
       id-token: write
       actions: read
     with:
-      # Same allowlist override as the claude job above (see the comment there).
+      # The reusable workflow's default allowlist is Python-oriented (pytest,
+      # ruff, uv, ...) — useless here and it auto-denies every pnpm command in
+      # headless runs. The override lives in .github/claude-settings.json
+      # (claude-code-action accepts a path as well as inline JSON, resolved
+      # against this repo's checkout). It replaces the default entirely, so
+      # the file repeats the git/gh/file-edit entries alongside the pnpm/turbo
+      # swap-ins.
       settings: .github/claude-settings.json
       trigger_phrase: "@auto"
       label_trigger: "auto"


### PR DESCRIPTION
The committed agent stubs lagged the current `meridianlabs-ai/agents` examples (caller-stub drift — the reusable workflows track `@main`, the stubs don't). This refresh brings in:

- trigger-hygiene bot guards (`!endsWith(github.actor, '[bot]')`) on the dev/auto gates
- the auto-LABEL kickoff exemption (machine-account labeling fires the kickoff; see inspect_ai#236/#237)
- draft-PR, release-please, and fork-PR handling on auto-review
- current gate comments

Preserved local adaptations: the `.github/claude-settings.json` permissions override on both jobs, and the dependabot guard on auto-review.

Companion change (already applied): the `auto` label now exists in this repo, so the autonomous loop can drive PRs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)