### PR TITLE
Add verify-log-viewer verification skill

### DIFF
--- a/apps/inspect/.claude/skills/verify-log-viewer/.gitignore
+++ b/apps/inspect/.claude/skills/verify-log-viewer/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+evidence/

--- a/apps/inspect/.claude/skills/verify-log-viewer/SKILL.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: verify-log-viewer
+description: Drive the real inspect log viewer (apps/inspect web UI) against real .eval fixture logs and capture evidence that user-facing behavior works — log list, sample detail, transcript, scores. Use when a change to the viewer needs proof it behaves correctly in the running app, not just in unit tests.
+---
+
+# Verify the inspect log viewer
+
+This skill launches the real viewer stack — an `inspect view` API server
+reading real `.eval` files, plus the app's vite dev server — and drives it
+with Playwright the way a user would. It is not the mocked e2e suite: the
+specs in `apps/inspect/e2e/` stub `/api` with MSW and in-memory JSON logs;
+this harness exercises the production transport (view-server API, binary
+`.eval` parsing, streaming) end to end.
+
+All commands below run from `apps/inspect`. The harness lives in this
+directory (`.claude/skills/verify-log-viewer/`); it never edits product code.
+
+## Configuration knobs
+
+Every command reads the same four env vars (defaults in parentheses):
+
+- `VERIFY_VIEWER_PORT` (5179) — vite dev server port for this harness.
+- `VERIFY_VIEW_SERVER_PORT` (7677) — `inspect view` API port for this harness.
+- `INSPECT_BIN` (`inspect` on PATH) — the inspect_ai CLI. Installing
+  inspect_ai in a venv puts `inspect` on PATH while that venv is active, so
+  the default works there. Outside a venv, point at one directly, e.g.
+  `INSPECT_BIN=~/code/inspect_ai/.venv/bin/inspect`.
+- `VERIFY_LOG_DIR` (`~/code/viewer-validation/logs`) — directory of `.eval`
+  fixture logs. The default holds ~23 deterministic mockllm logs
+  (viewer-rich, viewer-arithmetic, viewer-error, viewer-cancelled, …) — no
+  model calls, so runs are free and reproducible.
+
+Ports 5173/5174 (the apps' own dev servers), 5175/5176 (the mocked e2e
+suites), and 7575 (the user's real `inspect view`) are deliberately NOT used.
+
+## Doctor
+
+Before driving anything, run the read-only preflight:
+
+```sh
+.claude/skills/verify-log-viewer/doctor.sh
+```
+
+It reports whether the two harness ports are free (and who owns them if
+not), whether the inspect CLI resolves, and whether the fixture dir has
+`.eval` files. If a port is busy, stop that process or pick another port via
+the env vars — never drive a server this run did not start.
+
+## Launch
+
+Playwright owns the lifecycle: its config starts both servers, waits for
+readiness, and kills them at the end of the run. There is nothing to start
+by hand:
+
+```sh
+INSPECT_BIN=~/code/inspect_ai/.venv/bin/inspect \
+  pnpm exec playwright test --config .claude/skills/verify-log-viewer/playwright.verify.config.ts
+```
+
+Readiness: the view server is up when `http://127.0.0.1:7677/api/logs`
+returns the log listing; the viewer is up when `http://localhost:5179/`
+answers. Both use `reuseExistingServer: false` — a busy port fails the run
+instead of silently driving someone else's session.
+
+To start the stack manually for interactive poking (two terminals):
+
+```sh
+~/code/inspect_ai/.venv/bin/inspect view start \
+  --log-dir ~/code/viewer-validation/logs --port 7677 --display plain
+pnpm exec vite --config .claude/skills/verify-log-viewer/vite.verify.config.ts
+```
+
+Then open `http://localhost:5179/`. Kill both processes (Ctrl-C) when done —
+kill the PIDs you started, never by process name.
+
+Why the extra vite config: the app's own `pnpm dev` proxies `/api` to the
+hardcoded port 7575 — the user's real `inspect view`. The view server sends
+no CORS headers and rejects cross-site requests, so the viewer must reach it
+same-origin through the proxy; `vite.verify.config.ts` extends the app's
+config and only re-points that proxy at the harness port.
+
+## Drive
+
+Write drives as Playwright specs in `drive/` (they run via the Launch
+command above; add `-g "<test name>"` to run one). The specs resolve
+`@playwright/test` through `apps/inspect/node_modules`, which is why this
+skill lives app-local rather than at the repo root.
+
+The feature map in [`features/`](features/README.md) is the maintained
+recipe book: what each feature is, how a user reaches it, exact selectors,
+and what observable end state proves it works. Read the README index first;
+a proof that drives one convenient entry point is incomplete when the map
+lists others.
+
+`drive/log-viewer.spec.ts` is the standing proof run — one test per mapped
+feature. Keep it passing; extend it when the map grows.
+
+## Evidence
+
+Proof artifacts go to `.claude/skills/verify-log-viewer/evidence/`
+(gitignored, named per feature, overwritten each run — the current contents
+are the latest proof). Playwright's own failure artifacts land in
+`test-results/` next to it.
+
+Standards for a proof:
+
+- Exercise the real user path (navigate, click, read) — not internal
+  setters, not test-only endpoints, and no MSW mocks anywhere.
+- Capture the action AND the resulting state: assert on rendered text/roles,
+  then screenshot the end state into `evidence/`.
+- The fixture logs are the ground truth — assert values that are actually in
+  the `.eval` file being driven (task name, sample input, score value), not
+  merely "something rendered".
+- Evidence survives cleanup: Playwright tears down the servers but never
+  touches `evidence/`.
+
+## Cleanup
+
+Nothing to do in the normal path: Playwright kills the two servers it
+spawned. After a crashed or interrupted run, check for strays with
+`doctor.sh` (it names the PID owning each harness port) and kill those PIDs
+specifically. Never `pkill -f inspect` or `pkill -f vite` — the user may be
+running their own.
+
+`test-results/` may be deleted freely; `evidence/` holds the proof — leave
+it.
+
+## Isolation
+
+Two harness runs cannot share ports: to run concurrently, give the second
+run different `VERIFY_VIEWER_PORT`/`VERIFY_VIEW_SERVER_PORT`. The fixture
+log dir is opened read-only by the view server, so concurrent readers are
+safe. The viewer stores per-origin state in IndexedDB keyed by port — a
+changed port is a cold cache, which is fine for verification.
+
+## Maintenance
+
+When the viewer's UI or routes change, update the feature map and the
+standing spec together — see `/maintain-verification-skill`.

--- a/apps/inspect/.claude/skills/verify-log-viewer/SKILL.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/SKILL.md
@@ -93,7 +93,10 @@ a proof that drives one convenient entry point is incomplete when the map
 lists others.
 
 `drive/log-viewer.spec.ts` is the standing proof run — one test per mapped
-feature. Keep it passing; extend it when the map grows.
+feature. Keep it passing; extend it when the map grows. When you prove a
+mapped sub-feature that has no standing test yet, add that test to the
+standing spec rather than writing a throwaway one — the map and the spec
+grow together.
 
 ## Evidence
 

--- a/apps/inspect/.claude/skills/verify-log-viewer/doctor.sh
+++ b/apps/inspect/.claude/skills/verify-log-viewer/doctor.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Read-only preflight: is this checkout/machine worth driving?
+# Usage: .claude/skills/verify-log-viewer/doctor.sh   (from apps/inspect)
+# Env (same knobs as playwright.verify.config.ts):
+#   VERIFY_VIEWER_PORT (5179) VERIFY_VIEW_SERVER_PORT (7677)
+#   INSPECT_BIN (inspect) VERIFY_LOG_DIR (~/code/viewer-validation/logs)
+
+viewer_port="${VERIFY_VIEWER_PORT:-5179}"
+view_server_port="${VERIFY_VIEW_SERVER_PORT:-7677}"
+inspect_bin="${INSPECT_BIN:-inspect}"
+log_dir="${VERIFY_LOG_DIR:-$HOME/code/viewer-validation/logs}"
+ok=0
+
+port_status() {
+  local port="$1" label="$2"
+  local owner
+  owner=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk 'NR==2 {print $1 " (pid " $2 ")"}')
+  if [ -n "$owner" ]; then
+    echo "BUSY  $label port $port owned by $owner — harness will refuse (reuseExistingServer: false); stop it or pick another port"
+    ok=1
+  else
+    echo "ok    $label port $port free"
+  fi
+}
+
+port_status "$view_server_port" "view-server"
+port_status "$viewer_port" "viewer"
+
+if command -v "$inspect_bin" >/dev/null 2>&1; then
+  echo "ok    inspect CLI: $("$inspect_bin" --version 2>/dev/null)"
+else
+  echo "FAIL  inspect CLI not found ($inspect_bin) — set INSPECT_BIN (see SKILL.md → Launch)"
+  ok=1
+fi
+
+eval_count=$(find "$log_dir" -maxdepth 1 -name '*.eval' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$eval_count" -gt 0 ]; then
+  echo "ok    fixtures: $eval_count .eval files in $log_dir"
+else
+  echo "FAIL  no .eval fixtures in $log_dir — set VERIFY_LOG_DIR"
+  ok=1
+fi
+
+exit "$ok"

--- a/apps/inspect/.claude/skills/verify-log-viewer/doctor.sh
+++ b/apps/inspect/.claude/skills/verify-log-viewer/doctor.sh
@@ -29,7 +29,7 @@ port_status "$viewer_port" "viewer"
 if command -v "$inspect_bin" >/dev/null 2>&1; then
   echo "ok    inspect CLI: $("$inspect_bin" --version 2>/dev/null)"
 else
-  echo "FAIL  inspect CLI not found ($inspect_bin) — set INSPECT_BIN (see SKILL.md → Launch)"
+  echo "FAIL  inspect CLI not found ($inspect_bin) — set INSPECT_BIN (see SKILL.md → Configuration knobs)"
   ok=1
 fi
 

--- a/apps/inspect/.claude/skills/verify-log-viewer/drive/log-viewer.spec.ts
+++ b/apps/inspect/.claude/skills/verify-log-viewer/drive/log-viewer.spec.ts
@@ -1,0 +1,113 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+// Real-backend drive: everything here talks to a live `inspect view` server
+// through the vite proxy. Never import test/expect from apps/inspect/e2e/
+// fixtures — that fixture auto-enables MSW and would silently mock /api.
+
+const evidence = join(import.meta.dirname, "..", "evidence");
+
+// Ground truth from the fixture logs in VERIFY_LOG_DIR (see features/README.md):
+// viewer-rich: 5 samples; sample 1/epoch 1 asks "What is 2+2?", answers
+// "The answer is 4.", scores includes=C; accuracy metric is 0.8.
+const kRichLog =
+  "2026-07-07T21-47-35-00-00_viewer-rich_M58v4LGnsyG2Gh3hwXxpeP.eval";
+const richSampleUrl = (tab: string) =>
+  `/#/logs/${encodeURIComponent(kRichLog)}/samples/sample/1/1/${tab}`;
+
+const shot = (page: import("@playwright/test").Page, name: string) =>
+  page.screenshot({ path: join(evidence, name) });
+
+test.beforeAll(() => {
+  mkdirSync(evidence, { recursive: true });
+});
+
+test("log list (Tasks view) shows fixture logs and opens one", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const grid = page.getByRole("grid", { name: "Evaluation logs" });
+  await expect(grid).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByRole("gridcell").filter({ hasText: "viewer_arithmetic" }).first()
+  ).toBeVisible();
+  await expect(
+    page.getByRole("gridcell").filter({ hasText: "viewer_rich" }).first()
+  ).toBeVisible();
+  await shot(page, "log-list-tasks-view.png");
+
+  await page
+    .getByRole("gridcell")
+    .filter({ hasText: "viewer_rich" })
+    .first()
+    .click();
+  await page.waitForURL(/#\/tasks\//);
+  await expect(page.getByRole("tab", { name: /^Samples?$/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await shot(page, "log-list-opened-log.png");
+});
+
+test("sample list of an opened log shows its samples and opens detail", async ({
+  page,
+}) => {
+  await page.goto(`/#/logs/${encodeURIComponent(kRichLog)}`);
+  const samples = page.getByRole("grid", { name: "Samples" });
+  await expect(samples).toBeVisible({ timeout: 15_000 });
+  const firstSample = samples
+    .getByRole("gridcell")
+    .filter({ hasText: "What is 2+2?" })
+    .first();
+  await expect(firstSample).toBeVisible();
+  await shot(page, "sample-list.png");
+
+  await firstSample.click();
+  await page.waitForURL(/\/samples\/sample\//);
+  await expect(page.locator("[id^='sample-heading-']")).toBeVisible({
+    timeout: 15_000,
+  });
+  await shot(page, "sample-detail-opened.png");
+});
+
+test("sample messages tab renders the conversation", async ({ page }) => {
+  await page.goto(richSampleUrl("messages"));
+  const panel = page.locator("#messages-contents");
+  await expect(panel).toBeVisible({ timeout: 15_000 });
+  await expect(panel.getByText("What is 2+2?").first()).toBeVisible();
+  await expect(panel.getByText("The answer is 4.").first()).toBeVisible();
+  await shot(page, "sample-messages.png");
+});
+
+test("sample transcript tab renders the event timeline", async ({ page }) => {
+  await page.goto(richSampleUrl("transcript"));
+  const panel = page.locator("#transcript-contents");
+  await expect(panel).toBeVisible({ timeout: 15_000 });
+  // The fixture sample's events include a model event and a score event.
+  await expect(panel.getByText(/model call/i).first()).toBeVisible();
+  await expect(panel.getByText("The answer is 4.").first()).toBeVisible();
+  await expect(page.locator(".transcript-outline")).toBeVisible();
+  await shot(page, "sample-transcript.png");
+});
+
+test("scores render in the log list and the sample scoring tab", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const grid = page.getByRole("grid", { name: "Evaluation logs" });
+  await expect(grid).toBeVisible({ timeout: 15_000 });
+  const richRow = grid
+    .getByRole("row")
+    .filter({ hasText: "viewer_rich" })
+    .first();
+  await expect(richRow.locator('[data-col-id="score"]')).toContainText("0.8");
+  await shot(page, "scores-log-list.png");
+
+  await page.goto(richSampleUrl("scoring"));
+  const scoring = page.locator("#scoring-contents");
+  await expect(scoring).toBeVisible({ timeout: 15_000 });
+  await expect(scoring.getByText("includes").first()).toBeVisible();
+  await expect(scoring.getByText("C", { exact: true }).first()).toBeVisible();
+  await shot(page, "scores-sample-scoring-tab.png");
+});

--- a/apps/inspect/.claude/skills/verify-log-viewer/drive/log-viewer.spec.ts
+++ b/apps/inspect/.claude/skills/verify-log-viewer/drive/log-viewer.spec.ts
@@ -91,6 +91,52 @@ test("sample transcript tab renders the event timeline", async ({ page }) => {
   await shot(page, "sample-transcript.png");
 });
 
+test("log list task column filter narrows rows and reset restores", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const grid = page.getByRole("grid", { name: "Evaluation logs" });
+  await expect(grid).toBeVisible({ timeout: 15_000 });
+
+  const richCell = page
+    .getByRole("gridcell")
+    .filter({ hasText: "viewer_rich" })
+    .first();
+  const arithmeticCell = page
+    .getByRole("gridcell")
+    .filter({ hasText: "viewer_arithmetic" })
+    .first();
+  await expect(richCell).toBeVisible();
+  await expect(arithmeticCell).toBeVisible();
+  // Footer count is the canonical row count — the grid is virtualized, so
+  // DOM row counts lie (see features/log-list.md).
+  const footerCount = page.getByText(/^[\d,]+( \/ [\d,]+)? items$/);
+  const totalItems = (await footerCount.innerText()).replace(/ items$/, "");
+  await shot(page, "log-list-filter-before.png");
+
+  const taskHeader = page
+    .getByRole("columnheader")
+    .filter({ has: page.getByText("Task", { exact: true }) });
+  await taskHeader
+    .getByRole("button", { name: "Filter task", exact: true })
+    .click();
+  await page.locator("#task-op").selectOption("contains");
+  await page.getByPlaceholder("Filter").fill("rich");
+  await page.getByRole("button", { name: "Apply" }).click();
+
+  await expect(richCell).toBeVisible();
+  await expect(arithmeticCell).not.toBeVisible();
+  // Two matches: the fixture dir holds viewer_rich as both .eval and .json.
+  await expect(footerCount).toHaveText(`2 / ${totalItems} items`);
+  await shot(page, "log-list-filter-applied.png");
+
+  await page.getByRole("button", { name: "Reset Filters" }).click();
+  await expect(arithmeticCell).toBeVisible();
+  await expect(richCell).toBeVisible();
+  await expect(footerCount).toHaveText(`${totalItems} items`);
+  await shot(page, "log-list-filter-reset.png");
+});
+
 test("scores render in the log list and the sample scoring tab", async ({
   page,
 }) => {

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/README.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/README.md
@@ -15,13 +15,14 @@ then use the matching feature file as the recipe.
 - The default fixture dir `~/code/viewer-validation/logs` is deterministic
   mockllm output. Ground truth used by the standing spec:
 
-| Fixture log | Facts to assert against |
-| --- | --- |
+| Fixture log                                                         | Facts to assert against                                                                                                                                                             |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `2026-07-07T21-47-35-00-00_viewer-rich_M58v4LGnsyG2Gh3hwXxpeP.eval` | task `viewer_rich`, 5 samples, accuracy 0.8; sample 1/epoch 1: input `What is 2+2?`, assistant `The answer is 4.`, target `4`, score `includes: C`, 17 events (model, score, spans) |
-| `...viewer-arithmetic_7hC9oRtKWCL5jqeA7zUWfq.eval` | task `viewer_arithmetic`, 3 samples, accuracy 0.0 |
-| `...viewer-error_RbzFqVPn2h6kkuqHN3gt3F.eval` | status `error` — exercises error display |
-| `...viewer-cancelled_*.eval` (7 files) | one task with many runs; one run cancelled |
-| `...viewer-grid_ixJgGBWxnCrNnk7qzyHU7S.eval` | 24 samples — enough rows to exercise the samples grid |
+| `...viewer-rich_9GnzUtiNvgakGMKyahfeyu.json`                        | a second `viewer_rich` log in JSON format — task-name matches (e.g. filtering "rich") intentionally return 2 rows, not 1                                                            |
+| `...viewer-arithmetic_7hC9oRtKWCL5jqeA7zUWfq.eval`                  | task `viewer_arithmetic`, 3 samples, accuracy 0.0                                                                                                                                   |
+| `...viewer-error_RbzFqVPn2h6kkuqHN3gt3F.eval`                       | status `error` — exercises error display                                                                                                                                            |
+| `...viewer-cancelled_*.eval` (7 files)                              | one task with many runs; one run cancelled                                                                                                                                          |
+| `...viewer-grid_ixJgGBWxnCrNnk7qzyHU7S.eval`                        | 24 samples — enough rows to exercise the samples grid                                                                                                                               |
 
 ## Driving conventions
 

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/README.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/README.md
@@ -1,0 +1,72 @@
+# Log viewer verification map
+
+This directory is the maintained source for verifying the user-facing
+behavior of the inspect log viewer. Read this index before driving the app,
+then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Run `doctor.sh` and require every line `ok` (see SKILL.md → Doctor).
+- Launch through the Playwright config (SKILL.md → Launch): a real
+  `inspect view` server on `VERIFY_VIEW_SERVER_PORT` reading
+  `VERIFY_LOG_DIR`, and the viewer at `http://localhost:5179`.
+- Never drive an instance this run did not start (`reuseExistingServer` is
+  false for exactly this reason).
+- The default fixture dir `~/code/viewer-validation/logs` is deterministic
+  mockllm output. Ground truth used by the standing spec:
+
+| Fixture log | Facts to assert against |
+| --- | --- |
+| `2026-07-07T21-47-35-00-00_viewer-rich_M58v4LGnsyG2Gh3hwXxpeP.eval` | task `viewer_rich`, 5 samples, accuracy 0.8; sample 1/epoch 1: input `What is 2+2?`, assistant `The answer is 4.`, target `4`, score `includes: C`, 17 events (model, score, spans) |
+| `...viewer-arithmetic_7hC9oRtKWCL5jqeA7zUWfq.eval` | task `viewer_arithmetic`, 3 samples, accuracy 0.0 |
+| `...viewer-error_RbzFqVPn2h6kkuqHN3gt3F.eval` | status `error` — exercises error display |
+| `...viewer-cancelled_*.eval` (7 files) | one task with many runs; one run cancelled |
+| `...viewer-grid_ixJgGBWxnCrNnk7qzyHU7S.eval` | 24 samples — enough rows to exercise the samples grid |
+
+## Driving conventions
+
+The viewer is a hash-routed React app (`#/...` URLs). Prefer, in order:
+
+1. `getByRole` — `grid` (named "Evaluation logs" / "Samples"), `row`,
+   `gridcell`, `columnheader`, `tab`, `dialog`, `button`, `navigation`.
+2. `getByLabel` / aria-label, then `getByPlaceholder`.
+3. The few explicit test ids: `error-panel`, `score-grid`, `find-band-*`.
+4. Stable DOM ids: `#<tabId>-contents` tab panels, `[id^="sample-heading-"]`,
+   `#turn-<uuid>`.
+5. `[class*="_moduleClass_"]` CSS-module fragments only as a last resort.
+
+Deep-link instead of clicking through when the feature under proof isn't the
+navigation itself:
+`/#/logs/<encodeURIComponent(file)>/samples/sample/<id>/<epoch>/<tab>`.
+Sample tab ids: `messages transcript scoring usage metadata error retries json`.
+Log workspace tab ids: `samples json info models task timeline error`.
+
+Readiness is always a web-first assertion on content (`expect(...).toBeVisible()`),
+never `networkidle` or fixed sleeps. The app boot gate blocks on
+`GET /api/logs`, then `/api/log-files`, `/api/log-headers`, `/api/logs/:file`.
+
+Do not import `test`/`expect` from `apps/inspect/e2e/fixtures/app.ts` — that
+fixture auto-enables MSW and silently mocks `/api`. Import from
+`@playwright/test`.
+
+## Proof and skip reporting
+
+- Assert values that are actually in the fixture being driven (task name,
+  input text, score value), then screenshot the end state into `evidence/`.
+- Capture the action and the resulting state (e.g. list before click, log
+  view after), not only the final screen.
+- Report an unreachable path with the attempted selector and the unmet
+  precondition; a skipped entry point is not verified by a different path.
+
+## Features
+
+- [Log list](./log-list.md) — Tasks/Folders views, listing real logs,
+  opening one, column filters, find band.
+- [Sample list](./sample-list.md) — the samples grid inside a log and the
+  top-level Samples view.
+- [Sample messages](./sample-messages.md) — the conversation rendering in a
+  sample's Messages tab.
+- [Transcript](./transcript.md) — the event timeline, outline, and turn
+  navigation in a sample's Transcript tab.
+- [Scores](./scores.md) — score column in the log list, log-level scoring
+  detail, and the sample Scoring tab.

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/log-list.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/log-list.md
@@ -43,8 +43,14 @@ Preconditions:
   `header.getByRole("button", { name: "Filter task", exact: true })`, then
   `page.locator("#task-op").selectOption("contains")`,
   `page.getByPlaceholder("Filter").fill("rich")`,
-  `page.getByRole("button", { name: "Apply" })`. Row count drops; reset via
+  `page.getByRole("button", { name: "Apply" })`. Assert the footer count
+  (below), then reset via
   `page.getByRole("button", { name: "Reset Filters" })`.
+- **Row counts.** The footer (bottom right) is the canonical count — it is
+  immune to virtualization. Unfiltered it reads `<N> items`; filtered it
+  reads `<matched> / <N> items` (e.g. `2 / 25 items` after filtering task
+  contains "rich" on the default fixtures). Assert on that text, not on DOM
+  row counts.
 - **Find.** `page.keyboard.press("ControlOrMeta+f")`, type into
   `page.getByPlaceholder("Find")`; `getByTestId("find-band-match-count")`
   shows `"1 of N"`; `find-band-next`/`find-band-prev` step matches.
@@ -61,6 +67,7 @@ Preconditions:
 - Buttons whose aria-labels contain "Samples" exist outside the navbar;
   always scope the view switcher to `getByRole("navigation")`.
 - The grid is virtualized: a row far down the list may not be in the DOM
-  until scrolled. Filter or find instead of scrolling blindly.
+  until scrolled. Filter or find instead of scrolling blindly, and count via
+  the footer text, never via DOM rows.
 - Sort indicators are aria-hidden icons (`i.bi-arrow-down`); assert on them
   by class if sorting is under proof.

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/log-list.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/log-list.md
@@ -1,0 +1,66 @@
+# Log list
+
+The landing surface: a grid of eval logs from the served log directory, in
+three top-level views (Tasks, Folders, Samples) switched by a segmented
+control in the navbar. Rows show status, task, model, score, and counts;
+activating a row opens that log.
+
+## Sub-features
+
+- `list-render` shows one row per log with status icon, task, model, score.
+- `list-views` switches Tasks / Folders / Samples via the segmented control.
+- `list-open` opens a log from a row (click or Enter) and routes to it.
+- `list-filter` filters rows per column via the header funnel button.
+- `list-find` incremental find across the grid (Cmd/Ctrl-F band).
+
+## How to get to it (user POV)
+
+- Open `http://localhost:5179/` — the default route is the Tasks view.
+- `#/logs` is the Folders view; `#/tasks` is the Tasks view explicitly.
+- The navbar segmented control switches views from anywhere.
+
+## Driving it with Playwright
+
+Preconditions:
+
+- Baseline launch (features/README.md); fixture dir is the default one.
+
+- **List renders.** `page.goto("/")`, then
+  `page.getByRole("grid", { name: "Evaluation logs" })` is visible and
+  `page.getByRole("gridcell").filter({ hasText: "viewer_rich" }).first()` is
+  visible. Cells carry `data-col-id="<columnId>"` (`task`, `model`, `score`,
+  `status`, `totalSamples`, …) for column-scoped assertions.
+- **Switch views.** Scope to the navbar to avoid name collisions:
+  `page.getByRole("navigation").getByRole("button", { name: "Folders" })`
+  (also `"Tasks"`, `"Samples"`). After switching, the URL is `#/logs` /
+  `#/tasks` and the grid re-renders.
+- **Open a log.** Click a `gridcell` in the target row (rows are divs with
+  onClick — there is no link role), then `page.waitForURL(/#\/tasks\//)` (or
+  `/#\/logs\//` from Folders view). The log view renders with a
+  `getByRole("tab", { name: /^Samples?$/ })` tab ("Sample" when the log has
+  exactly one).
+- **Filter a column.** In the `Task` column header:
+  `header.getByRole("button", { name: "Filter task", exact: true })`, then
+  `page.locator("#task-op").selectOption("contains")`,
+  `page.getByPlaceholder("Filter").fill("rich")`,
+  `page.getByRole("button", { name: "Apply" })`. Row count drops; reset via
+  `page.getByRole("button", { name: "Reset Filters" })`.
+- **Find.** `page.keyboard.press("ControlOrMeta+f")`, type into
+  `page.getByPlaceholder("Find")`; `getByTestId("find-band-match-count")`
+  shows `"1 of N"`; `find-band-next`/`find-band-prev` step matches.
+- **Proof.** Screenshot the populated list and the opened log into
+  `evidence/`; assert a task name and a score value that exist in the
+  fixture (e.g. `viewer_rich`, `0.8`).
+
+## Gotchas
+
+- Column header accessible names include the filter funnel's aria-label —
+  match header text with
+  `getByRole("columnheader").filter({ has: page.getByText("Task", { exact: true }) })`,
+  not by accessible name.
+- Buttons whose aria-labels contain "Samples" exist outside the navbar;
+  always scope the view switcher to `getByRole("navigation")`.
+- The grid is virtualized: a row far down the list may not be in the DOM
+  until scrolled. Filter or find instead of scrolling blindly.
+- Sort indicators are aria-hidden icons (`i.bi-arrow-down`); assert on them
+  by class if sorting is under proof.

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/sample-list.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/sample-list.md
@@ -1,0 +1,55 @@
+# Sample list
+
+The grid of samples for one log (the log view's default tab) and the
+top-level Samples view that lists samples across all logs. Rows show id,
+epoch, input, target, answer, score, and status; activating a row opens the
+sample detail.
+
+## Sub-features
+
+- `samples-in-log` lists a log's samples in the log view's Samples tab.
+- `samples-open` opens a sample's detail from a row.
+- `samples-global` lists samples across logs in the top-level Samples view.
+
+## How to get to it (user POV)
+
+- Open any log from the log list — the log view lands on its Samples tab.
+- Direct: `#/logs/<encodedLogPath>` (defaults to the samples tab) or
+  `#/logs/<encodedLogPath>/samples`.
+- Navbar segmented control → `Samples` for the cross-log view (`#/samples`).
+
+## Driving it with Playwright
+
+Preconditions:
+
+- Baseline launch. `viewer-rich` (5 samples) or `viewer-grid` (24 samples,
+  for virtualization) as the target log.
+
+- **Grid renders.** `page.goto("/#/logs/" + encodeURIComponent(logFile))`,
+  then `page.getByRole("grid", { name: "Samples" })` is visible. Column ids
+  for `data-col-id`: `displayIndex`, `sampleId`, `epoch`, `input`, `target`,
+  `answer`, `tokens`, `duration`, `error`, `limit`.
+- **Content is the fixture's.** For viewer-rich:
+  `samplesGrid.getByRole("gridcell").filter({ hasText: "What is 2+2?" }).first()`
+  is visible.
+- **Open a sample.** Click that gridcell, then
+  `page.waitForURL(/\/samples\/sample\//)` and
+  `page.locator("[id^='sample-heading-']")` is visible — the sample header
+  with input/target/answer/score.
+- **Cross-log view.** `page.getByRole("navigation").getByRole("button", { name: "Samples" })`;
+  the same `grid` named "Samples" renders rows from multiple logs (extra
+  columns `task`, `logFile`). Opening a row routes to
+  `#/samples/<logPath>/sample/<id>/<epoch>/...`.
+- **Proof.** Screenshot the grid and the opened sample detail; assert the
+  fixture's input text and sample count.
+
+## Gotchas
+
+- Both grids are named "Samples" — on a page that could have either, scope
+  by URL first.
+- The samples grid is virtualized; with viewer-grid's 24 rows, assert
+  visible rows or scroll deliberately, don't count DOM rows and expect 24.
+- Sample ids in URLs are `encodeURIComponent`'d before path encoding; ids
+  containing `/` need double care — build URLs with the same encoding.
+- The log view tab is labeled `Sample` (singular) when the log has exactly
+  one sample — match `/^Samples?$/`.

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/sample-messages.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/sample-messages.md
@@ -1,0 +1,43 @@
+# Sample messages
+
+The Messages tab of a sample detail: the conversation (system/user/
+assistant/tool messages) rendered as chat, with markdown, images, and
+tool-call formatting.
+
+## Sub-features
+
+- `messages-render` shows every message with its role and content.
+- `messages-markdown` renders markdown/code content (not raw text).
+- `messages-deeplink` `?message=<id>` scrolls to and highlights a message.
+
+## How to get to it (user POV)
+
+- Open a sample, then choose the `Messages` tab.
+- Direct: `#/logs/<encodedLogPath>/samples/sample/<id>/<epoch>/messages`.
+
+## Driving it with Playwright
+
+Preconditions:
+
+- Baseline launch; viewer-rich sample 1/epoch 1 as the target.
+
+- **Panel renders.** `page.goto(url)` with the deep link above; the tab
+  panel is the stable id `page.locator("#messages-contents")`.
+- **Conversation content.** Within the panel,
+  `panel.getByText("What is 2+2?")` (user) and
+  `panel.getByText("The answer is 4.")` (assistant) are visible.
+- **Tab switching.** From another tab,
+  `page.getByRole("tab", { name: "Messages" }).click()` selects it
+  (`aria-selected="true"`); the tab button's DOM id is the tab id.
+- **Proof.** Screenshot the rendered conversation; assert both roles'
+  fixture texts, not just one.
+
+## Gotchas
+
+- The chat list's own DOM id embeds a visit counter
+  (`sample-display-chat-<id>-<visitId>`) — never select by it; use
+  `#messages-contents`.
+- The message list is virtualized for long conversations; a message deep in
+  the transcript may need `?message=<id>` or scrolling to enter the DOM.
+- Images render as `img[src^='data:image']` — assert on that prefix when a
+  fixture contains images (viewer-rich does in later samples).

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/scores.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/scores.md
@@ -1,0 +1,55 @@
+# Scores
+
+Score display at every level: the score column in the log list, the
+log-level scoring summary (header grid with a detail dialog when metrics
+overflow), and the per-sample Scoring tab with scorer, answer, target, and
+explanation.
+
+## Sub-features
+
+- `scores-list-column` log-list `score` column shows the headline metric.
+- `scores-log-header` log view header shows scorer/metric summary; the
+  "All scoring..." button opens the Scoring Detail dialog when metrics
+  overflow.
+- `scores-sample-tab` sample Scoring tab shows scorer name, score value,
+  answer, target, explanation.
+
+## How to get to it (user POV)
+
+- Log list: the `Score` column on every row.
+- Log view: the header above the tabs; `All scoring...` when many metrics.
+- Sample detail: the `Scoring` tab
+  (`#/logs/<encodedLogPath>/samples/sample/<id>/<epoch>/scoring`).
+
+## Driving it with Playwright
+
+Preconditions:
+
+- Baseline launch; viewer-rich (accuracy 0.8; sample 1 scores
+  `includes: C`) as the target.
+
+- **List column.** On `/`, the viewer-rich row's score cell:
+  `row.locator('[data-col-id="score"]')` contains `0.8`. Per-metric rotated
+  columns are headed `"<scorer> / <metric>"` (e.g. `includes / accuracy`).
+- **Log header.** Open the log; the header renders the scorer summary. With
+  many metrics: `page.getByRole("button", { name: "All scoring..." })`
+  opens `page.getByRole("dialog", { name: "Scoring Detail" })` whose scroll
+  container is `dialog.getByTestId("score-grid")` (explicit test hook).
+  viewer-rich's single scorer does NOT overflow — use a multi-metric
+  fixture to prove the dialog.
+- **Sample tab.** Deep-link to `/scoring`;
+  `page.locator("#scoring-contents")` contains the scorer name `includes`
+  and the value `C`; sort control is
+  `getByRole("button", { name: "Sort scores" })`.
+- **Proof.** Screenshots of the list column and the scoring tab; assert the
+  numeric metric (0.8) and the sample score letter (C) — values that come
+  from the fixture, not placeholders.
+
+## Gotchas
+
+- `getByText("C", { exact: true })` can match stray single letters — scope
+  to `#scoring-contents` first.
+- The Scoring Detail dialog only exists when metrics overflow the header;
+  don't report `scores-log-header` proven on a one-metric fixture.
+- Metric values are rounded for display — assert the displayed rounding
+  (`0.8`), not full precision from the log.

--- a/apps/inspect/.claude/skills/verify-log-viewer/features/transcript.md
+++ b/apps/inspect/.claude/skills/verify-log-viewer/features/transcript.md
@@ -1,0 +1,53 @@
+# Transcript
+
+The Transcript tab of a sample detail: the event timeline (solver spans,
+model calls, scoring, state changes) with a collapsible outline sidebar,
+per-event expansion, and turn navigation.
+
+## Sub-features
+
+- `transcript-render` shows the event timeline for the sample.
+- `transcript-outline` sidebar outline mirrors the span/turn structure.
+- `transcript-events` model-call events show summary/info/messages/api tabs.
+- `transcript-turns` next/previous turn navigation and focused turn view.
+
+## How to get to it (user POV)
+
+- Open a sample — Transcript is the default sample tab.
+- Direct: `#/logs/<encodedLogPath>/samples/sample/<id>/<epoch>/transcript`.
+- A single event: append `/event?event=<eventId>`.
+
+## Driving it with Playwright
+
+Preconditions:
+
+- Baseline launch; viewer-rich sample 1/epoch 1 (17 events: model, score,
+  spans) as the target.
+
+- **Panel renders.** Deep-link, then `page.locator("#transcript-contents")`
+  is visible.
+- **Events present.** `panel.getByText(/model call/i).first()` is visible
+  (the fixture's mockllm call renders as "Model Call: mockllm/model"); the
+  score event renders a SCORE block with target `4` and score `C`.
+- **Outline.** `page.locator(".transcript-outline")` is visible and contains
+  the span names (`generate`, `scoring` for this fixture).
+- **Expand/collapse.** Toolbar
+  `page.getByRole("button", { name: /collapse|expand/i }).first()` toggles
+  event bodies.
+- **Turn navigation.** `getByRole("button", { name: "Next turn" })` /
+  `{ name: "Previous turn" }`; per-turn anchors are `#turn-<eventUuid>`;
+  `getByRole("link", { name: "Open focused turn view" })` enters focus mode,
+  `getByRole("button", { name: "Exit focus mode" })` leaves it.
+- **Proof.** Screenshot the timeline showing the model call and score event;
+  assert fixture-specific texts (input, answer, score value).
+
+## Gotchas
+
+- Outline rows are only selectable via CSS-module fragments
+  (`[class*="eventRow"]`) — brittle; prefer asserting on outline text.
+- One-turn samples disable turn-nav buttons — use a multi-turn fixture when
+  proving `transcript-turns`.
+- Some turn-nav store writes are debounced with no DOM signal; the existing
+  suite (`e2e/turn-navigation.spec.ts`) uses explicit `waitForTimeout` there
+  as a documented exception — copy that pattern only for that case.
+- Event bodies lazy-render; assert visibility per event, not DOM counts.

--- a/apps/inspect/.claude/skills/verify-log-viewer/playwright.verify.config.ts
+++ b/apps/inspect/.claude/skills/verify-log-viewer/playwright.verify.config.ts
@@ -1,0 +1,53 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { defineConfig, devices } from "@playwright/test";
+
+const viewerPort = process.env.VERIFY_VIEWER_PORT ?? "5179";
+const viewServerPort = process.env.VERIFY_VIEW_SERVER_PORT ?? "7677";
+const baseURL = `http://localhost:${viewerPort}`;
+
+// `inspect` must be an inspect_ai CLI; see SKILL.md → Launch for where one
+// lives on this machine if it isn't on PATH.
+const inspectBin = process.env.INSPECT_BIN ?? "inspect";
+const logDir =
+  process.env.VERIFY_LOG_DIR ?? join(homedir(), "code/viewer-validation/logs");
+
+const skillDir = import.meta.dirname;
+const appDir = join(skillDir, "../../..");
+
+export default defineConfig({
+  testDir: join(skillDir, "drive"),
+  outputDir: join(skillDir, "test-results"),
+  fullyParallel: false,
+  reporter: "list",
+  timeout: 60_000,
+  use: {
+    baseURL,
+    screenshot: "only-on-failure",
+    viewport: { width: 1280, height: 900 },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // reuseExistingServer stays false on both: a port already owned by
+  // something else means we'd be driving (and possibly corrupting) a
+  // session we didn't start — refuse instead.
+  webServer: [
+    {
+      command: `${inspectBin} view start --log-dir ${logDir} --port ${viewServerPort} --display plain`,
+      url: `http://127.0.0.1:${viewServerPort}/api/logs`,
+      reuseExistingServer: false,
+      timeout: 30_000,
+    },
+    {
+      command: `pnpm exec vite --config ${join(skillDir, "vite.verify.config.ts")}`,
+      cwd: appDir,
+      env: {
+        VERIFY_VIEWER_PORT: viewerPort,
+        VERIFY_VIEW_SERVER_PORT: viewServerPort,
+      },
+      url: baseURL,
+      reuseExistingServer: false,
+      timeout: 60_000,
+    },
+  ],
+});

--- a/apps/inspect/.claude/skills/verify-log-viewer/vite.verify.config.ts
+++ b/apps/inspect/.claude/skills/verify-log-viewer/vite.verify.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, mergeConfig } from "vite";
+
+import { rewriteLoopbackOrigin } from "../../../../../tooling/vite-plugins/index.js";
+import base from "../../../vite.config.ts";
+
+// The app's own dev config pins the /api proxy to 7575 — the port a user's
+// real `inspect view` owns. Verification runs its own view server on a
+// dedicated port so it never reads (or disturbs) the user's session.
+const viewServerUrl = `http://127.0.0.1:${process.env.VERIFY_VIEW_SERVER_PORT ?? "7677"}`;
+const viewerPort = Number(process.env.VERIFY_VIEWER_PORT ?? "5179");
+
+export default defineConfig((env) =>
+  mergeConfig(base(env), {
+    server: {
+      port: viewerPort,
+      strictPort: true,
+      proxy: {
+        "/api": {
+          target: viewServerUrl,
+          changeOrigin: true,
+          configure: rewriteLoopbackOrigin(viewServerUrl),
+        },
+      },
+    },
+  })
+);


### PR DESCRIPTION
Adds an agent skill (`apps/inspect/.claude/skills/verify-log-viewer/`) that drives the real log viewer against real `.eval` logs and captures evidence that user-facing behavior works.

## Why

The e2e suite mocks `/api` with MSW and in-memory JSON logs — it never exercises the view-server API's real responses, binary `.eval` parsing, or the boot path against a real server. This harness covers that layer: it launches a real `inspect view` server on a dedicated port plus the app's vite dev server (a small config extending the app's re-points the `/api` proxy off 7575 so a user's own view server is never touched), and drives it with Playwright.

It complements the MSW suite, not replaces it: pure UI logic still belongs in `e2e/`; this is for verification where realness matters (transport, parsing, whole-stack boot). It requires a local inspect_ai venv, so it's a local proof tool, not CI.

## Contents

- `SKILL.md` — launch / doctor / drive / evidence / cleanup
- `doctor.sh` — read-only preflight (ports, inspect CLI, fixtures)
- `playwright.verify.config.ts` + `vite.verify.config.ts` — the harness; Playwright owns both servers' lifecycle, `reuseExistingServer: false`
- `drive/log-viewer.spec.ts` — standing proof: log list, open log, sample list/detail, messages, transcript, scores, column filter (6 tests, ~11s, deterministic mockllm fixtures)
- `features/` — maintained map of user-facing features with real routes/selectors/gotchas

## Validation

- Suite run repeatedly against the viewer-validation fixture logs; screenshots + fixture-grounded assertions (task names, score values, message text).
- Cold-tested: a context-free agent was told only "verify column filtering works — the repo has a verification skill." It found the skill, recovered `INSPECT_BIN` from the docs, followed the map's recipe verbatim, and proved narrow/reset first try. Its four findings (doc pointer, standing-spec rule, footer-count assertion, fixture-table gap) are folded into the second commit.