### PR TITLE
feat: suppression ledger + CI gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Comment ledger delta on PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,51 @@ jobs:
       - name: Check linting
         run: pnpm lint
 
+  suppressions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # Dep-free by design: no pnpm install needed.
+      - name: Check suppressions ledger
+        run: node scripts/check-suppressions.mjs
+
+      - name: Test the gate script
+        run: node --test scripts/check-suppressions.test.mjs
+
+      - name: Comment ledger delta on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --depth=1 origin "$BASE_REF"
+          git show "origin/$BASE_REF:suppressions.json" > /tmp/base-suppressions.json 2>/dev/null \
+            || echo '{}' > /tmp/base-suppressions.json
+          body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json suppressions.json)
+          # Sticky comment: match on the marker, not --edit-last, so other
+          # bot comments on the PR are never clobbered.
+          cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            -q '.[] | select(.body | startswith("<!-- suppressions-delta -->")) | .id' | head -1)
+          if [ -n "$body" ] && [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" -f body="$body" > /dev/null
+          elif [ -n "$body" ]; then
+            gh pr comment "$PR" --body "$body"
+          elif [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" \
+              -f body="$(printf '<!-- suppressions-delta -->\nThis PR no longer changes the suppression ledger.')" > /dev/null
+          fi
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: suppressions-check
+        name: suppressions ledger
+        entry: node scripts/check-suppressions.mjs
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,22 @@ Design docs live per-app; consult them when working in the relevant area:
   remove those guards until their boundary normalizes; the suppression
   comment names the surface.
 
+## Suppression gate
+
+- Do NOT suppress lint or type errors — fix the code. See
+  [CONTRIBUTING.md](CONTRIBUTING.md); a deterministic gate enforces this
+  (`pnpm suppressions:check` against `suppressions.json`). A suppression
+  that just makes an error go away will be rejected.
+- In the rare case a suppression is genuinely correct (`@ts-ignore` and
+  `@ts-nocheck` are banned outright), it requires both: an explicit
+  `-- reason` in the comment, and `pnpm suppressions:update` to record it
+  in `suppressions.json`.
+- Every new suppression requires human maintainer approval of the
+  `suppressions.json` diff; expect the PR to be blocked until then, and
+  say in the PR description why no fix is possible.
+- If the `suppressions` CI check fails, never hand-edit the ledger to make
+  it pass — run `pnpm suppressions:update` and let the diff speak.
+
 ## Code Style — React Compiler & Memoization
 
   **React Compiler is enabled** in both apps' vite builds (SWC

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,11 +55,11 @@ Design docs live per-app; consult them when working in the relevant area:
 
 ## Suppression gate
 
-- Do NOT suppress lint or type errors — fix the code. See
+- Do NOT suppress lint or type errors. Fix the code. See
   [CONTRIBUTING.md](CONTRIBUTING.md); a deterministic gate enforces this
-  (`pnpm suppressions:check` against `suppressions.json`). A suppression
-  that just makes an error go away will be rejected.
-- In the rare case a suppression is genuinely correct (`@ts-ignore` and
+  (`pnpm suppressions:check` against `suppressions.json`). Maintainers
+  reject suppressions that just make an error go away.
+- In the rare case a suppression is correct (`@ts-ignore` and
   `@ts-nocheck` are banned outright), it requires both: an explicit
   `-- reason` in the comment, and `pnpm suppressions:update` to record it
   in `suppressions.json`.
@@ -67,7 +67,8 @@ Design docs live per-app; consult them when working in the relevant area:
   `suppressions.json` diff; expect the PR to be blocked until then, and
   say in the PR description why no fix is possible.
 - If the `suppressions` CI check fails, never hand-edit the ledger to make
-  it pass — run `pnpm suppressions:update` and let the diff speak.
+  it pass. Run `pnpm suppressions:update` so the change shows in the
+  ledger diff.
 
 ## Code Style — React Compiler & Memoization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,57 @@
 # Contributing
 
 Conventions, code style, and testing guidance live in [AGENTS.md](AGENTS.md).
-This file covers the policies contributors must follow.
+This file covers the policies and workflow contributors must follow.
+
+## Before you write code
+
+Search existing issues and open PRs first so you don't duplicate work
+that's already in flight.
+
+For anything non-trivial, open an issue and agree on direction before
+writing code. Changes here often need coordinated submodule bumps in
+inspect_ai and inspect_scout, so a wrong direction costs more than the
+code itself. [docs/submodule-guide.md](docs/submodule-guide.md) explains
+how the repos fit together.
+
+## Working on ts-mono
+
+```
+git clone https://github.com/meridianlabs-ai/ts-mono.git
+cd ts-mono
+pnpm install
+pre-commit install   # optional but recommended hooks
+```
+
+pnpm only, never npm or yarn. Before pushing, run the checks CI runs:
+
+```
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm format:check
+pnpm suppressions:check
+```
+
+CI also runs `pnpm build` and the Playwright e2e suites.
+[docs/scripts.md](docs/scripts.md) explains how workspace scripts are
+organized. If you work on ts-mono through a parent repo's submodule
+checkout, the submodule guide covers that flow too.
+
+## Using AI tools
+
+AI-assisted contributions are welcome. We use these tools ourselves. The
+requirements:
+
+- Understand every line you submit, and be able to explain and defend it.
+  If you can't, don't submit it.
+- Note the tooling you used in the PR description.
+- Use your tools to review your changes, not just implement them. Review
+  passes in a fresh context before opening a PR catch a lot; summarize
+  what they found in the PR description. Use a strong model for review.
+  Small fast-tier models rarely surface real issues.
+- If you are a coding agent, read [AGENTS.md](AGENTS.md) before opening
+  a PR.
 
 ## Lint / type-check suppressions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,24 +7,23 @@ This file covers the policies contributors must follow.
 
 **Don't suppress. Fix the code.**
 
-A lint or type error means the tooling found a problem. The answer is to
-fix the problem — restructure the code, fix the types, narrow the input —
-not to silence the tool. If you're reaching for `eslint-disable` or
-`@ts-expect-error` and you can't articulate precisely why the tool is
-wrong *here* and why no fix is possible, stop: the suppression is almost
-certainly the wrong move, and the PR will not be accepted on "it made the
-error go away" grounds.
+A lint or type error means the tooling found a problem. Fix the problem
+instead of silencing the tool: restructure the code, fix the types, narrow
+the input. If you're reaching for `eslint-disable` or `@ts-expect-error`
+and you can't say exactly why the tool is wrong here and why no fix is
+possible, stop. The suppression is almost certainly the wrong move, and
+maintainers won't accept a PR on "it made the error go away" grounds.
 
-Every suppression comment is registered by count in `suppressions.json`.
-CI fails if that file doesn't match the code.
+`suppressions.json` counts every suppression comment by file and rule.
+CI fails if it doesn't match the code.
 
-In the rare case a suppression is genuinely correct:
+In the rare case a suppression is correct:
 
 1. Write the reason into the comment:
    `// eslint-disable-next-line <rule> -- <why the tool is wrong here and no fix exists>`
 2. Run `pnpm suppressions:update` and commit the ledger diff. That diff is
-   your request for sign-off: a maintainer must accept every new
-   suppression, and the reason alone doesn't earn acceptance.
+   your request for sign-off. A maintainer must accept every new
+   suppression; the reason alone doesn't earn acceptance.
 
-Removing one: delete the comment, run `pnpm suppressions:update`. The
+To remove one, delete the comment and run `pnpm suppressions:update`. The
 total only goes down over time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,7 @@ In the rare case a suppression is correct:
 
 To remove one, delete the comment and run `pnpm suppressions:update`. The
 total only goes down over time.
+
+Moving or renaming a file is handled the same way: `pnpm suppressions:update`
+moves its ledger entries. The reason-less baseline is tracked per rule
+across the whole repo, so a move never trips the ratchet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Conventions, code style, and testing guidance live in [AGENTS.md](AGENTS.md).
+This file covers the policies contributors must follow.
+
+## Lint / type-check suppressions
+
+**Don't suppress. Fix the code.**
+
+A lint or type error means the tooling found a problem. The answer is to
+fix the problem — restructure the code, fix the types, narrow the input —
+not to silence the tool. If you're reaching for `eslint-disable` or
+`@ts-expect-error` and you can't articulate precisely why the tool is
+wrong *here* and why no fix is possible, stop: the suppression is almost
+certainly the wrong move, and the PR will not be accepted on "it made the
+error go away" grounds.
+
+Every suppression comment is registered by count in `suppressions.json`.
+CI fails if that file doesn't match the code.
+
+In the rare case a suppression is genuinely correct:
+
+1. Write the reason into the comment:
+   `// eslint-disable-next-line <rule> -- <why the tool is wrong here and no fix exists>`
+2. Run `pnpm suppressions:update` and commit the ledger diff. That diff is
+   your request for sign-off: a maintainer must accept every new
+   suppression, and the reason alone doesn't earn acceptance.
+
+Removing one: delete the comment, run `pnpm suppressions:update`. The
+total only goes down over time.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "dev": "turbo run dev",
-    "e2e": "turbo run e2e"
+    "e2e": "turbo run e2e",
+    "suppressions:check": "node scripts/check-suppressions.mjs",
+    "suppressions:update": "node scripts/check-suppressions.mjs --update"
   },
   "//": "manypkg requires root deps in 'dependencies', not 'devDependencies'. The root is private and never published, so the distinction is meaningless here — it's a consistency convention.",
   "manypkg": {

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Gate for lint/type-check suppression comments. suppressions.json (the
+// ledger) must exactly match the suppression comments in the code — any
+// add, remove, or move fails CI until the ledger is regenerated, so every
+// change shows up as a reviewable ledger diff in the PR.
+//
+// The per-entry `undescribed` count (suppressions lacking a `-- reason`)
+// is a ratchet: --update refuses to increase it, so new suppressions must
+// carry a reason while the baselined reason-less ones burn down over time.
+// See CONTRIBUTING.md.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const LEDGER_PATH = "suppressions.json";
+const UPDATE_HINT = "run `pnpm suppressions:update`";
+
+// scripts/ holds this gate (its source and tests mention the directives it
+// scans for); types/generated.ts files are eslint-ignored generated code,
+// so directives there would be inert anyway.
+const EXCLUDED = [/^scripts\//, /(^|\/)types\/generated\.ts$/];
+
+// A directive counts only when it opens a comment (`//` or `/*`), so the
+// same text inside a string literal is ignored unless the string itself
+// looks like a comment — an accepted false-positive window.
+const DIRECTIVE_RE =
+  /(?:\/\/|\/\*)\s*(?:(eslint-disable(?:-next-line|-line)?)(?![\w-])|(@ts-expect-error|@ts-ignore|@ts-nocheck)\b)([^\n]*)/g;
+
+// eslint treats ` -- ` (whitespace-delimited) as the description separator.
+const DESCRIPTION_SEP = /\s--(?:\s|$)/;
+
+const stripBlockClose = (text) => text.split("*/")[0];
+
+const parseEslintDirective = (rest) => {
+  const [rulesPart, ...descParts] = stripBlockClose(rest).split(DESCRIPTION_SEP);
+  const rules = rulesPart
+    .split(",")
+    .map((r) => r.trim())
+    .filter(Boolean);
+  const described = descParts.join(" ").trim().length > 0;
+  return (rules.length ? rules : ["*"]).map((rule) => ({ rule, described }));
+};
+
+const parseTsDirective = (directive, rest) => {
+  // Mirrors @typescript-eslint/ban-ts-comment: @ts-expect-error is fine
+  // with a description (>= 3 chars); @ts-ignore/@ts-nocheck never are.
+  const desc = stripBlockClose(rest)
+    .replace(/^\s*(--|:)?\s*/, "")
+    .trim();
+  const described = directive === "@ts-expect-error" && desc.length >= 3;
+  return [{ rule: directive, described }];
+};
+
+export const scanSource = (text) =>
+  [...text.matchAll(DIRECTIVE_RE)].flatMap(
+    ([, eslintDirective, tsDirective, rest]) =>
+      eslintDirective
+        ? parseEslintDirective(rest)
+        : parseTsDirective(tsDirective, rest),
+  );
+
+const tallyRules = (records) =>
+  Object.fromEntries(
+    [...Map.groupBy(records, (r) => r.rule)]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([rule, group]) => {
+        const undescribed = group.filter((r) => !r.described).length;
+        return [
+          rule,
+          undescribed
+            ? { count: group.length, undescribed }
+            : { count: group.length },
+        ];
+      }),
+  );
+
+export const buildLedger = (perFile) =>
+  Object.fromEntries(
+    [...perFile]
+      .filter(([, records]) => records.length > 0)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([file, records]) => [file, tallyRules(records)]),
+  );
+
+const entryKey = (file, rule) => file + "\t" + rule;
+const keyOf = (key) => key.split("\t").join(" — ");
+
+const entries = (ledger) =>
+  Object.entries(ledger).flatMap(([file, rules]) =>
+    Object.entries(rules).map(([rule, tally]) => [
+      entryKey(file, rule),
+      { count: tally.count, undescribed: tally.undescribed ?? 0 },
+    ]),
+  );
+
+// Every (file, rule) pair whose count differs between ledger and code.
+export const diffLedgers = (ledger, actual) => {
+  const before = new Map(entries(ledger));
+  const after = new Map(entries(actual));
+  return [...new Set([...before.keys(), ...after.keys()])]
+    .map((key) => ({
+      key,
+      before: before.get(key)?.count ?? 0,
+      after: after.get(key)?.count ?? 0,
+    }))
+    .filter(({ before, after }) => before !== after);
+};
+
+// Every (file, rule) pair where reason-less suppressions grew.
+export const ratchetViolations = (ledger, actual) => {
+  const before = new Map(entries(ledger));
+  return entries(actual)
+    .map(([key, { undescribed }]) => ({
+      key,
+      before: before.get(key)?.undescribed ?? 0,
+      after: undescribed,
+    }))
+    .filter(({ before, after }) => after > before);
+};
+
+export const totals = (ledger) =>
+  entries(ledger).reduce(
+    (acc, [, { count, undescribed }]) => ({
+      count: acc.count + count,
+      undescribed: acc.undescribed + undescribed,
+    }),
+    { count: 0, undescribed: 0 },
+  );
+
+const listFiles = () =>
+  execFileSync(
+    "git",
+    ["ls-files", "-z", "--", "*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs"],
+    { encoding: "utf8" },
+  )
+    .split("\0")
+    .filter((f) => f && !EXCLUDED.some((re) => re.test(f)));
+
+const scanRepo = () =>
+  buildLedger(
+    new Map(listFiles().map((f) => [f, scanSource(readFileSync(f, "utf8"))])),
+  );
+
+const readLedger = () =>
+  existsSync(LEDGER_PATH) ? JSON.parse(readFileSync(LEDGER_PATH, "utf8")) : {};
+
+const summarize = (ledger) => {
+  const { count, undescribed } = totals(ledger);
+  return `${count} suppressions (${undescribed} without a \`-- reason\`) in ${Object.keys(ledger).length} files`;
+};
+
+const main = () => {
+  const update = process.argv.includes("--update");
+  // No ledger yet: the first --update captures the baseline as-is.
+  const bootstrap = !existsSync(LEDGER_PATH);
+  const ledger = readLedger();
+  const actual = scanRepo();
+
+  const violations = update && bootstrap ? [] : ratchetViolations(ledger, actual);
+  for (const { key, before, after } of violations) {
+    console.error(
+      `UNDESCRIBED: ${keyOf(key)} — ${after} suppression(s) without a \`-- reason\`, ledger allows ${before}.` +
+        ` New suppressions need a reason in the comment. If the file moved, rename its ledger entry by hand instead.`,
+    );
+  }
+
+  if (update) {
+    if (violations.length) process.exit(1);
+    writeFileSync(LEDGER_PATH, JSON.stringify(actual, null, 2) + "\n");
+    console.log(`${LEDGER_PATH} updated: ${summarize(actual)}.`);
+    return;
+  }
+
+  const diffs = diffLedgers(ledger, actual);
+  for (const { key, before, after } of diffs) {
+    console.error(
+      after > before
+        ? `NEW: ${keyOf(key)} — ${after} in code, ${before} in ledger. Fix the code instead if at all possible;` +
+            ` a genuinely unavoidable suppression needs a \`-- reason\` — then ${UPDATE_HINT} and get maintainer sign-off on the ledger diff.`
+        : `REMOVED: ${keyOf(key)} — ${after} in code, ${before} in ledger. ${UPDATE_HINT} to record the shrink.`,
+    );
+  }
+
+  if (diffs.length || violations.length) process.exit(1);
+  console.log(`suppressions ledger matches: ${summarize(actual)}.`);
+};
+
+if (process.argv[1] === new URL(import.meta.url).pathname) main();

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -4,13 +4,15 @@
 // add, remove, or move fails CI until the ledger is regenerated, so every
 // change shows up as a reviewable ledger diff in the PR.
 //
-// The per-entry `undescribed` count (suppressions lacking a `-- reason`)
-// is a ratchet: --update refuses to increase it, so new suppressions must
-// carry a reason while the baselined reason-less ones burn down over time.
-// See CONTRIBUTING.md.
+// The `undescribed` count (suppressions lacking a `-- reason`) is a
+// ratchet: --update refuses to increase any rule's repo-wide total, so new
+// suppressions must carry a reason while the baselined reason-less ones
+// burn down over time. The ratchet is per rule, not per file, so moving a
+// file doesn't trip it. See CONTRIBUTING.md.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LEDGER_PATH = "suppressions.json";
 const UPDATE_HINT = "run `pnpm suppressions:update`";
@@ -93,28 +95,42 @@ const entries = (ledger) =>
     ]),
   );
 
