### PR TITLE
docs: run types:generate from apps/scout in submodule guide

### DIFF
--- a/docs/submodule-guide.md
+++ b/docs/submodule-guide.md
@@ -101,9 +101,9 @@ Changes that require new or modified Python API endpoints.
    ```bash
    .venv/bin/python scripts/export_openapi_schema.py
    ```
-3. Regenerate TypeScript types (from inside the submodule):
+3. Regenerate TypeScript types (the `types:generate` script lives in `apps/scout`, not the monorepo root):
    ```bash
-   cd <submodule-path>
+   cd <submodule-path>/apps/scout
    pnpm types:generate
    ```
 4. Develop the frontend against the new types (`pnpm dev`)
@@ -198,7 +198,7 @@ git commit -m "Re-export openapi.json"
 Regenerate types from the committed `openapi.json`:
 
 ```bash
-cd <submodule-path>
+cd <submodule-path>/apps/scout
 pnpm types:generate
 ```
 


### PR DESCRIPTION
The submodule guide tells readers to run `pnpm types:generate` from the monorepo root, but the script is defined only in `apps/scout` (no root script, no turbo task), so the command fails as written. Fixed both occurrences (type-generation workflow step 3 and the `generated.ts` FAQ) to `cd <submodule-path>/apps/scout` first.

Companion to inspect_scout#585, which fixes the same defect in that repo's AGENTS.md and CONTRIBUTING.md.

### Agent review
- Reviewer: none separate for this 2-line docs fix; the underlying fact (script defined only in apps/scout/package.json, absent from root package.json and turbo.json) was verified by a fresh-context review agent during inspect_scout#585