### PR TITLE
Add sandbox_prebuilt to EvalConfig generated types (upstream inspect_ai#4934)

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1424,6 +1424,8 @@ export interface components {
             sample_shuffle?: boolean | number | null;
             /** Sandbox Cleanup */
             sandbox_cleanup?: boolean | null;
+            /** Sandbox Prebuilt */
+            sandbox_prebuilt?: boolean | null;
             /** Score Display */
             score_display?: boolean | null;
             /** Score On Error */

--- a/packages/inspect-common/src/utils/effectiveConfig.ts
+++ b/packages/inspect-common/src/utils/effectiveConfig.ts
@@ -34,6 +34,7 @@ const EVAL_CONFIG_KEYS: Record<keyof EvalConfig, true> = {
   sample_id: true,
   sample_shuffle: true,
   sandbox_cleanup: true,
+  sandbox_prebuilt: true,
   score_display: true,
   score_on_error: true,
   time_limit: true,


### PR DESCRIPTION
Regenerated types for upstream PR [UKGovernmentBEIS/inspect_ai#4934](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4934), which adds a `sandbox_prebuilt` option to `EvalConfig` (skip docker sandbox builds and verify prebuilt images at task init).

Tracking issue: meridianlabs-ai/inspect_ai#269.

## Changes

- `packages/inspect-common/src/types/generated.ts`: regenerated via `python src/inspect_ai/_view/schema.py` against PR #4934's head (`8e7a7c354`) merged with current upstream `main` (`3f294e61b`), with `inspect-scout` installed (its view-server routes are part of the schema). The diff is exactly the new optional `sandbox_prebuilt?: boolean | null` field on `EvalConfig`.
- `packages/inspect-common/src/utils/effectiveConfig.ts`: added `sandbox_prebuilt` to the `EVAL_CONFIG_KEYS` compile-time drift guard (its purpose is to break on exactly this kind of regeneration).

No scout `generated.ts` sync needed: an optional (noneable) field addition is compatible for structural typing.

## Verification

- `pnpm typecheck`: 9/9 packages pass
- `pnpm test`: 109 files / 1144 tests pass
- The corresponding `inspect-openapi.json` regeneration on the Python side is likewise exactly the `sandbox_prebuilt` property (needs to be committed to the #4934 branch along with the gitlink bump — see landing notes on the tracking issue).

## Landing order (two-phase, per land-ts-mono)

Do **not** merge this PR until UKGovernmentBEIS/inspect_ai#4934 is green (except `submodule-on-main`) and provisionally approved — once this merges, ts-mono `main` will reference a type that doesn't exist in inspect_ai `main` until #4934 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
