### PR TITLE
fix(inspect-components): make vitest suite order-independent under shared jsdom

### DIFF
--- a/packages/inspect-components/tsconfig.json
+++ b/packages/inspect-components/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "types": []
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src", "vitest.config.ts", "vitest.setup.ts"],
   "exclude": ["node_modules", "dist"],
   "cmkOptions": {
     "enabled": true,

--- a/packages/inspect-components/vitest.config.ts
+++ b/packages/inspect-components/vitest.config.ts
@@ -1,15 +1,34 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
 import { configDefaults, defineConfig } from "vitest/config";
 
 // vi.mock() is unreliable under a shared module cache (isolate: false): a
 // file that ran earlier in the same worker may already have evaluated the
 // mocked module — or an importer of it — and those cached copies win over
-// the mock. Any test file that vi.mock()s a module must run in the
-// isolated project below.
-const moduleMockingTests = [
-  "src/transcript/TranscriptViewNodes.test.tsx",
-  "src/transcript/event/StopReasonBadge.test.tsx",
-  "src/transcript/outline/useOutlineScrollSync.test.ts",
-];
+// the mock. Every test file that registers a module mock must run in the
+// isolated project below, so detect them by content scan rather than a
+// hand-kept list: a new vi.mock() file that silently landed in the shared
+// project would reintroduce an order-dependent, CI-only flake.
+const findModuleMockingTests = (root: string): string[] => {
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (/\.test\.tsx?$/.test(entry.name)) {
+        if (/\bvi\.(mock|doMock)\(/.test(readFileSync(path, "utf8")))
+          found.push(relative(import.meta.dirname, path));
+      }
+    }
+  };
+  walk(root);
+  return found.sort();
+};
+
+const moduleMockingTests = findModuleMockingTests(
+  join(import.meta.dirname, "src")
+);
 
 export default defineConfig({
   test: {
@@ -25,14 +44,20 @@ export default defineConfig({
           exclude: [...configDefaults.exclude, ...moduleMockingTests],
         },
       },
-      {
-        test: {
-          name: "isolated",
-          environment: "jsdom",
-          setupFiles: ["./vitest.setup.ts"],
-          include: moduleMockingTests,
-        },
-      },
+      // A project with an empty include errors, so only materialize it while
+      // module-mocking test files exist.
+      ...(moduleMockingTests.length > 0
+        ? [
+            {
+              test: {
+                name: "isolated",
+                environment: "jsdom",
+                setupFiles: ["./vitest.setup.ts"],
+                include: moduleMockingTests,
+              },
+            },
+          ]
+        : []),
     ],
   },
 });

--- a/packages/inspect-components/vitest.config.ts
+++ b/packages/inspect-components/vitest.config.ts
@@ -1,10 +1,38 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
+
+// vi.mock() is unreliable under a shared module cache (isolate: false): a
+// file that ran earlier in the same worker may already have evaluated the
+// mocked module — or an importer of it — and those cached copies win over
+// the mock. Any test file that vi.mock()s a module must run in the
+// isolated project below.
+const moduleMockingTests = [
+  "src/transcript/TranscriptViewNodes.test.tsx",
+  "src/transcript/event/StopReasonBadge.test.tsx",
+  "src/transcript/outline/useOutlineScrollSync.test.ts",
+];
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
-    // Reuse each worker's jsdom across files: per-file boot was 4x the
-    // suite's total CPU and regressed inspect_ai CI 39s -> 55s (#579)
-    isolate: false,
+    projects: [
+      {
+        test: {
+          name: "shared-jsdom",
+          environment: "jsdom",
+          // Reuse each worker's jsdom across files: per-file boot was 4x the
+          // suite's total CPU and regressed inspect_ai CI 39s -> 55s (#579)
+          isolate: false,
+          setupFiles: ["./vitest.setup.ts"],
+          exclude: [...configDefaults.exclude, ...moduleMockingTests],
+        },
+      },
+      {
+        test: {
+          name: "isolated",
+          environment: "jsdom",
+          setupFiles: ["./vitest.setup.ts"],
+          include: moduleMockingTests,
+        },
+      },
+    ],
   },
 });

