### PR TITLE
Split suppression delta comment into a pull_request_target workflow so it posts on fork PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,14 @@ jobs:
       - name: Check linting
         run: pnpm lint
 
+  # Enforcement only: it runs fine with the read-only token fork PRs get.
+  # The PR delta comment is posted by suppressions-comment.yml
+  # (pull_request_target), which needs a write token — keep the two
+  # concerns in their separate workflows.
   suppressions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 
@@ -56,34 +59,8 @@ jobs:
       - name: Check suppressions ledger
         run: node scripts/check-suppressions.mjs
 
-      - name: Test the gate script
-        run: node --test scripts/check-suppressions.test.mjs
-
-      - name: Comment ledger delta on PR
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          BASE_REF: ${{ github.base_ref }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          git fetch --depth=1 origin "$BASE_REF"
-          git show "origin/$BASE_REF:suppressions.json" > /tmp/base-suppressions.json 2>/dev/null \
-            || echo '{}' > /tmp/base-suppressions.json
-          body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json suppressions.json)
-          # Sticky comment: match on the marker, not --edit-last, so other
-          # bot comments on the PR are never clobbered.
-          cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
-            -q '.[] | select(.body | startswith("<!-- suppressions-delta -->")) | .id' | head -1)
-          if [ -n "$body" ] && [ -n "$cid" ]; then
-            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" -f body="$body" > /dev/null
-          elif [ -n "$body" ]; then
-            gh pr comment "$PR" --body "$body"
-          elif [ -n "$cid" ]; then
-            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" \
-              -f body="$(printf '<!-- suppressions-delta -->\nThis PR no longer changes the suppression ledger.')" > /dev/null
-          fi
+      - name: Test the gate scripts
+        run: node --test scripts/check-suppressions.test.mjs scripts/suppressions-pr-delta.test.mjs
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/suppressions-comment.yml
+++ b/.github/workflows/suppressions-comment.yml
@@ -1,0 +1,89 @@
+# Posts the sticky suppression-ledger delta comment on PRs, fork PRs
+# included — see scripts/suppressions-pr-delta.mjs and the suppressions
+# section in CONTRIBUTING.md.
+#
+# SECURITY MODEL — read before editing.
+#
+# This workflow runs on pull_request_target, which executes in the BASE
+# repo's context with a WRITE token even for fork PRs. That is the only
+# reason it exists: the plain pull_request token on a fork PR is read-only
+# and cannot post the comment (enforcement lives in ci.yaml's suppressions
+# job, where read-only is enough). A pull_request_target workflow that runs
+# PR-controlled code hands that write token to the PR author, so this job
+# keeps three invariants:
+#
+#   1. Only BASE code runs. The checkout below has no `ref`, so it checks
+#      out the base branch: the delta script and the base ledger are the
+#      base repo's own trusted copies. A PR's changes to the script take
+#      effect only after a maintainer merges them.
+#   2. PR content is data, never code. The PR's suppressions.json is read
+#      with `git show` on the fetched head ref — that reads a blob and
+#      executes nothing. The PR head is never checked out.
+#   3. No dependency installs. The delta script is node-builtins-only by
+#      design; running `pnpm install` would execute PR-controllable
+#      dependency and lifecycle scripts.
+#
+# Do NOT "fix" this workflow by checking out the PR head, running any
+# script from it, or adding an install step — any of those breaks the
+# security model.
+name: Suppressions comment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      # No `ref`: on pull_request_target this checks out the BASE branch
+      # (trusted script + base ledger). Never add ref: pull_request.head.
+      - uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Comment ledger delta on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # The PR's ledger is fetched and read as DATA: `git show` reads
+          # a blob and executes nothing. The PR head is never checked out.
+          git fetch --depth=1 origin "pull/$PR/head"
+          git show FETCH_HEAD:suppressions.json > /tmp/head-suppressions.json 2>/dev/null \
+            || echo '{}' > /tmp/head-suppressions.json
+          # The workspace is the base branch, so its ledger is the base side.
+          if [ -f suppressions.json ]; then
+            cp suppressions.json /tmp/base-suppressions.json
+          else
+            echo '{}' > /tmp/base-suppressions.json
+          fi
+          # Base script, node builtins only — no installs (see the security
+          # model above).
+          body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json /tmp/head-suppressions.json)
+          # Sticky comment: match on the marker, not --edit-last, so other
+          # bot comments on the PR are never clobbered.
+          cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            -q '.[] | select(.body | startswith("<!-- suppressions-delta -->")) | .id' | head -1)
+          if [ -n "$body" ] && [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" -f body="$body" > /dev/null
+          elif [ -n "$body" ]; then
+            gh pr comment "$PR" --body "$body"
+          elif [ -n "$cid" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$cid" \
+              -f body="$(printf '<!-- suppressions-delta -->\nThis PR no longer changes the suppression ledger.')" > /dev/null
+          fi

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -113,6 +113,7 @@ export const diffLedgers = (ledger, actual) => {
   const before = new Map(entries(ledger));
   const after = new Map(entries(actual));
   return [...new Set([...before.keys(), ...after.keys()])]
+    .sort((a, b) => a.localeCompare(b))
     .map((key) => ({
       key,
       before: before.get(key) ?? NONE,
@@ -164,11 +165,28 @@ export const totals = (ledger) =>
 const listFiles = () =>
   execFileSync(
     "git",
-    ["ls-files", "-z", "--", "*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs"],
+    [
+      "ls-files",
+      "-z",
+      "--cached",
+      "--others",
+      "--exclude-standard",
+      "--",
+      "*.ts",
+      "*.tsx",
+      "*.js",
+      "*.jsx",
+      "*.mjs",
+      "*.cjs",
+    ],
     { encoding: "utf8" },
   )
     .split("\0")
-    .filter((f) => f && !EXCLUDED.some((re) => re.test(f)));
+    // Untracked, non-ignored files count too, so an update run before
+    // `git add` sees newly authored code; unstaged deletions still present
+    // in the index are skipped so ordinary edit-then-update workflows do
+    // not fail opening them.
+    .filter((f) => f && !EXCLUDED.some((re) => re.test(f)) && existsSync(f));
 
 const scanRepo = () =>
   buildLedger(
@@ -193,7 +211,16 @@ const main = () => {
     }).trim(),
   );
 
-  const update = process.argv.includes("--update");
+  const args = process.argv.slice(2);
+  const unknown = args.filter((a) => a !== "--update");
+  if (unknown.length) {
+    // A silently-ignored typo (e.g. --updat) would run check mode instead.
+    console.error(
+      `unknown argument(s): ${unknown.join(" ")} (expected --update)`,
+    );
+    process.exit(2);
+  }
+  const update = args.includes("--update");
   // No ledger yet: the first --update captures the baseline as-is.
   const bootstrap = !existsSync(LEDGER_PATH);
   const ledger = readLedger();
@@ -208,7 +235,16 @@ const main = () => {
   }
 
   if (update) {
-    if (violations.length) process.exit(1);
+    if (violations.length) {
+      console.error(
+        "refusing to record reason-less growth; fix the code or add a `-- reason` segment.",
+      );
+      process.exit(1);
+    }
+    if (bootstrap)
+      // A missing ledger silently skips the ratchet above; say so, or
+      // deleting the file becomes an invisible bypass.
+      console.log("no existing ledger: baseline captured, ratchet not applied.");
     writeFileSync(LEDGER_PATH, JSON.stringify(actual, null, 2) + "\n");
     console.log(`${LEDGER_PATH} updated: ${summarize(actual)}.`);
     return;

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -96,11 +96,25 @@ export const buildLedger = (perFile) =>
 const entryKey = (file, rule) => file + "\t" + rule;
 const keyOf = (key) => key.split("\t").join(" — ");
 
+// Ledger JSON reaching the delta renderer can come from a fork PR head
+// (see suppressions-pr-delta.mjs), so tally values are untrusted: coerce
+// them to finite numbers and tolerate malformed shapes here, or a crafted
+// string count would ride `+` concatenation through totals() into the
+// rendered comment, bypassing the cell() escaping. Trusted inputs (the
+// committed ledger, the gate's own scan) are unaffected.
+const obj = (value) =>
+  typeof value === "object" && value !== null ? value : {};
+const num = (value) =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
 const entries = (ledger) =>
-  Object.entries(ledger).flatMap(([file, rules]) =>
-    Object.entries(rules).map(([rule, tally]) => [
+  Object.entries(obj(ledger)).flatMap(([file, rules]) =>
+    Object.entries(obj(rules)).map(([rule, tally]) => [
       entryKey(file, rule),
-      { count: tally.count, undescribed: tally.undescribed ?? 0 },
+      {
+        count: num(obj(tally).count),
+        undescribed: num(obj(tally).undescribed),
+      },
     ]),
   );
 

--- a/scripts/check-suppressions.test.mjs
+++ b/scripts/check-suppressions.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   buildLedger,
@@ -180,6 +185,55 @@ test("ratchet still fires when a move also adds a reason-less suppression", () =
     ),
     [{ rule: "r", before: 2, after: 3 }],
   );
+});
+
+// --- CLI: bootstrap, ratchet refusal, unknown args (throwaway git repo) ---
+
+const GATE = fileURLToPath(new URL("./check-suppressions.mjs", import.meta.url));
+
+const initRepo = (files) => {
+  const repo = mkdtempSync(join(tmpdir(), "supp-gate-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+  for (const [name, content] of Object.entries(files))
+    writeFileSync(join(repo, name), content);
+  // ls-files sees tracked files via the index; staging suffices (no commit).
+  execFileSync("git", ["add", "-A"], { cwd: repo });
+  return repo;
+};
+
+const runGate = (repo, ...args) =>
+  spawnSync(process.execPath, [GATE, ...args], { cwd: repo, encoding: "utf8" });
+
+test("bootstrap --update captures the baseline and says so; untracked files count", () => {
+  const repo = initRepo({ "a.ts": "// @ts-expect-error why not\n" });
+  // Written after `git add`, so untracked: an update run before staging
+  // newly authored code must still see it.
+  writeFileSync(join(repo, "b.ts"), "// @ts-expect-error also why\n");
+  const result = runGate(repo, "--update");
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /ratchet not applied/);
+  assert.match(result.stdout, /2 suppressions .* in 2 files/);
+  assert.equal(runGate(repo).status, 0);
+});
+
+test("--update refuses to record reason-less growth", () => {
+  const repo = initRepo({ "a.ts": "// @ts-expect-error why not\n" });
+  assert.equal(runGate(repo, "--update").status, 0);
+  writeFileSync(
+    join(repo, "a.ts"),
+    "// @ts-expect-error why not\nfoo(); // eslint-disable-line a/rule\n",
+  );
+  const refused = runGate(repo, "--update");
+  assert.equal(refused.status, 1);
+  assert.match(refused.stderr, /UNDESCRIBED: a\/rule/);
+  assert.match(refused.stderr, /refusing to record reason-less growth/);
+});
+
+test("unknown arguments are rejected, not silently ignored", () => {
+  const repo = initRepo({});
+  const result = runGate(repo, "--updat");
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /unknown argument\(s\): --updat/);
 });
 
 test("totals sums counts and undescribed", () => {

--- a/scripts/check-suppressions.test.mjs
+++ b/scripts/check-suppressions.test.mjs
@@ -245,3 +245,10 @@ test("totals sums counts and undescribed", () => {
     { count: 6, undescribed: 4 },
   );
 });
+
+test("totals coerces non-numeric tallies to 0 (fork ledgers are untrusted)", () => {
+  assert.deepEqual(
+    totals({ "a.ts": { r: { count: "9\n[x](https://y)", undescribed: "9" } } }),
+    { count: 0, undescribed: 0 },
+  );
+});

--- a/scripts/suppressions-pr-delta.mjs
+++ b/scripts/suppressions-pr-delta.mjs
@@ -24,13 +24,18 @@ const load = (path) => {
 
 // Ledger text (file paths, rule names) can come from a fork PR; render it
 // inert inside the table cell: no raw HTML, no `|` cell breaks, no newlines.
+// GFM still parses inline markdown between inline HTML tags, so also no `[`
+// (links/images could render live inside the bot comment) and no backticks
+// (stray code spans).
 const cell = (value) =>
   `<code>${value
     .replace(/[\r\n]+/g, " ")
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
-    .replaceAll("|", "&#124;")}</code>`;
+    .replaceAll("|", "&#124;")
+    .replaceAll("[", "&#91;")
+    .replaceAll("`", "&#96;")}</code>`;
 
 // The comment body for a base -> head ledger change, or null if none.
 // An undescribed-only change (a `-- reason` added or removed) renders too:
@@ -80,7 +85,16 @@ export const render = (base, head) => {
 };
 
 const main = () => {
-  const [basePath, headPath] = process.argv.slice(2);
+  const paths = process.argv.slice(2);
+  if (paths.length !== 2) {
+    // A tolerated bad invocation would print nothing and exit 0, which the
+    // workflow reads as "ledger unchanged" and uses to reset the sticky
+    // comment. (Missing *files* stay tolerated: load's {} fallback covers
+    // branches that predate the ledger.)
+    console.error("usage: suppressions-pr-delta.mjs <base.json> <head.json>");
+    process.exit(2);
+  }
+  const [basePath, headPath] = paths;
   const body = render(load(basePath), load(headPath));
   if (body !== null) console.log(body);
 };

--- a/scripts/suppressions-pr-delta.mjs
+++ b/scripts/suppressions-pr-delta.mjs
@@ -2,10 +2,17 @@
 // Renders the markdown body for the sticky PR comment describing how this
 // PR changes suppressions.json. Prints nothing when the ledger is
 // unchanged. Usage: node suppressions-pr-delta.mjs <base.json> <head.json>
+//
+// suppressions-comment.yml runs this from the base branch with no
+// dependency install (see the security model there), so it must stay
+// node-builtins-only — sibling script imports included.
 
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-const MARKER = "<!-- suppressions-delta -->";
+import { diffLedgers, totals } from "./check-suppressions.mjs";
+
+export const MARKER = "<!-- suppressions-delta -->";
 
 const load = (path) => {
   try {
@@ -15,76 +22,69 @@ const load = (path) => {
   }
 };
 
-const flatten = (ledger) =>
-  new Map(
-    Object.entries(ledger).flatMap(([file, rules]) =>
-      Object.entries(rules).map(([rule, tally]) => [
-        `${file}\t${rule}`,
-        { count: tally.count, undescribed: tally.undescribed ?? 0 },
-      ]),
-    ),
-  );
+// Ledger text (file paths, rule names) can come from a fork PR; render it
+// inert inside the table cell: no raw HTML, no `|` cell breaks, no newlines.
+const cell = (value) =>
+  `<code>${value
+    .replace(/[\r\n]+/g, " ")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("|", "&#124;")}</code>`;
 
-const sum = (map, field) =>
-  [...map.values()].reduce((acc, tally) => acc + tally[field], 0);
+// The comment body for a base -> head ledger change, or null if none.
+// An undescribed-only change (a `-- reason` added or removed) renders too:
+// otherwise such a ledger diff would produce nothing and the workflow
+// would falsely reset the sticky comment to "no longer changes the ledger".
+export const render = (base, head) => {
+  const rows = diffLedgers(base, head);
+  if (rows.length === 0) return null;
 
-const [basePath, headPath] = process.argv.slice(2);
-const base = flatten(load(basePath));
-const head = flatten(load(headPath));
+  const before = totals(base);
+  const after = totals(head);
+  const delta = after.count - before.count;
+  const undescribedDelta = after.undescribed - before.undescribed;
+  const needsAttention = delta > 0 || undescribedDelta > 0;
+  const deltaCell = delta === 0 ? "±0" : `${delta}`;
+  const heading =
+    undescribedDelta > 0 && delta <= 0
+      ? `⚠️ Reason-less suppressions grew: ${before.undescribed} → ${after.undescribed} (+${undescribedDelta}); total ${before.count} → ${after.count} (${deltaCell})`
+      : delta > 0
+        ? `⚠️ Suppression ledger grew: ${before.count} → ${after.count} (+${delta})`
+        : `Suppression ledger changed: ${before.count} → ${after.count} (${deltaCell})`;
 
-const NONE = { count: 0, undescribed: 0 };
+  const table = rows
+    .map(({ key, before, after }) => {
+      const [file, rule] = key.split("\t");
+      const change = after.count - before.count;
+      const changeCell =
+        change === 0 ? "±0" : `${change > 0 ? "+" : ""}${change}`;
+      const reasonNote =
+        before.undescribed === after.undescribed
+          ? ""
+          : ` (reason-less ${before.undescribed} → ${after.undescribed})`;
+      return `| ${cell(file)} | ${cell(rule)} | ${changeCell}${reasonNote} |`;
+    })
+    .join("\n");
 
-// Undescribed-only changes count too (someone added/removed a `-- reason`):
-// otherwise such a ledger diff would render nothing and the workflow would
-// falsely reset the sticky comment to "no longer changes the ledger".
-const rows = [...new Set([...base.keys(), ...head.keys()])]
-  .map((key) => ({
-    key,
-    before: base.get(key) ?? NONE,
-    after: head.get(key) ?? NONE,
-  }))
-  .filter(
-    ({ before, after }) =>
-      before.count !== after.count || before.undescribed !== after.undescribed,
-  )
-  .sort((a, b) => a.key.localeCompare(b.key));
+  const undescribedLine =
+    before.undescribed === after.undescribed
+      ? ""
+      : `\nReason-less (baselined) suppressions: ${before.undescribed} → ${after.undescribed}\n`;
 
-if (rows.length === 0) process.exit(0);
-
-const totalBefore = sum(base, "count");
-const totalAfter = sum(head, "count");
-const delta = totalAfter - totalBefore;
-const heading =
-  delta > 0
-    ? `⚠️ Suppression ledger grew: ${totalBefore} → ${totalAfter} (+${delta})`
-    : `Suppression ledger changed: ${totalBefore} → ${totalAfter} (${delta === 0 ? "±0" : delta})`;
-
-const table = rows
-  .map(({ key, before, after }) => {
-    const [file, rule] = key.split("\t");
-    const change = after.count - before.count;
-    const changeCell =
-      change === 0 ? "±0" : `${change > 0 ? "+" : ""}${change}`;
-    const reasonNote =
-      before.undescribed === after.undescribed
-        ? ""
-        : ` (reason-less ${before.undescribed} → ${after.undescribed})`;
-    return `| \`${file}\` | \`${rule}\` | ${changeCell}${reasonNote} |`;
-  })
-  .join("\n");
-
-const undescribedBefore = sum(base, "undescribed");
-const undescribedAfter = sum(head, "undescribed");
-const undescribedLine =
-  undescribedBefore === undescribedAfter
-    ? ""
-    : `\nReason-less (baselined) suppressions: ${undescribedBefore} → ${undescribedAfter}\n`;
-
-const footer =
-  delta > 0
+  const footer = needsAttention
     ? "\nEvery new suppression needs a `-- reason` in the comment and maintainer sign-off of this ledger diff — see CONTRIBUTING.md."
     : "";
 
-console.log(
-  `${MARKER}\n### ${heading}\n\n| File | Rule | Change |\n|---|---|---|\n${table}\n${undescribedLine}${footer}`,
-);
+  return `${MARKER}\n### ${heading}\n\n| File | Rule | Change |\n|---|---|---|\n${table}\n${undescribedLine}${footer}`;
+};
+
+const main = () => {
+  const [basePath, headPath] = process.argv.slice(2);
+  const body = render(load(basePath), load(headPath));
+  if (body !== null) console.log(body);
+};
+
+// fileURLToPath, not URL.pathname: pathname percent-encodes spaces etc.,
+// which would make this guard silently false on such checkouts.
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/suppressions-pr-delta.test.mjs
+++ b/scripts/suppressions-pr-delta.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { MARKER, render } from "./suppressions-pr-delta.mjs";
+
+test("renders nothing when unchanged", () => {
+  const ledger = { "a.ts": { r: { count: 1, undescribed: 1 } } };
+  assert.equal(render(ledger, ledger), null);
+});
+
+test("growth renders marker, warning heading, row, and footer", () => {
+  const body = render({}, { "a.ts": { r: { count: 1 } } });
+  assert.ok(body.startsWith(MARKER));
+  assert.match(body, /⚠️ Suppression ledger grew: 0 → 1 \(\+1\)/);
+  assert.ok(body.includes("| <code>a.ts</code> | <code>r</code> | +1 |"));
+  assert.match(body, /maintainer sign-off/);
+});
+
+test("shrink renders plain heading without footer", () => {
+  const body = render(
+    { "a.ts": { r: { count: 2 } } },
+    { "a.ts": { r: { count: 1 } } },
+  );
+  assert.match(body, /Suppression ledger changed: 2 → 1 \(-1\)/);
+  assert.doesNotMatch(body, /maintainer sign-off/);
+});
+
+test("undescribed-only change still renders", () => {
+  const body = render(
+    { "a.ts": { r: { count: 1, undescribed: 1 } } },
+    { "a.ts": { r: { count: 1 } } },
+  );
+  assert.ok(
+    body.includes("| <code>a.ts</code> | <code>r</code> | ±0 (reason-less 1 → 0) |"),
+  );
+  assert.match(body, /Reason-less \(baselined\) suppressions: 1 → 0/);
+});
+
+test("warns when reason-less count grows without total growth", () => {
+  const body = render(
+    { "a.ts": { r: { count: 1 } } },
+    { "a.ts": { r: { count: 1, undescribed: 1 } } },
+  );
+  assert.match(body, /⚠️ Reason-less suppressions grew: 0 → 1 \(\+1\)/);
+  assert.match(body, /maintainer sign-off/);
+});
+
+test("escapes untrusted table cell text", () => {
+  const body = render({}, { "a`\n<b>|.ts": { "r`\n<b>|": { count: 1 } } });
+  assert.ok(body.includes("<code>a` &lt;b&gt;&#124;.ts</code>"));
+  assert.ok(body.includes("<code>r` &lt;b&gt;&#124;</code>"));
+});

--- a/scripts/suppressions-pr-delta.test.mjs
+++ b/scripts/suppressions-pr-delta.test.mjs
@@ -64,6 +64,31 @@ test("markdown link/image syntax cannot form in a cell", () => {
   assert.ok(body.includes("<code>!&#91;](https://evil.example/p.png)</code>"));
 });
 
+test("non-numeric tally values from a fork ledger cannot inject markdown", () => {
+  const payload = "0\n\n[click](https://evil.example)";
+  const body = render(
+    { "a.ts": { r: { count: 1 } } },
+    {
+      "a.ts": { r: { count: payload, undescribed: payload } },
+      "b.ts": { r: { count: 2 } },
+    },
+  );
+  // Crafted strings coerce to 0 and never reach the heading, the per-row
+  // reason-less note, or the reason-less summary line.
+  assert.ok(!body.includes("evil.example"));
+  assert.match(body, /⚠️ Suppression ledger grew: 1 → 2 \(\+1\)/);
+});
+
+test("malformed ledger shapes render without throwing", () => {
+  const body = render(null, {
+    "a.ts": null,
+    "b.ts": 5,
+    "c.ts": { r: null, s: { count: 1 } },
+  });
+  assert.match(body, /⚠️ Suppression ledger grew: 0 → 1 \(\+1\)/);
+  assert.ok(body.includes("| <code>c.ts</code> | <code>s</code> | +1 |"));
+});
+
 // --- CLI arg handling ---
 
 const SCRIPT = fileURLToPath(

--- a/scripts/suppressions-pr-delta.test.mjs
+++ b/scripts/suppressions-pr-delta.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { MARKER, render } from "./suppressions-pr-delta.mjs";
 
@@ -46,7 +48,42 @@ test("warns when reason-less count grows without total growth", () => {
 });
 
 test("escapes untrusted table cell text", () => {
-  const body = render({}, { "a`\n<b>|.ts": { "r`\n<b>|": { count: 1 } } });
-  assert.ok(body.includes("<code>a` &lt;b&gt;&#124;.ts</code>"));
-  assert.ok(body.includes("<code>r` &lt;b&gt;&#124;</code>"));
+  const body = render({}, { "a`\n<b>|[.ts": { "r`\n<b>|[": { count: 1 } } });
+  assert.ok(body.includes("<code>a&#96; &lt;b&gt;&#124;&#91;.ts</code>"));
+  assert.ok(body.includes("<code>r&#96; &lt;b&gt;&#124;&#91;</code>"));
+});
+
+test("markdown link/image syntax cannot form in a cell", () => {
+  const body = render(
+    {},
+    { "![](https://evil.example/p.png)": { "[x](https://y)": { count: 1 } } },
+  );
+  // No raw `[` may survive: without an opening bracket the `](url)` tail
+  // is inert text, so no live link or image can render.
+  assert.ok(!body.includes("["));
+  assert.ok(body.includes("<code>!&#91;](https://evil.example/p.png)</code>"));
+});
+
+// --- CLI arg handling ---
+
+const SCRIPT = fileURLToPath(
+  new URL("./suppressions-pr-delta.mjs", import.meta.url),
+);
+
+const runDelta = (...args) =>
+  spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8" });
+
+test("CLI rejects missing or extra path args instead of printing nothing", () => {
+  for (const args of [[], ["only-base.json"], ["a.json", "b.json", "extra"]]) {
+    const result = runDelta(...args);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /usage: suppressions-pr-delta\.mjs/);
+    assert.equal(result.stdout, "");
+  }
+});
+
+test("CLI still tolerates missing ledger files (pre-ledger branches)", () => {
+  const result = runDelta("no-such-base.json", "no-such-head.json");
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "");
 });


### PR DESCRIPTION
## Why

The "Comment ledger delta" step ran inside ci.yaml's `suppressions` job on `pull_request`. On fork PRs that event's `GITHUB_TOKEN` is read-only, so the comment silently failed to post: a properly-ledgered new suppression from a fork landed green with nothing drawing a reviewer's eye to the ledger diff. inspect_ai's port of this gate (UKGovernmentBEIS/inspect_ai#5136) hit and fixed the same problem; this brings the fix back, plus the other language-agnostic improvements that came out of that PR's review rounds.

## What

- ci.yaml `suppressions` job: comment step and its `pull-requests: write` removed. Enforcement (gate check + script tests) stays on `pull_request` with `contents: read`.
- New `.github/workflows/suppressions-comment.yml` on `pull_request_target` posts the sticky delta comment, so it works on fork PRs too. Same `<!-- suppressions-delta -->` marker logic as before.

## Security

`pull_request_target` carries a write token even on fork PRs, which is a remote-code-execution footgun if the job ever runs PR-controlled code. The workflow keeps three invariants, documented in a header block in the YAML:

1. Only base code runs. `actions/checkout` has no `ref`, so it checks out the base branch: the delta script and base ledger are the trusted copies. A PR's edits to the script take effect only after merge.
2. PR content is data, never code. The PR's `suppressions.json` is read with `git fetch` + `git show FETCH_HEAD:suppressions.json`, which reads a blob and executes nothing. The PR head is never checked out.
3. No dependency installs. The delta script is node-builtins-only (it imports only `node:fs`, `node:url`, and its sibling gate script); `pnpm install` would execute PR-controllable lifecycle and dependency scripts.

The delta comment also now escapes ledger text (file paths, rule names) before rendering it into the comment table, since that text can come from a fork.

## Ported from the inspect_ai version

Small, language-agnostic improvements its review rounds produced:

- Delta comment escapes untrusted cell text (HTML, `|`, newlines).
- Warning heading and footer when the reason-less count grows even though the total does not (previously rendered as a plain non-warning change).
- Delta script reuses `diffLedgers`/`totals` from the gate script instead of duplicating them, and exports a testable `render()`.
- `diffLedgers` output is sorted, so check-mode error messages and comment rows come out in stable order.
- Unknown CLI args are rejected (a typo like `--updat` used to silently run check mode instead of update).
- Bootstrap `--update` says the ratchet was not applied, so deleting the ledger is not an invisible bypass.
- `--update` prints why it refuses on reason-less growth instead of exiting silently after the UNDESCRIBED lines.
- `git ls-files --cached --others --exclude-standard` with an existence filter: an update run before `git add` sees newly authored files, and unstaged deletions do not crash the scan.
- Tests: 6 delta render tests (new file) and 3 CLI tests against a throwaway git repo (bootstrap, ratchet refusal, unknown args). CI runs both test files.

Not ported, flagged for completeness:

- `--allow-growth` update override: inspect_ai needs it for merges from its upstream that bring in reason-less suppressions on lines it must not edit. ts-mono has no such merge flow. Easy to add later if one appears.
- `release/**` branch triggers on both workflows: ts-mono has no release branches.
- The mypy/ruff directive-semantics fixes (tokenize handling, legacy type comments, file-wide spelling rules) are Python-specific, N/A here.

## Testability caveat

A `pull_request_target` workflow runs from the base branch's copy, so the new workflow does not run for this PR. It activates for PRs opened after this merges. The delta body logic was verified locally instead: add, remove, unchanged, and missing-file cases all render correctly via the CLI, plus the unit tests above.

## Verification

- `pnpm check` passes (manypkg, suppressions gate, lint, typecheck, format).
- `pnpm test` passes.
- `node --test scripts/check-suppressions.test.mjs scripts/suppressions-pr-delta.test.mjs`: 28 pass.
- Gate check mode on the real repo: ledger matches (727 suppressions in 308 files), confirming the `ls-files` change does not alter a clean checkout's scan.
