### PR TITLE
ci: add the @auto loop stub (claude-auto.yml)

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -1,0 +1,77 @@
+# Copy to .github/workflows/claude-auto.yml in a Meridian repo to enable the
+# @auto autonomous loop (design/auto-agent.md). Independent of the dev agent
+# (claude.yml) and reviewer (claude-review.yml).
+#
+# Requires the MARVIN_TOKEN org secret scoped to this repo (same as claude.yml).
+#
+# REQUIRED EDIT: under `workflows:` list THIS repo's CI workflow name(s) — the
+# `name:` field of each CI workflow (not its filename). workflow_run is the only
+# event that reliably fires for GitHub-Actions CI completing (check_suite is
+# suppressed for Actions-created suites), and it must name what it reacts to.
+# Find names with: gh workflow list.
+
+name: Claude Auto
+
+on:
+  # Phase 1: react to CI completing (so we can fix failures).
+  workflow_run:
+    # <-- replace with this repo's CI workflow name(s), e.g. ["Build"]
+    workflows: ["CI"]
+    types: [completed]
+  # Phase 2/3: react to the reviewer's marked summary comment. issue_comment
+  # fires from the default branch, so this works on pristine-base forks too
+  # (unlike pull_request_review).
+  issue_comment:
+    types: [created]
+
+jobs:
+  # CI-failure -> fix. Only a *failed* CI run for a *same-repo* PR (same-repo
+  # excludes untrusted fork PRs). The reusable workflow does the authoritative
+  # gate (open PR + `auto` label + attempt cap).
+  ci-fix:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      # ts-mono: pnpm/turbo permissions override (see claude.yml's stubs for
+      # rationale) — replaces the reusable workflow's Python-oriented default.
+      settings: .github/claude-settings.json
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      ci_run_id: ${{ github.event.workflow_run.id }}
+
+  # Review -> fix / handoff. The marker is a cheap router (it's forgeable — only
+  # the reviewer posts it in practice); the reusable workflow does the authoritative
+  # gating (comment author == reviewer, same-repo, `auto` label, round cap), so
+  # the security boundary is there, not here.
+  review-fix:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '<!-- claude-review-summary -->')
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      # ts-mono: pnpm/turbo permissions override (see claude.yml's stubs for
+      # rationale) — replaces the reusable workflow's Python-oriented default.
+      settings: .github/claude-settings.json
+      pr_number: ${{ github.event.issue.number }}
+      comment_author: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
ts-mono has the dev agent and reviewer stubs but never got the @auto loop engine — `enable-claude.sh`'s stub list predates `claude-auto-stub.yml`. Observed: the reviewer's `suggestions` verdict on auto-labeled ts-mono#557 fired into a repo with no `claude-auto.yml`, so no fix round ever ran and the anchor issue (meridianlabs-ai/inspect_ai#251) stalled at Agent.

Adapted from `agents/examples/claude-auto-stub.yml`: the `workflow_run` trigger's `workflows: ["CI"]` already matches this repo's CI workflow name, and both jobs carry the repo's `.github/claude-settings.json` pnpm permissions override (same as the other stubs).

Companion fix in the agents repo adds the stub to `enable-claude.sh` so future enables include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)