### PR TITLE
perf: make listing diff linear

### DIFF
--- a/apps/inspect/src/log_data/listingSync.ts
+++ b/apps/inspect/src/log_data/listingSync.ts
@@ -66,13 +66,13 @@ export const syncListing = async (
   // Fetch the updated list of logs from the server
   const response = await api.get_logs(mtime, localFiles.length);
   const updatedLogs = response.files;
+  const localFilesByName = new Map(localFiles.map((file) => [file.name, file]));
+  const updatedNames = new Set(updatedLogs.map((file) => file.name));
 
   const deleted =
     response.response_type === "full"
       ? localFiles
-          .filter(
-            (current) => !updatedLogs.find((f) => f.name === current.name)
-          )
+          .filter((current) => !updatedNames.has(current.name))
           .map((file) => file.name)
       : [];
 
@@ -80,7 +80,7 @@ export const syncListing = async (
   // (or whose mtimes are missing, in which case assume changed).
   const invalidated = updatedLogs
     .filter((remoteLog) => {
-      const localCopy = localFiles.find((f) => f.name === remoteLog.name);
+      const localCopy = localFilesByName.get(remoteLog.name);
       if (!localCopy) {
         return true;
       }


### PR DESCRIPTION
## Summary

- index the local listing by name before detecting invalidated files
- index updated names before detecting deleted files
- preserve existing full, incremental, and missing-mtime diff behavior while reducing the diff from quadratic to linear time

Partially addresses #401 (item 2 only).

## Validation

- `pnpm --filter @meridianlabs/log-viewer exec vitest run src/log_data/listingSync.test.ts` — 1 file, 6 tests passed
- `pnpm --filter @meridianlabs/log-viewer test` — 113 files, 1178 tests passed
- `pnpm check` — 33 tasks passed
- `pnpm test` — 9 tasks passed
- commit and pre-push hooks — lint, format, and check passed