-// Every (file, rule) pair whose count differs between ledger and code.
+const NONE = { count: 0, undescribed: 0 };
+
+// Every (file, rule) pair whose count or undescribed count differs between
+// ledger and code — adding a `-- reason` must be recorded too, or a stale
+// undescribed allowance would let the reason be deleted again unnoticed.
 export const diffLedgers = (ledger, actual) => {
   const before = new Map(entries(ledger));
   const after = new Map(entries(actual));
   return [...new Set([...before.keys(), ...after.keys()])]
     .map((key) => ({
       key,
-      before: before.get(key)?.count ?? 0,
-      after: after.get(key)?.count ?? 0,
+      before: before.get(key) ?? NONE,
+      after: after.get(key) ?? NONE,
     }))
-    .filter(({ before, after }) => before !== after);
+    .filter(
+      ({ before, after }) =>
+        before.count !== after.count ||
+        before.undescribed !== after.undescribed,
+    );
 };
 
-// Every (file, rule) pair where reason-less suppressions grew.
+const undescribedByRule = (ledger) => {
+  const byRule = new Map();
+  for (const rules of Object.values(ledger))
+    for (const [rule, tally] of Object.entries(rules))
+      byRule.set(rule, (byRule.get(rule) ?? 0) + (tally.undescribed ?? 0));
+  return byRule;
+};
+
+// Every rule whose repo-wide reason-less count grew. Summed across files so
+// moving a file never trips the ratchet; a move still shows in the ledger
+// diff via diffLedgers, and --update records it.
 export const ratchetViolations = (ledger, actual) => {
-  const before = new Map(entries(ledger));
-  return entries(actual)
-    .map(([key, { undescribed }]) => ({
-      key,
-      before: before.get(key)?.undescribed ?? 0,
-      after: undescribed,
-    }))
+  const before = undescribedByRule(ledger);
+  return [...undescribedByRule(actual)]
+    .map(([rule, after]) => ({ rule, before: before.get(rule) ?? 0, after }))
     .filter(({ before, after }) => after > before);
 };
 
