### PR TITLE
feat: add manual log header collapse

### DIFF
--- a/apps/inspect/e2e/top-level-views.spec.ts
+++ b/apps/inspect/e2e/top-level-views.spec.ts
@@ -117,6 +117,28 @@ test.describe("Top-level views", () => {
     expect(page.url()).toMatch(/#\/logs\//);
   });
 
+  test("log header can be collapsed and expanded manually", async ({
+  page,
+  network,
+}) => {
+    setupLogListHandlers(network);
+    await page.goto("/");
+    await gridCell(page, "task-alpha").click();
+    await page.waitForURL(/#\/tasks\//);
+
+    const collapse = page.getByRole("button", { name: "Collapse header" });
+    await expect(collapse).toBeVisible();
+    await collapse.click();
+
+    const expand = page.getByRole("button", { name: "Expand header" });
+    await expect(expand).toBeVisible();
+    await expect(page.locator("#task-title-collapsed")).toBeVisible();
+    await expand.click();
+
+    await expect(collapse).toBeVisible();
+    await expect(page.locator("#task-title")).toBeVisible();
+  });
+
   test("Tasks view does not show folder grouping", async ({
     page,
     network,

--- a/apps/inspect/e2e/top-level-views.spec.ts
+++ b/apps/inspect/e2e/top-level-views.spec.ts
@@ -7,6 +7,11 @@
  * - Each view renders its expected content
  * - Route prefixes are preserved when navigating into a log and back
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { http, HttpResponse } from "msw";
+
 import { expect, test } from "./fixtures/app";
 import {
   columnHeader,
@@ -14,6 +19,16 @@ import {
   segmentButton,
   setupLogListHandlers,
 } from "./fixtures/log-list-scenario";
+
+const TITLE_TEST_LOG = "title-collapse.eval";
+const titleTestLogBytes = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../src/log_data/chunked/fixtures/logs/original/ais-decoder.eval",
+      import.meta.url
+    )
+  )
+);
 
 test.describe("Top-level views", () => {
   test("default route shows the Tasks view", async ({ page, network }) => {
@@ -118,13 +133,28 @@ test.describe("Top-level views", () => {
   });
 
   test("log header can be collapsed and expanded manually", async ({
-  page,
-  network,
-}) => {
-    setupLogListHandlers(network);
-    await page.goto("/");
-    await gridCell(page, "task-alpha").click();
-    await page.waitForURL(/#\/tasks\//);
+    page,
+    network,
+  }) => {
+    network.use(
+      http.get("*/api/logs", () => HttpResponse.json({ log_dir: "/logs" })),
+      http.get("*/api/log-files*", () =>
+        HttpResponse.json({
+          files: [{ name: TITLE_TEST_LOG, task: "title-collapse" }],
+          response_type: "full",
+        })
+      ),
+      http.get("*/api/log-info/:file", () =>
+        HttpResponse.json({ size: titleTestLogBytes.length })
+      ),
+      http.get("*/api/log-bytes/:file", ({ request }) => {
+        const url = new URL(request.url);
+        const start = Number(url.searchParams.get("start"));
+        const end = Number(url.searchParams.get("end"));
+        return new HttpResponse(titleTestLogBytes.subarray(start, end + 1));
+      })
+    );
+    await page.goto(`/#/tasks/${TITLE_TEST_LOG}`);
 
     const collapse = page.getByRole("button", { name: "Collapse header" });
     await expect(collapse).toBeVisible();

--- a/apps/inspect/src/app/log-view/LogView.tsx
+++ b/apps/inspect/src/app/log-view/LogView.tsx
@@ -37,6 +37,7 @@ import { useSamplesTabConfig } from "./tabs/SamplesTab";
 import { useTaskTabConfig } from "./tabs/TaskTab";
 import { useTimelineTab } from "./tabs/timeline/TimelineTab";
 import { TitleView } from "./title-view/TitleView";
+import { useManualTitleCollapse } from "./title-view/useManualTitleCollapse";
 import { TabDescriptor } from "./types";
 
 export const LogView: FC = () => {
@@ -122,9 +123,12 @@ export const LogView: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabKeys]);
 
-  const { hidden: titleCollapsed } = useScrollDirection(scrollRefs, {
+  const { hidden: autoTitleCollapsed } = useScrollDirection(scrollRefs, {
     stayHiddenOnUpScroll: true,
   });
+  const selectedLogFile = useStore((state) => state.logs.selectedLogFile);
+  const { collapsed: titleCollapsed, setCollapsed: setTitleCollapsed } =
+    useManualTitleCollapse(autoTitleCollapsed, selectedLogFile);
 
   const selectedTab = useStore((state) => state.app.tabs.workspace);
   const setSelectedTab = useStore((state) => state.appActions.setWorkspaceTab);
@@ -173,6 +177,7 @@ export const LogView: FC = () => {
           status={selectedLogDetails?.status}
           tags={selectedLogDetails?.tags}
           collapsed={titleCollapsed}
+          onCollapsedChange={setTitleCollapsed}
         />
         <div ref={divRef} className={clsx("workspace", styles.workspace)}>
           <div className={clsx("log-detail", styles.tabContainer)}>

--- a/apps/inspect/src/app/log-view/title-view/TitleView.module.css
+++ b/apps/inspect/src/app/log-view/title-view/TitleView.module.css
@@ -20,6 +20,7 @@
   width: 100%;
   display: grid;
   overflow: hidden;
+  padding-right: 2.25rem;
   transition: opacity 120ms linear;
 }
 
@@ -49,4 +50,12 @@
 .collapsedSlot > * {
   min-height: 0;
   overflow: hidden;
+}
+
+.collapseToggle {
+  position: absolute;
+  z-index: 1;
+  top: 0.2rem;
+  right: 0.25rem;
+  padding: 0.15rem 0.35rem;
 }

--- a/apps/inspect/src/app/log-view/title-view/TitleView.tsx
+++ b/apps/inspect/src/app/log-view/title-view/TitleView.tsx
@@ -7,10 +7,12 @@ import {
   EvalSpec,
   EvalStats,
 } from "@tsmono/inspect-common/types";
+import { ToolButton } from "@tsmono/react/components";
 
 import { EvalLogStatus } from "../../../@types/extraInspect";
 import { RunningMetric } from "../../../client/api/types";
 import { useTotalSampleCount } from "../../../state/hooks";
+import { ApplicationIcons } from "../../appearance/icons";
 
 import { CollapsedTitleBar } from "./CollapsedTitleBar";
 import { PrimaryBar } from "./PrimaryBar";
@@ -25,7 +27,8 @@ interface TitleViewProps {
   evalStats?: EvalStats;
   status?: EvalLogStatus;
   tags?: string[];
-  collapsed?: boolean;
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
 }
 
 /**
@@ -40,6 +43,7 @@ export const TitleView: FC<TitleViewProps> = ({
   runningMetrics,
   tags,
   collapsed,
+  onCollapsedChange,
 }) => {
   const totalSampleCount = useTotalSampleCount();
 
@@ -52,7 +56,11 @@ export const TitleView: FC<TitleViewProps> = ({
         collapsed ? styles.collapsed : undefined
       )}
     >
-      <div className={styles.expandedSlot} aria-hidden={collapsed}>
+      <div
+        id="log-title-expanded"
+        className={styles.expandedSlot}
+        aria-hidden={collapsed}
+      >
         <div className={styles.expandedInner}>
           <PrimaryBar
             evalSpec={evalSpec}
@@ -81,6 +89,20 @@ export const TitleView: FC<TitleViewProps> = ({
           sampleCount={totalSampleCount}
         />
       </div>
+      <ToolButton
+        className={styles.collapseToggle}
+        icon={
+          collapsed
+            ? ApplicationIcons.expand.down
+            : ApplicationIcons.collapse.up
+        }
+        aria-label={collapsed ? "Expand header" : "Collapse header"}
+        title={collapsed ? "Expand header" : "Collapse header"}
+        aria-controls="log-title-expanded"
+        aria-expanded={!collapsed}
+        onClick={() => onCollapsedChange(!collapsed)}
+        subtle
+      />
     </nav>
   );
 };

--- a/apps/inspect/src/app/log-view/title-view/useManualTitleCollapse.test.ts
+++ b/apps/inspect/src/app/log-view/title-view/useManualTitleCollapse.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useManualTitleCollapse } from "./useManualTitleCollapse";
+
+describe("useManualTitleCollapse", () => {
+  it("follows scrolling until the user chooses a state", () => {
+    const { result, rerender } = renderHook(
+      ({ autoCollapsed }) =>
+        useManualTitleCollapse(autoCollapsed, "first.eval"),
+      { initialProps: { autoCollapsed: false } }
+    );
+
+    rerender({ autoCollapsed: true });
+    expect(result.current.collapsed).toBe(true);
+
+    act(() => result.current.setCollapsed(false));
+    rerender({ autoCollapsed: true });
+    expect(result.current.collapsed).toBe(false);
+  });
+
+  it("returns to scroll-driven state for a different log", () => {
+    const { result, rerender } = renderHook(
+      ({ scope, autoCollapsed }) =>
+        useManualTitleCollapse(autoCollapsed, scope),
+      { initialProps: { scope: "first.eval", autoCollapsed: true } }
+    );
+
+    act(() => result.current.setCollapsed(false));
+    rerender({ scope: "second.eval", autoCollapsed: true });
+
+    expect(result.current.collapsed).toBe(true);
+  });
+});

--- a/apps/inspect/src/app/log-view/title-view/useManualTitleCollapse.ts
+++ b/apps/inspect/src/app/log-view/title-view/useManualTitleCollapse.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+
+interface ManualCollapse {
+  scope: string | undefined;
+  collapsed: boolean;
+}
+
+export const useManualTitleCollapse = (
+  autoCollapsed: boolean,
+  scope: string | undefined
+) => {
+  const [manual, setManual] = useState<ManualCollapse | null>(null);
+  const collapsed =
+    manual !== null && manual.scope === scope
+      ? manual.collapsed
+      : autoCollapsed;
+
+  const setCollapsed = useCallback(
+    (next: boolean) => setManual({ scope, collapsed: next }),
+    [scope]
+  );
+
+  return { collapsed, setCollapsed };
+};


### PR DESCRIPTION
## Summary

- add an accessible chevron control that manually collapses or expands the log header
- preserve the user's explicit choice while scroll-driven headroom state changes
- reset the explicit choice when navigating to a different log

Fixes #270.

## Validation

- `pnpm --filter @meridianlabs/log-viewer exec vitest run src/app/log-view/title-view/useManualTitleCollapse.test.ts`  -  1 file, 2 tests passed; proves manual state overrides later automatic changes and resets for another log
- `pnpm exec playwright test e2e/top-level-views.spec.ts --config playwright.config.ts --grep "log header can be collapsed"`  -  1 Chromium test passed
- `pnpm exec playwright test e2e/top-level-views.spec.ts --config playwright.config.ts`  -  all 15 neighboring Chromium tests passed
- `pnpm --filter @meridianlabs/log-viewer test`  -  114 files, 1,180 tests passed
- `pnpm --filter @meridianlabs/log-viewer build`  -  production bundle built successfully
- `pnpm check`  -  33 tasks passed
- `pnpm test`  -  9 workspace tasks passed
- commit and pre-push hooks  -  lint, format, and check passed

## Visual verification

- inspected expanded and collapsed layouts in Chromium at 1280×720
- the control uses existing Bootstrap/tool-button styling and theme variables; no themed colors were introduced

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme before: expanded log header without a manual collapse control](https://raw.githubusercontent.com/deepujain/ts-mono/pr-assets-270/.pr-assets/270/before-light.png) | ![Light theme after: expanded log header with the new collapse control](https://raw.githubusercontent.com/deepujain/ts-mono/pr-assets-270/.pr-assets/270/after-light.png) |
| Dark | ![Dark theme before: expanded log header without a manual collapse control](https://raw.githubusercontent.com/deepujain/ts-mono/pr-assets-270/.pr-assets/270/before-dark.png) | ![Dark theme after: collapsed log header with the new expand control](https://raw.githubusercontent.com/deepujain/ts-mono/pr-assets-270/.pr-assets/270/after-dark.png) |

## Risk

- the manual choice is scoped to the active log and intentionally returns to scroll-driven behavior after navigating to another log