--- a/packages/inspect-components/vitest.setup.ts
+++ b/packages/inspect-components/vitest.setup.ts
@@ -1,0 +1,11 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Unmount everything Testing Library rendered after every test. With a shared
+// jsdom (isolate: false) a mount leaked by one file — render() or renderHook()
+// without cleanup — stays live for every later file in the worker, where its
+// window-capture key listeners swallow events from the tests actually running
+// (auto-cleanup is off because tests import vitest APIs instead of globals).
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
Fixes the `StopReasonBadge` failure on main ([CI run](https://github.com/meridianlabs-ai/ts-mono/actions/runs/32990867978/job/98247870467)) and a second latent flake with the same root cause: the `isolate: false` speedup from #580 made test files order-dependent in two ways. Both reproduce locally with `vitest run --maxWorkers=1` on `main` (which maximizes file-sharing per worker, like CI's 2-core runners); the whole suite passes locally with default parallelism, which is why the flake only showed up in CI.

## Failure 1: `vi.mock()` is order-dependent under a shared module cache

`StopReasonBadge.test.tsx` mocks the `@tsmono/inspect-components/content` barrel to stub out `MetaDataGrid`. With `isolate: false`, when an earlier file in the same worker has already evaluated the mocked module **or one of its importers**, those cached copies win over the mock. Deterministic repro on main:

```
vitest run --maxWorkers=1 src/transcript/TranscriptVirtualListComponent.test.tsx \
  src/transcript/event/StopReasonBadge.test.tsx
```

`TranscriptVirtualListComponent.test.tsx` transitively evaluates `StopReasonBadge.tsx` bound to the real barrel; the later test file's mock never reaches it, the real `MetaDataGrid` renders, and `useProperty` throws `useComponentStateHooks must be used within a ComponentStateProvider` — exactly the CI failure. `useOutlineScrollSync.test.ts` (mocks `@tsmono/react/hooks`) fails the same way in single-worker runs, and `TranscriptViewNodes.test.tsx` (mocks `./TranscriptVirtualList`) carries the same hazard.

**Fix:** split the suite into two vitest projects. The three `vi.mock()`-using files run in an `isolated` project with default per-file isolation; the other 87 keep the shared-jsdom speedup. The config comment tells future authors that any new `vi.mock()` file must go on that list.

## Failure 2: mounts leaked by files without `afterEach(cleanup)` swallow window keys

Once triaging under `--maxWorkers=1`, a second flake surfaced (~1 in 5 full-suite runs): `useTranscriptKeyboardNavigation.test.tsx > acts on j when the transcript container is visible` — `onNext` never fired. RTL auto-cleanup is off in this package (tests import vitest APIs rather than using globals), and five test files render/`renderHook` without ever cleaning up, so their mounts stay live for every later file in the worker. In particular `useFocusTurnNavigation.test.tsx` leaks hook mounts whose inner `useTranscriptKeyboardNavigation` keeps a window-capture keydown listener; its visibility gate is skipped entirely (the leaked hook's `scrollRef` never attaches, so `container` is null), so the stale listener claims `j` via `stopImmediatePropagation()` before the instance under test sees it. Verified with a throwaway probe: a leaked `useFocusTurnNavigation` mount reduces a fresh instance's `onNext` calls to 0.

**Fix:** a shared `vitest.setup.ts` registering `@testing-library/react` `cleanup()` after every test, wired into both projects. Existing per-file `afterEach(cleanup)` calls are unaffected (cleanup is idempotent).

`tsconfig.json` adds `vitest.setup.ts` to `include` so typed lint covers it.

## Validation

- Deterministic repro pair above: fails on main, passes here
- `vitest run --maxWorkers=1` (full suite): fails on main (2–4 files), passes here
- Full suite 15/15 consecutive green under default parallelism (was ~1 failure per 5 runs)
- `--project=isolated` runs exactly the 3 mock files (28 tests); totals unchanged at 90 files / 937 tests
- `typecheck`, `lint`, `format:check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144cgE3tJWntWzRPQjDX51v

---
_Generated by [Claude Code](https://claude.ai/code/session_0144cgE3tJWntWzRPQjDX51v)_