@@ -150,6 +166,15 @@ const summarize = (ledger) => {
 };
 
 const main = () => {
+  // git ls-files scopes to cwd and LEDGER_PATH is relative — anchor both to
+  // the repo root so invocation from a subdirectory can't scan or write a
+  // partial ledger.
+  process.chdir(
+    execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+    }).trim(),
+  );
+
   const update = process.argv.includes("--update");
   // No ledger yet: the first --update captures the baseline as-is.
   const bootstrap = !existsSync(LEDGER_PATH);
@@ -157,10 +182,10 @@ const main = () => {
   const actual = scanRepo();
 
   const violations = update && bootstrap ? [] : ratchetViolations(ledger, actual);
-  for (const { key, before, after } of violations) {
+  for (const { rule, before, after } of violations) {
     console.error(
-      `UNDESCRIBED: ${keyOf(key)} — ${after} suppression(s) without a \`-- reason\`, ledger allows ${before}.` +
-        ` New suppressions need a reason in the comment. If the file moved, rename its ledger entry by hand instead.`,
+      `UNDESCRIBED: ${rule} — ${after} suppression(s) without a \`-- reason\` repo-wide, ledger allows ${before}.` +
+        ` New suppressions need a reason in the comment.`,
     );
   }
 
@@ -174,10 +199,12 @@ const main = () => {
   const diffs = diffLedgers(ledger, actual);
   for (const { key, before, after } of diffs) {
     console.error(
-      after > before
-        ? `NEW: ${keyOf(key)} — ${after} in code, ${before} in ledger. Fix the code instead if at all possible;` +
+      after.count > before.count
+        ? `NEW: ${keyOf(key)} — ${after.count} in code, ${before.count} in ledger. Fix the code instead if at all possible;` +
             ` a genuinely unavoidable suppression needs a \`-- reason\` — then ${UPDATE_HINT} and get maintainer sign-off on the ledger diff.`
-        : `REMOVED: ${keyOf(key)} — ${after} in code, ${before} in ledger. ${UPDATE_HINT} to record the shrink.`,
+        : after.count < before.count
+          ? `REMOVED: ${keyOf(key)} — ${after.count} in code, ${before.count} in ledger. ${UPDATE_HINT} to record the shrink.`
+          : `REASONS: ${keyOf(key)} — ${after.undescribed} without a \`-- reason\` in code, ${before.undescribed} in ledger. ${UPDATE_HINT} to record it.`,
     );
   }
 
@@ -185,4 +212,6 @@ const main = () => {
   console.log(`suppressions ledger matches: ${summarize(actual)}.`);
 };
 
-if (process.argv[1] === new URL(import.meta.url).pathname) main();
+// fileURLToPath, not URL.pathname: pathname percent-encodes spaces etc.,
+// which would make this guard silently false on such checkouts.
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-suppressions.test.mjs
+++ b/scripts/check-suppressions.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildLedger,
+  diffLedgers,
+  ratchetViolations,
+  scanSource,
+  totals,
+} from "./check-suppressions.mjs";
+
+test("line directive with description", () => {
+  assert.deepEqual(
+    scanSource("// eslint-disable-next-line a/rule -- fire-and-forget\n"),
+    [{ rule: "a/rule", described: true }],
+  );
+});
+
+test("line directive without description", () => {
+  assert.deepEqual(scanSource("// eslint-disable-next-line a/rule\n"), [
+    { rule: "a/rule", described: false },
+  ]);
+});
+
+test("multiple rules in one directive count separately", () => {
+  assert.deepEqual(scanSource("// eslint-disable-next-line a, b/c -- why\n"), [
+    { rule: "a", described: true },
+    { rule: "b/c", described: true },
+  ]);
+});
+
+test("trailing eslint-disable-line after code", () => {
+  assert.deepEqual(scanSource("foo(); // eslint-disable-line a/rule\n"), [
+    { rule: "a/rule", described: false },
+  ]);
+});
+
+test("block directive, description cut at comment close", () => {
+  assert.deepEqual(scanSource("/* eslint-disable a/rule -- legacy */ x();\n"), [
+    { rule: "a/rule", described: true },
+  ]);
+});
+
+test("bare block disable maps to *", () => {
+  assert.deepEqual(scanSource("/* eslint-disable */\n"), [
+    { rule: "*", described: false },
+  ]);
+});
+
+test("@ts-expect-error with and without description", () => {
+  assert.deepEqual(
+    scanSource("// @ts-expect-error the schema lies\n// @ts-expect-error\n"),
+    [
+      { rule: "@ts-expect-error", described: true },
+      { rule: "@ts-expect-error", described: false },
+    ],
+  );
+});
+
+test("@ts-ignore is never described", () => {
+  assert.deepEqual(scanSource("// @ts-ignore some excuse\n"), [
+    { rule: "@ts-ignore", described: false },
+  ]);
+});
+
+test("directive text outside a comment is ignored", () => {
+  assert.deepEqual(scanSource('const s = "eslint-disable-next-line a";\n'), []);
+});
+
+test("buildLedger tallies per file and rule, omitting zero undescribed", () => {
+  const ledger = buildLedger(
+    new Map([
+      [
+        "b.ts",
+        [
+          { rule: "r", described: false },
+          { rule: "r", described: true },
+        ],
+      ],
+      ["a.ts", [{ rule: "r", described: true }]],
+      ["empty.ts", []],
+    ]),
+  );
+  assert.deepEqual(ledger, {
+    "a.ts": { r: { count: 1 } },
+    "b.ts": { r: { count: 2, undescribed: 1 } },
+  });
+  assert.deepEqual(Object.keys(ledger), ["a.ts", "b.ts"]);
+});
+
+test("diffLedgers reports growth and shrink", () => {
+  const diffs = diffLedgers(
+    { "a.ts": { r: { count: 2 } }, "gone.ts": { r: { count: 1 } } },
+    { "a.ts": { r: { count: 3 } } },
+  );
+  assert.deepEqual(
+    diffs.map(({ before, after }) => [before, after]),
+    [
+      [2, 3],
+      [1, 0],
+    ],
+  );
+});
+
+test("ratchet flags undescribed growth, allows shrink and described growth", () => {
+  const ledger = { "a.ts": { r: { count: 2, undescribed: 2 } } };
+  assert.equal(
+    ratchetViolations(ledger, { "a.ts": { r: { count: 3, undescribed: 3 } } })
+      .length,
+    1,
+  );
+  assert.equal(
+    ratchetViolations(ledger, { "a.ts": { r: { count: 3, undescribed: 2 } } })
+      .length,
+    0,
+  );
+  assert.equal(
+    ratchetViolations(ledger, { "a.ts": { r: { count: 1, undescribed: 1 } } })
+      .length,
+    0,
+  );
+});
+
+test("ratchet flags a new file with an undescribed suppression", () => {
+  assert.equal(
+    ratchetViolations({}, { "new.ts": { r: { count: 1, undescribed: 1 } } })
+      .length,
+    1,
+  );
+});
+
+test("totals sums counts and undescribed", () => {
+  assert.deepEqual(
+    totals({
+      "a.ts": { r: { count: 2, undescribed: 1 }, s: { count: 1 } },
+      "b.ts": { r: { count: 3, undescribed: 3 } },
+    }),
+    { count: 6, undescribed: 4 },
+  );
+});

--- a/scripts/check-suppressions.test.mjs
+++ b/scripts/check-suppressions.test.mjs
@@ -94,11 +94,22 @@ test("diffLedgers reports growth and shrink", () => {
     { "a.ts": { r: { count: 3 } } },
   );
   assert.deepEqual(
-    diffs.map(({ before, after }) => [before, after]),
+    diffs.map(({ before, after }) => [before.count, after.count]),
     [
       [2, 3],
       [1, 0],
     ],
+  );
+});
+
+test("diffLedgers reports an undescribed-only change (reason added)", () => {
+  const diffs = diffLedgers(
+    { "a.ts": { r: { count: 2, undescribed: 2 } } },
+    { "a.ts": { r: { count: 2, undescribed: 1 } } },
+  );
+  assert.deepEqual(
+    diffs.map(({ before, after }) => [before.undescribed, after.undescribed]),
+    [[2, 1]],
   );
 });
 
@@ -126,6 +137,26 @@ test("ratchet flags a new file with an undescribed suppression", () => {
     ratchetViolations({}, { "new.ts": { r: { count: 1, undescribed: 1 } } })
       .length,
     1,
+  );
+});
+
+test("ratchet is per rule across files: a file move does not trip it", () => {
+  assert.deepEqual(
+    ratchetViolations(
+      { "old.ts": { r: { count: 2, undescribed: 2 } } },
+      { "new.ts": { r: { count: 2, undescribed: 2 } } },
+    ),
+    [],
+  );
+});
+
+test("ratchet still fires when a move also adds a reason-less suppression", () => {
+  assert.deepEqual(
+    ratchetViolations(
+      { "old.ts": { r: { count: 2, undescribed: 2 } } },
+      { "new.ts": { r: { count: 3, undescribed: 3 } } },
+    ),
+    [{ rule: "r", before: 2, after: 3 }],
   );
 });
 

