### PR TITLE
Rewrite compiler-unsupported syntax so 15 more files compile (React Compiler)

### DIFF
--- a/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
+++ b/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
@@ -40,8 +40,6 @@ export const ViewerOptionsPopover: FC<ViewerOptionsPopoverProps> = ({
       setClearMessage("Failed to clear database");
       setTimeout(() => setClearMessage(null), 3000);
     }
-    // Not a finally clause: React Compiler can't lower try/finally, and the
-    // catch never rethrows, so running after the block is equivalent.
     setIsClearing(false);
   };
 

--- a/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
+++ b/apps/inspect/src/app/log-list/ViewerOptionsPopover.tsx
@@ -39,9 +39,10 @@ export const ViewerOptionsPopover: FC<ViewerOptionsPopoverProps> = ({
       console.error("Failed to clear database:", error);
       setClearMessage("Failed to clear database");
       setTimeout(() => setClearMessage(null), 3000);
-    } finally {
-      setIsClearing(false);
     }
+    // Not a finally clause: React Compiler can't lower try/finally, and the
+    // catch never rethrows, so running after the block is equivalent.
+    setIsClearing(false);
   };
 
   return (

--- a/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
@@ -362,8 +362,6 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
         setError(formatEditError(err));
       }
     }
-    // Not a finally clause: React Compiler can't lower try/finally, and the
-    // catch never rethrows, so running after the block is equivalent.
     window.clearTimeout(indicatorTimer);
     setSubmitting(false);
     inFlightRef.current = false;

--- a/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditMetadataDialog.tsx
@@ -119,6 +119,17 @@ export const serializeEntry = (entry: MetaEntry): unknown => {
   }
 };
 
