### PR TITLE
ci: make e2e a required check and cap it at 20 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,8 +187,11 @@ jobs:
   e2e:
     needs: changes
     if: needs.changes.outputs.e2e-apps != '[]'
-    continue-on-error: true  # TODO: remove once e2e tests prove stable
     runs-on: ubuntu-latest
+    # Successful runs finish well inside 7 minutes; past 20 the job has hung
+    # rather than run long. Without this, nine hung jobs ran to the 6h default
+    # cap — three of them on main.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,9 +188,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.e2e-apps != '[]'
     runs-on: ubuntu-latest
-    # Successful runs finish well inside 7 minutes; past 20 the job has hung
-    # rather than run long. Without this, nine hung jobs ran to the 6h default
-    # cap — three of them on main.
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -230,6 +227,9 @@ jobs:
         run: pnpm --filter ./apps/${{ matrix.app }} exec playwright install-deps chromium
 
       - name: Run e2e tests
+        # A step timeout SIGINTs Playwright so it finalizes the report and the
+        # upload step still runs; the job-level timeout is the backstop.
+        timeout-minutes: 15
         run: pnpm --filter ./apps/${{ matrix.app }} e2e
 
       - name: Upload test results


### PR DESCRIPTION
Drops `continue-on-error: true` from the e2e matrix (the `TODO: remove once e2e tests prove stable` from #391) and adds `timeout-minutes: 20`.

```diff
   e2e:
     needs: changes
     if: needs.changes.outputs.e2e-apps != '[]'
-    continue-on-error: true  # TODO: remove once e2e tests prove stable
     runs-on: ubuntu-latest
+    timeout-minutes: 20
```

## They have proven stable

Every CI run since the e2e matrix landed in #391 (2026-07-09) — 732 runs, **1,305 e2e job executions** over seven weeks:

| | |
| --- | --- |
| success | 1,277 |
| failure | 19 (1.5%) |
| hung / cancelled | 9 |
| failures on `main` | **0 / 296** |
| consecutive green since the last failure (Aug 20) | 228 |

Two things make that stronger than the raw rate:

**The failures cluster, they don't scatter.** All 19 fall on seven branches — `transcript-navigation` (4), a dependabot minor-and-patch group (5), react-table 9.1.2 (2), and so on. Flake scatters across unrelated branches; this is the shape of real breakage. Both apps also set `retries: 2` under CI, so each of those 19 is a test that failed three consecutive times.

**Nothing has ever merged with e2e red.** Six of the seven branches went green before merging. The seventh, `dependabot/npm_and_yarn/tanstack/react-table-9.1.2`, failed e2e on Aug 17 and was closed unmerged — superseded by #540, the hand-written TanStack v9 migration. e2e caught a genuinely breaking upgrade while it was still only advisory.

So the check is already treated as blocking by convention. Requiring it writes down what we do; it doesn't tighten anything.

## Why the timeout belongs in the same change

The flag was also absorbing hangs. Nine jobs ran to GitHub's 6-hour default cap, three of them on `main` (Aug 19 ×2, Aug 20). Today those are silently ignored; once e2e is required, a hang would stall a PR for six hours instead.

Successful runs: median **4.2 min**, p95 **6.8 min**, and 1,256 of 1,277 finish under 8 minutes. 20 minutes is ~3× p95 — loose enough not to trip on a slow runner, tight enough that a hang fails in minutes.

## Notes for review

- **The `e2e-status` fan-in needs no change.** With the flag gone, `needs.e2e.result` starts reporting the real outcome, and the existing script already exits 1 for anything other than `success` or `skipped` — so both a failure and a timeout block correctly. A skipped leg from the paths filter still passes.
- **Expect hangs to surface as failures now** rather than disappearing. That is the intent, but it is the one behavior change that could cause churn if the underlying hang is frequent; it ran at 0.7% (9/1,305) and clustered on Aug 18–20.
- **Not included, worth a follow-up:** there is no `concurrency` group, so superseded pushes keep running to completion. `cancel-in-progress` on pull_request events would cut wasted runner time, but it is orthogonal to making the check required, so I left it out to keep this small.
- **One caveat on the data:** `retries: 2` means job-level green overstates *per-test* stability — a test that passes on the third attempt reports success, and retry counts live only in the Playwright HTML report artifacts, not the jobs API. Job-level stability is the right bar for a required check, so this does not change the conclusion, but it does mean this PR is not evidence that the tests underneath are flake-free.

Method: `GET /actions/workflows/ci.yaml/runs` paged back to 2026-07-09, then `GET /actions/runs/{id}/jobs` for all 732 runs, keeping every job named `e2e (…)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnT2CBYBYXM57ucXB4p8o4)_