--- a/scripts/suppressions-pr-delta.mjs
+++ b/scripts/suppressions-pr-delta.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Renders the markdown body for the sticky PR comment describing how this
+// PR changes suppressions.json. Prints nothing when the ledger is
+// unchanged. Usage: node suppressions-pr-delta.mjs <base.json> <head.json>
+
+import { readFileSync } from "node:fs";
+
+const MARKER = "<!-- suppressions-delta -->";
+
+const load = (path) => {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+};
+
+const flatten = (ledger) =>
+  new Map(
+    Object.entries(ledger).flatMap(([file, rules]) =>
+      Object.entries(rules).map(([rule, tally]) => [
+        `${file}\t${rule}`,
+        { count: tally.count, undescribed: tally.undescribed ?? 0 },
+      ]),
+    ),
+  );
+
+const sum = (map, field) =>
+  [...map.values()].reduce((acc, tally) => acc + tally[field], 0);
+
+const [basePath, headPath] = process.argv.slice(2);
+const base = flatten(load(basePath));
+const head = flatten(load(headPath));
+
+const rows = [...new Set([...base.keys(), ...head.keys()])]
+  .map((key) => ({
+    key,
+    before: base.get(key)?.count ?? 0,
+    after: head.get(key)?.count ?? 0,
+  }))
+  .filter(({ before, after }) => before !== after)
+  .sort((a, b) => a.key.localeCompare(b.key));
+
+if (rows.length === 0) process.exit(0);
+
+const totalBefore = sum(base, "count");
+const totalAfter = sum(head, "count");
+const delta = totalAfter - totalBefore;
+const heading =
+  delta > 0
+    ? `⚠️ Suppression ledger grew: ${totalBefore} → ${totalAfter} (+${delta})`
+    : `Suppression ledger changed: ${totalBefore} → ${totalAfter} (${delta === 0 ? "±0" : delta})`;
+
+const table = rows
+  .map(({ key, before, after }) => {
+    const [file, rule] = key.split("\t");
+    const change = after - before;
+    return `| \`${file}\` | \`${rule}\` | ${change > 0 ? "+" : ""}${change} |`;
+  })
+  .join("\n");
+
+const undescribedBefore = sum(base, "undescribed");
+const undescribedAfter = sum(head, "undescribed");
+const undescribedLine =
+  undescribedBefore === undescribedAfter
+    ? ""
+    : `\nReason-less (baselined) suppressions: ${undescribedBefore} → ${undescribedAfter}\n`;
+
+const footer =
+  delta > 0
+    ? "\nEvery new suppression needs a `-- reason` in the comment and maintainer sign-off of this ledger diff — see CONTRIBUTING.md."
+    : "";
+
+console.log(
+  `${MARKER}\n### ${heading}\n\n| File | Rule | Change |\n|---|---|---|\n${table}\n${undescribedLine}${footer}`,
+);

