### PR TITLE
perf(inspect): point-read running sample summaries

### DIFF
--- a/apps/inspect/src/client/database/sampleSummaryLookup.test.ts
+++ b/apps/inspect/src/client/database/sampleSummaryLookup.test.ts
@@ -1,0 +1,38 @@
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { testLogDetails, testSampleSummary } from "../api/testClientApi";
+import { prepareLogDetails } from "../utils/type-utils";
+
+import { DB_NAME } from "./schema";
+import { createDatabaseService, DatabaseService } from "./service";
+
+const FILE = "/logs/run.eval";
+
+let db: DatabaseService;
+
+beforeEach(async () => {
+  db = createDatabaseService();
+  await db.openDatabase();
+});
+
+afterEach(async () => {
+  await db.closeDatabase();
+  await Dexie.delete(DB_NAME);
+});
+
+describe("hasCompletedSampleSummary", () => {
+  it("point-reads logical sample identity across string and numeric ids", async () => {
+    const details = testLogDetails({
+      sampleSummaries: [
+        testSampleSummary({ id: 1, epoch: 2, completed: true }),
+        testSampleSummary({ id: "other", epoch: 2, completed: false }),
+      ],
+    });
+    await db.writeLogDetails({ [FILE]: prepareLogDetails(details) });
+
+    expect(await db.hasCompletedSampleSummary(FILE, "1", 2)).toBe(true);
+    expect(await db.hasCompletedSampleSummary(FILE, "other", 2)).toBe(false);
+    expect(await db.hasCompletedSampleSummary(FILE, "missing", 2)).toBe(false);
+  });
+});

--- a/apps/inspect/src/client/database/service.ts
+++ b/apps/inspect/src/client/database/service.ts
@@ -34,6 +34,19 @@ const newRow = (handle: LogHandle): Log => ({
   details_settled_seq: 0,
 });
 
+/** IndexedDB distinguishes numeric and string keys, while sample identity
+ *  compares their string forms. Probe both equivalent key forms. */
+const sampleIdsForLookup = (id: string | number): (string | number)[] => {
+  const text = String(id);
+  if (typeof id === "number") {
+    return Number.isNaN(id) ? [text] : [id, text];
+  }
+  const numeric = Number(id);
+  return !Number.isNaN(numeric) && String(numeric) === id
+    ? [id, numeric]
+    : [id];
+};
+
 /**
  * Database service for caching and retrieving log data.
  * Works with a DatabaseManager instance to handle database operations.
@@ -263,6 +276,22 @@ export class DatabaseService {
             .where("file_path")
             .startsWith(scopePrefix(scope.prefix));
     return collection.toArray();
+  }
+
+  async hasCompletedSampleSummary(
+    filePath: string,
+    id: string | number,
+    epoch: number
+  ): Promise<boolean> {
+    const db = this.getDb();
+    const keys = sampleIdsForLookup(id).map(
+      (sampleId) =>
+        [filePath, sampleId, epoch] as [string, string | number, number]
+    );
+    const records = await db.sample_summaries.bulkGet(keys);
+    return records.some(
+      (record) => record !== undefined && record.summary.completed !== false
+    );
   }
 
   // === RETRIEVAL FACTS ===

--- a/apps/inspect/src/log_data/runningSampleLookup.test.ts
+++ b/apps/inspect/src/log_data/runningSampleLookup.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { testEvalSample } from "@tsmono/inspect-common/testing";
+import { EvalSample } from "@tsmono/inspect-common/types";
+
+import { initAppConfig } from "../app_config";
+import { SampleHandle } from "../app/types";
+import { SampleSummary } from "../client/api/types";
+import { deriveSampleFields } from "../client/utils/derive";
+import { queryClient } from "../state/queryClient";
+
+import { setListing } from "./logsContent";
+import { streamRunningSampleTick } from "./runningSampleQuery";
+import { sampleQueryKey } from "./sampleQuery";
+import { samplesListingKey, SamplesListingRow } from "./samplesListing";
+import { testClientAPI, testSampleSummary } from "./testFixtures";
+
+const LOG_DIR = "/logs";
+
+const mockApi = {
+  get_log_sample: vi.fn(),
+  get_log_sample_data: vi.fn(),
+  log_message: vi.fn(),
+};
+const api = testClientAPI(mockApi);
+
+const handle: SampleHandle = {
+  id: "sample-1",
+  epoch: 1,
+  logFile: "late.eval",
+};
+
+const seedSummary = (logFile: string, summary: SampleSummary) => {
+  queryClient.setQueryData<SamplesListingRow[]>(
+    samplesListingKey({ logDir: LOG_DIR, scope: { file: logFile } }),
+    [
+      {
+        logFile,
+        summary,
+        derived: deriveSampleFields(summary),
+        log: {},
+      },
+    ]
+  );
+};
+
+beforeEach(() => {
+  mockApi.get_log_sample.mockReset();
+  mockApi.get_log_sample_data.mockReset();
+  mockApi.log_message.mockReset();
+  initAppConfig({
+    api,
+    singleFileMode: false,
+    loader: "replicator",
+    inspect_version: "",
+    scout_version: null,
+    logDir: LOG_DIR,
+  });
+});
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe("running sample summary lookup", () => {
+  it("resolves a listed log that appears after streaming starts", async () => {
+    mockApi.get_log_sample_data.mockResolvedValue({ status: "NotModified" });
+
+    const first = await streamRunningSampleTick(api, LOG_DIR, handle);
+    expect(first.finalized).toBe(false);
+
+    setListing(LOG_DIR, [{ name: "/logs/late.eval" }]);
+    seedSummary(
+      "/logs/late.eval",
+      testSampleSummary({ id: "sample-1", epoch: 1, completed: true })
+    );
+    mockApi.get_log_sample.mockResolvedValueOnce(
+      testEvalSample({ id: "sample-1", epoch: 1 })
+    );
+
+    const second = await streamRunningSampleTick(api, LOG_DIR, handle);
+    expect(second.finalized).toBe(true);
+    expect(
+      queryClient.getQueryData<EvalSample>(sampleQueryKey(handle))
+    ).toBeDefined();
+  });
+});

--- a/apps/inspect/src/log_data/runningSampleQuery.ts
+++ b/apps/inspect/src/log_data/runningSampleQuery.ts
@@ -10,14 +10,14 @@ import { ClientAPI, LogDetails, SampleSummary } from "../client/api/types";
 import { queryClient } from "../state/queryClient";
 
 import { useLogHeader } from "./log";
-import { resolveLogKey } from "./logsContent";
+import { getLogRows } from "./logsContent";
 import {
   fetchSample,
   SampleNotFoundError,
   synthesizeErroredSampleFromSummary,
 } from "./sampleFetch";
 import { kSampleGcTimeMs, sampleQueryKey } from "./sampleQuery";
-import { readSettledSummaries } from "./samplesListing";
+import { hasCompletedSettledSummary } from "./samplesListing";
 import {
   createSampleStreamSession,
   SampleEvent,
@@ -100,6 +100,9 @@ interface StreamSlot {
   key: string;
   session: SampleStreamSession;
   last: RunningSampleData | undefined;
+  /** Listing collection used for the last storage-key resolution. */
+  listingRows?: ReturnType<typeof getLogRows>;
+  listedLogFile?: string;
   /** Backfill latch: the stream has caught up to live at least once. */
   reachedLive: boolean;
 }
