### PR TITLE
Consolidate duplicated test fixtures into shared testing exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ Design docs live per-app; consult them when working in the relevant area:
   [front-end-testing.md](apps/scout/design/front-end-testing.md)
 - Tests must be isolated and deterministic; no shared mutable state or
   order dependencies
+- **Fixture placement**: builders for a package's public types live in that
+  package's testing subpath export — `@tsmono/inspect-common/testing`,
+  `@tsmono/react/testing`, `@tsmono/inspect-components/transcript/test-helpers`.
+  Builders for app-private types stay in the app (e.g.
+  `apps/scout/src/test/objectFactories.ts`,
+  `apps/inspect/src/log_data/testFixtures.ts`). Thin test-local wrappers
+  that parameterize a shared builder (fixed timestamps, positional args)
+  are fine; a test file re-declaring the field list of a shared type is
+  the sign the builder belongs upstream. Production code never imports
+  from a testing export.
 
 ## Pull Requests
 

--- a/apps/inspect/e2e/timeline.spec.ts
+++ b/apps/inspect/e2e/timeline.spec.ts
@@ -10,13 +10,15 @@
 
 import { http, HttpResponse } from "msw";
 
+import {
+  testTimelineEvent,
+  testTimelineSpan,
+} from "@tsmono/inspect-common/testing";
 import type {
   ChatMessage,
   EvalSample,
   ModelEvent,
   ModelOutput,
-  TimelineEvent as ServerTimelineEvent,
-  TimelineSpan as ServerTimelineSpan,
   Timeline,
 } from "@tsmono/inspect-common/types";
 
@@ -74,48 +76,26 @@ function createModelEvent(overrides?: {
   };
 }
 