--- a/scripts/suppressions-pr-delta.mjs
+++ b/scripts/suppressions-pr-delta.mjs
@@ -32,13 +32,21 @@ const [basePath, headPath] = process.argv.slice(2);
 const base = flatten(load(basePath));
 const head = flatten(load(headPath));
 
+const NONE = { count: 0, undescribed: 0 };
+
+// Undescribed-only changes count too (someone added/removed a `-- reason`):
+// otherwise such a ledger diff would render nothing and the workflow would
+// falsely reset the sticky comment to "no longer changes the ledger".
 const rows = [...new Set([...base.keys(), ...head.keys()])]
   .map((key) => ({
     key,
-    before: base.get(key)?.count ?? 0,
-    after: head.get(key)?.count ?? 0,
+    before: base.get(key) ?? NONE,
+    after: head.get(key) ?? NONE,
   }))
-  .filter(({ before, after }) => before !== after)
+  .filter(
+    ({ before, after }) =>
+      before.count !== after.count || before.undescribed !== after.undescribed,
+  )
   .sort((a, b) => a.key.localeCompare(b.key));
 
 if (rows.length === 0) process.exit(0);
@@ -54,8 +62,14 @@ const heading =
 const table = rows
   .map(({ key, before, after }) => {
     const [file, rule] = key.split("\t");
-    const change = after - before;
-    return `| \`${file}\` | \`${rule}\` | ${change > 0 ? "+" : ""}${change} |`;
+    const change = after.count - before.count;
+    const changeCell =
+      change === 0 ? "±0" : `${change > 0 ? "+" : ""}${change}`;
+    const reasonNote =
+      before.undescribed === after.undescribed
+        ? ""
+        : ` (reason-less ${before.undescribed} → ${after.undescribed})`;
+    return `| \`${file}\` | \`${rule}\` | ${changeCell}${reasonNote} |`;
   })
   .join("\n");
 

