### PR TITLE
Regenerate scout types: model_roles values may be a list

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -3121,7 +3121,7 @@ export interface components {
             model?: components["schemas"]["ModelConfig-Output"] | null;
             /** Model Roles */
             model_roles?: {
-                [key: string]: components["schemas"]["ModelConfig-Output"];
+                [key: string]: components["schemas"]["ModelConfig-Output"] | components["schemas"]["ModelConfig-Output"][];
             } | null;
             options: components["schemas"]["ScanOptions"];
             /** Packages */


### PR DESCRIPTION
Regenerates `apps/scout/src/types/generated.ts` for the scout-side change conforming to inspect_ai model-role lists (UKGovernmentBEIS/inspect_ai#4991): `ScanSpec.model_roles` values are now `ModelConfig | ModelConfig[]`.

Paired scout PR: meridianlabs-ai/inspect_scout#581

Do not merge before the scout PR is green except `submodule-on-main` and provisionally approved (two-phase landing).