+// Module-level so the dialog stays compilable: React Compiler can't lower
+// loops inside try/catch, and serializeEntry must run under the catch that
+// classifies MetadataParseError.
+const buildMetadataSet = (entries: MetaEntry[]): Record<string, unknown> => {
+  const metadata_set: Record<string, unknown> = {};
+  for (const entry of entries) {
+    metadata_set[entry.key] = serializeEntry(entry);
+  }
+  return metadata_set;
+};
+
 const seedFor = (type: NewType): unknown => {
   switch (type) {
     case "string":
@@ -312,13 +323,19 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
     // Don't clear `error` here — see EditTagsDialog for the no-flash
     // rationale. Delayed "Saving…" indicator likewise.
     const indicatorTimer = window.setTimeout(() => setSubmitting(true), 200);
+    // Hoisted out of the try: React Compiler can't lower value blocks
+    // (||, ?., ternaries) inside try/catch and would bail out. Only
+    // serializeEntry stays inside — its MetadataParseError is what the
+    // catch classifies.
+    const changedEntries = entries.filter((e) => e.isNew || e.dirty);
+    const provenance = {
+      author: author.trim(),
+      reason: reason.trim() || undefined,
+      metadata: {},
+      timestamp: new Date().toISOString(),
+    };
     try {
-      const metadata_set: Record<string, unknown> = {};
-      for (const entry of entries) {
-        if (entry.isNew || entry.dirty) {
-          metadata_set[entry.key] = serializeEntry(entry);
-        }
-      }
+      const metadata_set = buildMetadataSet(changedEntries);
       const edit: MetadataEdit = {
         type: "metadata",
         metadata_set,
@@ -326,15 +343,12 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
       };
       await api.edit_log(logFile, {
         edits: [edit],
-        provenance: {
-          author: author.trim(),
-          reason: reason.trim() || undefined,
-          metadata: {},
-          timestamp: new Date().toISOString(),
-        },
+        provenance,
       });
       setShowing(false);
-      onSaved?.();
+      if (onSaved) {
+        onSaved();
+      }
     } catch (err) {
       if (err instanceof MetadataParseError) {
         // Show a per-key message and bail out before any network call.
@@ -347,11 +361,12 @@ export const EditMetadataDialog: FC<EditMetadataDialogProps> = ({
       } else {
         setError(formatEditError(err));
       }
-    } finally {
-      window.clearTimeout(indicatorTimer);
-      setSubmitting(false);
-      inFlightRef.current = false;
     }
+    // Not a finally clause: React Compiler can't lower try/finally, and the
+    // catch never rethrows, so running after the block is equivalent.
+    window.clearTimeout(indicatorTimer);
+    setSubmitting(false);
+    inFlightRef.current = false;
   };
 
   return (

--- a/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
@@ -166,8 +166,6 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
     } catch (err) {
       setError(formatEditError(err));
     }
-    // Not a finally clause: React Compiler can't lower try/finally, and the
-    // catch never rethrows, so running after the block is equivalent.
     window.clearTimeout(indicatorTimer);
     setSubmitting(false);
     inFlightRef.current = false;

--- a/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
+++ b/apps/inspect/src/app/log-view/title-view/EditTagsDialog.tsx
@@ -141,6 +141,14 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
     // before any network IO) don't flash the indicator on and off.
     // For slower saves the indicator still appears.
     const indicatorTimer = window.setTimeout(() => setSubmitting(true), 200);
+    // Hoisted out of the try: React Compiler can't lower value blocks
+    // (||, ?.) inside try/catch and would bail out the component.
+    const provenance = {
+      author: author.trim(),
+      reason: reason.trim() || undefined,
+      metadata: {},
+      timestamp: new Date().toISOString(),
+    };
     try {
       const edit: TagsEdit = {
         type: "tags",
@@ -149,22 +157,20 @@ export const EditTagsDialog: FC<EditTagsDialogProps> = ({
       };
       await api.edit_log(logFile, {
         edits: [edit],
-        provenance: {
-          author: author.trim(),
-          reason: reason.trim() || undefined,
-          metadata: {},
-          timestamp: new Date().toISOString(),
-        },
+        provenance,
       });
       setShowing(false);
-      onSaved?.();
+      if (onSaved) {
+        onSaved();
+      }
     } catch (err) {
       setError(formatEditError(err));
-    } finally {
-      window.clearTimeout(indicatorTimer);
-      setSubmitting(false);
-      inFlightRef.current = false;
     }
+    // Not a finally clause: React Compiler can't lower try/finally, and the
+    // catch never rethrows, so running after the block is equivalent.
+    window.clearTimeout(indicatorTimer);
+    setSubmitting(false);
+    inFlightRef.current = false;
   };
 
   return (

--- a/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
+++ b/apps/inspect/src/app/log-view/title-view/ScoreGrid.tsx
@@ -130,7 +130,11 @@ const ScoreGroupTable: FC<ScoreGroupTableProps> = ({
     const metricColumns: ColumnDef<ScoreGridFeatures, ScoreGridRow>[] = [];
     let idx = 0;
     for (const [runIdx, run] of runs.entries()) {
-      const children = run.metrics.map((m) => leafCol(m.name, idx++));
+      // Indexing arithmetic (not idx++ in the lambda) keeps this compilable
+      // by React Compiler, which can't lower captured UpdateExpressions.
+      const runStart = idx;
+      const children = run.metrics.map((m, i) => leafCol(m.name, runStart + i));
+      idx += run.metrics.length;
       if (isGroupRun(run)) {
         metricColumns.push({
           id: `group_${runIdx}`,

--- a/apps/inspect/src/app/log-view/useShowTimeline.ts
+++ b/apps/inspect/src/app/log-view/useShowTimeline.ts
@@ -88,9 +88,10 @@ export const useShowTimelineForModel = (): ((
       const newTab =
         !!event && (event.metaKey || event.ctrlKey || event.shiftKey);
       if (!newTab) {
+        const bandId = timelineBandId("connections", model);
         setPropertyValue(kTimelineBag, bandsKey, {
           ...bands,
-          [timelineBandId("connections", model)]: true,
+          [bandId]: true,
         });
       }
       showTimeline(event);

--- a/apps/inspect/src/components/DownloadLogButton.tsx
+++ b/apps/inspect/src/components/DownloadLogButton.tsx
@@ -34,8 +34,6 @@ export const DownloadLogButton = ({
       console.error("Failed to download log:", error);
       setDownloadState("error");
     }
-    // Not a finally clause: React Compiler can't lower try/finally, and the
-    // catch never rethrows, so running after the block is equivalent.
     setTimeout(() => {
       setDownloadState("idle");
     }, 1250);

--- a/apps/inspect/src/components/DownloadLogButton.tsx
+++ b/apps/inspect/src/components/DownloadLogButton.tsx
@@ -33,11 +33,12 @@ export const DownloadLogButton = ({
     } catch (error) {
       console.error("Failed to download log:", error);
       setDownloadState("error");
-    } finally {
-      setTimeout(() => {
-        setDownloadState("idle");
-      }, 1250);
     }
+    // Not a finally clause: React Compiler can't lower try/finally, and the
+    // catch never rethrows, so running after the block is equivalent.
+    setTimeout(() => {
+      setDownloadState("idle");
+    }, 1250);
   };
 
   const getIcon = (): string => {

--- a/apps/inspect/src/log_data/chunkedSampleQuery.ts
+++ b/apps/inspect/src/log_data/chunkedSampleQuery.ts
@@ -88,9 +88,15 @@ export const useChunkedSample = (
     queryKey: chunkedSampleQueryKey(handle),
     queryFn: handle
       ? async (): Promise<ChunkedSampleData | null> => {
+          // The api guard lives outside the try: React Compiler can't lower
+          // value blocks (?. here) inside try/catch and would bail out.
+          const api = getApi();
+          if (!api.get_log_zip_access) {
+            return null;
+          }
           let zip;
           try {
-            zip = await getApi().get_log_zip_access?.(handle.logFile);
+            zip = await api.get_log_zip_access(handle.logFile);
           } catch {
             return null;
           }

--- a/apps/inspect/src/log_data/messagesExport.ts
+++ b/apps/inspect/src/log_data/messagesExport.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { type SampleMessagesData } from "./messageRows";
 import { type EvalSampleData } from "./sampleData";
 import { sampleMessagesSource } from "./sampleMessagesSource";
 
@@ -21,11 +22,17 @@ export const useMessagesExport = (
     if (!source) {
       return undefined;
     }
-    return async () => {
-      const parts: string[] = [];
-      for await (const part of source.exportText()) {
-        parts.push(part);
-      }
-      return parts;
-    };
+    return () => collectExportText(source);
   }, [sampleData]);
+
+// Module-level so the hook stays compilable: React Compiler can't lower
+// for-await inside a component/hook body.
+const collectExportText = async (
+  source: SampleMessagesData
+): Promise<string[]> => {
+  const parts: string[] = [];
+  for await (const part of source.exportText()) {
+    parts.push(part);
+  }
+  return parts;
+};

--- a/apps/scout/src/app/components/columnSizing/index.ts
+++ b/apps/scout/src/app/components/columnSizing/index.ts
@@ -2,6 +2,7 @@ export {
   clampSize,
   getColumnConstraints,
   getColumnId,
+  mergeCalculatedSizing,
   DEFAULT_MAX_SIZE,
   DEFAULT_MIN_SIZE,
   DEFAULT_SIZE,

--- a/apps/scout/src/app/components/columnSizing/types.ts
+++ b/apps/scout/src/app/components/columnSizing/types.ts
@@ -73,6 +73,28 @@ export function clampSize(
 }
 
 /**
+ * Merge freshly calculated sizes with the current sizing state: calculated
+ * sizes win except for manually resized columns, whose current size is
+ * preserved. Module-level (not inline in the hooks) so they stay compilable:
+ * React Compiler can't lower loops inside try/catch.
+ */
+export function mergeCalculatedSizing(
+  calculatedSizing: ColumnSizingState,
+  resizedSet: Set<string>,
+  currentSizing: ColumnSizingState
+): ColumnSizingState {
+  const newSizing: ColumnSizingState = {};
+  for (const [columnId, size] of Object.entries(calculatedSizing)) {
+    if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
+      newSizing[columnId] = currentSizing[columnId];
+    } else {
+      newSizing[columnId] = size;
+    }
+  }
+  return newSizing;
+}
+
+/**
  * Get the column ID from a column definition.
  */
 export function getColumnId<TData extends RowData>(

--- a/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeCSVButtons.tsx
+++ b/apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeCSVButtons.tsx
@@ -111,13 +111,15 @@ export const ScannerDataframeDownloadCSVButton: FC = () => {
   const handleDownload = useCallback(() => {
     if (!gridApi) return;
 
+    // Hoisted out of the try: React Compiler can't lower value blocks
+    // (?? here) inside try/catch and would bail out the component.
+    const scannerName = sanitizeFilename(selectedScanner ?? "scan");
+    // Use visible columns from column selector, falling back to defaults
+    const columnKeys = visibleColumns ?? defaultColumns;
+
     try {
       const timestamp = getFileTimestamp();
-      const scannerName = sanitizeFilename(selectedScanner ?? "scan");
       const fileName = `${scannerName}_${timestamp}.csv`;
-
-      // Use visible columns from column selector, falling back to defaults
-      const columnKeys = visibleColumns ?? defaultColumns;
 
       gridApi.exportDataAsCsv({ fileName, columnKeys });
       setStatus("success");

--- a/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
@@ -40,6 +40,25 @@ interface UseColumnSizingResult {
  * Hook for managing column sizing with min/max constraints and auto-sizing.
  * Manually resized columns are preserved during auto-sizing operations.
  */
+// Merge: use calculated sizes for non-manually-resized columns, preserve
+// existing sizes for manually resized columns. Module-level so the hook
+// stays compilable: React Compiler can't lower loops inside try/catch.
+const mergeCalculatedSizing = (
+  calculatedSizing: ColumnSizingState,
+  resizedSet: Set<string>,
+  currentSizing: ColumnSizingState
+): ColumnSizingState => {
+  const newSizing: ColumnSizingState = {};
+  for (const [columnId, size] of Object.entries(calculatedSizing)) {
+    if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
+      newSizing[columnId] = currentSizing[columnId];
+    } else {
+      newSizing[columnId] = size;
+    }
+  }
+  return newSizing;
+};
+
 export function useColumnSizing({
   columns,
   tableRef,
@@ -169,26 +188,23 @@ export function useColumnSizing({
         constraints,
       });
 
-      // Merge: use calculated sizes for non-manually-resized columns,
-      // preserve existing sizes for manually resized columns
-      const newSizing: ColumnSizingState = {};
-      for (const [columnId, size] of Object.entries(calculatedSizing)) {
-        if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
-          // Preserve manually resized column's current size
-          newSizing[columnId] = currentSizing[columnId];
-        } else {
-          // Use calculated size
-          newSizing[columnId] = size;
-        }
-      }
+      const newSizing = mergeCalculatedSizing(
+        calculatedSizing,
+        resizedSet,
+        currentSizing
+      );
 
       setTableState((prev) => ({
         ...prev,
         columnSizing: newSizing,
       }));
-    } finally {
+    } catch (err) {
+      // Rethrowing catch instead of finally: React Compiler can't lower
+      // try/finally, and the ref reset must survive a computeSizes throw.
       isAutoSizingRef.current = false;
+      throw err;
     }
+    isAutoSizingRef.current = false;
   }, [tableRef, setTableState]);
 
   // Reset a single column to its auto-calculated size
@@ -230,9 +246,13 @@ export function useColumnSizing({
             };
           });
         }
-      } finally {
+      } catch (err) {
+        // Rethrowing catch instead of finally: React Compiler can't lower
+        // try/finally, and the ref reset must survive a computeSizes throw.
         isAutoSizingRef.current = false;
+        throw err;
       }
+      isAutoSizingRef.current = false;
     },
     [tableRef, setTableState]
   );

--- a/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/scans/columnSizing/useColumnSizing.ts
@@ -7,6 +7,7 @@ import {
   ColumnSizingStrategyKey,
   getColumnConstraints,
   getSizingStrategy,
+  mergeCalculatedSizing,
 } from "../../components/columnSizing";
 import { ScanColumn, ScanRow } from "../columns";
 
@@ -40,25 +41,6 @@ interface UseColumnSizingResult {
  * Hook for managing column sizing with min/max constraints and auto-sizing.
  * Manually resized columns are preserved during auto-sizing operations.
  */
-// Merge: use calculated sizes for non-manually-resized columns, preserve
-// existing sizes for manually resized columns. Module-level so the hook
-// stays compilable: React Compiler can't lower loops inside try/catch.
-const mergeCalculatedSizing = (
-  calculatedSizing: ColumnSizingState,
-  resizedSet: Set<string>,
-  currentSizing: ColumnSizingState
-): ColumnSizingState => {
-  const newSizing: ColumnSizingState = {};
-  for (const [columnId, size] of Object.entries(calculatedSizing)) {
-    if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
-      newSizing[columnId] = currentSizing[columnId];
-    } else {
-      newSizing[columnId] = size;
-    }
-  }
-  return newSizing;
-};
-
 export function useColumnSizing({
   columns,
   tableRef,

--- a/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
@@ -41,6 +41,25 @@ interface UseColumnSizingResult {
  * Hook for managing column sizing with min/max constraints and auto-sizing.
  * Manually resized columns are preserved during auto-sizing operations.
  */
+// Merge: use calculated sizes for non-manually-resized columns, preserve
+// existing sizes for manually resized columns. Module-level so the hook
+// stays compilable: React Compiler can't lower loops inside try/catch.
+const mergeCalculatedSizing = (
+  calculatedSizing: ColumnSizingState,
+  resizedSet: Set<string>,
+  currentSizing: ColumnSizingState
+): ColumnSizingState => {
+  const newSizing: ColumnSizingState = {};
+  for (const [columnId, size] of Object.entries(calculatedSizing)) {
+    if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
+      newSizing[columnId] = currentSizing[columnId];
+    } else {
+      newSizing[columnId] = size;
+    }
+  }
+  return newSizing;
+};
+
 export function useColumnSizing({
   columns,
   tableRef,
@@ -172,26 +191,23 @@ export function useColumnSizing({
         constraints,
       });
 
-      // Merge: use calculated sizes for non-manually-resized columns,
-      // preserve existing sizes for manually resized columns
-      const newSizing: ColumnSizingState = {};
-      for (const [columnId, size] of Object.entries(calculatedSizing)) {
-        if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
-          // Preserve manually resized column's current size
-          newSizing[columnId] = currentSizing[columnId];
-        } else {
-          // Use calculated size
-          newSizing[columnId] = size;
-        }
-      }
+      const newSizing = mergeCalculatedSizing(
+        calculatedSizing,
+        resizedSet,
+        currentSizing
+      );
 
       setTableState((prev) => ({
         ...prev,
         columnSizing: newSizing,
       }));
-    } finally {
+    } catch (err) {
+      // Rethrowing catch instead of finally: React Compiler can't lower
+      // try/finally, and the ref reset must survive a computeSizes throw.
       isAutoSizingRef.current = false;
+      throw err;
     }
+    isAutoSizingRef.current = false;
   }, [tableRef, setTableState]);
 
   // Reset a single column to its auto-calculated size
@@ -233,9 +249,13 @@ export function useColumnSizing({
             };
           });
         }
-      } finally {
+      } catch (err) {
+        // Rethrowing catch instead of finally: React Compiler can't lower
+        // try/finally, and the ref reset must survive a computeSizes throw.
         isAutoSizingRef.current = false;
+        throw err;
       }
+      isAutoSizingRef.current = false;
     },
     [tableRef, setTableState]
   );

--- a/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
+++ b/apps/scout/src/app/transcripts/columnSizing/useColumnSizing.ts
@@ -8,6 +8,7 @@ import {
   ColumnSizingStrategyKey,
   getColumnConstraints,
   getSizingStrategy,
+  mergeCalculatedSizing,
 } from "../../components/columnSizing";
 import { TranscriptColumn } from "../columns";
 
@@ -41,25 +42,6 @@ interface UseColumnSizingResult {
  * Hook for managing column sizing with min/max constraints and auto-sizing.
  * Manually resized columns are preserved during auto-sizing operations.
  */
-// Merge: use calculated sizes for non-manually-resized columns, preserve
-// existing sizes for manually resized columns. Module-level so the hook
-// stays compilable: React Compiler can't lower loops inside try/catch.
-const mergeCalculatedSizing = (
-  calculatedSizing: ColumnSizingState,
-  resizedSet: Set<string>,
-  currentSizing: ColumnSizingState
-): ColumnSizingState => {
-  const newSizing: ColumnSizingState = {};
-  for (const [columnId, size] of Object.entries(calculatedSizing)) {
-    if (resizedSet.has(columnId) && currentSizing[columnId] !== undefined) {
-      newSizing[columnId] = currentSizing[columnId];
-    } else {
-      newSizing[columnId] = size;
-    }
-  }
-  return newSizing;
-};
-
 export function useColumnSizing({
   columns,
   tableRef,

--- a/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
+++ b/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
@@ -280,9 +280,6 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
     } catch (err) {
       setError(errorMessage(err, "Operation failed"));
     }
-    // Not a finally clause: React Compiler can't lower try/finally. Every
-    // early return inside the try already resets isProcessing itself, and
-    // the catch never rethrows, so running after the block is equivalent.
     setIsProcessing(false);
   };
 

--- a/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
+++ b/apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx
@@ -34,6 +34,11 @@ const KEEP_ORIGINAL_SPLIT = "__keep__";
 /** Sentinel value meaning "remove split (set to null)" */
 const NO_SPLIT = "__none__";
 
+// Module-level so components stay compilable: React Compiler can't lower
+// value blocks (the ternary here) inside try/catch.
+const errorMessage = (err: unknown, fallback: string): string =>
+  err instanceof Error ? err.message : fallback;
+
 interface CopyMoveCasesModalProps {
   /** Whether to show the modal */
   show: boolean;
@@ -169,9 +174,7 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
       await createSetMutation.mutateAsync({ path: newUri, cases: [] });
       return newUri;
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to create validation set";
-      setError(message);
+      setError(errorMessage(err, "Failed to create validation set"));
       return undefined;
     }
   };
@@ -262,7 +265,7 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
           await deleteCasesMutation.mutateAsync(selectedIds);
         } catch (err) {
           // Cases were copied but deletion failed - inform user
-          const message = err instanceof Error ? err.message : "Unknown error";
+          const message = errorMessage(err, "Unknown error");
           setError(
             `Cases copied successfully, but failed to delete from source: ${message}`
           );
@@ -275,11 +278,12 @@ export const CopyMoveCasesModal: FC<CopyMoveCasesModalProps> = ({
       onSuccess();
       handleHide();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Operation failed";
-      setError(message);
-    } finally {
-      setIsProcessing(false);
+      setError(errorMessage(err, "Operation failed"));
     }
+    // Not a finally clause: React Compiler can't lower try/finally. Every
+    // early return inside the try already resets isProcessing itself, and
+    // the catch never rethrows, so running after the block is equivalent.
+    setIsProcessing(false);
   };
 
   const title = mode === "copy" ? "Copy Cases" : "Move Cases";

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.tsx
@@ -444,7 +444,7 @@ export const TranscriptViewNodes = forwardRef<
     container.addEventListener("keydown", abort, { passive: true });
     const settle = () => {
       if (cancelled) return;
-      attempts++;
+      attempts += 1;
       const el = container.querySelector<HTMLElement>(selector);
       if (el) {
         const delta =

--- a/packages/react/src/components/CopyButton.tsx
+++ b/packages/react/src/components/CopyButton.tsx
@@ -4,6 +4,9 @@ import { FC, useState } from "react";
 import { useComponentIcons } from "./ComponentIconContext";
 import styles from "./CopyButton.module.css";
 
+const toCopyError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error("Failed to copy");
+
 interface CopyButtonProps {
   icon?: string;
   title?: string;
@@ -27,19 +30,23 @@ export const CopyButton: FC<CopyButtonProps> = ({
   const [isCopied, setIsCopied] = useState(false);
 
   const handleClick = async (): Promise<void> => {
+    // No value blocks (?., ??, ternary) inside the try/catch — React
+    // Compiler can't lower those yet and would bail out the component.
     try {
       await navigator.clipboard.writeText(value);
       setIsCopied(true);
-      onCopySuccess?.();
+      if (onCopySuccess) {
+        onCopySuccess();
+      }
 
       // Reset copy state after delay
       setTimeout(() => {
         setIsCopied(false);
       }, 1250);
     } catch (error) {
-      onCopyError?.(
-        error instanceof Error ? error : new Error("Failed to copy")
-      );
+      if (onCopyError) {
+        onCopyError(toCopyError(error));
+      }
     }
   };
 

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -100,7 +100,7 @@ export function useStatefulScrollPosition<
             return;
           }
 
-          attempts++;
+          attempts += 1;
           pollTimer = setTimeout(pollForRender, 100);
         };
 

--- a/packages/react/src/virtual/VirtualList.tsx
+++ b/packages/react/src/virtual/VirtualList.tsx
@@ -500,7 +500,7 @@ export function VirtualList<T>({
         jump();
         stable = Math.abs(el.scrollTop - lastTop) <= 1 ? stable + 1 : 0;
         lastTop = el.scrollTop;
-        if (stable < 3 && ++frames < 30) {
+        if (stable < 3 && (frames += 1) < 30) {
           settleFrameRef.current = requestAnimationFrame(settle);
         } else {
           finish();
@@ -579,7 +579,7 @@ export function VirtualList<T>({
           Math.abs(preTop - lastTop) > 1 || Math.abs(postTop - lastTop) > 1;
         stable = moved ? 0 : stable + 1;
         lastTop = postTop;
-        if (stable < 3 && ++frames < 30) {
+        if (stable < 3 && (frames += 1) < 30) {
           settleFrameRef.current = requestAnimationFrame(settle);
         } else {
           finish();

--- a/packages/zustand-devtools/src/ZustandDevtoolsPanel.tsx
+++ b/packages/zustand-devtools/src/ZustandDevtoolsPanel.tsx
@@ -40,10 +40,12 @@ export const ZustandDevtoolsPanel: FC<ZustandDevtoolsPanelProps> = ({
     (onChange: () => void) => {
       let timeout: number | null = null;
       const unsubscribe = store.subscribe(() => {
-        timeout ??= window.setTimeout(() => {
-          timeout = null;
-          onChange();
-        }, THROTTLE_MS);
+        if (timeout === null) {
+          timeout = window.setTimeout(() => {
+            timeout = null;
+            onChange();
+          }, THROTTLE_MS);
+        }
       });
       return () => {
         if (timeout !== null) window.clearTimeout(timeout);


### PR DESCRIPTION
Companion to #576. A repo-wide run of the reference `babel-plugin-react-compiler` (1.0.0) found 63 components/hooks bailing out of React Compiler, 19 of them on **syntax the compiler can't lower yet** (its `Todo` class) rather than rules-of-react violations. This PR rewrites those sites behavior-preservingly so the surrounding components compile.

**Result: bail-out sites 63 → 48, compiled functions 756 → 771.** Fifteen files now compile that previously ran completely unmemoized.

### The rewrites

| Blocker | Fix |
|---|---|
| `try/finally` | Where the catch never rethrows: cleanup moved after the block (equivalent). Where cleanup must survive a throw (`useColumnSizing`'s ref reset around `computeSizes`): rethrowing catch + trailing reset. |
| Value blocks (`\|\|`, `??`, `?.`, ternaries) and loops inside `try`/`catch` | Hoisted above the try, or extracted to module-level helpers. Only the genuinely throwing calls stay inside — e.g. `buildMetadataSet` keeps `serializeEntry` under the catch that classifies `MetadataParseError`. |
| Captured `idx++` / `++frames` in lambdas | Indexing arithmetic (`ScoreGrid`) or `+= 1` — the compiler lowers reassignment, just not `UpdateExpression`. |
| `??=`, computed `CallExpression` keys, `for await` in a hook, | Explicit `if`, hoisted const, module-level `collectExportText`. |

### Deliberately untouched

- **`useVisitId`** — its render-time module counter is rejected by the compiler regardless of syntax (`Globals`); the pattern is intentional, left as-is.
- **`VirtualList`, `TranscriptViewNodes`, `useChromeNavOwnership`** — these have deeper `PreserveManualMemo`/`Refs`/`Immutability` bail-outs that are judgment work, not mechanical; only their trivial syntax blockers are cleared here (they still bail, so their existing manual memoization remains load-bearing).
- The `Refs`/`Hooks`/`Suppression` bail-out classes (real rules-of-react flags) — separate follow-up material.

### Verification

- `turbo lint typecheck format:check test` green for both apps and all touched packages (inspect: 1185 tests, scout + packages all passing)
- Both apps build through the production SWC `reactCompiler` path
- Re-ran the Babel-reference bail-out report before/after; every touched file except the three "deliberately untouched" ones now compiles cleanly

Caveat: measurements use the Babel reference implementation; the production SWC Rust port's `Todo` list may differ at the margins, but these rewrites are neutral-to-positive under either.

No UI-visible changes (control-flow-equivalent rewrites only), so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdJMGhgZqwoxz6pxcVmMbN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdJMGhgZqwoxz6pxcVmMbN)_