--- a/suppressions.json
+++ b/suppressions.json
@@ -1,0 +1,1495 @@
+{
+  "apps/inspect/src/app_config/resolveBackend.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/App.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/app/flow/FlowButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-list/grid/columns/hooks.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/app/log-list/grid/LogListGrid.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-list/LogsPanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/LogSampleDetailView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2
+    }
+  },
+  "apps/inspect/src/app/log-view/LogView.tsx": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/LogViewContainer.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/LogViewLayout.tsx": {
+    "jsx-a11y/no-noninteractive-tabindex": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/tabs/TaskTab.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/tabs/timeline/HistoryList.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/incompatible-library": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/title-view/CollapsedTitleBar.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/log-view/title-view/ResultsPanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/navbar/ViewSegmentedControl.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/inspect/src/app/plan/DatasetDetailView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/routing/loaders/LogLoadController.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/routing/logNavigation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/app/routing/sampleNavigation.ts": {
+    "@ts-expect-error": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/app/samples-panel/SampleDetailView.tsx": {
+    "@ts-expect-error": {
+      "count": 6
+    },
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/app/samples/descriptor/samplesDescriptor.tsx": {
+    "@ts-expect-error": {
+      "count": 8
+    }
+  },
+  "apps/inspect/src/app/samples/descriptor/score/ListScoreDescriptor.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/app/samples/descriptor/score/ObjectScoreDescriptor.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/samples/list/samplesView.converters.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/inspect/src/app/samples/print/SamplePrintView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/inspect/src/app/samples/sample-tools/sample-filter/completions.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/samples/sample-tools/sample-filter/SampleFilter.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/samples/SampleDisplay.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 5,
+      "undescribed": 5
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/samples/SampleSummaryView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/samples/transcript/chunked/ChunkedTranscriptPanel.tsx": {
+    "react-hooks/incompatible-library": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/app/shared/data-grid/DataGrid.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 4,
+      "undescribed": 4
+    },
+    "jsx-a11y/interactive-supports-focus": {
+      "count": 3,
+      "undescribed": 3
+    },
+    "jsx-a11y/no-noninteractive-element-interactions": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/incompatible-library": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/shared/data-grid/findMatches.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/shared/samples-grid/colorScale.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/app/shared/useKeyedMemo.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/app/shared/useStableValue.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/client/api/client-api.ts": {
+    "@ts-expect-error": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1
+    }
+  },
+  "apps/inspect/src/client/api/static-http/api-static-http.test.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/client/api/static-http/api-static-http.ts": {
+    "@ts-expect-error": {
+      "count": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/client/api/view-server/api-view-server.test.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 7,
+      "undescribed": 7
+    }
+  },
+  "apps/inspect/src/client/api/view-server/api-view-server.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/client/api/view-server/request.test.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/client/database/manager.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/client/remote/remoteLogFile.ts": {
+    "@ts-expect-error": {
+      "count": 3
+    }
+  },
+  "apps/inspect/src/client/remote/remotePendingSampleData.test.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/client/remote/remoteZipFile.ts": {
+    "@ts-expect-error": {
+      "count": 3
+    }
+  },
+  "apps/inspect/src/client/remote/zstd-worker.ts": {
+    "@ts-expect-error": {
+      "count": 3
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/components/DownloadButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/databaseListings.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/fetchEngine.test.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 24,
+      "undescribed": 24
+    }
+  },
+  "apps/inspect/src/log_data/fetchEngine.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/inspect/src/log_data/messageRows.ts": {
+    "@typescript-eslint/require-await": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/sampleData.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/sampleFetch.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/sampleMessages.ts": {
+    "react-hooks/refs": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/samplesListing.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/sampleStream.test.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/sampleStream.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/scoreSchema.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/log_data/useLogsSync.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/state/appSlice.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/state/hooks.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/inspect/src/state/logSlice.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/state/logsSlice.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/state/sampleSlice.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/utils/attachments.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/inspect/src/utils/evallog.ts": {
+    "@ts-expect-error": {
+      "count": 2
+    }
+  },
+  "apps/inspect/src/utils/workQueue.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/e2e/fixtures/app.ts": {
+    "react-hooks/rules-of-hooks": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/api/api-scout-server.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/App.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/ActivityBarLayout.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/AddFilterButton.tsx": {
+    "jsx-a11y/no-autofocus": {
+      "count": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/components/ColumnPickerButton.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/components/columnSizing/strategies.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/DataframeView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/components/dataGrid/DataGrid.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "jsx-a11y/no-noninteractive-tabindex": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/incompatible-library": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/DownloadScanButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/EditableText.tsx": {
+    "react-hooks/refs": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/FilterBar.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/components/ProjectBar.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/components/TranscriptsNavbar.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/hooks/useScanResultSummaries.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/hooks/useSelectedScanner.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/hooks/useSelectedScanResultData.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/hooks/useWindowMessaging.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/project/components/FormFields.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/project/configUtils.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/project/ProjectPanel.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/project/SettingsContent.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/runScan/ActiveScanView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 2
+    },
+    "react-hooks/purity": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/info/ScanInfo.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeColumnsPopover.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/dataframe/ScannerDataframeCSVButtons.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/list/ScannerResultsHeader.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/list/ScannerResultsList.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/scan/scanners/list/ScannerResultsRow.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/results/ScannerResultsBody.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/results/ScannerResultsSearch.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/scanners/ScannerSidebar.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scan/ScanPanelBody.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scannerResult/result/ResultBody.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/scout/src/app/scannerResult/ScannerResultPanel.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/scans/ScansGrid.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/server/useTopicInvalidation.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/server/useValidations.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 9,
+      "undescribed": 9
+    }
+  },
+  "apps/scout/src/app/timeline/components/TimelineEventsView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/transcript/TranscriptBody.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/transcript/TranscriptEventPanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/transcripts/columns.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/transcripts/TranscriptsGrid.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/utils/arrow.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/utils/refs.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/preserve-manual-memoization": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/validation/components/CopyMoveCasesModal.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/validation/components/ValidationCaseCard.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/validation/components/ValidationCaseEditor.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/app/validation/components/ValidationCaseLabelsEditor.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/validation/components/ValidationCaseTargetEditor.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/app/validation/components/ValidationSetSelector.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "apps/scout/src/app/validation/ValidationPanel.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "apps/scout/src/AppRouter.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "apps/scout/src/debugging/navigationDebugging.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "apps/scout/src/types/json-value.ts": {
+    "@typescript-eslint/no-empty-object-type": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-common/src/utils/modelFallbacks.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/chat/ChatMessage.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/chat/ChatMessageRow.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/content-data/ContentDataView.tsx": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/MessageContent.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "jsx-a11y/media-has-caption": {
+      "count": 2,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/messageSearchText.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/messagesToStr.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "packages/inspect-components/src/chat/tools/ClientToolCall.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/tools/tool.ts": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/chat/tools/ToolOutput.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/columnFilter/ColumnFilterControl.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/columnFilter/ColumnFilterEditor.tsx": {
+    "jsx-a11y/no-autofocus": {
+      "count": 2
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/columnFilter/DurationInput.tsx": {
+    "jsx-a11y/no-autofocus": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/config/ConfigChangedChip.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/content/copyText.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/content/MetaDataGrid.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/content/RecordTree.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "packages/inspect-components/src/content/RenderedContent.tsx": {
+    "@typescript-eslint/no-base-to-string": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-call": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-return": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/unbound-method": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/content/types.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-redundant-type-constituents": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript-search/referenceLabels.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript-search/SearchPanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/transcript-search/useSearchQueries.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/BranchPoint.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/event/EventPanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/event/StopReasonBadge.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/eventText.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/FocusTurnView.tsx": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/GoToTurnBar.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/hooks/useTranscriptCollapse.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "packages/inspect-components/src/transcript/hooks/useTranscriptKeyboardNavigation.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/ModelEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/ScoreEditEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/transcript/SpanEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/state/StateEventRenderers.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/transcript/StepEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/SubtaskEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/components/TimelineSwimLanes.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/contentItems.test.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 3,
+      "undescribed": 3
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/core.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/markers.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/timeline/swimlaneLayout.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/ToolEventView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/TranscriptViewNodes.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/transcript/transform/treeify.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/inspect-components/src/usage/configsForUsage.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/inspect-components/src/usage/ModelUsagePanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/AnsiDisplay.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/AsciinemaPlayerImpl.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/AutocompleteInput.tsx": {
+    "jsx-a11y/no-autofocus": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/CopyButton.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/ExpandablePanel.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "packages/react/src/components/FindBand.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 6,
+      "undescribed": 6
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/MarkdownDiv.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/MarkdownDivWithReferences.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/markdownRendering.ts": {
+    "no-misleading-character-class": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/components/Modal.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "packages/react/src/components/NavPills.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2
+    }
+  },
+  "packages/react/src/components/PopOver.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "react-hooks/refs": {
+      "count": 4,
+      "undescribed": 3
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "packages/react/src/components/SegmentedControl.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/hooks/useChromeNavOwnership.ts": {
+    "react-hooks/immutability": {
+      "count": 3
+    },
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/react/src/hooks/useDebouncedCallback.ts": {
+    "react-hooks/refs": {
+      "count": 1
+    }
+  },
+  "packages/react/src/hooks/useListKeyboardNavigation.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1
+    }
+  },
+  "packages/react/src/hooks/useScrollDirection.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    },
+    "react-hooks/refs": {
+      "count": 2
+    },
+    "react-hooks/use-memo": {
+      "count": 1
+    }
+  },
+  "packages/react/src/hooks/useStatefulScrollPosition.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/react/src/hooks/useWhyDidYouUpdate.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-argument": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-assignment": {
+      "count": 1,
+      "undescribed": 1
+    },
+    "@typescript-eslint/no-unsafe-member-access": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/virtual/use-scaled-virtualizer.ts": {
+    "react-hooks/incompatible-library": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/react/src/virtual/use-virtual-list-state.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/scout-components/src/scanner-result-detail/ScannerResultDetailView.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/scout-components/src/scanner-result-detail/ValidationResult.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/scout-components/src/scanner-result-detail/Value.tsx": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/scout-components/src/sentinels/viewerConfig.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/theme/src/bootstrap.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 4,
+      "undescribed": 3
+    }
+  },
+  "packages/util/src/ansi.ts": {
+    "no-control-regex": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/util/src/browser.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/util/src/format.ts": {
+    "@ts-expect-error": {
+      "count": 1
+    }
+  },
+  "packages/util/src/json-value.ts": {
+    "@typescript-eslint/no-empty-object-type": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/util/src/jsonrpc.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/util/src/queue.ts": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/util/src/sync.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 2,
+      "undescribed": 2
+    }
+  },
+  "packages/zustand-devtools/src/entries.ts": {
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 1,
+      "undescribed": 1
+    }
+  },
+  "packages/zustand-devtools/src/TreeNode.tsx": {
+    "@typescript-eslint/no-floating-promises": {
+      "count": 1,
+      "undescribed": 1
+    }
+  }
+}


