### PR TITLE
feat: add record_input to scan options and null-guard input type guards

### DIFF
--- a/apps/scout/e2e/fixtures/test-data.ts
+++ b/apps/scout/e2e/fixtures/test-data.ts
@@ -94,7 +94,7 @@ export function createStatus(overrides?: Partial<Status>): Status {
     spec: {
       scan_id: "aBcDeFgHiJkLmNoPqRsTuV",
       scan_name: "eval-safety",
-      options: { max_transcripts: 25 },
+      options: { max_transcripts: 25, record_input: "copy" },
       packages: {},
       scanners: {},
       timestamp: "2024-01-01T00:00:00Z",

--- a/apps/scout/e2e/scan.spec.ts
+++ b/apps/scout/e2e/scan.spec.ts
@@ -39,7 +39,7 @@ test("clicking a scan row opens the scan detail panel", async ({
           spec: {
             scan_id: SCAN_ID,
             scan_name: "eval-safety",
-            options: { max_transcripts: 25 },
+            options: { max_transcripts: 25, record_input: "copy" },
             packages: {},
             scanners: {},
             timestamp: "2024-01-15T10:30:00Z",

--- a/apps/scout/src/app/server/useStartScan.test.ts
+++ b/apps/scout/src/app/server/useStartScan.test.ts
@@ -22,7 +22,7 @@ const mockStatus: Status = {
   spec: {
     scan_id: "test-scan-id",
     scan_name: "test-scan",
-    options: { max_transcripts: 25 },
+    options: { max_transcripts: 25, record_input: "copy" },
     packages: {},
     scanners: {},
     timestamp: "2024-01-01T00:00:00Z",

--- a/apps/scout/src/app/types.ts
+++ b/apps/scout/src/app/types.ts
@@ -151,31 +151,31 @@ export function isTranscriptInput(
   input_type: "transcript";
   input: Transcript;
 } {
-  return input.input_type === "transcript";
+  return input.input_type === "transcript" && input.input != null;
 }
 
 export function isMessageInput(input: ScannerInput): input is ScannerInput & {
   input_type: "message";
   input: ChatMessage;
 } {
-  return input.input_type === "message";
+  return input.input_type === "message" && input.input != null;
 }
 
 export function isMessagesInput(input: ScannerInput): input is ScannerInput & {
   input_type: "messages";
   input: ChatMessage[];
 } {
-  return input.input_type === "messages";
+  return input.input_type === "messages" && input.input != null;
 }
 
 export function isEventInput(
   input: ScannerInput
 ): input is ScannerInput & { input_type: "event"; input: EventType } {
-  return input.input_type === "event";
+  return input.input_type === "event" && input.input != null;
 }
 
 export function isEventsInput(
   input: ScannerInput
 ): input is ScannerInput & { input_type: "events"; input: Event[] } {
-  return input.input_type === "events";
+  return input.input_type === "events" && input.input != null;
 }

--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -2962,6 +2962,12 @@ export interface components {
              * @default 25
              */
             max_transcripts: number;
+            /**
+             * Record Input
+             * @default copy
+             * @enum {string}
+             */
+            record_input: "copy" | "reference";
             /** Results Buffer */
             results_buffer?: number | null;
             /** Shuffle */


### PR DESCRIPTION
## Summary

inspect_scout is gaining `scan(..., record_input="copy" | "reference")` (meridianlabs-ai/inspect_scout#575 and its follow-up): reference-mode rows store `input` as NULL and carry `input_storage`/`input_content` columns instead. The shipped scout viewer's `is*Input` type guards dereference `input.input_type` unguarded, so a reference row would throw a `TypeError` before the app can render anything.

## What changed

- `apps/scout/src/types/generated.ts` regenerated from the new `openapi.json` (`ScanOptions` gains the required `record_input: "copy" | "reference"` field).
- The five `is*Input` guards in `apps/scout/src/app/types.ts` now reject `null`/missing `input` instead of throwing, so reference rows fall through to the existing "no input" rendering.
- The three fixtures that build `ScanOptions` set `record_input: "copy"`.

Viewer-side resolution of reference rows (fetching the referenced sample on demand) is a follow-up.

`pnpm typecheck` and `pnpm test` pass at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
