### PR TITLE
chore: suppression burn-down (floating promises + file-wide condition disables)

### DIFF
--- a/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
+++ b/apps/inspect/src/app/log-list/grid/columns/hooks.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { useCallback, useMemo } from "react";
 
@@ -385,6 +384,7 @@ export const useLogListColumns = (
         accessorFn: (row) => row.totalSamples,
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }
@@ -401,6 +401,7 @@ export const useLogListColumns = (
         accessorFn: (row) => row.completedSamples,
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }
@@ -430,6 +431,7 @@ export const useLogListColumns = (
         accessorFn: (row) => row.totalTokens,
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }
@@ -450,6 +452,7 @@ export const useLogListColumns = (
           row.duration === undefined ? null : formatTime(row.duration),
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }
@@ -514,6 +517,7 @@ export const useLogListColumns = (
             : `${formatPrettyDecimal(row.percentCompleted)}%`,
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }
@@ -530,6 +534,7 @@ export const useLogListColumns = (
         accessorFn: (row) => row.sampleErrors,
         cell: ({ getValue }) => {
           const value = getValue<number | undefined>();
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- getValue's type argument is an unchecked assertion; row data may contain nulls the type omits
           if (value === undefined || value === null) {
             return <EmptyCell />;
           }

--- a/apps/inspect/src/log_data/fetchEngine.test.ts
+++ b/apps/inspect/src/log_data/fetchEngine.test.ts
@@ -180,14 +180,23 @@ const createFakeApi = (options: FakeApiOptions = {}) => {
   // Releasing a gate lets the worker claim the next item, which opens a new
   // gate asynchronously after the queue's inter-batch delay — so drain on a
   // fixed schedule rather than stopping the moment gates look empty (a gate
-  // can still be a beat away from appearing).
-  const releaseAll = async () => {
-    for (let i = 0; i < 100; i++) {
+  // can still be a beat away from appearing). Synchronous fire-and-forget:
+  // tests await the conditions they care about, not the drain.
+  const releaseAll = () => {
+    const drain = () => {
       while (gates.length > 0) {
         gates.shift()?.resolve();
       }
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
+    };
+    drain();
+    let remaining = 100;
+    const timer = setInterval(() => {
+      drain();
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(timer);
+      }
+    }, 5);
   };
 
   return {
@@ -387,7 +396,6 @@ describe("FetchEngine.ensure (detailed)", () => {
       priority: "user",
     });
     await vi.waitFor(() => expect(fake.detailCalls.length).toBe(1));
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
 
     await Promise.all([first, second]);
@@ -482,7 +490,6 @@ describe("FetchEngine.ensure (detailed)", () => {
       depth: "detailed",
       priority: "user",
     });
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await Promise.all([blocker, background, user]);
 
@@ -519,7 +526,6 @@ describe("FetchEngine.ensure (detailed)", () => {
       priority: "user",
     });
     expect(cAgain).toBe(c);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await Promise.all([blocker, c, d]);
 
@@ -699,7 +705,6 @@ describe("FetchEngine.applyListing", () => {
       persistListing: true,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
 
     // The re-enqueued invalidation fetch must be fresh — the older attempt's
@@ -753,7 +758,6 @@ describe("FetchEngine.applyListing", () => {
     });
 
     await expect(doomed).rejects.toThrow("Log file deleted: doomed.eval");
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await blocker;
     expect(fake.detailCalls.map((call) => call.file)).toEqual(["blocker.eval"]);
@@ -851,13 +855,11 @@ describe("FetchEngine.applyListing", () => {
     // Enqueued AFTER the details backfill: both are Medium, ties break by
     // insertion order, so the details fetch claims first and the coalesce
     // has this still-queued preview to remove.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("a.eval", {
+    await engine.ensure("a.eval", {
       depth: "previewed",
       priority: "background",
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await blocker;
 
@@ -1020,8 +1022,7 @@ describe("FetchEngine unified queue (previews + details share one queue)", () =>
     });
     await vi.waitFor(() => expect(fake.detailCalls.length).toBe(1));
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("backfill.eval", {
+    await engine.ensure("backfill.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1030,7 +1031,6 @@ describe("FetchEngine unified queue (previews + details share one queue)", () =>
       priority: "user",
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await Promise.all([blocker, user]);
     await vi.waitFor(() => expect(fake.summaryCalls.length).toBeGreaterThan(0));
@@ -1090,8 +1090,7 @@ describe("FetchEngine unified queue (previews + details share one queue)", () =>
     });
     await vi.waitFor(() => expect(fake.detailCalls.length).toBe(1));
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("a.eval", {
+    await engine.ensure("a.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1100,7 +1099,6 @@ describe("FetchEngine unified queue (previews + details share one queue)", () =>
       priority: "user",
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await Promise.all([blocker, details]);
     await tick();
@@ -1128,10 +1126,8 @@ describe("FetchEngine unified queue (previews + details share one queue)", () =>
       deleted: [],
       persistListing: true,
     });
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("a.eval", { depth: "previewed", priority: "user" });
+    await engine.ensure("a.eval", { depth: "previewed", priority: "user" });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await blocker;
     await vi.waitFor(() => expect(fake.summaryCalls.length).toBeGreaterThan(0));
@@ -1155,7 +1151,6 @@ describe("FetchEngine status", () => {
       priority: "user",
     });
     await vi.waitFor(() => expect(engine.getStatus().syncing).toBe(true));
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await fetching;
     await tick();
@@ -1185,7 +1180,6 @@ describe("FetchEngine.stop", () => {
     });
 
     engine.stop();
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
 
     await expect(blocker).rejects.toThrow("Fetch engine stopped");
@@ -1203,8 +1197,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     const fake = createFakeApi({ failSummaryFor: ["bad.eval"] });
     const { engine, sinkCalls } = await createEngine({ api: fake.api });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("bad.eval", {
+    await engine.ensure("bad.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1227,8 +1220,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     });
     const { engine, sinkCalls } = await createEngine({ api: fake.api });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("flaky.eval", {
+    await engine.ensure("flaky.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1237,8 +1229,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     });
 
     failing = false;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("flaky.eval", {
+    await engine.ensure("flaky.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1280,8 +1271,7 @@ describe("FetchEngine fetch-state (retrieval errors)", () => {
     });
 
     for (let i = 0; i < 5; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      engine.ensure("bad.eval", {
+      await engine.ensure("bad.eval", {
         depth: "previewed",
         priority: "background",
       });
@@ -1511,7 +1501,6 @@ describe("FetchEngine passive vs active demand (F2)", () => {
       depth: "detailed",
       priority: "user",
     });
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
 
     await Promise.all([passive, active]);
@@ -1573,8 +1562,7 @@ describe("FetchEngine clears stale preview fetch-state on details success (F4)",
     });
 
     for (let i = 0; i < 5; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      engine.ensure("bad.eval", {
+      await engine.ensure("bad.eval", {
         depth: "previewed",
         priority: "background",
       });
@@ -1638,7 +1626,14 @@ describe("FetchEngine generation drops post-restart in-flight settles (F5)", () 
     await expect(inFlight).rejects.toThrow("Fetch engine stopped");
 
     // The old batch's network call finally resolves, well after the switch.
-    await fakeA.releaseAll();
+    fakeA.releaseAll();
+    await vi.waitFor(() =>
+      expect(fakeA.api.get_log_details).toHaveResolvedTimes(1)
+    );
+    // Let the engine's post-settle continuations (which must all be
+    // generation-discarded) run before asserting nothing landed.
+    await tick();
+    await tick();
 
     expect(callsB.fetchStates["a.eval"]).toBeUndefined();
     expect(callsB.writeDetails.some((batch) => "a.eval" in batch)).toBe(false);
@@ -1877,16 +1872,14 @@ describe("FetchEngine batched flush trailing coalesce (F7)", () => {
     });
 
     // a.eval's preview settles → its flush starts and blocks on the gate.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("a.eval", {
+    await engine.ensure("a.eval", {
       depth: "previewed",
       priority: "background",
     });
     await vi.waitFor(() => expect(firstWrite).toBe(false));
 
     // b.eval's preview settles while that flush is in flight.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    engine.ensure("b.eval", {
+    await engine.ensure("b.eval", {
       depth: "previewed",
       priority: "background",
     });
@@ -1927,7 +1920,6 @@ describe("FetchEngine opts.fresh on dedupe-join (F6)", () => {
       fresh: true,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fake.releaseAll();
     await Promise.all([first, second]);
 

--- a/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
+++ b/apps/scout/src/app/scan/scanners/ScannerSidebar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { FC, Fragment, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router";
@@ -137,6 +136,7 @@ const toEntries = (status?: Status): ScanResultsOutlineEntry[] => {
     return [];
   }
   const entries: ScanResultsOutlineEntry[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
   const scanners = status.summary.scanners || {};
   for (const scanner of Object.keys(scanners)) {
     // The summary
@@ -147,6 +147,7 @@ const toEntries = (status?: Status): ScanResultsOutlineEntry[] => {
 
     const formattedParams: string[] = [];
     if (scanInfo) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
       const params = scanInfo.params || {};
       for (const [key, value] of Object.entries(params)) {
         formattedParams.push(`${key}=${JSON.stringify(value)}`);
@@ -197,15 +198,19 @@ const resolveValidations = (
   const result: Record<string, number> = {};
 
   // Add metrics in display order: accuracy, precision, recall, f1
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
   if (m.accuracy !== null && m.accuracy !== undefined) {
     result["accuracy"] = m.accuracy;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
   if (m.precision !== null && m.precision !== undefined) {
     result["precision"] = m.precision;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
   if (m.recall !== null && m.recall !== undefined) {
     result["recall"] = m.recall;
   }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: scan-status API response not normalized (#555)
   if (m.f1 !== null && m.f1 !== undefined) {
     result["f1"] = m.f1;
   }

--- a/apps/scout/src/app/server/useValidations.ts
+++ b/apps/scout/src/app/server/useValidations.ts
@@ -113,7 +113,7 @@ export const useCreateValidationSet = () => {
     },
 
     onSuccess: () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- intentional background reconciliation after the optimistic append; invalidateQueries never rejects
       queryClient.invalidateQueries({
         queryKey: validationQueryKeys.sets(),
       });
@@ -140,16 +140,16 @@ export const useUpdateValidationCase = (uri: string) => {
     mutationFn: ({ caseId, data }) =>
       api.upsertValidationCase(uri, caseId, data),
 
-    onMutate: ({ caseId, data }) => {
+    onMutate: async ({ caseId, data }) => {
       // Cancel any outgoing refetches to avoid overwriting optimistic update
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.cancelQueries({
-        queryKey: validationQueryKeys.case({ url: uri, caseId }),
-      });
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.cancelQueries({
-        queryKey: validationQueryKeys.cases(uri),
-      });
+      await Promise.all([
+        queryClient.cancelQueries({
+          queryKey: validationQueryKeys.case({ url: uri, caseId }),
+        }),
+        queryClient.cancelQueries({
+          queryKey: validationQueryKeys.cases(uri),
+        }),
+      ]);
 
       // Snapshot the previous values for rollback
       const previousCase = queryClient.getQueryData<ValidationCase>(
@@ -196,11 +196,11 @@ export const useUpdateValidationCase = (uri: string) => {
       // Invalidate both queries to sync with server.
       // Since we've already optimistically updated both caches, the invalidation
       // will refetch in the background without causing UI flicker.
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- intentional background reconciliation after the optimistic update; invalidateQueries never rejects
       queryClient.invalidateQueries({
         queryKey: validationQueryKeys.case({ url: uri, caseId }),
       });
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises -- intentional background reconciliation after the optimistic update; invalidateQueries never rejects
       queryClient.invalidateQueries({
         queryKey: validationQueryKeys.cases(uri),
       });
@@ -216,9 +216,10 @@ export const useDeleteValidationCase = (uri: string) => {
   const api = useApi();
   return useMutation<void, Error, string>({
     mutationFn: (caseId) => api.deleteValidationCase(uri, caseId),
-    onSuccess: () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.invalidateQueries({
+    // Not optimistic: stay pending until the refetch lands so the deleted
+    // row can't linger after the spinner stops.
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: validationQueryKeys.cases(uri),
       });
     },
@@ -241,14 +242,6 @@ export const useBulkDeleteValidationCases = (uri: string) => {
       const succeeded = results.filter((r) => r.status === "fulfilled").length;
       const failed = results.filter((r) => r.status === "rejected").length;
 
-      // Always invalidate cache if at least one succeeded
-      if (succeeded > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        queryClient.invalidateQueries({
-          queryKey: validationQueryKeys.cases(uri),
-        });
-      }
-
       // Throw if all failed
       if (failed === results.length) {
         const errors = results
@@ -258,6 +251,14 @@ export const useBulkDeleteValidationCases = (uri: string) => {
       }
 
       return { succeeded, failed };
+    },
+    // Reached only when at least one deletion succeeded (all-failed throws).
+    // Not optimistic: stay pending until the refetch lands so deleted rows
+    // can't linger after the spinner stops.
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: validationQueryKeys.cases(uri),
+      });
     },
   });
 };
@@ -270,9 +271,10 @@ export const useDeleteValidationSet = () => {
   const api = useApi();
   return useMutation<void, Error, string>({
     mutationFn: (uri) => api.deleteValidationSet(uri),
-    onSuccess: () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.invalidateQueries({
+    // Not optimistic: stay pending until the refetch lands so the deleted
+    // set can't linger after the spinner stops.
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: validationQueryKeys.sets(),
       });
     },
@@ -287,9 +289,10 @@ export const useRenameValidationSet = () => {
   const api = useApi();
   return useMutation<string, Error, { uri: string; newName: string }>({
     mutationFn: ({ uri, newName }) => api.renameValidationSet(uri, newName),
-    onSuccess: () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      queryClient.invalidateQueries({
+    // Not optimistic: stay pending until the refetch lands so the old name
+    // can't linger after the spinner stops.
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: validationQueryKeys.sets(),
       });
     },

--- a/apps/scout/src/app/transcript/TranscriptBody.tsx
+++ b/apps/scout/src/app/transcript/TranscriptBody.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import {
   FC,
@@ -124,6 +123,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
   const visitId = useVisitId(transcript.transcript_id);
 
   // Selected tab — default to Events when the transcript has events
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
   const hasEvents = transcript.events && transcript.events.length > 0;
   const defaultTab = hasEvents
     ? kTranscriptEventsTabId
@@ -417,6 +417,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
           <div className={styles.chatList}>
             <ChatViewVirtualList
               id={`transcript-${visitId}`}
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
               messages={transcript.messages || []}
               initialMessageId={messageParam}
               scrollRef={scrollRef}
@@ -509,6 +510,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
   // Events tab first when available, then Messages
   const tabPanels = [...(eventsPanel ? [eventsPanel] : []), messagesPanel];
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
   if (transcript.metadata && Object.keys(transcript.metadata).length > 0) {
     tabPanels.push(
       <TabPanel
@@ -524,6 +526,7 @@ export const TranscriptBody: FC<TranscriptBodyProps> = ({
         <div className={styles.scrollable}>
           <MetaDataGrid
             id="transcript-metadata-grid"
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
             entries={transcript.metadata || {}}
             className={clsx(styles.metadata)}
             options={{ striped: true, copyButton: true }}
@@ -586,6 +589,7 @@ const CopyToolbarButton: FC<{
     setTimeout(() => setIcon(ApplicationIcons.copy), 1250);
   }, []);
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
   if (!transcript) {
     return undefined;
   }
@@ -608,6 +612,7 @@ const CopyToolbarButton: FC<{
           }
         },
         Transcript: () => {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: API response surface not normalized (#555)
           if (transcript.messages) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             navigator.clipboard.writeText(messagesToStr(transcript.messages));

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import clsx from "clsx";
 import { FC, useMemo, useRef, useState } from "react";
 
@@ -69,6 +68,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
 
   // Note: despite the type system saying otherwise, this has appeared empirically
   // to sometimes be undefined
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
   const outputMessages = event.output?.choices?.map((choice) => {
     return choice.message;
   });
@@ -111,7 +111,9 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     // "no visible content".
     const outputs =
       event.pending || isCancelled
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
         ? (outputMessages || []).filter((m) => !isLivePlaceholderMessage(m))
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
         : outputMessages || [];
     return showAllMessages
       ? [...event.input, ...outputs]
@@ -265,6 +267,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
       <div data-name="Messages" className={styles.container}>
         <ChatView
           id={`${eventNode.id}-model-input-full`}
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
           messages={[...event.input, ...(outputMessages || [])]}
           tools={{
             collapseToolMessages: context?.hasToolEvents !== false,
@@ -306,10 +309,12 @@ interface APIViewProps {
 
 export const APIView: FC<APIViewProps> = ({ call, className }) => {
   const requestCode = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
     return JSON.stringify(call.request, undefined, 2) ?? "";
   }, [call.request]);
 
   const responseCode = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
     return JSON.stringify(call.response, undefined, 2) ?? "";
   }, [call.response]);
 

--- a/packages/inspect-components/src/transcript/ModelEventView.tsx
+++ b/packages/inspect-components/src/transcript/ModelEventView.tsx
@@ -111,10 +111,10 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     // "no visible content".
     const outputs =
       event.pending || isCancelled
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
-        ? (outputMessages || []).filter((m) => !isLivePlaceholderMessage(m))
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
-        : outputMessages || [];
+        ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
+          (outputMessages || []).filter((m) => !isLivePlaceholderMessage(m))
+        : // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive: model-event data observed to defy the types at runtime; verify normalizer coverage before removing (#555)
+          outputMessages || [];
     return showAllMessages
       ? [...event.input, ...outputs]
       : [...userMessages, ...outputs];

--- a/packages/inspect-components/src/transcript/eventText.ts
+++ b/packages/inspect-components/src/transcript/eventText.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import type { Content } from "@tsmono/inspect-common/types";
 import { isRecord } from "@tsmono/util";
 
@@ -123,6 +122,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
         fields.push(["function", toolEvent.function]);
       }
       // Tool arguments
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (toolEvent.arguments) {
         fields.push(["arguments", JSON.stringify(toolEvent.arguments)]);
       }
@@ -238,6 +238,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
         fields.push(["type", subtaskEvent.type]);
       }
       // Input/result shown in summary
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (subtaskEvent.input) {
         fields.push(["input", sanitizeStringify(subtaskEvent.input)]);
       }
@@ -267,6 +268,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
       if (scoreEvent.score.explanation) {
         fields.push(["explanation", scoreEvent.score.explanation]);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (scoreEvent.score.value !== undefined) {
         const val = scoreEvent.score.value;
         fields.push([
@@ -327,6 +329,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
       if (sampleLimitEvent.message) {
         fields.push(["message", sampleLimitEvent.message]);
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (sampleLimitEvent.type) {
         fields.push(["type", sampleLimitEvent.type]);
       }
@@ -362,6 +365,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "approval": {
       const approvalEvent = event;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (approvalEvent.decision) {
         fields.push(["decision", approvalEvent.decision]);
       }
@@ -376,6 +380,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
 
     case "sandbox": {
       const sandboxEvent = event;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       if (sandboxEvent.action) {
         fields.push(["action", sandboxEvent.action]);
       }
@@ -396,6 +401,7 @@ export const extractEventFields = (event: EventType): [string, string][] => {
       const stateEvent = event;
       for (const change of stateEvent.changes) {
         fields.push(["path", change.path]);
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
         if (change.value !== undefined) {
           fields.push([
             "value",

--- a/packages/inspect-components/src/transcript/timeline/core.ts
+++ b/packages/inspect-components/src/transcript/timeline/core.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /**
  * Transcript nodes: hierarchical structure for visualization and scanning.
  *
@@ -44,6 +43,7 @@ type TreeItem = SpanNode | Event;
 function isSpanNode(item: TreeItem): item is SpanNode {
   return (
     typeof item === "object" &&
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
     item !== null &&
     "children" in item &&
     Array.isArray(item.children)
@@ -407,9 +407,11 @@ function convertServerSpan(
   server: ServerTimelineSpan,
   lookup: Map<string, Event>
 ): TimelineSpan {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
   const content = (server.content ?? [])
     .map((item) => convertServerContentItem(item, lookup))
     .filter((item): item is TimelineEvent | TimelineSpan => item !== null);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
   const branches = (server.branches ?? [])
     .map((b) => convertServerSpan(b, lookup))
     .filter((b) => b.content.length > 0 || b.branches.length > 0);
@@ -533,9 +535,11 @@ function getEventTokens(event: Event): number {
   if (event.event === "model") {
     const usage = event.output.usage;
     if (usage) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       const inputTokens = usage.input_tokens ?? 0;
       const cacheRead = usage.input_tokens_cache_read ?? 0;
       const cacheWrite = usage.input_tokens_cache_write ?? 0;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
       const outputTokens = usage.output_tokens ?? 0;
       return inputTokens + cacheRead + cacheWrite + outputTokens;
     }
@@ -836,7 +840,7 @@ function eventToNode(event: Event): TimelineEvent | TimelineSpan {
     const agentName = event.agent;
     const nestedEvents = event.events.filter(isEvent);
 
-    if (agentName && nestedEvents && nestedEvents.length > 0) {
+    if (agentName && nestedEvents.length > 0) {
       // Recursively process nested events to handle nested tool agents
       const nestedContent: (TimelineEvent | TimelineSpan)[] = nestedEvents.map(
         (e) => eventToNode(e)
@@ -1319,6 +1323,7 @@ function normalizeSystemPrompt(prompt: string): string {
  */
 function getSystemPromptForEvent(event: ModelEvent): string | null {
   const input = event.input;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
   if (!input) return null;
   for (const msg of input) {
     if (msg.role === "system") {
@@ -1450,6 +1455,7 @@ function isWarmupCall(event: ModelEvent): boolean {
   }
   // Check that the last user message is a single word
   const input = event.input;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
   if (!input) return false;
   for (let i = input.length - 1; i >= 0; i--) {
     const msg = input[i];
@@ -1720,6 +1726,7 @@ function extractAgentResults(parent: TimelineSpan): void {
         if (nextItem.type !== "event") continue;
         if (nextItem.event.event === "model") {
           const modelEvent = nextItem.event;
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard on eval-log event data; verify normalizer coverage before removing (#555)
           if (modelEvent.input) {
             for (const msg of modelEvent.input) {
               if (msg.role === "tool" && msg.tool_call_id === toolCallId) {

--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 /**
  * Fixture-driven tests for buildTimeline().
  *
@@ -404,10 +403,8 @@ function assertScoringSpanMatches(
   expect(scorerSpans.length).toBe(1);
   const scoring = scorerSpans[0]!;
 
-  if (expected.event_uuids !== undefined) {
-    const actualUuids = getDirectEventUuids(scoring);
-    expect(actualUuids).toEqual(expected.event_uuids);
-  }
+  const actualUuids = getDirectEventUuids(scoring);
+  expect(actualUuids).toEqual(expected.event_uuids);
 }
 
 function assertSpanMatches(
@@ -422,10 +419,7 @@ function assertSpanMatches(
   expect(actual!.id).toBe(expected.id);
   expect(actual!.name).toBe(expected.name);
 
-  if (
-    expected.source &&
-    (expected.source.source === "span" || expected.source.source === "tool")
-  ) {
+  if (expected.source) {
     expect(actual!.spanType).toBe("agent");
   }
 
@@ -502,12 +496,7 @@ function assertSpanMatches(
           expect(spanItem.name).toBe(expectedItem.name);
         }
         if (expectedItem.source) {
-          if (
-            expectedItem.source.source === "span" ||
-            expectedItem.source.source === "tool"
-          ) {
-            expect(spanItem.spanType).toBe("agent");
-          }
+          expect(spanItem.spanType).toBe("agent");
         }
         if (expectedItem.nested_uuids) {
           const allUuids = getAllEventUuids(spanItem);
@@ -630,12 +619,7 @@ function assertTimelineMatches(
             expect(spanItem.name).toBe(expectedItem.name);
           }
           if (expectedItem.source) {
-            if (
-              expectedItem.source.source === "span" ||
-              expectedItem.source.source === "tool"
-            ) {
-              expect(spanItem.spanType).toBe("agent");
-            }
+            expect(spanItem.spanType).toBe("agent");
           }
           if (expectedItem.nested_uuids) {
             const allUuids = getAllEventUuids(spanItem);

--- a/suppressions.json
+++ b/suppressions.json
@@ -920,8 +920,7 @@
   },
   "apps/scout/src/app/server/useValidations.ts": {
     "@typescript-eslint/no-floating-promises": {
-      "count": 9,
-      "undescribed": 9
+      "count": 3
     }
   },
   "apps/scout/src/app/timeline/components/TimelineEventsView.tsx": {

--- a/suppressions.json
+++ b/suppressions.json
@@ -23,9 +23,8 @@
     }
   },
   "apps/inspect/src/app/log-list/grid/columns/hooks.tsx": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 6
     },
     "react-hooks/exhaustive-deps": {
       "count": 1
@@ -879,9 +878,8 @@
     }
   },
   "apps/scout/src/app/scan/scanners/ScannerSidebar.tsx": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 6
     }
   },
   "apps/scout/src/app/scan/ScanPanelBody.tsx": {
@@ -934,9 +932,8 @@
       "count": 2,
       "undescribed": 2
     },
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 6
     },
     "react-hooks/refs": {
       "count": 1
@@ -1307,9 +1304,8 @@
     }
   },
   "packages/inspect-components/src/transcript/eventText.ts": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 7
     }
   },
   "packages/inspect-components/src/transcript/FocusTurnView.tsx": {
@@ -1334,9 +1330,8 @@
     }
   },
   "packages/inspect-components/src/transcript/ModelEventView.tsx": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 6
     }
   },
   "packages/inspect-components/src/transcript/ScoreEditEventView.tsx": {
@@ -1379,16 +1374,11 @@
     }
   },
   "packages/inspect-components/src/transcript/timeline/core.ts": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
+    "@typescript-eslint/no-unnecessary-condition": {
+      "count": 8
     }
   },
   "packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts": {
-    "@typescript-eslint/no-unnecessary-condition (file-wide)": {
-      "count": 1,
-      "undescribed": 1
-    },
     "@typescript-eslint/no-unsafe-type-assertion": {
       "count": 2
     }

--- a/suppressions.json
+++ b/suppressions.json
@@ -431,12 +431,6 @@
       "undescribed": 1
     }
   },
-  "apps/inspect/src/log_data/fetchEngine.test.ts": {
-    "@typescript-eslint/no-floating-promises": {
-      "count": 24,
-      "undescribed": 24
-    }
-  },
   "apps/inspect/src/log_data/fetchEngine.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 3,


### PR DESCRIPTION
Suppression-ledger burn-down: the two biggest `no-floating-promises` hotspots, plus conversion of the 7 file-wide `no-unnecessary-condition` disables to per-line. Ledger: 511 → 513 total but **reason-less 338 → 298**, and zero file-wide disables of this rule remain (each previously counted as 1 while hiding 45 real sites and suppressing all future ones).

## fetchEngine.test.ts (−24, file now suppression-free)

- `releaseAll()` in the test fake is now synchronous (setInterval drain, same 100×5ms schedule), so bare fire-and-forget calls are legal — 13 suppressions gone.
- The 11 backgrounded `ensure(previewed)` calls are now awaited. `ensure` with `depth: "previewed"` resolves at enqueue (see the `ensure` docstring), so this is a no-op at runtime — 11 suppressions gone.
- The one site that awaited the full 500ms drain (F5) now waits for the in-flight mock call to settle (`vi.waitFor` + `toHaveResolvedTimes`) plus two ticks, instead of sleeping.

## useValidations.ts (−6, 3 kept with reasons)

Split by mutation kind (query-core's `invalidateQueries`/`cancelQueries` never reject — refetch/cancel errors are caught internally unless `throwOnError` — so this is purely about whether `isPending` covers the refetch):

- **Non-optimistic** (delete case, bulk delete, delete set, rename set): `await queryClient.invalidateQueries(...)` in async `onSuccess`. Mutation stays pending until the refetch lands, so a deleted row / old name can't linger after the spinner stops — matches how ValidationPanel gates its buttons on `isPending`. Bulk delete's invalidation moves from `mutationFn` to `onSuccess` (its `succeeded > 0` guard was redundant: all-failed throws).
- **Optimistic** (create set, update case): invalidation stays fire-and-forget — background reconciliation is the design — now carrying `-- reason` directives. `useUpdateValidationCase.onMutate` now awaits its two `cancelQueries` (the documented optimistic-update pattern; create-set already did).

## File-wide `no-unnecessary-condition` disables → per-line (7 headers hiding 45 sites)

`eventText.ts`, `timeline/core.ts`, `ModelEventView.tsx`, `fixtureTimeline.test.ts`, scout `TranscriptBody.tsx` + `ScannerSidebar.tsx`, inspect `log-list/grid/columns/hooks.tsx`. Conservative pass — **guards on wire/API data were kept, not deleted**:

- **39 per-line directives with reasons** naming why each guard stays: unnormalized API surfaces (scout responses, scan status), types-lie sites pending #555 normalizer verification (e.g. `ModelEventView.tsx`'s documented empirically-undefined `event.output`), and `getValue<T>()`'s unchecked generic in the grid.
- **5 sites deleted** — the only ones provable by local reasoning: a truthiness check on a `.filter()` result (always an array) in `timeline/core.ts`, and in `fixtureTimeline.test.ts` a dead undefined-guard plus three exhaustive-union comparisons (`x === "span" || x === "tool"` over a `"span" | "tool"` type).

Follow-up (not this PR): per-site #555 verification to actually remove the kept guards — check/add normalizer fills, then delete downstream guards.

## Verified

- inspect: full `vitest run` 1234 tests pass (fetchEngine 52/52, faster — no 500ms sleep)
- scout: full `vitest run` 270 tests pass
- inspect-components: full `vitest run` 953 tests pass
- eslint clean on all touched files
- `node scripts/check-suppressions.mjs` passes