### PR DESCRIPTION
## What

A register of every lint/type-check suppression and a gate that stops new ones from landing unreviewed.

- **`suppressions.json`** (new, root): every `eslint-disable*` / `@ts-expect-error` comment registered by per-file, per-rule count. Initial baseline: **433 suppressions (350 without a `-- reason`) in 206 files**.
- **`scripts/check-suppressions.mjs`**: dep-free gate. Check mode fails on any mismatch between ledger and code — growth *or* shrink — so every suppression change surfaces as a reviewable ledger diff in the PR. `pnpm suppressions:update` regenerates it.
- **Reason ratchet**: each entry's `undescribed` count (suppressions lacking `-- reason`) can only shrink; `--update` refuses to raise it. New suppressions must carry a reason in the comment; the 350 baselined reason-less ones burn down over time. `@ts-ignore`/`@ts-nocheck` always count as undescribed → blocked everywhere the scan reaches.
- **CI job `suppressions`**: runs the check + the gate's tests (no pnpm install; seconds), and posts a sticky comment with the ledger delta on any PR that touches it, quoting totals — so the approving maintainer can't miss a growth.
- **Policy**: new `CONTRIBUTING.md` ("Don't suppress. Fix the code." — a reason is required but insufficient; a maintainer must accept every new suppression via the ledger diff). `AGENTS.md` gains a machine-readable Suppression gate section. Pre-commit hook added as local convenience.

## How the gate interacts with approval

A suppression cannot be added invisibly: no ledger diff → red check; ledger diff → sticky delta comment in front of the maintainer who approves the PR. No CODEOWNERS — maintainers already approve every PR, so visibility is the missing piece, not signatures.

## Verified

- 14 node:test cases (parsing incl. multi-rule/block/bare/trailing forms and ts directives, tallying, diff directions, ratchet).
- End to end: reason-less add → check **and** `--update` refuse; described add → check fails until `--update` records it; removal → check forces the shrink to be recorded.
- Initial ledger cross-checked against a `git grep` census of origin/main (360 `eslint-disable-next-line`, 174 `no-unnecessary-condition`, 102 `no-floating-promises`, 29 described `@ts-expect-error`, zero `@ts-ignore`/`@ts-nocheck`).

## After merge (maintainer action)

Make `suppressions` a **required status check** in branch protection — that's the actual teeth.