### PR TITLE
Consolidate setup docs into a proper root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ pointing at a local checkout (see [Generated types](#generated-types)).
 ## Getting started
 
 Requires Node.js >= 22.13. pnpm is the only supported package manager, and
-[corepack](https://nodejs.org/api/corepack.html) (built into Node.js) installs
-the pinned version for you:
+[corepack](https://nodejs.org/api/corepack.html) installs the pinned version
+for you (corepack ships with Node.js 22/24; Node 25+ no longer bundles it —
+`npm install -g corepack` first):
 
 ```bash
 corepack enable   # once
@@ -45,13 +46,18 @@ across workspaces:
 | `pnpm typecheck` | Typecheck only                                       |
 | `pnpm format`    | Format with Prettier                                 |
 
-Scope any of these to one workspace with `--filter`:
+Scope any of these to one workspace with `--filter`. Extra args to the root
+scripts pass through to `turbo run`, so Turbo's task graph still applies
+(e.g. `generate:css` runs before `lint`/`typecheck`):
 
 ```bash
-pnpm --filter scout dev
-pnpm --filter @meridianlabs/log-viewer test
-pnpm --filter @tsmono/inspect-common typecheck
+pnpm dev --filter=scout
+pnpm test --filter=@meridianlabs/log-viewer
+pnpm check --filter=scout
 ```
+
+(Prefer this over `pnpm --filter <workspace> <script>`, which runs the leaf
+script directly and skips Turbo's dependency graph.)
 
 Workspace scripts are single-concern leaf commands; all composition lives in
 `turbo.json` — see [scripts.md](docs/scripts.md) for the conventions.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-See [AGENTS.md](AGENTS.md)
+# ts-mono
+
+TypeScript monorepo powering the web UIs of
+[Inspect AI](https://inspect.aisi.org.uk/) and
+[Inspect Scout](https://github.com/meridianlabs-ai/inspect_scout): the eval
+log viewer, the Scout viewer, and the shared packages behind them.
+
+## How this repo is consumed
+
+Parent repos (`inspect_ai`, `inspect_scout`) embed this monorepo as a **git
+submodule** and commit the built output, so Python contributors and end users
+never need Node.js. If you're doing frontend work inside a parent repo, read
+the [submodule guide](docs/submodule-guide.md) — it covers setup, keeping the
+submodule in sync, and the build-and-bump workflow.
+
+You can also clone and develop this repo standalone. The one caveat: type
+generation reads OpenAPI schemas from the Python repos, so `types:generate`
+needs either submodule mode or a `TSMONO_PYTHON_ROOT_*` environment variable
+pointing at a local checkout (see [Generated types](#generated-types)).
+
+## Getting started
+
+Requires Node.js >= 22.13. pnpm is the only supported package manager, and
+[corepack](https://nodejs.org/api/corepack.html) (built into Node.js) installs
+the pinned version for you:
+
+```bash
+corepack enable   # once
+pnpm install
+```
+
+## Common commands
+
+Run everything from the repo root — [Turbo](https://turbo.build/) orchestrates
+across workspaces:
+
+| Command          | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| `pnpm dev`       | Start dev servers (inspect on :5173, scout on :5174) |
+| `pnpm build`     | Build all workspaces                                 |
+| `pnpm test`      | Run unit/integration tests (vitest)                  |
+| `pnpm e2e`       | Run Playwright e2e tests                             |
+| `pnpm check`     | Lint, typecheck, format check, manypkg check         |
+| `pnpm lint`      | Lint only                                            |
+| `pnpm typecheck` | Typecheck only                                       |
+| `pnpm format`    | Format with Prettier                                 |
+
+Scope any of these to one workspace with `--filter`:
+
+```bash
+pnpm --filter scout dev
+pnpm --filter @meridianlabs/log-viewer test
+pnpm --filter @tsmono/inspect-common typecheck
+```
+
+Workspace scripts are single-concern leaf commands; all composition lives in
+`turbo.json` — see [scripts.md](docs/scripts.md) for the conventions.
+
+## Workspaces
+
+| Workspace                                              | Purpose                                                                                                       |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| [`apps/inspect`](apps/inspect/README.md)               | Inspect log viewer — runs standalone, statically hosted, in VS Code, or embedded via `@meridianlabs/log-viewer` |
+| [`apps/scout`](apps/scout/README.md)                   | Inspect Scout viewer — browse scans, scanner results, and transcripts                                          |
+| [`packages/inspect-common`](packages/inspect-common)   | Shared non-UI code for eval logs: generated API types, boundary normalization, query builder, test fixtures    |
+| [`packages/inspect-components`](packages/inspect-components) | Shared React components for rendering eval logs (chat, transcript, content, usage, …)                    |
+| [`packages/scout-components`](packages/scout-components) | React components shared across Scout surfaces                                                                |
+| [`packages/react`](packages/react)                     | Shared React infrastructure: hooks, components, icons, virtualization, react-query helpers                     |
+| [`packages/theme`](packages/theme)                     | Theme layer bridging Bootstrap tokens and VS Code webview variables                                            |
+| [`packages/util`](packages/util)                       | General TypeScript utilities (barrel export — import from the package root)                                    |
+| [`packages/zustand-devtools`](packages/zustand-devtools) | Dev panel for inspecting zustand stores                                                                      |
+| `tooling/*`                                            | Shared eslint, prettier, tsconfig, and vite configs                                                            |
+
+## Generated types
+
+API types are generated from OpenAPI schemas exported by the Python repos —
+no schema copies are committed here:
+
+- **`apps/scout`** generates from inspect_scout's `openapi.json`
+- **`packages/inspect-common`** generates from inspect_ai's
+  `inspect-openapi.json`
+
+Run `pnpm types:generate` in the relevant workspace after the Python API
+changes. Each workspace's README documents its pipeline; the parent repos' CI
+validates that committed schemas and generated types stay in sync.
+
+## Documentation
+
+- [Submodule guide](docs/submodule-guide.md) — developing inside a parent repo
+- [Script conventions](docs/scripts.md) — Turbo orchestration and workspace scripts
+- [AGENTS.md](AGENTS.md) — code style, testing, and type-safety conventions
+  (written for coding agents; the rules apply to humans too)
+- Design docs live per-app:
+  - [Viewer startup/data-layer domain ownership](apps/inspect/design/domain-ownership.md) (inspect)
+  - [Frontend testing: integration tests + MSW](apps/scout/design/front-end-testing.md) (scout)
+  - [React Query patterns](apps/scout/design/react-query.md) (scout)

--- a/apps/inspect/README.md
+++ b/apps/inspect/README.md
@@ -7,14 +7,18 @@ Inspect VS Code extension, and can be embedded in external applications via
 the [`@meridianlabs/log-viewer`](https://www.npmjs.com/package/@meridianlabs/log-viewer)
 npm package.
 
+For repo setup (corepack, pnpm, install), see the
+[root README](../../README.md).
+
 ## Development
 
-Run commands from this directory (or orchestrate from the repo root via
-Turbo — see [scripts.md](../../docs/scripts.md)):
+Run commands from this directory, or from the repo root with
+`pnpm --filter @meridianlabs/log-viewer <command>` (see
+[scripts.md](../../docs/scripts.md) for Turbo orchestration):
 
 | Command          | Description                               |
 | ---------------- | ----------------------------------------- |
-| `pnpm dev`       | Start the Vite dev server                 |
+| `pnpm dev`       | Start the Vite dev server on :5173        |
 | `pnpm build`     | Build the bundled app                     |
 | `pnpm build:lib` | Build the embeddable library into `lib/`  |
 | `pnpm test`      | Run unit/integration tests (vitest)       |

--- a/apps/inspect/README.md
+++ b/apps/inspect/README.md
@@ -13,8 +13,9 @@ For repo setup (corepack, pnpm, install), see the
 ## Development
 
 Run commands from this directory, or from the repo root with
-`pnpm --filter @meridianlabs/log-viewer <command>` (see
-[scripts.md](../../docs/scripts.md) for Turbo orchestration):
+`pnpm <command> --filter=@meridianlabs/log-viewer` (the root scripts pass the
+filter through to `turbo run`, preserving task dependencies — see
+[scripts.md](../../docs/scripts.md)):
 
 | Command          | Description                               |
 | ---------------- | ----------------------------------------- |

--- a/apps/scout/README.md
+++ b/apps/scout/README.md
@@ -1,115 +1,56 @@
 # Inspect Scout Viewer
 
-A React-based web viewer for Inspect AI evaluation logs.
+React web app for
+[Inspect Scout](https://github.com/meridianlabs-ai/inspect_scout) — browse
+scans, scanner results, and transcripts. The production build is copied into
+the inspect_scout Python package (via the
+[submodule workflow](../../docs/submodule-guide.md)) and served by Scout's
+view server.
 
-## Prerequisites
-
-This project uses [pnpm](https://pnpm.io/) as its package manager, managed through [corepack](https://nodejs.org/api/corepack.html).
-
-### Setup
-
-**Enable corepack** (required once):
-
-```bash
-corepack enable
-```
-
-That's it! Corepack is built into Node.js 16.9+ and will automatically install the correct pnpm version (specified in `package.json`) when you run pnpm commands.
-
-**Alternative:** If you prefer to install pnpm manually, see the [official pnpm installation guide](https://pnpm.io/installation).
-
-### Install Dependencies
-
-```bash
-pnpm install
-```
+For repo setup (corepack, pnpm, install), see the
+[root README](../../README.md).
 
 ## Development
 
-Start the development server:
+Run commands from this directory, or from the repo root with
+`pnpm --filter scout <command>`:
 
-```bash
-pnpm dev
-```
+| Command           | Description                                        |
+| ----------------- | -------------------------------------------------- |
+| `pnpm dev`        | Start the Vite dev server on :5174                 |
+| `pnpm build`      | Build the app (copies output into the Python repo) |
+| `pnpm watch`      | Rebuild on change                                  |
+| `pnpm test`       | Run unit/integration tests (vitest)                |
+| `pnpm test:watch` | Run tests in watch mode                            |
+| `pnpm e2e`        | Run Playwright e2e tests (`e2e:ui`, `e2e:headed`)  |
+| `pnpm lint`       | Lint (`lint:fix` to auto-fix)                      |
+| `pnpm typecheck`  | Type check                                         |
+| `pnpm format`     | Format with Prettier                               |
 
-Build for production:
+The dev server proxies `/api` to a Scout view server expected at
+`http://127.0.0.1:7576`.
 
-```bash
-pnpm build
-```
+## TypeScript types from OpenAPI
 
-Watch mode for development:
-
-```bash
-pnpm watch
-```
-
-Preview production build:
-
-```bash
-pnpm preview
-```
-
-## Code Quality
-
-Run linting:
-
-```bash
-pnpm lint
-```
-
-Auto-fix linting issues:
-
-```bash
-pnpm lint:fix
-```
-
-Format code:
-
-```bash
-pnpm format
-```
-
-Check formatting:
-
-```bash
-pnpm format:check
-```
-
-Type check:
-
-```bash
-pnpm typecheck
-```
-
-Run all checks (lint, format, typecheck):
-
-```bash
-pnpm check
-```
-
-## TypeScript Types from OpenAPI
-
-Types are auto-generated from the FastAPI OpenAPI spec to keep client/server in sync.
-
-### How It Works
-
-The type generation pipeline:
+API types are generated from inspect_scout's FastAPI OpenAPI spec to keep
+client and server in sync:
 
 ```
-Python Pydantic models → openapi.json (in inspect_scout) → generated.ts → built app
+Python Pydantic models → openapi.json (in inspect_scout) → src/types/generated.ts
 ```
 
-1. **Schema source**: The OpenAPI schema lives in the inspect_scout Python
-   repo at `src/inspect_scout/_view/openapi.json` — no copy is committed here
+1. **Schema source**: the schema lives in the inspect_scout Python repo at
+   `src/inspect_scout/_view/openapi.json` — no copy is committed here
 2. **Generate types**: `scripts/generate-types.js` locates the Python repo
    (requires running ts-mono as a submodule of inspect_scout, or setting
-   `TSMONO_PYTHON_ROOT_INSPECT_SCOUT` to a local inspect_scout checkout) and
-   runs `openapi-typescript` against the schema
+   `TSMONO_PYTHON_ROOT_INSPECT_SCOUT` to a local checkout) and runs
+   `openapi-typescript` against the schema
 3. **Type adapter**: `src/types/api-types.ts` re-exports types with clean names
-4. **Usage**: Import types from `src/types/index.ts` in your code
+4. **Usage**: import types from `src/types/index.ts`
 
-### Updating Types After API Changes
+(`packages/inspect-common` has a parallel pipeline for inspect_ai's schema.)
+
+### Updating types after API changes
 
 When Python Pydantic models change:
 
@@ -122,18 +63,11 @@ pnpm types:generate
 ```
 
 Commit the updated schema in inspect_scout and `src/types/generated.ts` here.
+inspect_scout's CI regenerates both and fails if they differ from what's
+committed.
 
-### CI Validation
+## Tech stack
 
-Schema and generated-type freshness is validated by inspect_scout's CI, which
-regenerates the files and fails if they differ from the committed versions. If
-that fails, run the commands above and commit the updated files.
-
-## Tech Stack
-
-- React 19
-- TypeScript
-- Vite
-- Bootstrap 5
-- AG Grid
-- React Router
+React 19, TypeScript, Vite, react-router, zustand, TanStack
+(Query/Table/Virtual), Bootstrap 5, vitest + MSW, Playwright. AG Grid remains
+in the dataframe view only — new tables use TanStack Table.

--- a/apps/scout/README.md
+++ b/apps/scout/README.md
@@ -13,12 +13,13 @@ For repo setup (corepack, pnpm, install), see the
 ## Development
 
 Run commands from this directory, or from the repo root with
-`pnpm --filter scout <command>`:
+`pnpm <command> --filter=scout` (the root scripts pass the filter through to
+`turbo run`, preserving task dependencies):
 
 | Command           | Description                                        |
 | ----------------- | -------------------------------------------------- |
 | `pnpm dev`        | Start the Vite dev server on :5174                 |
-| `pnpm build`      | Build the app (copies output into the Python repo) |
+| `pnpm build`      | Build the app (copied into the Python repo when running as a submodule) |
 | `pnpm watch`      | Rebuild on change                                  |
 | `pnpm test`       | Run unit/integration tests (vitest)                |
 | `pnpm test:watch` | Run tests in watch mode                            |
@@ -46,7 +47,7 @@ Python Pydantic models → openapi.json (in inspect_scout) → src/types/generat
    `TSMONO_PYTHON_ROOT_INSPECT_SCOUT` to a local checkout) and runs
    `openapi-typescript` against the schema
 3. **Type adapter**: `src/types/api-types.ts` re-exports types with clean names
-4. **Usage**: import types from `src/types/index.ts`
+4. **Usage**: import types from `src/types/api-types.ts`
 
 (`packages/inspect-common` has a parallel pipeline for inspect_ai's schema.)
 

--- a/packages/inspect-common/README.md
+++ b/packages/inspect-common/README.md
@@ -1,0 +1,36 @@
+# @tsmono/inspect-common
+
+Shared non-UI code for working with Inspect AI eval logs: generated API
+types, boundary normalization (`/normalize`), a query/condition builder
+(`/query`), and test fixtures (`/testing`).
+
+## TypeScript types from OpenAPI
+
+Types in `src/types/generated.ts` are generated from inspect_ai's OpenAPI
+schema — no schema copy is committed here:
+
+```
+Python Pydantic models → inspect-openapi.json (in inspect_ai) → src/types/generated.ts
+```
+
+`scripts/generate-types.js` locates the Python repo (requires running ts-mono
+as a submodule of inspect_ai, or setting `TSMONO_PYTHON_ROOT_INSPECT_AI` to a
+local checkout) and runs `openapi-typescript` against
+`src/inspect_ai/_view/inspect-openapi.json`.
+
+When Python models change, re-export the schema in inspect_ai, then:
+
+```bash
+pnpm types:generate
+```
+
+and commit the updated `generated.ts`. (`apps/scout` has a parallel pipeline
+for inspect_scout's schema.)
+
+## Normalization
+
+Raw eval-log/journal JSON must pass through `/normalize`
+(`normalizeEvalSample`, `normalizeEvents`, …) at the parse boundary before
+the generated types can be trusted — old files omit fields the schema
+declares required. See the type-safety section in
+[AGENTS.md](../../AGENTS.md).


### PR DESCRIPTION
The root README was a one-line pointer to AGENTS.md, while repo setup (corepack, pnpm) lived only in apps/scout/README.md — a pre-monorepo holdover whose commands read as if scout were standalone.

- Root README: what the repo is, submodule consumption model, workspace map, setup, root-level Turbo commands with --filter examples, and a docs index
- apps/scout/README.md: identity paragraph, command table from actual scripts (test/e2e were missing), refreshed tech stack (TanStack, zustand, vitest/MSW; AG Grid is dataframe-view-only now)
- apps/inspect/README.md: point at root README for setup, note dev port
- packages/inspect-common/README.md: new — documents the inspect_ai type-generation pipeline, previously undocumented