### PR TITLE
feat: display Score.reason in the log viewer

### DIFF
--- a/apps/inspect/src/app/samples/scores/SampleScoresGrid.tsx
+++ b/apps/inspect/src/app/samples/scores/SampleScoresGrid.tsx
@@ -76,11 +76,12 @@ export const SampleScoresGrid: FC<SampleScoresGridProps> = ({
           return undefined;
         }
         const scoreData = evalSample.scores[scorer];
-        // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
+        if (!scoreData) {
+          return undefined;
+        }
         const explanation = scoreData.explanation || "(No Explanation)";
-        // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
         const answer = scoreData.answer;
-        // @ts-expect-error pre-existing noUncheckedIndexedAccess violation (TODO: narrow when touched)
+        const reason = scoreData.reason;
         const metadata = scoreData.metadata || {};
 
         return (
@@ -102,6 +103,31 @@ export const SampleScoresGrid: FC<SampleScoresGridProps> = ({
                 }}
               />
             </div>
+
+            {reason ? (
+              <Fragment key={`${scorer}-reason`}>
+                <div
+                  className={clsx(
+                    "text-size-smaller",
+                    "text-style-label",
+                    "text-style-secondary",
+                    styles.fullWidth
+                  )}
+                >
+                  Reason
+                </div>
+                <div className={clsx(styles.fullWidth, "text-size-base")}>
+                  {reason}
+                </div>
+                <div
+                  className={clsx(
+                    styles.separator,
+                    styles.separatorPadded,
+                    styles.fullWidth
+                  )}
+                ></div>
+              </Fragment>
+            ) : undefined}
 
             {Object.keys(metadata).length > 0 ? (
               <Fragment key={`${scorer}-metadata`}>

--- a/packages/inspect-components/src/transcript/ScoreEventView.tsx
+++ b/packages/inspect-components/src/transcript/ScoreEventView.tsx
@@ -59,6 +59,17 @@ export const ScoreEventView: FC<ScoreEventViewProps> = ({
         <div className={clsx(styles.wrappingContent)}>
           <RenderedText markdown={event.score.explanation || ""} />
         </div>
+        {event.score.reason ? (
+          <Fragment>
+            <div className={clsx(styles.separator)}></div>
+            <div className={"text-style-label"}>Reason</div>
+            {/* reason is a categorical literal (refusal, grader_failed, ...) or
+                a short custom string — render verbatim, not as markdown. */}
+            <div className={clsx(styles.wrappingContent)}>
+              {event.score.reason}
+            </div>
+          </Fragment>
+        ) : null}
         <div className={clsx(styles.separator)}></div>
         <div className={"text-style-label"}>Score</div>
         <ScoreValue score={event.score.value} />


### PR DESCRIPTION
## What

The `Score` object recently gained a `reason` field (the grader's reason / failure category — `refusal`, `no_response`, `grader_failed`, `scoring_failed`, or a free-form string). The viewer parses it (it's in the generated schema types) but doesn't render it anywhere, so it's silently dropped from the UI.

This wires it up in the two score detail surfaces, rendered **only when present** (the field is optional/often null):

- **Transcript Score event** (`ScoreEventView`) — a labeled `Reason` section next to Answer/Explanation.
- **Sample Scores grid** (`SampleScoresGrid`) — a full-width `Reason` row, mirroring how Metadata is rendered (no grid-template change).

The compact samples-table score column (`samplesDescriptor`) is intentionally left untouched — happy to add it there too if you want it in the table.


## Screenshots

### Sample Scores grid

<img width="1280" height="900" alt="scores-grid-light-after" src="https://github.com/user-attachments/assets/ca5d79bb-e592-461b-ac43-31fa417fe2e7" />

### Transcript Score event

<img width="1280" height="900" alt="transcript-score-light-after" src="https://github.com/user-attachments/assets/7fb2d481-71f0-41d2-b6ea-24ac61c3edcd" />


## Notes / AGENTS.md conformance

- `reason` is optional (`reason?: … | null`), not required-with-default, so no `normalize` change is needed per the boundary-normalization convention.
- Rather than add a new `@ts-expect-error`, the touched `scoreData` block is now narrowed with an `if (!scoreData) return undefined;` guard, which lets the pre-existing `noUncheckedIndexedAccess` suppressions (marked "TODO: narrow when touched") be removed.
- No manual memoization added (React Compiler).
- Verified locally: `typecheck` and `lint` pass for `@tsmono/inspect-components` and `@meridianlabs/log-viewer`.

## Before marking ready (outstanding)

- [ ] **Screenshots** — per AGENTS.md, UI-appearance changes need before/after screenshots in **both light and dark** themes. I couldn't run the viewer from my environment; needs a maintainer (or a follow-up from me on a machine with the viewer) to capture the Score event panel and the Scores grid with a reason present.
- [ ] Confirm placement/wording, and whether the grid should be a column vs. the full-width row used here.
- [ ] Consider a behavior test (reason renders when present / hidden when absent) via the transcript test-helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)