### PR TITLE
Revert jsdom-by-default in inspect-components tests; jsdom is opt-in again

### DIFF
--- a/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
+++ b/packages/inspect-components/src/chat/ChatViewVirtualList.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/chat/MessageContent.test.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/inspect-components/src/chat/tools/AnnotatedScreenshot.test.tsx
+++ b/packages/inspect-components/src/chat/tools/AnnotatedScreenshot.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { ReactNode } from "react";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
+++ b/packages/inspect-components/src/chat/tools/ToolCallView.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/columnFilter/ColumnFilterEditor.test.tsx
+++ b/packages/inspect-components/src/columnFilter/ColumnFilterEditor.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/columnFilter/useColumnFilter.test.ts
+++ b/packages/inspect-components/src/columnFilter/useColumnFilter.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/content/MetaDataGrid.test.tsx
+++ b/packages/inspect-components/src/content/MetaDataGrid.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,

--- a/packages/inspect-components/src/content/RecordTree.test.tsx
+++ b/packages/inspect-components/src/content/RecordTree.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,

--- a/packages/inspect-components/src/indicators/LoadingEventsIndicator.test.tsx
+++ b/packages/inspect-components/src/indicators/LoadingEventsIndicator.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/media/MediaReference.test.tsx
+++ b/packages/inspect-components/src/media/MediaReference.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/media/mediaRendering.test.tsx
+++ b/packages/inspect-components/src/media/mediaRendering.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript-search/useSearchQueries.test.ts
+++ b/packages/inspect-components/src/transcript-search/useSearchQueries.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";

--- a/packages/inspect-components/src/transcript/BranchPoint.test.tsx
+++ b/packages/inspect-components/src/transcript/BranchPoint.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
+++ b/packages/inspect-components/src/transcript/EmptyBranchView.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/GoToTurnBar.test.tsx
+++ b/packages/inspect-components/src/transcript/GoToTurnBar.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {
   act,
   cleanup,

--- a/packages/inspect-components/src/transcript/InfoEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/InfoEventView.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/ScoreValue.test.tsx
+++ b/packages/inspect-components/src/transcript/ScoreValue.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/ToolEventView.test.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptViewNodes.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {
   act,
   cleanup,

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/event/StopReasonBadge.test.tsx
+++ b/packages/inspect-components/src/transcript/event/StopReasonBadge.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useDeepLinkResolution.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { useMemo } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useEventNodeData.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useFocusLaneScope.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // jsdom: the timeline barrel transitively imports vscode-elements web
 // components, which touch CSSStyleSheet at module load.
 import { act, renderHook } from "@testing-library/react";

--- a/packages/inspect-components/src/transcript/hooks/useFocusTurnNavigation.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useFocusTurnNavigation.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // jsdom: the hook mounts window key listeners via
 // useTranscriptKeyboardNavigation.
 import { renderHook } from "@testing-library/react";

--- a/packages/inspect-components/src/transcript/hooks/useListPositionManager.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useListPositionManager.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useOutlineAutoHide.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSelectionActions.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useSidebarScrollCoupling.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTimelinePipeline.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
+++ b/packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/OutlineRow.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
+++ b/packages/inspect-components/src/transcript/outline/TranscriptOutline.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/resolveOutlineSelection.test.ts
+++ b/packages/inspect-components/src/transcript/outline/resolveOutlineSelection.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import { eventNode } from "../testHelpers";

--- a/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineCollapse.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineNodes.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
+++ b/packages/inspect-components/src/transcript/outline/useOutlineScrollSync.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import type { RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
+++ b/packages/inspect-components/src/transcript/search/sampleSearch.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
+++ b/packages/inspect-components/src/transcript/search/useTranscriptSearchSource.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, render } from "@testing-library/react";
 import { useRef } from "react";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineMinimap.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
+++ b/packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useActiveTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useActiveTimeline.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTimelineConfig.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/inspect-components/tsconfig.json
+++ b/packages/inspect-components/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "types": []
   },
-  "include": ["src", "vitest.config.ts"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"],
   "cmkOptions": {
     "enabled": true,

--- a/packages/inspect-components/vitest.config.ts
+++ b/packages/inspect-components/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "jsdom",
-  },
-});

--- a/packages/inspect-components/vitest.config.ts
+++ b/packages/inspect-components/vitest.config.ts
@@ -3,8 +3,5 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
-    // Reuse each worker's jsdom across files: per-file boot was 4x the
-    // suite's total CPU and regressed inspect_ai CI 39s -> 55s (#579)
-    isolate: false,
   },
 });


### PR DESCRIPTION
Reverts #547 (jsdom as the package-wide vitest default) and #580 (`isolate: false` to share each worker's jsdom across files), returning `packages/inspect-components` to per-file `// @vitest-environment jsdom` opt-in with vitest's default per-file isolation. `vitest.config.ts` is deleted outright — with node as the default environment there is nothing left to configure.

#580 existed to claw back the cost #547 introduced (every one of the ~90 test files booting jsdom under per-file isolation, #579), but the shared jsdom traded that for cross-file state: `vi.mock()` became order-dependent against the shared module cache, and mounts leaked by files without `afterEach(cleanup)` swallowed window key events in later files — the source of the `StopReasonBadge` CI failure on main ([run](https://github.com/meridianlabs-ai/ts-mono/actions/runs/32990867978/job/98247870467)) and the flakes #582 (closed in favor of this) papered over with config. With per-file isolation restored, that entire class of order-dependence is gone structurally, and only the ~44 files that actually render or touch the DOM pay for jsdom.

On top of the two reverts, one commit adds the opt-in pragma to the two test files created after #547 (`ScoreValue.test.tsx`, `useListPositionManager.test.ts`) — with node as the default they fail on `document is not defined`. Every other pragma-less test file passes in node.

The #547 revert had two trivial conflicts (both from changes that landed since): `tsconfig.json` keeps its current shape (`types: []`, `cmkOptions`) and only drops the now-deleted `vitest.config.ts` from `include`; `useTimelinePipeline.test.ts` keeps its current `act` import and regains its pragma.

## Validation

- Full suite: 935 passed / 2 skipped across 90 files, all checks (`typecheck`, `lint` with typed lint, `format:check`) pass
- The two CI flakes on main can't recur: the deterministic repro (`vitest run --maxWorkers=1 src/transcript/TranscriptVirtualListComponent.test.tsx src/transcript/event/StopReasonBadge.test.tsx`, which fails on main's shared cache) passes here, since each file gets a fresh module registry again

One measurement worth having in front of you before merging: on the machine used for validation, this branch runs the suite in ~42s wall (per-file jsdom boot for the ~44 DOM files dominates) versus ~7s on current main with the shared jsdom. That is the cost #579/#580 were about; this PR accepts it in exchange for isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144cgE3tJWntWzRPQjDX51v

---
_Generated by [Claude Code](https://claude.ai/code/session_0144cgE3tJWntWzRPQjDX51v)_