### PR TITLE
Document React Compiler memoization conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,34 @@ Design docs live per-app; consult them when working in the relevant area:
   remove those guards until their boundary normalizes; the suppression
   comment names the surface.
 
+## Code Style — React Compiler & Memoization
+
+  **React Compiler is enabled** in both apps' vite builds (SWC
+  `reactCompiler`, see #536). It auto-memoizes components and hooks, so
+  manual memoization is dead weight in new code:
+
+  - Do NOT write `useMemo`, `useCallback`, or `React.memo` for
+    performance. Write plain functions and values; the compiler inserts
+    memoization finer-grained than hand-written deps arrays.
+  - Much existing code predates the compiler and memoizes everything —
+    do not copy that style into new code.
+  - The remaining legitimate use is referential identity as a
+    *correctness* requirement TypeScript/compiler can't see (e.g. a
+    render-time cache like `useKeyedMemo`/`useStableValue`, marked
+    `"use no memo"`). Those carry a comment saying why.
+  - The compiler bails out per-function; in a bailed-out component,
+    existing manual memoization is load-bearing. Don't bulk-strip
+    `useMemo`/`useCallback` from code you aren't otherwise changing, and
+    before removing it from a component you are changing, confirm the
+    component compiles (React DevTools shows a ✨ badge; the
+    `react-hooks` ESLint rules flag most bail-out causes).
+  - Unsupported syntax anywhere in a component/hook body bails out the
+    whole function — keep gnarly imperative code (`try/finally`,
+    mutation-heavy loops, `for await`) in module-level helpers instead
+    of inline in the component.
+  - Vitest runs uncompiled code (the SWC plugin is vite-only); only e2e
+    and the real apps exercise compiled output.
+
 ## Code Style — Comments                                                       
                                                                                 
   Add comments only for non-obvious decisions:                                  


### PR DESCRIPTION
React Compiler has been on in both apps since #536, but AGENTS.md (and via symlink CLAUDE.md) still described nothing about it — so agents keep replicating the pre-compiler style of wrapping everything in `useMemo`/`useCallback`, since that's what the surrounding code shows them.

Adds a **Code Style — React Compiler & Memoization** section covering:

- The compiler is enabled (SWC `reactCompiler` in both apps' vite builds) and auto-memoizes — new code must not use `useMemo`/`useCallback`/`React.memo` for performance, and must not copy the pre-compiler style of the existing code.
- The one remaining legitimate use: referential identity as a correctness requirement (the `"use no memo"` render-time caches like `useKeyedMemo`/`useStableValue`), always with a why-comment.
- Why existing memoization must **not** be bulk-stripped: the compiler bails out per-function, and in a bailed-out component the manual memoization is load-bearing. A repo-wide analysis with the reference `babel-plugin-react-compiler` found ~92% of functions compile, with the 63 bail-out sites concentrated in the hottest components (`SampleDisplay`, `TranscriptPanel`, both `DataGrid`s, `VirtualList`, `TranscriptViewNodes`, `EventPanel`). Removal is opportunistic and per-component, after confirming the component compiles.
- Whole-function bail-out semantics of unsupported syntax (keep `try/finally`, mutation-heavy loops, `for await` in module-level helpers).
- Vitest runs uncompiled code — only e2e and the real apps exercise compiled output.

Docs-only change; no code affected. A companion PR will follow with mechanical fixes for the compiler-unsupported-syntax bail-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdJMGhgZqwoxz6pxcVmMbN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdJMGhgZqwoxz6pxcVmMbN)_