-function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid };
-}
-
-function makeServerSpan(
-  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
-): ServerTimelineSpan {
-  return {
-    type: "span",
-    span_type: null,
-    content: [],
-    branches: [],
-    branched_from: null,
-    description: null,
-    utility: false,
-    tool_invoked: false,
-    agent_result: null,
-    outline: null,
-    ...overrides,
-  } as ServerTimelineSpan;
-}
-
 function createSampleTimeline(eventUuids: string[]): Timeline {
   return {
     name: "default",
     description: "Agent timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        makeServerEvent(eventUuids[0]!),
-        makeServerSpan({
+        testTimelineEvent({ event: eventUuids[0]! }),
+        testTimelineSpan({
           id: "explore",
           name: "Explore",
           span_type: "agent",
-          content: [makeServerEvent(eventUuids[1]!)],
+          content: [testTimelineEvent({ event: eventUuids[1]! })],
         }),
-        makeServerSpan({
+        testTimelineSpan({
           id: "build",
           name: "Build",
           span_type: "agent",
-          content: [makeServerEvent(eventUuids[2]!)],
+          content: [testTimelineEvent({ event: eventUuids[2]! })],
         }),
       ],
     }),
@@ -282,16 +262,18 @@ test("scrubbing the minimap scrolls the event list", async ({
   const timeline: Timeline = {
     name: "default",
     description: "Long timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        ...events.slice(0, 29).map((e) => makeServerEvent(e.uuid!)),
-        makeServerSpan({
+        ...events
+          .slice(0, 29)
+          .map((e) => testTimelineEvent({ event: e.uuid! })),
+        testTimelineSpan({
           id: "deep",
           name: "Deep",
           span_type: "agent",
-          content: [makeServerEvent(events[29]!.uuid!)],
+          content: [testTimelineEvent({ event: events[29]!.uuid! })],
         }),
       ],
     }),

--- a/packages/inspect-common/src/testing/index.ts
+++ b/packages/inspect-common/src/testing/index.ts
@@ -7,7 +7,9 @@
  * break loudly (at typecheck) when the generated types move, casts don't.
  */
 import type {
+  AnchorEvent,
   ApprovalEvent,
+  BranchEvent,
   ChatCompletionChoice,
   ChatMessageAssistant,
   ChatMessageSystem,
@@ -40,6 +42,9 @@ import type {
   StateEvent,
   StepEvent,
   SubtaskEvent,
+  Timeline,
+  TimelineEvent,
+  TimelineSpan,
   ToolCall,
   ToolEvent,
 } from "../types";
@@ -196,6 +201,26 @@ export const testInfoEvent = (
   ...overrides,
 });
 
+export const testAnchorEvent = (
+  overrides: Partial<AnchorEvent> = {}
+): AnchorEvent => ({
+  event: "anchor",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  anchor_id: "anchor-1",
+  ...overrides,
+});
+
+export const testBranchEvent = (
+  overrides: Partial<BranchEvent> = {}
+): BranchEvent => ({
+  event: "branch",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  from_anchor: "anchor-1",
+  ...overrides,
+});
+
 export const testScore = (overrides: Partial<Score> = {}): Score => ({
   value: 1,
   history: [],
@@ -337,6 +362,38 @@ export const testInputEvent = (
   working_start: 0,
   input: "",
   input_ansi: "",
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Timelines
+// ---------------------------------------------------------------------------
+
+export const testTimelineEvent = (
+  overrides: Partial<TimelineEvent> = {}
+): TimelineEvent => ({
+  type: "event",
+  event: "evt-1",
+  ...overrides,
+});
+
+export const testTimelineSpan = (
+  overrides: Partial<TimelineSpan> = {}
+): TimelineSpan => ({
+  type: "span",
+  id: "span-1",
+  name: "span",
+  content: [],
+  branches: [],
+  tool_invoked: false,
+  utility: false,
+  ...overrides,
+});
+
+export const testTimeline = (overrides: Partial<Timeline> = {}): Timeline => ({
+  name: "default",
+  description: "Test timeline",
+  root: testTimelineSpan({ id: "root", name: "Transcript" }),
   ...overrides,
 });
 

--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -1,14 +1,11 @@
 import { render } from "@testing-library/react";
-import { useSyncExternalStore } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { testAssistantMessage } from "@tsmono/inspect-common/testing";
 import type { ChatMessage } from "@tsmono/inspect-common/types";
 import { ExtendedFindProvider } from "@tsmono/react/components";
-import {
-  ComponentStateProvider,
-  type ComponentStateHooks,
-} from "@tsmono/react/state";
+import { ComponentStateProvider } from "@tsmono/react/state";
+import { makeReactiveStateStore } from "@tsmono/react/testing";
 
 import {
   ChatViewRowsVirtualList,
@@ -26,41 +23,13 @@ beforeEach(() => {
   Element.prototype.scrollTo = function () {};
 });
 
-/** An inspectable in-memory ComponentStateHooks store. */
-function makeStateStore() {
-  const store = new Map<string, unknown>();
-  const listeners = new Set<() => void>();
-  let version = 0;
-  const key = (id: string, prop: string) => `${id}::${prop}`;
-  const write = (id: string, prop: string, value: unknown) => {
-    store.set(key(id, prop), value);
-    version++;
-    listeners.forEach((l) => l());
-  };
-  const hooks: ComponentStateHooks = {
-    useValue: (id, prop, defaultValue) => {
-      useSyncExternalStore(
-        (cb) => (listeners.add(cb), () => listeners.delete(cb)),
-        () => version
-      );
-      return store.has(key(id, prop)) ? store.get(key(id, prop)) : defaultValue;
-    },
-    useSetValue: () => write,
-    useRemoveValue: () => (id, prop) => write(id, prop, undefined),
-    useEntries: () => undefined,
-    useRemoveAll: () => () => {},
-    useRemoveByPrefix: () => () => {},
-  };
-  return { store, hooks };
-}
-
 /** Mounts the list over an inspectable store and returns the persisted follow flag. */
 function mountFollow(props: {
   running: boolean;
   initialMessageId?: string;
   followRequested?: boolean;
 }) {
-  const { store, hooks } = makeStateStore();
+  const { store, hooks } = makeReactiveStateStore();
 
   render(
     <ComponentStateProvider hooks={hooks}>
@@ -88,7 +57,7 @@ describe("ChatViewRowsVirtualList paging", () => {
     hasMoreRows?: boolean;
     onLoadMoreRows?: () => void;
   }) => {
-    const { hooks } = makeStateStore();
+    const { hooks } = makeReactiveStateStore();
     const ui = (p: typeof props) => (
       <ComponentStateProvider hooks={hooks}>
         <ExtendedFindProvider>

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
@@ -9,7 +9,6 @@ import {
   createRef,
   useCallback,
   useState,
-  useSyncExternalStore,
   type MutableRefObject,
   type ReactNode,
 } from "react";
@@ -23,6 +22,7 @@ import {
   ComponentStateProvider,
   type ComponentStateHooks,
 } from "@tsmono/react/state";
+import { makeReactiveStateStore } from "@tsmono/react/testing";
 import type { VirtualListHandle } from "@tsmono/react/virtual";
 
 import {
@@ -70,46 +70,6 @@ vi.mock("./TranscriptVirtualList", () => ({
     );
   },
 }));
-
-// TranscriptViewNodes reads AND writes the transcript's `follow` property
-// (live-tail state). A reactive Map-backed store (like production zustand)
-// whose backing Map the tests can read/seed.
-const makeReactiveHooks = () => {
-  const store = new Map<string, unknown>();
-  const listeners = new Set<() => void>();
-  let version = 0;
-  const subscribe = (cb: () => void) => {
-    listeners.add(cb);
-    return () => {
-      listeners.delete(cb);
-    };
-  };
-  const emit = () => {
-    version++;
-    listeners.forEach((l) => l());
-  };
-  const key = (id: string, prop: string) => `${id}::${prop}`;
-  const hooks: ComponentStateHooks = {
-    useValue: (id, prop, defaultValue) => {
-      useSyncExternalStore(subscribe, () => version);
-      return store.has(key(id, prop)) ? store.get(key(id, prop)) : defaultValue;
-    },
-    useSetValue: () => (id, prop, value) => {
-      const k = key(id, prop);
-      if (!store.has(k) || store.get(k) !== value) {
-        store.set(k, value);
-        emit();
-      }
-    },
-    useRemoveValue: () => (id, prop) => {
-      if (store.delete(key(id, prop))) emit();
-    },
-    useEntries: () => undefined,
-    useRemoveAll: () => () => {},
-    useRemoveByPrefix: () => () => {},
-  };
-  return { hooks, store };
-};
 
 const noopStateHooks: ComponentStateHooks = {
   useValue: (_id, _prop, defaultValue) => defaultValue,
@@ -423,7 +383,7 @@ describe("TranscriptViewNodes j-past-last arms follow (S4)", () => {
     running: boolean,
     seedFollow?: boolean
   ) => {
-    const { hooks, store } = makeReactiveHooks();
+    const { hooks, store } = makeReactiveStateStore();
     if (seedFollow !== undefined) store.set("test::follow", seedFollow);
     const scrollRef = createRef<HTMLDivElement>();
     const onNavigatedToEvent = vi.fn();
@@ -490,7 +450,7 @@ describe("TranscriptViewNodes focus-entry follow arming (S3)", () => {
   const eventNodes = [model("m1"), model("m2")];
 
   const renderWrapper = (running: boolean, seedFollow?: boolean) => {
-    const { hooks, store } = makeReactiveHooks();
+    const { hooks, store } = makeReactiveStateStore();
     if (seedFollow !== undefined) store.set("test::follow", seedFollow);
     const scrollRef = createRef<HTMLDivElement>();
     capturedEventCallbacks = undefined;
@@ -542,7 +502,7 @@ describe("TranscriptViewNodes `f` focus targeting (following vs current turn)", 
     seedFollow: boolean | undefined,
     initialEventId: string
   ) => {
-    const { hooks, store } = makeReactiveHooks();
+    const { hooks, store } = makeReactiveStateStore();
     if (seedFollow !== undefined) store.set("test::follow", seedFollow);
     const scrollRef = createRef<HTMLDivElement>();
     const opened: string[] = [];

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -74,7 +74,8 @@ describe("TranscriptVirtualList relativeIndent", () => {
 });
 
 // The finish-scroll behavior under test only reproduces with a store that
-// actually re-renders on setProperty, hence the reactive fake below.
+// actually re-renders on setProperty, hence the reactive fake from
+// @tsmono/react/testing.
 describe("TranscriptVirtualList finish scroll-to-top", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { createRef, useSyncExternalStore } from "react";
+import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { testInfoEvent } from "@tsmono/inspect-common/testing";
@@ -8,6 +8,7 @@ import {
   ComponentStateProvider,
   type ComponentStateHooks,
 } from "@tsmono/react/state";
+import { makeReactiveStateHooks } from "@tsmono/react/testing";
 import type { VirtualListHandle } from "@tsmono/react/virtual";
 
 import {
@@ -72,44 +73,8 @@ describe("TranscriptVirtualList relativeIndent", () => {
   });
 });
 
-// Reactive Map-backed ComponentStateHooks, mirroring production's
-// zustand-selector adapters: a set re-renders every subscribed component,
-// with stable action references. The finish-scroll behavior under test only
-// reproduces with a store that actually re-renders on setProperty.
-function makeReactiveStateHooks(): ComponentStateHooks {
-  const store = new Map<string, unknown>();
-  const listeners = new Set<() => void>();
-  let version = 0;
-  const subscribe = (cb: () => void) => {
-    listeners.add(cb);
-    return () => {
-      listeners.delete(cb);
-    };
-  };
-  const getKey = (id: string, prop: string) => `${id}::${prop}`;
-  const setValue = (id: string, prop: string, value: unknown) => {
-    const key = getKey(id, prop);
-    if (!store.has(key) || store.get(key) !== value) {
-      store.set(key, value);
-      version++;
-      listeners.forEach((l) => l());
-    }
-  };
-  return {
-    useValue: (id: string, prop: string, defaultValue?: unknown) => {
-      useSyncExternalStore(subscribe, () => version);
-      return store.has(getKey(id, prop))
-        ? store.get(getKey(id, prop))
-        : defaultValue;
-    },
-    useSetValue: () => setValue,
-    useRemoveValue: () => () => {},
-    useEntries: () => undefined,
-    useRemoveAll: () => () => {},
-    useRemoveByPrefix: () => () => {},
-  };
-}
-
+// The finish-scroll behavior under test only reproduces with a store that
+// actually re-renders on setProperty, hence the reactive fake below.
 describe("TranscriptVirtualList finish scroll-to-top", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -7,12 +7,12 @@ import {
   testChatCompletionChoice,
   testModelEvent,
   testModelOutput,
+  testTimelineEvent,
+  testTimelineSpan,
 } from "@tsmono/inspect-common/testing";
 import type {
   Event,
   Timeline as ServerTimeline,
-  TimelineEvent as ServerTimelineEvent,
-  TimelineSpan as ServerTimelineSpan,
 } from "@tsmono/inspect-common/types";
 
 import { useTranscriptTimeline, type SelectOptions } from "../timeline/hooks";
@@ -51,44 +51,22 @@ function makeModelEvent(
   });
 }
 
-function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid };
-}
-
-function makeServerSpan(
-  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
-): ServerTimelineSpan {
-  return {
-    type: "span",
-    span_type: null,
-    content: [],
-    branches: [],
-    branched_from: null,
-    description: null,
-    utility: false,
-    tool_invoked: false,
-    agent_result: null,
-    outline: null,
-    ...overrides,
-  };
-}
-
 /** evt-1 at root, evt-2 inside a utility-flagged agent span "util-a". */
 function makeUtilityTimeline(): ServerTimeline {
   return {
     name: "default",
     description: "Test timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        makeServerEvent("evt-1"),
-        makeServerSpan({
+        testTimelineEvent({ event: "evt-1" }),
+        testTimelineSpan({
           id: "util-a",
           name: "Util A",
           span_type: "agent",
           utility: true,
-          content: [makeServerEvent("evt-2")],
+          content: [testTimelineEvent({ event: "evt-2" })],
         }),
       ],
     }),
@@ -100,16 +78,16 @@ function makeAgentTimeline(): ServerTimeline {
   return {
     name: "default",
     description: "Test timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        makeServerEvent("evt-1"),
-        makeServerSpan({
+        testTimelineEvent({ event: "evt-1" }),
+        testTimelineSpan({
           id: "agent-a",
           name: "Agent A",
           span_type: "agent",
-          content: [makeServerEvent("evt-2")],
+          content: [testTimelineEvent({ event: "evt-2" })],
         }),
       ],
     }),
@@ -291,19 +269,19 @@ describe("useDeepLinkResolution → cross-timeline switch", () => {
   const timelineA: ServerTimeline = {
     name: "A",
     description: "Timeline A",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root-a",
       name: "A",
-      content: [makeServerEvent("evt-1")],
+      content: [testTimelineEvent({ event: "evt-1" })],
     }),
   };
   const timelineB: ServerTimeline = {
     name: "B",
     description: "Timeline B",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root-b",
       name: "B",
-      content: [makeServerEvent("evt-9")],
+      content: [testTimelineEvent({ event: "evt-9" })],
     }),
   };
 

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -2,18 +2,19 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
+  testAnchorEvent,
   testAssistantMessage,
   testChatCompletionChoice,
   testInfoEvent,
   testModelEvent,
   testModelOutput,
+  testTimelineEvent,
+  testTimelineSpan,
 } from "@tsmono/inspect-common/testing";
 import type {
   AnchorEvent,
   Event,
   Timeline as ServerTimeline,
-  TimelineEvent as ServerTimelineEvent,
-  TimelineSpan as ServerTimelineSpan,
 } from "@tsmono/inspect-common/types";
 
 import { InMemoryStateWrapper } from "../testHelpers";
@@ -61,39 +62,12 @@ function makeAnchorEvent(
   anchorId: string,
   startSec: number
 ): AnchorEvent {
-  return {
-    event: "anchor",
+  return testAnchorEvent({
     uuid,
     anchor_id: anchorId,
     timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
     working_start: startSec,
-    span_id: null,
-    pending: null,
-    metadata: null,
-    source: null,
-  };
-}
-
-function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid };
-}
-
-function makeServerSpan(
-  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
-): ServerTimelineSpan {
-  return {
-    type: "span",
-    span_type: null,
-    content: [],
-    branches: [],
-    branched_from: null,
-    description: null,
-    utility: false,
-    tool_invoked: false,
-    agent_result: null,
-    outline: null,
-    ...overrides,
-  };
+  });
 }
 
 // =============================================================================
@@ -136,17 +110,20 @@ describe("useTimelinePipeline", () => {
       {
         name: "default",
         description: "Flat branch",
-        root: makeServerSpan({
+        root: testTimelineSpan({
           id: "root",
           name: "Transcript",
-          content: [makeServerEvent("main"), makeServerEvent("anchor")],
+          content: [
+            testTimelineEvent({ event: "main" }),
+            testTimelineEvent({ event: "anchor" }),
+          ],
           branches: [
-            makeServerSpan({
+            testTimelineSpan({
               id: "branch-1",
               name: "Branch 1",
               span_type: "branch",
               branched_from: "fork-1",
-              content: [makeServerEvent("branch-event")],
+              content: [testTimelineEvent({ event: "branch-event" })],
             }),
           ],
         }),

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render } from "@testing-library/react";
-import { useSyncExternalStore } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { testInfoEvent } from "@tsmono/inspect-common/testing";
@@ -7,6 +6,7 @@ import {
   ComponentStateProvider,
   type ComponentStateHooks,
 } from "@tsmono/react/state";
+import { makeReactiveStateHooks } from "@tsmono/react/testing";
 
 import { EventNode } from "../types";
 
@@ -31,49 +31,6 @@ describe("outlineNodeRunning", () => {
     ).toBe(false);
   });
 });
-
-// A reactive component-state store backed by a Map the test can inspect, so
-// VirtualList's persisted snapshots survive across mounts like production.
-const makeReactiveStateHooks = () => {
-  const store = new Map<string, unknown>();
-  const listeners = new Set<() => void>();
-  let version = 0;
-  const subscribe = (cb: () => void) => {
-    listeners.add(cb);
-    return () => {
-      listeners.delete(cb);
-    };
-  };
-  const emit = () => {
-    version++;
-    listeners.forEach((l) => l());
-  };
-  const getKey = (id: string, prop: string) => `${id}::${prop}`;
-  const hooks: ComponentStateHooks = {
-    useValue: (id: string, prop: string, defaultValue?: unknown) => {
-      useSyncExternalStore(subscribe, () => version);
-      return store.has(getKey(id, prop))
-        ? store.get(getKey(id, prop))
-        : defaultValue;
-    },
-    useSetValue: () => (id: string, prop: string, value: unknown) => {
-      if (
-        !store.has(getKey(id, prop)) ||
-        store.get(getKey(id, prop)) !== value
-      ) {
-        store.set(getKey(id, prop), value);
-        emit();
-      }
-    },
-    useRemoveValue: () => (id: string, prop: string) => {
-      if (store.delete(getKey(id, prop))) emit();
-    },
-    useEntries: () => undefined,
-    useRemoveAll: () => () => {},
-    useRemoveByPrefix: () => () => {},
-  };
-  return { hooks, store };
-};
 
 const node = (id: string): EventNode =>
   new EventNode(
@@ -120,7 +77,7 @@ describe("TranscriptOutline persistence scoping", () => {
     // Hosts that never clear the property bag (scout has no equivalent of
     // inspect's SampleLoadController) rely on the persistence key itself
     // being scoped per transcript.
-    const { hooks } = makeReactiveStateHooks();
+    const hooks = makeReactiveStateHooks();
 
     // Transcript A: user scrolls the outline's sticky container; the
     // debounced persist records the offset.
@@ -146,7 +103,7 @@ describe("TranscriptOutline persistence scoping", () => {
   });
 
   it("restores the offset when the same transcript remounts", () => {
-    const { hooks } = makeReactiveStateHooks();
+    const hooks = makeReactiveStateHooks();
 
     const scrollElA = document.createElement("div");
     document.body.appendChild(scrollElA);

--- a/packages/inspect-components/src/transcript/timeline/core.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.test.ts
@@ -9,19 +9,23 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  testAnchorEvent,
   testAssistantMessage,
+  testBranchEvent,
   testChatCompletionChoice,
   testModelEvent,
   testModelOutput,
   testModelUsage,
   testSpanBeginEvent,
   testSpanEndEvent,
+  testStepEvent,
+  testTimeline,
+  testTimelineEvent,
+  testTimelineSpan,
   testUserMessage,
 } from "@tsmono/inspect-common/testing";
 import type {
   Event,
-  Timeline as ServerTimeline,
-  TimelineEvent as ServerTimelineEvent,
   TimelineSpan as ServerTimelineSpan,
 } from "@tsmono/inspect-common/types";
 
@@ -40,72 +44,33 @@ import {
 // Helpers
 // =============================================================================
 
-function makeEvent(
+const BASE = new Date("2025-01-15T10:00:00Z").getTime();
+
+const iso = (sec: number) => new Date(BASE + sec * 1000).toISOString();
+
+function makeModelEvent(
   uuid: string,
-  type: string,
   startSec: number,
-  endSec?: number,
-  tokens?: number
+  endSec: number,
+  tokens: number
 ): Event {
-  const base = new Date("2025-01-15T10:00:00Z").getTime();
-  return {
-    event: type,
+  return testModelEvent({
     uuid,
-    timestamp: new Date(base + startSec * 1000).toISOString(),
-    completed: endSec
-      ? new Date(base + endSec * 1000).toISOString()
-      : undefined,
+    timestamp: iso(startSec),
+    completed: iso(endSec),
     working_start: startSec,
-    pending: false,
-    metadata: null,
-    ...(type === "model"
-      ? {
-          model: "test-model",
-          output: {
-            usage: {
-              input_tokens: tokens ? Math.floor(tokens * 0.6) : 0,
-              output_tokens: tokens ? tokens - Math.floor(tokens * 0.6) : 0,
-              total_tokens: tokens ?? 0,
-              input_tokens_cache_read: null,
-              input_tokens_cache_write: null,
-              reasoning_tokens: null,
-              total_cost: null,
-            },
-          },
-        }
-      : {}),
-  } as Event;
+    output: testModelOutput({
+      usage: testModelUsage({
+        input_tokens: Math.floor(tokens * 0.6),
+        output_tokens: tokens - Math.floor(tokens * 0.6),
+        total_tokens: tokens,
+      }),
+    }),
+  });
 }
 
-function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid };
-}
-
-function makeServerSpan(
-  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
-): ServerTimelineSpan {
-  return {
-    type: "span",
-    span_type: null,
-    content: [],
-    branches: [],
-    branched_from: null,
-    description: null,
-    utility: false,
-    tool_invoked: false,
-    agent_result: null,
-    outline: null,
-    ...overrides,
-  };
-}
-
-function makeServerTimeline(root: ServerTimelineSpan): ServerTimeline {
-  return {
-    name: "test",
-    description: "test timeline",
-    root,
-  };
-}
+const makeServerTimeline = (root: ServerTimelineSpan) =>
+  testTimeline({ name: "test", description: "test timeline", root });
 
 // =============================================================================
 // Tests
@@ -115,15 +80,18 @@ describe("convertServerTimeline", () => {
   describe("UUID resolution", () => {
     it("resolves event UUIDs to full Event objects", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 10, 20, 200),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 10, 20, 200),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1"), makeServerEvent("evt-2")],
+          content: [
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineEvent({ event: "evt-2" }),
+          ],
         })
       );
 
@@ -142,13 +110,16 @@ describe("convertServerTimeline", () => {
     });
 
     it("filters out events with missing UUIDs", () => {
-      const events = [makeEvent("evt-1", "model", 0, 10, 100)];
+      const events = [makeModelEvent("evt-1", 0, 10, 100)];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1"), makeServerEvent("evt-missing")],
+          content: [
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineEvent({ event: "evt-missing" }),
+          ],
         })
       );
 
@@ -162,10 +133,10 @@ describe("convertServerTimeline", () => {
 
     it("handles empty events array", () => {
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1")],
+          content: [testTimelineEvent({ event: "evt-1" })],
         })
       );
 
@@ -178,28 +149,28 @@ describe("convertServerTimeline", () => {
   describe("nested spans", () => {
     it("converts nested span hierarchy", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 10, 20, 200),
-        makeEvent("evt-3", "model", 20, 30, 300),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 10, 20, 200),
+        makeModelEvent("evt-3", 20, 30, 300),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
           content: [
-            makeServerEvent("evt-1"),
-            makeServerSpan({
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineSpan({
               id: "child",
               name: "explore",
               span_type: "agent",
               content: [
-                makeServerEvent("evt-2"),
-                makeServerSpan({
+                testTimelineEvent({ event: "evt-2" }),
+                testTimelineSpan({
                   id: "grandchild",
                   name: "build",
                   span_type: "agent",
-                  content: [makeServerEvent("evt-3")],
+                  content: [testTimelineEvent({ event: "evt-3" })],
                 }),
               ],
             }),
@@ -226,21 +197,21 @@ describe("convertServerTimeline", () => {
     });
 
     it("preserves span properties through conversion", () => {
-      const events = [makeEvent("evt-1", "model", 0, 10, 100)];
+      const events = [makeModelEvent("evt-1", 0, 10, 100)];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
           content: [
-            makeServerSpan({
+            testTimelineSpan({
               id: "agent-1",
               name: "helper",
               span_type: "agent",
               utility: true,
               description: "A helper agent",
               agent_result: "Done helping",
-              content: [makeServerEvent("evt-1")],
+              content: [testTimelineEvent({ event: "evt-1" })],
             }),
           ],
         })
@@ -258,18 +229,18 @@ describe("convertServerTimeline", () => {
     });
 
     it("filters out empty child spans (all events missing)", () => {
-      const events = [makeEvent("evt-1", "model", 0, 10, 100)];
+      const events = [makeModelEvent("evt-1", 0, 10, 100)];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
           content: [
-            makeServerEvent("evt-1"),
-            makeServerSpan({
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineSpan({
               id: "empty",
               name: "ghost",
-              content: [makeServerEvent("evt-missing")],
+              content: [testTimelineEvent({ event: "evt-missing" })],
             }),
           ],
         })
@@ -286,28 +257,28 @@ describe("convertServerTimeline", () => {
   describe("branches", () => {
     it("converts branches with branchedFrom references", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 10, 20, 200),
-        makeEvent("evt-3", "model", 20, 30, 300),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 10, 20, 200),
+        makeModelEvent("evt-3", 20, 30, 300),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1")],
+          content: [testTimelineEvent({ event: "evt-1" })],
           branches: [
-            makeServerSpan({
+            testTimelineSpan({
               id: "branch-1",
               name: "branch",
               branched_from: "msg-123",
-              content: [makeServerEvent("evt-2")],
+              content: [testTimelineEvent({ event: "evt-2" })],
             }),
-            makeServerSpan({
+            testTimelineSpan({
               id: "branch-2",
               name: "branch",
               branched_from: "msg-456",
-              content: [makeServerEvent("evt-3")],
+              content: [testTimelineEvent({ event: "evt-3" })],
             }),
           ],
         })
@@ -323,25 +294,25 @@ describe("convertServerTimeline", () => {
     });
 
     it("filters out branch spans where all events are missing", () => {
-      const events = [makeEvent("evt-1", "model", 0, 10, 100)];
+      const events = [makeModelEvent("evt-1", 0, 10, 100)];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1")],
+          content: [testTimelineEvent({ event: "evt-1" })],
           branches: [
-            makeServerSpan({
+            testTimelineSpan({
               id: "branch-good",
               name: "branch",
               branched_from: "msg-1",
-              content: [makeServerEvent("evt-1")],
+              content: [testTimelineEvent({ event: "evt-1" })],
             }),
-            makeServerSpan({
+            testTimelineSpan({
               id: "branch-empty",
               name: "branch",
               branched_from: "msg-2",
-              content: [makeServerEvent("evt-missing")],
+              content: [testTimelineEvent({ event: "evt-missing" })],
             }),
           ],
         })
@@ -355,25 +326,25 @@ describe("convertServerTimeline", () => {
 
     it("handles nested branches within child spans", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 10, 20, 200),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 10, 20, 200),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
           content: [
-            makeServerSpan({
+            testTimelineSpan({
               id: "child",
               name: "agent",
-              content: [makeServerEvent("evt-1")],
+              content: [testTimelineEvent({ event: "evt-1" })],
               branches: [
-                makeServerSpan({
+                testTimelineSpan({
                   id: "child-branch",
                   name: "branch",
                   branched_from: "msg-nested",
-                  content: [makeServerEvent("evt-2")],
+                  content: [testTimelineEvent({ event: "evt-2" })],
                 }),
               ],
             }),
@@ -392,15 +363,18 @@ describe("convertServerTimeline", () => {
   describe("computed properties", () => {
     it("computes timing from resolved events", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 20, 30, 200),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 20, 30, 200),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1"), makeServerEvent("evt-2")],
+          content: [
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineEvent({ event: "evt-2" }),
+          ],
         })
       );
 
@@ -413,15 +387,18 @@ describe("convertServerTimeline", () => {
 
     it("computes token totals from resolved events", () => {
       const events = [
-        makeEvent("evt-1", "model", 0, 10, 100),
-        makeEvent("evt-2", "model", 10, 20, 200),
+        makeModelEvent("evt-1", 0, 10, 100),
+        makeModelEvent("evt-2", 10, 20, 200),
       ];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1"), makeServerEvent("evt-2")],
+          content: [
+            testTimelineEvent({ event: "evt-1" }),
+            testTimelineEvent({ event: "evt-2" }),
+          ],
         })
       );
 
@@ -488,10 +465,16 @@ describe("convertServerTimeline", () => {
   });
 
   describe("isEmptyBranch", () => {
-    const anchor = new TimelineEvent(makeEvent("a", "anchor", 0));
-    const branchEvt = new TimelineEvent(makeEvent("b", "branch", 0));
-    const stepEvt = new TimelineEvent(makeEvent("s", "step", 0));
-    const model = new TimelineEvent(makeEvent("m", "model", 0, 1, 10));
+    const anchor = new TimelineEvent(
+      testAnchorEvent({ uuid: "a", timestamp: iso(0), working_start: 0 })
+    );
+    const branchEvt = new TimelineEvent(
+      testBranchEvent({ uuid: "b", timestamp: iso(0), working_start: 0 })
+    );
+    const stepEvt = new TimelineEvent(
+      testStepEvent({ uuid: "s", timestamp: iso(0), working_start: 0 })
+    );
+    const model = new TimelineEvent(makeModelEvent("m", 0, 1, 10));
 
     it("returns true for an empty span", () => {
       const span = new TimelineSpan({
@@ -556,10 +539,16 @@ describe("convertServerTimeline", () => {
   });
 
   describe("filterEmptyBranches", () => {
-    const anchor = new TimelineEvent(makeEvent("a", "anchor", 0));
-    const stepEvt = new TimelineEvent(makeEvent("s", "step", 0));
-    const branchEvt = new TimelineEvent(makeEvent("b", "branch", 0));
-    const model = new TimelineEvent(makeEvent("m", "model", 0, 1, 10));
+    const anchor = new TimelineEvent(
+      testAnchorEvent({ uuid: "a", timestamp: iso(0), working_start: 0 })
+    );
+    const stepEvt = new TimelineEvent(
+      testStepEvent({ uuid: "s", timestamp: iso(0), working_start: 0 })
+    );
+    const branchEvt = new TimelineEvent(
+      testBranchEvent({ uuid: "b", timestamp: iso(0), working_start: 0 })
+    );
+    const model = new TimelineEvent(makeModelEvent("m", 0, 1, 10));
 
     function branch(
       id: string,
@@ -639,13 +628,13 @@ describe("convertServerTimeline", () => {
 
   describe("outline", () => {
     it("preserves outline data through conversion", () => {
-      const events = [makeEvent("evt-1", "model", 0, 10, 100)];
+      const events = [makeModelEvent("evt-1", 0, 10, 100)];
 
       const server = makeServerTimeline(
-        makeServerSpan({
+        testTimelineSpan({
           id: "root",
           name: "main",
-          content: [makeServerEvent("evt-1")],
+          content: [testTimelineEvent({ event: "evt-1" })],
           outline: {
             nodes: [{ event: "evt-1", children: [] }],
           },

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  testAnchorEvent,
   testAssistantMessage,
   testChatCompletionChoice,
   testModelEvent,
@@ -9,13 +10,12 @@ import {
   testModelUsage,
   testSpanBeginEvent,
   testSpanEndEvent,
+  testTimelineEvent,
+  testTimelineSpan,
 } from "@tsmono/inspect-common/testing";
 import type {
-  AnchorEvent,
   Event,
   Timeline as ServerTimeline,
-  TimelineEvent as ServerTimelineEvent,
-  TimelineSpan as ServerTimelineSpan,
 } from "@tsmono/inspect-common/types";
 
 import { useTranscriptTimeline } from "./useTranscriptTimeline";
@@ -83,28 +83,6 @@ function spanEnd(id: string): Event {
   });
 }
 
-function makeServerEvent(uuid: string): ServerTimelineEvent {
-  return { type: "event", event: uuid };
-}
-
-function makeServerSpan(
-  overrides: Partial<ServerTimelineSpan> & { id: string; name: string }
-): ServerTimelineSpan {
-  return {
-    type: "span",
-    span_type: null,
-    content: [],
-    branches: [],
-    branched_from: null,
-    description: null,
-    utility: false,
-    tool_invoked: false,
-    agent_result: null,
-    outline: null,
-    ...overrides,
-  };
-}
-
 // =============================================================================
 // useTranscriptTimeline hook
 // =============================================================================
@@ -119,22 +97,22 @@ describe("useTranscriptTimeline", () => {
   const serverTimeline: ServerTimeline = {
     name: "default",
     description: "Test timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        makeServerEvent("evt-1"),
-        makeServerSpan({
+        testTimelineEvent({ event: "evt-1" }),
+        testTimelineSpan({
           id: "agent-a",
           name: "Agent A",
           span_type: "agent",
-          content: [makeServerEvent("evt-2")],
+          content: [testTimelineEvent({ event: "evt-2" })],
         }),
-        makeServerSpan({
+        testTimelineSpan({
           id: "agent-b",
           name: "Agent B",
           span_type: "agent",
-          content: [makeServerEvent("evt-3")],
+          content: [testTimelineEvent({ event: "evt-3" })],
         }),
       ],
     }),
@@ -297,17 +275,12 @@ function makeAnchorEvent(
   anchorId: string,
   startSec: number
 ): Event {
-  return {
-    event: "anchor",
+  return testAnchorEvent({
     uuid,
     anchor_id: anchorId,
     timestamp: new Date(1705312800000 + startSec * 1000).toISOString(),
     working_start: startSec,
-    span_id: null,
-    pending: null,
-    metadata: null,
-    source: null,
-  } satisfies AnchorEvent;
+  });
 }
 
 describe("useTranscriptTimeline punch-down views", () => {
@@ -319,17 +292,20 @@ describe("useTranscriptTimeline punch-down views", () => {
   const branchTimeline: ServerTimeline = {
     name: "default",
     description: "Branch timeline",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
-      content: [makeServerEvent("evt-1"), makeServerEvent("evt-anchor")],
+      content: [
+        testTimelineEvent({ event: "evt-1" }),
+        testTimelineEvent({ event: "evt-anchor" }),
+      ],
       branches: [
-        makeServerSpan({
+        testTimelineSpan({
           id: "branch-1",
           name: "branch",
           span_type: "branch",
           branched_from: "fork-1",
-          content: [makeServerEvent("evt-branch")],
+          content: [testTimelineEvent({ event: "evt-branch" })],
         }),
       ],
     }),
@@ -392,17 +368,17 @@ describe("useTranscriptTimeline orphaned selection", () => {
   const utilityTimeline: ServerTimeline = {
     name: "default",
     description: "Utility lane test",
-    root: makeServerSpan({
+    root: testTimelineSpan({
       id: "root",
       name: "Transcript",
       content: [
-        makeServerEvent("evt-main"),
-        makeServerSpan({
+        testTimelineEvent({ event: "evt-main" }),
+        testTimelineSpan({
           id: "util-a",
           name: "Utility A",
           span_type: "agent",
           utility: true,
-          content: [makeServerEvent("evt-util")],
+          content: [testTimelineEvent({ event: "evt-util" })],
         }),
       ],
     }),

--- a/packages/react/src/test/component-state-hooks.ts
+++ b/packages/react/src/test/component-state-hooks.ts
@@ -26,7 +26,11 @@ export function makeStateHooks(): ComponentStateHooks {
 // Reactive variant: like production (zustand-selector adapters in both apps), a
 // set re-renders every subscribed component. The non-reactive version above
 // cannot exercise an effect whose own setProperty call re-runs it; this one can.
-export function makeReactiveStateHooks(): ComponentStateHooks {
+// Also returns the backing Map so tests can seed and assert on stored values.
+export function makeReactiveStateStore(): {
+  hooks: ComponentStateHooks;
+  store: Map<string, unknown>;
+} {
   const store = new Map<string, unknown>();
   const listeners = new Set<() => void>();
   let version = 0;
@@ -53,7 +57,7 @@ export function makeReactiveStateHooks(): ComponentStateHooks {
   const removeValue = (id: string, prop: string) => {
     if (store.delete(getKey(id, prop))) emit();
   };
-  return {
+  const hooks: ComponentStateHooks = {
     useValue: (id: string, prop: string, defaultValue?: unknown) => {
       useSyncExternalStore(subscribe, () => version);
       return store.has(getKey(id, prop))
@@ -66,4 +70,9 @@ export function makeReactiveStateHooks(): ComponentStateHooks {
     useRemoveAll: () => () => {},
     useRemoveByPrefix: () => () => {},
   };
+  return { hooks, store };
+}
+
+export function makeReactiveStateHooks(): ComponentStateHooks {
+  return makeReactiveStateStore().hooks;
 }

--- a/packages/react/src/virtual/VirtualList.test.tsx
+++ b/packages/react/src/virtual/VirtualList.test.tsx
@@ -1,11 +1,6 @@
 // @vitest-environment jsdom
 import { render } from "@testing-library/react";
-import {
-  createRef,
-  useSyncExternalStore,
-  type ReactNode,
-  type RefObject,
-} from "react";
+import { createRef, type ReactNode, type RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ExtendedFindProvider } from "../components/ExtendedFindContext";
@@ -15,6 +10,7 @@ import {
 } from "../state/ComponentStateContext";
 import {
   makeReactiveStateHooks,
+  makeReactiveStateStore,
   makeStateHooks,
 } from "../test/component-state-hooks";
 
@@ -173,51 +169,11 @@ describe("VirtualList follow arming (nav ownership)", () => {
   // A reactive store whose backing Map the test can read, so we can assert the
   // effective initial follow VirtualList writes through as the single source of
   // truth (the `<id>::follow` key).
-  const makeInspectableHooks = () => {
-    const store = new Map<string, unknown>();
-    const listeners = new Set<() => void>();
-    let version = 0;
-    const subscribe = (cb: () => void) => {
-      listeners.add(cb);
-      return () => {
-        listeners.delete(cb);
-      };
-    };
-    const emit = () => {
-      version++;
-      listeners.forEach((l) => l());
-    };
-    const key = (id: string, prop: string) => `${id}::${prop}`;
-    const setValue = (id: string, prop: string, value: unknown) => {
-      const k = key(id, prop);
-      if (!store.has(k) || store.get(k) !== value) {
-        store.set(k, value);
-        emit();
-      }
-    };
-    const hooks: ComponentStateHooks = {
-      useValue: (id: string, prop: string, defaultValue?: unknown) => {
-        useSyncExternalStore(subscribe, () => version);
-        return store.has(key(id, prop))
-          ? store.get(key(id, prop))
-          : defaultValue;
-      },
-      useSetValue: () => setValue,
-      useRemoveValue: () => (id: string, prop: string) => {
-        if (store.delete(key(id, prop))) emit();
-      },
-      useEntries: () => undefined,
-      useRemoveAll: () => () => {},
-      useRemoveByPrefix: () => () => {},
-    };
-    return { hooks, store };
-  };
-
   const mountFollow = (
     props: Partial<React.ComponentProps<typeof VirtualList<string>>>,
     seedFollow?: boolean
   ) => {
-    const { hooks, store } = makeInspectableHooks();
+    const { hooks, store } = makeReactiveStateStore();
     if (seedFollow !== undefined) store.set("follow-list::follow", seedFollow);
     const scrollRef = createRef<HTMLDivElement>();
     const view = render(
@@ -294,7 +250,7 @@ describe("VirtualList follow arming (nav ownership)", () => {
   // false→true flip a late-loading stream produces (data arrives after the
   // first render, so the sample only becomes live on a later commit).
   const mountFlippable = (initialLive: boolean, seedFollow?: boolean) => {
-    const { hooks, store } = makeInspectableHooks();
+    const { hooks, store } = makeReactiveStateStore();
     if (seedFollow !== undefined) store.set("follow-list::follow", seedFollow);
     const scrollRef = createRef<HTMLDivElement>();
     const props = {


### PR DESCRIPTION
Follow-up to the [#542 review nit](https://github.com/meridianlabs-ai/ts-mono/pull/542#discussion_r3824961042) about duplicated test data builders, generalized to the whole repo: fixtures for a package's public types belong in that package's testing subpath export, and test-local helpers should be thin wrappers over those — never re-declared field lists.

## Changes

**Shared timeline wire-type builders** (`@tsmono/inspect-common/testing`)
- Adds `testTimeline` / `testTimelineEvent` / `testTimelineSpan` (the `Timeline`/`TimelineEvent`/`TimelineSpan` wire types are owned by inspect-common) plus `testAnchorEvent` / `testBranchEvent`.
- Removes the verbatim `makeServerEvent`/`makeServerSpan`/`makeServerTimeline` copies from `core.test.ts`, `useTranscriptTimeline.test.ts`, `useTimelinePipeline.test.ts`, `useDeepLinkResolution.test.ts`, and `apps/inspect/e2e/timeline.spec.ts`; the anchor-event literals now delegate to `testAnchorEvent`.
- Replaces `core.test.ts`'s cast-based `makeEvent` (`as Event`) with cast-free wrappers over the shared builders — also removes an unnecessary `as ServerTimelineSpan` in the e2e spec.

**Shared state-hook fakes** (`@tsmono/react/testing`)
- Three inspect-components transcript tests re-implemented the reactive Map-backed `ComponentStateHooks` fake that `@tsmono/react/testing` already exports. Adds `makeReactiveStateStore` (same fake, returning the backing `Map` so tests can seed/assert stored values), rebuilds `makeReactiveStateHooks` on top of it, and swaps the three local copies for the shared imports.

**Convention documented** (`AGENTS.md`)
- New Testing bullet: package-owned types → that package's testing export; app-private types → in-app fixture modules; thin test-local wrappers over shared builders are fine; production code never imports testing exports.

Deliberately left alone: test-local scenario shorthands that parameterize shared builders (e.g. the per-file `makeModelEvent(uuid, startSec, …)` wrappers) — they're vocabulary, not duplicated ground truth — and the app-private factories in `apps/scout/src/test` and `apps/inspect/src/log_data/testFixtures.ts`, which have no consumers outside their apps.

## Verification

- `pnpm turbo run typecheck lint test` — all 27 tasks green across the 12 workspace packages (inspect-components: 927 passed / 2 skipped; inspect-common: 79; react: 221)
- `format:check` clean on all touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Skct829iZom4ddGHc6c5gx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Skct829iZom4ddGHc6c5gx)_