@@ -133,23 +136,28 @@ const slotFor = (
   return slot;
 };
 
+const listedLogFileFor = (
+  streamSlot: StreamSlot,
+  logDir: string,
+  logFile: string
+): string => {
+  const rows = getLogRows(logDir);
+  if (streamSlot.listingRows !== rows) {
+    const match = rows.find((row) => row.name.endsWith(logFile));
+    streamSlot.listingRows = rows;
+    streamSlot.listedLogFile = match?.name;
+  }
+  return streamSlot.listedLogFile ?? logFile;
+};
+
 /** The opened log's settled summaries report the sample completed (finalize
  *  input) — no pending merge, mirroring what the log file itself records. */
-const hasCompletedLogSummary = async (
+const hasCompletedLogSummary = (
   logDir: string,
+  logFile: string,
   handle: SampleHandle
-): Promise<boolean> => {
-  const summaries = await readSettledSummaries(
-    logDir,
-    resolveLogKey(logDir, handle.logFile)
-  );
-  return summaries.some(
-    (summary) =>
-      sampleIdsEqual(summary.id, handle.id) &&
-      summary.epoch === handle.epoch &&
-      summary.completed !== false
-  );
-};
+): Promise<boolean> =>
+  hasCompletedSettledSummary(logDir, logFile, handle.id, handle.epoch);
 
 const findLiveSummary = async (
   logDir: string,
@@ -208,8 +216,9 @@ export const streamRunningSampleTick = async (
   handle: SampleHandle
 ): Promise<RunningSampleData> => {
   const streamSlot = slotFor(api, logDir, handle);
+  const listedLogFile = listedLogFileFor(streamSlot, logDir, handle.logFile);
   const tick = await streamSlot.session.tick(
-    await hasCompletedLogSummary(logDir, handle)
+    await hasCompletedLogSummary(logDir, listedLogFile, handle)
   );
   const finalized = tick.done
     ? await finalizeRunningSample(api, logDir, handle, tick.bufferComplete)

--- a/apps/inspect/src/log_data/samplesListing.ts
+++ b/apps/inspect/src/log_data/samplesListing.ts
@@ -4,6 +4,7 @@ import { useAsyncDataFromQuery } from "@tsmono/react/hooks";
 import { AsyncData } from "@tsmono/util";
 
 import { EvalLogStatus } from "../@types/extraInspect";
+import { sampleIdsEqual } from "../app/shared/sample";
 import {
   Log,
   LogHeader,
@@ -178,6 +179,32 @@ export const readSettledSummaries = async (
     samplesListingKey({ logDir, scope })
   );
   return cached?.map((row) => row.summary) ?? [];
+};
+
+/** Whether one settled sample is complete, without materializing its file's
+ *  full summary list when IndexedDB is available. */
+export const hasCompletedSettledSummary = async (
+  logDir: string,
+  logFile: string,
+  id: string | number,
+  epoch: number
+): Promise<boolean> => {
+  const db = getDatabaseService();
+  if (db.opened()) {
+    return db.hasCompletedSampleSummary(logFile, id, epoch);
+  }
+  const scope: SamplesScope = { file: logFile };
+  const cached = queryClient.getQueryData<SamplesListingRow[]>(
+    samplesListingKey({ logDir, scope })
+  );
+  return (
+    cached?.some(
+      (row) =>
+        sampleIdsEqual(row.summary.id, id) &&
+        row.summary.epoch === epoch &&
+        row.summary.completed !== false
+    ) ?? false
+  );
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Partially addresses #401 (item 3).

Point-read the selected sample summary by its compound IndexedDB key on each stream tick instead of reading the file's full summary list. Preserve string/number sample ID equivalence and reuse the resolved listing key until the listing collection changes.

Validation: CI passed (lint, format, typecheck, build, test, and Inspect e2e).