### PR TITLE
ci: resolve companion mentions via anchor_repo

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -47,6 +47,7 @@ jobs:
       # ts-mono: pnpm/turbo permissions override (see claude.yml's stubs for
       # rationale) — replaces the reusable workflow's Python-oriented default.
       settings: .github/claude-settings.json
+      anchor_repo: meridianlabs-ai/inspect_ai
       head_branch: ${{ github.event.workflow_run.head_branch }}
       pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
       ci_run_id: ${{ github.event.workflow_run.id }}
@@ -73,10 +74,10 @@ jobs:
       # ts-mono: pnpm/turbo permissions override (see claude.yml's stubs for
       # rationale) — replaces the reusable workflow's Python-oriented default.
       settings: .github/claude-settings.json
-      # Companion PRs here anchor to FORK issues (claude/issue-N-* numbers
-      # reference meridianlabs-ai/inspect_ai), so the workflow's repo-local
-      # mention derivation cannot find the responsible human — name the
-      # pilot owner explicitly for convergence/escalation handoffs.
-      handoff_mention: ransomr
+      # Companion PRs here anchor to FORK issues: same-named branches
+      # reference meridianlabs-ai/inspect_ai's tracker, so mention
+      # derivation resolves them there (whoever owns the anchor issue —
+      # no login named in config).
+      anchor_repo: meridianlabs-ai/inspect_ai
       pr_number: ${{ github.event.issue.number }}
       comment_author: ${{ github.event.comment.user.login }}

--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -73,5 +73,10 @@ jobs:
       # ts-mono: pnpm/turbo permissions override (see claude.yml's stubs for
       # rationale) — replaces the reusable workflow's Python-oriented default.
       settings: .github/claude-settings.json
+      # Companion PRs here anchor to FORK issues (claude/issue-N-* numbers
+      # reference meridianlabs-ai/inspect_ai), so the workflow's repo-local
+      # mention derivation cannot find the responsible human — name the
+      # pilot owner explicitly for convergence/escalation handoffs.
+      handoff_mention: ransomr
       pr_number: ${{ github.event.issue.number }}
       comment_author: ${{ github.event.comment.user.login }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,6 +51,9 @@ jobs:
     # read-only. Absent -> those steps no-op.
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      # companion branches reference the fork's tracker (mention derivation)
+      anchor_repo: meridianlabs-ai/inspect_ai
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -115,6 +115,7 @@ jobs:
       # the file repeats the git/gh/file-edit entries alongside the pnpm/turbo
       # swap-ins.
       settings: .github/claude-settings.json
+      anchor_repo: meridianlabs-ai/inspect_ai
       # trigger_phrase is single-valued, so resolve it from the SAME source the
       # action will check for this event (comment > review > issue), not from a
       # union of all sources — otherwise a stale @claude in an enclosing issue
@@ -193,5 +194,6 @@ jobs:
       # the file repeats the git/gh/file-edit entries alongside the pnpm/turbo
       # swap-ins.
       settings: .github/claude-settings.json
+      anchor_repo: meridianlabs-ai/inspect_ai
       trigger_phrase: "@auto"
       label_trigger: "auto"


### PR DESCRIPTION
Supersedes the hardcoded-login approach after review feedback: instead of `handoff_mention: ransomr`, all three stubs now pass `anchor_repo: meridianlabs-ai/inspect_ai` to the reusable workflows (new input, agents@89e73c1). Mention derivation resolves companion branch numbers and fully-qualified refs against the anchor repo — guarded by the twin-branch check so ts-mono-native agent branches still resolve locally — then applies the usual author-unless-bot/assignee chain to whoever owns the anchor issue. Repo-level config; no person named.

Background: the review-fix escalation on ts-mono#557 pinged @dragonstyle because repo-local derivation resolved `claude/issue-251-*` to ts-mono's #251 (an unrelated PR). The agents-side guard also now refuses PR results outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)