### PR TITLE
Sample Activity view: operational timeline tab for samples (+ log Timeline→Activity relabel)

### DIFF
--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -168,13 +168,16 @@ test("compaction events render cliff drops, ▼ markers, and rows", async ({
   });
 
   // Every CompactionEvent shows in the pill count and on the ▼ rail
-  // (clusters keep the glyph and carry a ×N badge + concatenated labels).
+  // (clusters keep the glyph and carry a bordered ×N count box above it).
   await expect(
     page.getByRole("button", { name: /Compactions 18/ })
   ).toBeVisible();
   await expect(
     page.getByRole("button", { name: /Context compacted/ }).first()
   ).toBeVisible();
+  const clusterBoxes = page.locator("[class*='clusterBoxText']");
+  expect(await clusterBoxes.count()).toBeGreaterThan(0);
+  await expect(clusterBoxes.first()).toHaveText(/×\d+/);
 
   // Context band: dashed cliff drop per compaction, annotated "Nk → M".
   await page.getByRole("button", { name: "Context size" }).click();

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -26,6 +26,9 @@ const activityLog =
   evalLogs.filter((f) => f.includes("ascii-art")).pop();
 // The error-styling proofs need the flaky task's deliberate tool failures.
 const hasToolErrors = activityLog?.includes("flaky") === true;
+// The compaction proofs need the compaction task's threshold-triggered
+// CompactionEvents.
+const hasCompactions = activityLog?.includes("compaction") === true;
 
 const sampleUrl = (tab: string) =>
   `/#/logs/${encodeURIComponent(activityLog ?? "")}/samples/sample/${encodeURIComponent("ascii/car")}/1/${tab}`;
@@ -100,13 +103,24 @@ test("activity tab renders bands and history against a real dense log", async ({
         .count()
     ).toBeGreaterThan(0);
   } else {
-    // Error-free log: no phantom error styling anywhere — the Errors pill
-    // reads 0 (and disables), and no error glyph or failed span renders.
-    await expect(page.getByRole("button", { name: "Errors 0" })).toBeDisabled();
-    await expect(page.getByRole("button", { name: /errored/ })).toHaveCount(0);
-    await expect(
-      page.locator("[class*='failedSpan'], [class*='densityFailure']")
-    ).toHaveCount(0);
+    // Data-driven no-phantom check: whatever the log, error styling must
+    // agree with the Errors pill — zero count means zero glyphs and zero
+    // failed-span/hairline treatment.
+    const errorsPill = await page
+      .getByRole("button", { name: /^Errors \d+$/ })
+      .textContent();
+    const errorCount = Number(/\d+/.exec(errorsPill ?? "")?.[0] ?? "0");
+    if (errorCount === 0) {
+      await expect(
+        page.getByRole("button", { name: "Errors 0" })
+      ).toBeDisabled();
+      await expect(page.getByRole("button", { name: /errored/ })).toHaveCount(
+        0
+      );
+      await expect(
+        page.locator("[class*='failedSpan'], [class*='densityFailure']")
+      ).toHaveCount(0);
+    }
   }
   await shot(page, "sample-activity-all-bands-light.png");
 });
@@ -142,6 +156,48 @@ test("activity history filters and clicks through to the transcript", async ({
     await expect(page).toHaveURL(/\/transcript\?event=/, { timeout: 1000 });
   }).toPass({ timeout: 15_000 });
   await shot(page, "sample-activity-clickthrough-transcript.png");
+});
+
+test("compaction events render cliff drops, ▼ markers, and rows", async ({
+  page,
+}) => {
+  test.skip(!hasCompactions, "needs the compaction task's CompactionEvents");
+  await page.goto(sampleUrl("activity"));
+  await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Every CompactionEvent shows in the pill count and on the ▼ rail
+  // (clusters keep the glyph and carry a ×N badge + concatenated labels).
+  await expect(
+    page.getByRole("button", { name: /Compactions 18/ })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Context compacted/ }).first()
+  ).toBeVisible();
+
+  // Context band: dashed cliff drop per compaction, annotated "Nk → M".
+  await page.getByRole("button", { name: "Context size" }).click();
+  await expect(page.getByText("CONTEXT SIZE", { exact: true })).toBeVisible();
+  await expect(page.locator("[class*='compactionDrop']")).toHaveCount(18);
+  await expect(page.locator("[class*='compactionLabel']").first()).toHaveText(
+    /\d+k? → \d+k?/
+  );
+  await shot(page, "sample-activity-compactions-light.png");
+
+  // Marker click widens a filter that would hide its row.
+  await page.getByRole("button", { name: /Limits 1/ }).click();
+  await expect(page.getByText("Context compacted").first()).not.toBeVisible();
+  await page
+    .getByRole("button", { name: /Context compacted/ })
+    .first()
+    .click();
+  await expect(page.getByText("Context compacted").first()).toBeVisible();
+
+  // Densest fixture yet (1291 events / ~478 spans): the merged band must
+  // degrade to the per-pixel occupancy strip.
+  await page.getByRole("button", { name: "Model & tool activity" }).click();
+  await expect(page.getByText(/per-pixel occupancy/)).toBeVisible();
 });
 
 test.describe(() => {

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -13,8 +13,13 @@ const evidence = join(import.meta.dirname, "..", "evidence");
 const logDir =
   process.env.VERIFY_LOG_DIR ??
   join(process.env.HOME ?? "", "code", "viewer-validation", "logs");
-const evalLogs = readdirSync(logDir).filter((f) => f.endsWith(".eval"));
-const activityLog = evalLogs.find((f) => f.includes("ascii-art"));
+const evalLogs = readdirSync(logDir)
+  .filter((f) => f.endsWith(".eval"))
+  .sort();
+// Prefer the flaky variant (guaranteed tool-error rows); newest first.
+const activityLog =
+  evalLogs.filter((f) => f.includes("ascii-art-flaky")).pop() ??
+  evalLogs.filter((f) => f.includes("ascii-art")).pop();
 
 const sampleUrl = (tab: string) =>
   `/#/logs/${encodeURIComponent(activityLog ?? "")}/samples/sample/${encodeURIComponent("ascii/car")}/1/${tab}`;
@@ -46,8 +51,12 @@ test("activity tab renders bands and history against a real dense log", async ({
   await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible();
   // The flaky check_art tool guarantees error rows; scoring guarantees a
   // score row.
-  await expect(page.getByRole("button", { name: /Errors [1-9]/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Scores [1-9]/ })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Errors [1-9]/ })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Scores [1-9]/ })
+  ).toBeVisible();
   await shot(page, "sample-activity-default-light.png");
 
   // Opt-in bands via chips.
@@ -75,12 +84,20 @@ test("activity history filters and clicks through to the transcript", async ({
   ).toBeVisible();
   await shot(page, "sample-activity-errors-filter.png");
 
-  // Click-through to the transcript via event uuid.
-  await page
-    .getByRole("button", { name: "open in transcript →" })
-    .first()
-    .click();
-  await expect(page).toHaveURL(/\/transcript\?event=/);
+  // Click-through to the transcript via event uuid. Target the button in
+  // the first VISIBLE row (the flaky tool's first failure, "call 3"):
+  // clicking a DOM-order .first() button would scroll a mid-list row into
+  // view and virtualized re-measurement shifts the list under the cursor.
+  const firstErrorRow = page
+    .getByRole("button", { name: /transient failure on call 3/ })
+    .first();
+  await expect(firstErrorRow).toBeInViewport();
+  await expect(async () => {
+    await firstErrorRow
+      .getByRole("button", { name: "open in transcript →" })
+      .click();
+    await expect(page).toHaveURL(/\/transcript\?event=/, { timeout: 1000 });
+  }).toPass({ timeout: 15_000 });
   await shot(page, "sample-activity-clickthrough-transcript.png");
 });
 

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -16,10 +16,15 @@ const logDir =
 const evalLogs = readdirSync(logDir)
   .filter((f) => f.endsWith(".eval"))
   .sort();
-// Prefer the flaky variant (guaranteed tool-error rows); newest first.
+// VERIFY_ACTIVITY_LOG pins an exact filename within VERIFY_LOG_DIR;
+// otherwise prefer the flaky variant (guaranteed tool-error rows), newest
+// first.
 const activityLog =
+  process.env.VERIFY_ACTIVITY_LOG ??
   evalLogs.filter((f) => f.includes("ascii-art-flaky")).pop() ??
   evalLogs.filter((f) => f.includes("ascii-art")).pop();
+// The error-styling proofs need the flaky task's deliberate tool failures.
+const hasToolErrors = activityLog?.includes("flaky") === true;
 
 const sampleUrl = (tab: string) =>
   `/#/logs/${encodeURIComponent(activityLog ?? "")}/samples/sample/${encodeURIComponent("ascii/car")}/1/${tab}`;
@@ -49,14 +54,24 @@ test("activity tab renders bands and history against a real dense log", async ({
     page.getByText("WORKING / WAITING", { exact: true })
   ).toBeVisible();
   await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible();
-  // The flaky check_art tool guarantees error rows; scoring guarantees a
-  // score row.
-  await expect(
-    page.getByRole("button", { name: /Errors [1-9]/ })
-  ).toBeVisible();
+  // Scoring guarantees a score row; both fixture tasks terminate on a
+  // sample limit (message or token) → a limit marker ▲ and pill.
   await expect(
     page.getByRole("button", { name: /Scores [1-9]/ })
   ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Limits [1-9]/ })
+  ).toBeVisible();
+  // Matches both the rail glyph ▲ and its history row — assert the pair.
+  await expect(
+    page.getByRole("button", { name: /Sample hit (message|token) limit/ })
+  ).toHaveCount(2);
+  // The flaky check_art tool additionally guarantees error rows.
+  if (hasToolErrors) {
+    await expect(
+      page.getByRole("button", { name: /Errors [1-9]/ })
+    ).toBeVisible();
+  }
   await shot(page, "sample-activity-default-light.png");
 
   // Opt-in bands via chips.
@@ -72,6 +87,7 @@ test("activity tab renders bands and history against a real dense log", async ({
 test("activity history filters and clicks through to the transcript", async ({
   page,
 }) => {
+  test.skip(!hasToolErrors, "needs the flaky task's deliberate tool errors");
   await page.goto(sampleUrl("activity"));
   await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible({
     timeout: 20_000,

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -81,6 +81,21 @@ test("activity tab renders bands and history against a real dense log", async ({
   await expect(
     page.getByText("MODEL & TOOL ACTIVITY", { exact: true })
   ).toBeVisible();
+  if (hasToolErrors) {
+    // Failed tool calls: error ✕ glyph on the rail (single or clustered —
+    // cluster aria-labels concatenate member labels)…
+    await expect(
+      page.getByRole("button", { name: /Tool check_art errored/ }).first()
+    ).toBeVisible();
+    // …and the red-outlined span treatment in the merged band (or the red
+    // failure hairlines when the band has degraded to the density strip).
+    // SVG rects carry no roles — the CSS-module fragment is the one hook.
+    expect(
+      await page
+        .locator("[class*='failedSpan'], [class*='densityFailure']")
+        .count()
+    ).toBeGreaterThan(0);
+  }
   await shot(page, "sample-activity-all-bands-light.png");
 });
 

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -1,0 +1,102 @@
+import { mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+// Real-backend drive for the sample Activity tab against a real agentic
+// `.eval` log (50+ model turns, flaky tool errors, scoring). Generate the
+// fixture with test_evals/agentic/ascii_art_python.py@ascii_art_flaky and
+// point VERIFY_LOG_DIR at its log dir — see features/sample-activity.md.
+
+const evidence = join(import.meta.dirname, "..", "evidence");
+
+const logDir =
+  process.env.VERIFY_LOG_DIR ??
+  join(process.env.HOME ?? "", "code", "viewer-validation", "logs");
+const evalLogs = readdirSync(logDir).filter((f) => f.endsWith(".eval"));
+const activityLog = evalLogs.find((f) => f.includes("ascii-art"));
+
+const sampleUrl = (tab: string) =>
+  `/#/logs/${encodeURIComponent(activityLog ?? "")}/samples/sample/${encodeURIComponent("ascii/car")}/1/${tab}`;
+
+const shot = (page: import("@playwright/test").Page, name: string) =>
+  page.screenshot({ path: join(evidence, name), fullPage: true });
+
+test.beforeAll(() => {
+  mkdirSync(evidence, { recursive: true });
+});
+
+test.skip(
+  activityLog === undefined,
+  "no ascii-art .eval fixture in VERIFY_LOG_DIR — generate it per features/sample-activity.md"
+);
+
+test("activity tab renders bands and history against a real dense log", async ({
+  page,
+}) => {
+  await page.goto(sampleUrl("activity"));
+
+  await expect(page.getByRole("tab", { name: "Activity" })).toBeVisible({
+    timeout: 20_000,
+  });
+  // Curated default-on bands.
+  await expect(
+    page.getByText("WORKING / WAITING", { exact: true })
+  ).toBeVisible();
+  await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible();
+  // The flaky check_art tool guarantees error rows; scoring guarantees a
+  // score row.
+  await expect(page.getByRole("button", { name: /Errors [1-9]/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Scores [1-9]/ })).toBeVisible();
+  await shot(page, "sample-activity-default-light.png");
+
+  // Opt-in bands via chips.
+  await page.getByRole("button", { name: "Context size" }).click();
+  await expect(page.getByText("CONTEXT SIZE", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Model & tool activity" }).click();
+  await expect(
+    page.getByText("MODEL & TOOL ACTIVITY", { exact: true })
+  ).toBeVisible();
+  await shot(page, "sample-activity-all-bands-light.png");
+});
+
+test("activity history filters and clicks through to the transcript", async ({
+  page,
+}) => {
+  await page.goto(sampleUrl("activity"));
+  await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // Errors pill narrows to the flaky tool failures.
+  await page.getByRole("button", { name: /Errors [1-9]/ }).click();
+  await expect(
+    page.getByText(/art quality service unavailable/).first()
+  ).toBeVisible();
+  await shot(page, "sample-activity-errors-filter.png");
+
+  // Click-through to the transcript via event uuid.
+  await page
+    .getByRole("button", { name: "open in transcript →" })
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/transcript\?event=/);
+  await shot(page, "sample-activity-clickthrough-transcript.png");
+});
+
+test.describe(() => {
+  test.use({ colorScheme: "dark" });
+
+  test("activity tab renders in dark theme", async ({ page }) => {
+    await page.goto(sampleUrl("activity"));
+    await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByRole("button", { name: "Context size" }).click();
+    await page.getByRole("button", { name: "Model & tool activity" }).click();
+    await expect(
+      page.getByText("MODEL & TOOL ACTIVITY", { exact: true })
+    ).toBeVisible();
+    await shot(page, "sample-activity-all-bands-dark.png");
+  });
+});

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -19,9 +19,10 @@ const evalLogs = readdirSync(logDir)
 // VERIFY_ACTIVITY_LOG pins an exact filename within VERIFY_LOG_DIR;
 // otherwise prefer the flaky variant (guaranteed tool-error rows), newest
 // first.
+// || not ?? — an empty VERIFY_ACTIVITY_LOG means "not pinned".
 const activityLog =
-  process.env.VERIFY_ACTIVITY_LOG ??
-  evalLogs.filter((f) => f.includes("ascii-art-flaky")).pop() ??
+  process.env.VERIFY_ACTIVITY_LOG ||
+  evalLogs.filter((f) => f.includes("ascii-art-flaky")).pop() ||
   evalLogs.filter((f) => f.includes("ascii-art")).pop();
 // The error-styling proofs need the flaky task's deliberate tool failures.
 const hasToolErrors = activityLog?.includes("flaky") === true;
@@ -62,10 +63,13 @@ test("activity tab renders bands and history against a real dense log", async ({
   await expect(
     page.getByRole("button", { name: /Limits [1-9]/ })
   ).toBeVisible();
-  // Matches both the rail glyph ▲ and its history row — assert the pair.
+  // Matches the rail glyph ▲ and/or its history row (the row can sit
+  // outside the virtualized window on long logs) — assert one is visible.
   await expect(
-    page.getByRole("button", { name: /Sample hit (message|token) limit/ })
-  ).toHaveCount(2);
+    page
+      .getByRole("button", { name: /Sample hit (message|token) limit/ })
+      .first()
+  ).toBeVisible();
   // The flaky check_art tool additionally guarantees error rows.
   if (hasToolErrors) {
     await expect(

--- a/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
+++ b/apps/inspect/.agents/skills/verify-log-viewer/drive/sample-activity.spec.ts
@@ -95,6 +95,14 @@ test("activity tab renders bands and history against a real dense log", async ({
         .locator("[class*='failedSpan'], [class*='densityFailure']")
         .count()
     ).toBeGreaterThan(0);
+  } else {
+    // Error-free log: no phantom error styling anywhere — the Errors pill
+    // reads 0 (and disables), and no error glyph or failed span renders.
+    await expect(page.getByRole("button", { name: "Errors 0" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: /errored/ })).toHaveCount(0);
+    await expect(
+      page.locator("[class*='failedSpan'], [class*='densityFailure']")
+    ).toHaveCount(0);
   }
   await shot(page, "sample-activity-all-bands-light.png");
 });

--- a/apps/inspect/.agents/skills/verify-log-viewer/features/README.md
+++ b/apps/inspect/.agents/skills/verify-log-viewer/features/README.md
@@ -39,8 +39,9 @@ The viewer is a hash-routed React app (`#/...` URLs). Prefer, in order:
 Deep-link instead of clicking through when the feature under proof isn't the
 navigation itself:
 `/#/logs/<encodeURIComponent(file)>/samples/sample/<id>/<epoch>/<tab>`.
-Sample tab ids: `messages transcript scoring usage metadata error retries json`.
-Log workspace tab ids: `samples json info models task timeline error`.
+Sample tab ids: `messages transcript scoring activity usage metadata error retries json`.
+Log workspace tab ids: `samples json info models task timeline error` (the
+`timeline` tab is labeled "Activity" in the UI; the id is unchanged).
 
 Readiness is always a web-first assertion on content (`expect(...).toBeVisible()`),
 never `networkidle` or fixed sleeps. The app boot gate blocks on
@@ -71,3 +72,6 @@ fixture auto-enables MSW and silently mocks `/api`. Import from
   navigation in a sample's Transcript tab.
 - [Scores](./scores.md) — score column in the log list, log-level scoring
   detail, and the sample Scoring tab.
+- [Sample activity](./sample-activity.md) — the sample Activity tab: stacked
+  operational bands, marker rail, filterable history list, click-through to
+  the Transcript.

--- a/apps/inspect/.agents/skills/verify-log-viewer/features/sample-activity.md
+++ b/apps/inspect/.agents/skills/verify-log-viewer/features/sample-activity.md
@@ -1,0 +1,63 @@
+# Sample Activity tab
+
+The operational timeline for a single sample: stacked bands on one shared
+wall-clock axis (working/waiting with stall brackets, marker rail, token
+burn, context size with compaction drops, merged model+tool activity), with
+a filterable virtualized history list beneath. Companion rename: the
+log-level workspace tab with id `timeline` is now labeled **Activity**.
+
+## Reaching it
+
+- Deep link: `/#/logs/<enc(file)>/samples/sample/<enc(id)>/<epoch>/activity`
+  (sample ids can contain `/` — encodeURIComponent them).
+- Or open any sample and click the `Activity` tab (`getByRole("tab",
+  { name: "Activity" })`), a peer of Transcript / Messages / Scoring.
+- The tab is HIDDEN for logs whose events carry no timestamps (old logs)
+  and for chunked samples — its absence on such logs is correct behavior.
+
+## Fixture
+
+The mocked e2e suite (`apps/inspect/e2e/sample-activity.spec.ts`) covers
+the tab against synthetic events. For a real-density proof, generate an
+agentic log with 50+ model turns and intermittent tool failures:
+
+```sh
+cd ~/Development/test_evals/agentic
+inspect eval ascii_art_python.py@ascii_art_flaky \
+  --model openai/gpt-4o-mini --log-dir ./logs-sample-activity
+VERIFY_LOG_DIR=~/Development/test_evals/agentic/logs-sample-activity \
+  pnpm exec playwright test --config .agents/skills/verify-log-viewer/playwright.verify.config.ts drive/sample-activity.spec.ts
+```
+
+`drive/sample-activity.spec.ts` skips itself when no `ascii-art` log is in
+`VERIFY_LOG_DIR`. When the default fixture dir grows a suitable log, fold
+an Activity test into the standing spec.
+
+## Selectors
+
+- Band chips: `getByRole("button", { name: "Working / waiting" | "Markers"
+  | "Token burn" | "Context size" | "Model & tool activity" })` — default-on
+  set is the first three.
+- Band labels (SVG text, uppercase — use `exact: true` or the chip matches
+  too): `WORKING / WAITING`, `TOKEN BURN`, `CONTEXT SIZE`,
+  `MODEL & TOOL ACTIVITY`.
+- Marker glyphs: `getByRole("button", { name: <marker label> })`, e.g.
+  `Tool bash errored`.
+- History filter pills: `getByRole("button", { name: /Errors \d/ })` etc.;
+  search box `getByPlaceholder("filter by event or detail")`.
+- History rows: `role=button`; each row with an event uuid carries an
+  `open in transcript →` button.
+
+## Observable proof
+
+- Default bands render with a right-aligned mono headline
+  (`working <dur> · total <dur>`, `<N>k total`).
+- Retry-attributable stalls show a red bracket labeled
+  `<dur> · rate limit ×N` under the working band.
+- Chips toggle bands on/off and persist across tab switches.
+- Category pills filter the list additively; `All` resets; a glyph click
+  widens filters so its row is always revealed.
+- `open in transcript →` (and any span/glyph click-through) lands on
+  `/transcript?event=<uuid>` with the transcript scrolled to the event.
+- Dense logs (50+ turns): the merged model+tool band degrades to a
+  per-pixel occupancy strip and the headline appends `per-pixel occupancy`.

--- a/apps/inspect/.agents/skills/verify-log-viewer/features/sample-activity.md
+++ b/apps/inspect/.agents/skills/verify-log-viewer/features/sample-activity.md
@@ -11,7 +11,7 @@ log-level workspace tab with id `timeline` is now labeled **Activity**.
 - Deep link: `/#/logs/<enc(file)>/samples/sample/<enc(id)>/<epoch>/activity`
   (sample ids can contain `/` — encodeURIComponent them).
 - Or open any sample and click the `Activity` tab (`getByRole("tab",
-  { name: "Activity" })`), a peer of Transcript / Messages / Scoring.
+{ name: "Activity" })`), a peer of Transcript / Messages / Scoring.
 - The tab is HIDDEN for logs whose events carry no timestamps (old logs)
   and for chunked samples — its absence on such logs is correct behavior.
 
@@ -36,7 +36,7 @@ an Activity test into the standing spec.
 ## Selectors
 
 - Band chips: `getByRole("button", { name: "Working / waiting" | "Markers"
-  | "Token burn" | "Context size" | "Model & tool activity" })` — default-on
+| "Token burn" | "Context size" | "Model & tool activity" })` — default-on
   set is the first three.
 - Band labels (SVG text, uppercase — use `exact: true` or the chip matches
   too): `WORKING / WAITING`, `TOKEN BURN`, `CONTEXT SIZE`,

--- a/apps/inspect/e2e/sample-activity.spec.ts
+++ b/apps/inspect/e2e/sample-activity.spec.ts
@@ -353,13 +353,16 @@ test("activity tab is hidden for old logs without event timestamps", async ({
     timestamp: "",
     ...("completed" in event ? { completed: null } : {}),
   }));
+  // Deep-link straight to /activity: a shared Activity URL opened on a log
+  // whose tab is hidden must fall back to the Transcript, not go blank.
   await openSample(page, network, {
     events: legacyEvents,
-    tab: "transcript",
+    tab: "activity",
   });
 
   await expect(page.getByRole("tab", { name: "Transcript" })).toBeVisible();
   await expect(page.getByRole("tab", { name: "Activity" })).not.toBeVisible();
+  await expect(page.locator("#transcript-contents")).toBeVisible();
 });
 
 test("log-level tab is relabeled Activity", async ({ page, network }) => {

--- a/apps/inspect/e2e/sample-activity.spec.ts
+++ b/apps/inspect/e2e/sample-activity.spec.ts
@@ -1,0 +1,371 @@
+/**
+ * Sample Activity tab e2e tests.
+ *
+ * Exercises the new Activity tab in the sample display: tab presence,
+ * band rendering, band chips, history-list filters, marker → row selection,
+ * and click-through to the Transcript. Also covers the companion label-only
+ * rename of the log-level Timeline tab to "Activity".
+ */
+
+import { http, HttpResponse } from "msw";
+
+import type {
+  CompactionEvent,
+  EvalSample,
+  ModelEvent,
+  ModelOutput,
+  ScoreEvent,
+  ToolEvent,
+} from "@tsmono/inspect-common/types";
+
+import { expect, test } from "./fixtures/app";
+import {
+  createEvalLog,
+  createEvalSample,
+  createModelOutput,
+} from "./fixtures/test-data";
+
+const LOG_FILE = "test-sample-activity.json";
+
+type Events = EvalSample["events"];
+
+const kRunStart = Date.parse("2025-01-15T10:00:00.000Z") / 1000;
+const iso = (sec: number): string =>
+  new Date((kRunStart + sec) * 1000).toISOString();
+
+// ---------------------------------------------------------------------------
+// Event factories
+// ---------------------------------------------------------------------------
+
+function activityModelEvent(overrides: {
+  uuid: string;
+  startSec: number;
+  endSec: number;
+  workingStart: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  retries?: number;
+  /** Working seconds within the wall span (defaults to the whole span). */
+  working?: number;
+}): ModelEvent {
+  const input = overrides.inputTokens ?? 1000;
+  const output = overrides.outputTokens ?? 200;
+  const modelOutput: ModelOutput = {
+    ...createModelOutput("Model response"),
+    usage: {
+      input_tokens: input,
+      output_tokens: output,
+      total_tokens: input + output,
+    },
+  };
+  return {
+    event: "model",
+    uuid: overrides.uuid,
+    model: "claude-sonnet-4-5-20250929",
+    input: [],
+    output: modelOutput,
+    config: {},
+    tools: [],
+    tool_choice: "auto",
+    timestamp: iso(overrides.startSec),
+    completed: iso(overrides.endSec),
+    working_start: overrides.workingStart,
+    working_time: overrides.working ?? overrides.endSec - overrides.startSec,
+    retries: overrides.retries,
+  };
+}
+
+function activityToolEvent(overrides: {
+  uuid: string;
+  startSec: number;
+  endSec: number;
+  workingStart: number;
+  fn?: string;
+  errorMessage?: string;
+}): ToolEvent {
+  return {
+    event: "tool",
+    uuid: overrides.uuid,
+    id: overrides.uuid,
+    type: "function",
+    function: overrides.fn ?? "bash",
+    arguments: {},
+    result: "",
+    events: [],
+    timestamp: iso(overrides.startSec),
+    completed: iso(overrides.endSec),
+    working_start: overrides.workingStart,
+    working_time: overrides.endSec - overrides.startSec,
+    error: overrides.errorMessage
+      ? { type: "unknown", message: overrides.errorMessage }
+      : undefined,
+  };
+}
+
+function activityCompactionEvent(overrides: {
+  uuid: string;
+  atSec: number;
+  workingStart: number;
+  before: number;
+  after: number;
+}): CompactionEvent {
+  return {
+    event: "compaction",
+    uuid: overrides.uuid,
+    type: "summary",
+    timestamp: iso(overrides.atSec),
+    working_start: overrides.workingStart,
+    tokens_before: overrides.before,
+    tokens_after: overrides.after,
+  };
+}
+
+function activityScoreEvent(overrides: {
+  uuid: string;
+  atSec: number;
+  workingStart: number;
+}): ScoreEvent {
+  return {
+    event: "score",
+    uuid: overrides.uuid,
+    intermediate: false,
+    score: { value: 1, history: [] },
+    scorer: "activity_scorer",
+    timestamp: iso(overrides.atSec),
+    working_start: overrides.workingStart,
+  };
+}
+
+/** A sample with working gaps, a retrying model call, a failed tool call,
+ *  a compaction, and a score — every Activity surface has something on it. */
+function activityEvents(): Events {
+  return [
+    activityModelEvent({
+      uuid: "model-1",
+      startSec: 0,
+      endSec: 10,
+      workingStart: 0,
+      inputTokens: 5_000,
+    }),
+    // Retrying call: 30s of wall clock, 5s of work — a 25s stall inside.
+    activityModelEvent({
+      uuid: "model-retry",
+      startSec: 10,
+      endSec: 40,
+      workingStart: 10,
+      working: 5,
+      retries: 3,
+      inputTokens: 20_000,
+    }),
+    activityToolEvent({
+      uuid: "tool-ok",
+      startSec: 40,
+      endSec: 44,
+      workingStart: 15,
+    }),
+    activityToolEvent({
+      uuid: "tool-fail",
+      startSec: 44,
+      endSec: 48,
+      workingStart: 19,
+      errorMessage: "exit 127",
+    }),
+    activityCompactionEvent({
+      uuid: "compact-1",
+      atSec: 50,
+      workingStart: 23,
+      before: 142_000,
+      after: 38_000,
+    }),
+    activityModelEvent({
+      uuid: "model-2",
+      startSec: 52,
+      endSec: 60,
+      workingStart: 23,
+      inputTokens: 38_000,
+    }),
+    activityScoreEvent({ uuid: "score-1", atSec: 62, workingStart: 31 }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Page = Parameters<Parameters<typeof test>[2]>[0]["page"];
+type Network = Parameters<Parameters<typeof test>[2]>[0]["network"];
+
+async function openSample(
+  page: Page,
+  network: Network,
+  options?: { events?: Events; tab?: string }
+) {
+  const events = options?.events ?? activityEvents();
+  const sample = createEvalSample({
+    id: 1,
+    epoch: 1,
+    messages: [
+      { role: "user", content: "Hello", source: "input" },
+      { role: "assistant", content: "Hi there", source: "generate" },
+    ],
+    events,
+  });
+  const evalLog = createEvalLog({ samples: [sample] });
+
+  network.use(
+    http.get("*/api/logs", () => HttpResponse.json({ log_dir: "/logs" })),
+    http.get("*/api/log-files*", () => {
+      return HttpResponse.json({
+        files: [{ name: LOG_FILE, task: "chat-test", task_id: "chat-test" }],
+        response_type: "full",
+      });
+    }),
+    http.get("*/api/logs/:file", () => HttpResponse.json(evalLog)),
+    http.get("*/api/log-headers*", () => {
+      return HttpResponse.json([
+        {
+          eval_id: evalLog.eval.eval_id,
+          run_id: evalLog.eval.run_id,
+          task: evalLog.eval.task,
+          task_id: evalLog.eval.task_id,
+          task_version: evalLog.eval.task_version,
+          model: evalLog.eval.model,
+          status: evalLog.status,
+          started_at: evalLog.stats.started_at,
+          completed_at: evalLog.stats.completed_at,
+        },
+      ]);
+    })
+  );
+
+  const encodedFile = encodeURIComponent(LOG_FILE);
+  await page.goto(
+    `/#/logs/${encodedFile}/samples/sample/1/1/${options?.tab ?? "activity"}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("activity tab appears and its default bands render", async ({
+  page,
+  network,
+}) => {
+  await openSample(page, network, { tab: "transcript" });
+
+  const activityTab = page.getByRole("tab", { name: "Activity" });
+  await expect(activityTab).toBeVisible();
+  await activityTab.click();
+
+  // Curated default-on bands.
+  await expect(
+    page.getByText("WORKING / WAITING", { exact: true })
+  ).toBeVisible();
+  await expect(page.getByText("TOKEN BURN", { exact: true })).toBeVisible();
+  // The retry-attributable stall is bracketed and labeled.
+  await expect(page.getByText(/rate limit ×3/)).toBeVisible();
+  // Opt-in bands stay off by default.
+  await expect(
+    page.getByText("CONTEXT SIZE", { exact: true })
+  ).not.toBeVisible();
+  await expect(
+    page.getByText("MODEL & TOOL ACTIVITY", { exact: true })
+  ).not.toBeVisible();
+});
+
+test("band chips toggle opt-in bands", async ({ page, network }) => {
+  await openSample(page, network);
+
+  await page.getByRole("button", { name: "Context size" }).click();
+  await expect(page.getByText("CONTEXT SIZE", { exact: true })).toBeVisible();
+  // Compaction annotated as a cliff drop.
+  await expect(page.getByText("142k → 38k").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "Model & tool activity" }).click();
+  await expect(
+    page.getByText("MODEL & TOOL ACTIVITY", { exact: true })
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Token burn" }).click();
+  await expect(page.getByText("TOKEN BURN", { exact: true })).not.toBeVisible();
+});
+
+test("history list filters by category pill and search", async ({
+  page,
+  network,
+}) => {
+  await openSample(page, network);
+
+  // All incident rows render.
+  await expect(page.getByText(/exit 127/)).toBeVisible();
+  await expect(page.getByText(/scorer activity_scorer/)).toBeVisible();
+
+  // Errors pill narrows to error rows (failed tool + rate-limit stall).
+  await page.getByRole("button", { name: /Errors/ }).click();
+  await expect(page.getByText(/exit 127/)).toBeVisible();
+  await expect(page.getByText(/scorer activity_scorer/)).not.toBeVisible();
+
+  // All resets; search narrows.
+  await page.getByRole("button", { name: /All/ }).click();
+  await page.getByPlaceholder("filter by event or detail").fill("compacted");
+  await expect(page.getByText("Context compacted")).toBeVisible();
+  await expect(page.getByText(/exit 127/)).not.toBeVisible();
+});
+
+test("marker click selects and reveals its history row", async ({
+  page,
+  network,
+}) => {
+  await openSample(page, network);
+
+  // Narrow to Scores so the error row is filtered out…
+  await page.getByRole("button", { name: /Scores/ }).click();
+  await expect(page.getByText(/exit 127/)).not.toBeVisible();
+
+  // …then click the error glyph: the filter widens and the row appears.
+  await page.getByRole("button", { name: "Tool bash errored" }).click();
+  await expect(page.getByText(/exit 127/)).toBeVisible();
+});
+
+test("history row clicks through to the transcript event", async ({
+  page,
+  network,
+}) => {
+  await openSample(page, network);
+
+  await page
+    .getByRole("button", { name: "open in transcript →" })
+    .first()
+    .click();
+
+  await expect(page).toHaveURL(/\/transcript\?event=/);
+  // The transcript panel is showing.
+  await expect(page.getByRole("tab", { name: "Transcript" })).toBeVisible();
+});
+
+test("activity tab is hidden for old logs without event timestamps", async ({
+  page,
+  network,
+}) => {
+  const legacyEvents: Events = activityEvents().map((event) => ({
+    ...event,
+    timestamp: "",
+    ...("completed" in event ? { completed: null } : {}),
+  }));
+  await openSample(page, network, {
+    events: legacyEvents,
+    tab: "transcript",
+  });
+
+  await expect(page.getByRole("tab", { name: "Transcript" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Activity" })).not.toBeVisible();
+});
+
+test("log-level tab is relabeled Activity", async ({ page, network }) => {
+  await openSample(page, network, { tab: "transcript" });
+
+  const encodedFile = encodeURIComponent(LOG_FILE);
+  await page.goto(`/#/logs/${encodedFile}`);
+  await expect(page.getByRole("tab", { name: "Activity" })).toBeVisible();
+});

--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineTab.tsx
@@ -75,8 +75,10 @@ export const useTimelineTab = (
   const scrollRef = useRef<HTMLDivElement | null>(null);
   return useMemo(() => {
     return {
+      // Label-only rename (sample Activity's companion) — the internal tab
+      // id and persisted store keys deliberately stay "timeline".
       id: kLogViewTimelineTabId,
-      label: "Timeline",
+      label: "Activity",
       scrollable: true,
       scrollRef,
       component: TimelineTab,

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -24,6 +24,10 @@ import {
   RecordTree,
 } from "@tsmono/inspect-components/content";
 import {
+  hasEventTimestamps,
+  SampleActivityPanel,
+} from "@tsmono/inspect-components/sample-activity";
+import {
   dynamicDefaultExcludeEvents,
   eventsToStr,
   type TranscriptLayoutRightRailProps,
@@ -57,6 +61,7 @@ import {
   type ActivityRailItem,
 } from "@tsmono/react/components";
 import {
+  navigateAndForget,
   useChromeNavOwnership,
   useElementHeight,
   useVisitId,
@@ -64,9 +69,10 @@ import {
 import { isHostedEnvironment, isVscode } from "@tsmono/util";
 
 import { Events } from "../../@types/extraInspect";
-import { getApi } from "../../app_config";
+import { getApi, useLogDir } from "../../app_config";
 import { SampleSummary } from "../../client/api/types";
 import {
+  kSampleActivityTabId,
   kSampleErrorTabId,
   kSampleJsonTabId,
   kSampleMessagesTabId,
@@ -93,7 +99,9 @@ import { formatDateTime } from "../../utils/format";
 import { ApplicationIcons } from "../appearance/icons";
 import { useSampleDetailNavigation } from "../routing/sampleNavigation";
 import {
+  makeLogsPath,
   printSampleUrl,
+  sampleEventUrl,
   useFullSampleMessageUrlBuilder,
   useLogOrSampleRouteParams,
   useRoutePrefix,
@@ -410,6 +418,45 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
 
   const { isDebugFilter, isDefaultFilter, isNoneFilter } =
     useTranscriptFilter(defaultExcludeEvents);
+
+  // ── Activity tab ──────────────────────────────────────────────────────
+  // Hidden entirely for old logs whose events lack timestamps (design spec);
+  // chunked samples carry an empty shell events array, so they hide it too.
+  const logDir = useLogDir();
+  const hasActivityTab = hasEventTimestamps(sampleEvents);
+  // Durable Activity UI state (band toggles, filters, selection) is keyed
+  // per log + sample so it survives tab switches without leaking across
+  // samples.
+  const activityPersistScope = `${selectedSampleHandle?.logFile ?? ""}:${String(
+    selectedSampleHandle?.id ?? id
+  )}:${selectedSampleHandle?.epoch ?? 1}`;
+  // Click-through target for every Activity span, glyph, and history row:
+  // the Transcript tab scrolled to the event (?event=<uuid>). Modifier
+  // clicks open the same route in a new browser tab.
+  const openEventInTranscript = (uuid: string, event: MouseEvent) => {
+    let targetLogPath = urlLogPath;
+    if (!targetLogPath && selectedLogFile) {
+      targetLogPath = makeLogsPath(selectedLogFile, logDir);
+    }
+    const sampleId = urlSampleId ?? selectedSampleHandle?.id;
+    const sampleEpoch = urlEpoch ?? selectedSampleHandle?.epoch;
+    if (!targetLogPath || sampleId === undefined || sampleEpoch === undefined) {
+      return;
+    }
+    const url = sampleEventUrl(
+      sampleUrlBuilder,
+      uuid,
+      targetLogPath,
+      sampleId,
+      sampleEpoch
+    );
+    if (event.metaKey || event.ctrlKey || event.shiftKey) {
+      openInNewTab(`#${url}`);
+      return;
+    }
+    setSelectedTab(kSampleTranscriptTabId);
+    navigateAndForget(navigate, url);
+  };
 
   const api = getApi();
   const downloadFiles = useStore((state) => state.capabilities.downloadFiles);
@@ -983,6 +1030,31 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
                 scrollRef={scrollRef}
               />
             </TabPanel>
+            {hasActivityTab ? (
+              <TabPanel
+                key={kSampleActivityTabId}
+                id={kSampleActivityTabId}
+                className={clsx("sample-tab", styles.fullWidth)}
+                title="Activity"
+                onSelected={onSelectedTab}
+                selected={effectiveSelectedTab === kSampleActivityTabId}
+                scrollable={false}
+              >
+                <div className={styles.tabContent}>
+                  <SampleActivityPanel
+                    events={sampleEvents}
+                    startedAt={sample?.started_at}
+                    completedAt={sample?.completed_at}
+                    workingTime={sample?.working_time}
+                    totalTime={sample?.total_time}
+                    running={running}
+                    scrollRef={scrollRef}
+                    persistScope={activityPersistScope}
+                    onOpenEvent={openEventInTranscript}
+                  />
+                </div>
+              </TabPanel>
+            ) : null}
             {sampleUsages.length > 0 ? (
               <TabPanel
                 id={kSampleUsageTabId}

--- a/apps/inspect/src/app/samples/SampleDisplay.tsx
+++ b/apps/inspect/src/app/samples/SampleDisplay.tsx
@@ -904,6 +904,11 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
               onSelected={onSelectedTab}
               selected={
                 effectiveSelectedTab === kSampleTranscriptTabId ||
+                // A shared /activity URL on a log whose events lack
+                // timestamps hides that tab — fall back here rather than
+                // leaving no panel selected.
+                (effectiveSelectedTab === kSampleActivityTabId &&
+                  !hasActivityTab) ||
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentional: persisted webview/store state isn't validated (#555); a restored store may omit the tab selection
                 effectiveSelectedTab === undefined
               }

--- a/apps/inspect/src/constants.ts
+++ b/apps/inspect/src/constants.ts
@@ -24,6 +24,7 @@ export const kWorkspaceTabs = [
 export const kSampleMessagesTabId = `messages`;
 export const kSampleTranscriptTabId = `transcript`;
 export const kSampleScoringTabId = `scoring`;
+export const kSampleActivityTabId = `activity`;
 export const kSampleMetdataTabId = `metadata`;
 export const kSampleUsageTabId = `usage`;
 export const kSampleErrorTabId = `error`;
@@ -38,6 +39,7 @@ export const kSampleTabIds = [
   kSampleMessagesTabId,
   kSampleTranscriptTabId,
   kSampleScoringTabId,
+  kSampleActivityTabId,
   kSampleUsageTabId,
   kSampleMetdataTabId,
   kSampleErrorTabId,

--- a/packages/inspect-common/src/testing/index.ts
+++ b/packages/inspect-common/src/testing/index.ts
@@ -29,6 +29,7 @@ import type {
   Event,
   InfoEvent,
   InputEvent,
+  InterruptEvent,
   LoggerEvent,
   ModelConfig,
   ModelEvent,
@@ -375,6 +376,17 @@ export const testInputEvent = (
   working_start: 0,
   input: "",
   input_ansi: "",
+  ...overrides,
+});
+
+export const testInterruptEvent = (
+  overrides: Partial<InterruptEvent> = {}
+): InterruptEvent => ({
+  event: "interrupt",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  interrupted: "generate",
+  source: "user_cancel",
   ...overrides,
 });
 

--- a/packages/inspect-components/package.json
+++ b/packages/inspect-components/package.json
@@ -13,6 +13,7 @@
     "./columnFilter": "./src/columnFilter/index.ts",
     "./config": "./src/config/index.ts",
     "./content": "./src/content/index.ts",
+    "./sample-activity": "./src/sample-activity/index.ts",
     "./theme": "./src/theme/index.ts",
     "./transcript": "./src/transcript/index.ts",
     "./transcript/test-helpers": "./src/transcript/timeline/testHelpers.ts",

--- a/packages/inspect-components/src/config/ConfigChangedChip.tsx
+++ b/packages/inspect-components/src/config/ConfigChangedChip.tsx
@@ -28,7 +28,8 @@ interface TimelineLinkProps {
   className?: string;
 }
 
-/** The "View on timeline" affordance shared by the config/usage surfaces. */
+/** The "View on activity" affordance shared by the config/usage surfaces
+ *  (targets the log-level Activity tab, formerly labeled Timeline). */
 export const TimelineLink: FC<TimelineLinkProps> = ({ onClick, className }) => (
   <button
     type="button"
@@ -36,7 +37,7 @@ export const TimelineLink: FC<TimelineLinkProps> = ({ onClick, className }) => (
     onClick={onClick}
   >
     <i className="bi bi-graph-up" aria-hidden="true" />
-    View on timeline
+    View on activity
   </button>
 );
 

--- a/packages/inspect-components/src/sample-activity/ActivityChart.module.css
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.module.css
@@ -1,0 +1,367 @@
+.chart {
+  position: relative;
+  width: 100%;
+}
+
+.svg {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* Uppercase 9px band labels, letter-spacing set inline (SVG attr). */
+.bandLabel {
+  font-size: 9px;
+  fill: var(--bs-secondary-color);
+}
+
+.bandHeadline {
+  font-size: 9px;
+  fill: var(--bs-secondary-color);
+  font-family: var(--bs-font-monospace);
+}
+
+.axisLine {
+  stroke: var(--bs-border-color);
+}
+
+.axisLabel {
+  font-size: 9px;
+  fill: var(--bs-secondary-color);
+}
+
+.yTickLabel {
+  font-size: 9px;
+  fill: var(--bs-secondary-color);
+}
+
+/* ── working / waiting ── */
+
+.workingBlock {
+  fill: #5b8ec4;
+}
+
+.stallBracket {
+  stroke: #adb5bd;
+  stroke-width: 1;
+  fill: none;
+}
+
+.stallBracketRetry {
+  stroke: #b04a3c;
+  stroke-width: 1;
+  fill: none;
+}
+
+.stallLabel {
+  font-size: 9px;
+  fill: var(--bs-secondary-color);
+}
+
+.stallLabelRetry {
+  font-size: 9px;
+  fill: #b04a3c;
+}
+
+/* ── curves ── */
+
+.tokenSeries {
+  fill: none;
+  stroke: #495057;
+  stroke-width: 1.2;
+}
+
+.contextSeries {
+  fill: none;
+  stroke: #3a7bd5;
+  stroke-width: 1.2;
+}
+
+.contextDot {
+  fill: #3a7bd5;
+  pointer-events: none;
+}
+
+.compactionDrop {
+  stroke: #2b6a94;
+  stroke-dasharray: 3 2;
+}
+
+.compactionLabel {
+  font-size: 9px;
+  fill: #2b6a94;
+}
+
+.crosshair {
+  stroke: var(--bs-secondary-color);
+  stroke-dasharray: 3 3;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hoverDotTokens {
+  fill: #495057;
+  pointer-events: none;
+}
+
+.hoverDotContext {
+  fill: #3a7bd5;
+  pointer-events: none;
+}
+
+.lineHit {
+  fill: transparent;
+}
+
+.lineTooltip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  z-index: 9;
+}
+
+/* ── model & tool activity ── */
+
+.rowLabel {
+  font-size: 9px;
+  fill: var(--bs-body-color);
+}
+
+.rowLabelMuted {
+  fill: #adb5bd;
+}
+
+.modelSpan {
+  fill: #64748b;
+}
+
+.toolSpan {
+  fill: #4f8f8b;
+}
+
+/* Failed tool call: red-outlined span (handoff decision 4). */
+.failedSpan {
+  fill: #fdf1ef;
+  stroke: #b04a3c;
+}
+
+.pendingSpan {
+  opacity: 0.55;
+}
+
+.clickableSpan {
+  cursor: pointer;
+}
+
+/* Grader / secondary-role rows render muted (handoff decision 4). */
+.roleRow {
+  opacity: 0.7;
+}
+
+.burstLabel {
+  font-size: 8px;
+  fill: #2f6f6b;
+}
+
+.retryBadge {
+  font-size: 9px;
+  fill: #b04a3c;
+}
+
+.densityFailure {
+  fill: #b04a3c;
+  pointer-events: none;
+}
+
+.densityHit {
+  fill: transparent;
+  cursor: pointer;
+}
+
+/* ── marker rail ── */
+
+.marker {
+  cursor: pointer;
+  outline: none;
+}
+
+.markerHit {
+  fill: transparent;
+}
+
+.clusterCount {
+  font-size: 8px;
+}
+
+.markerPopover {
+  position: absolute;
+  max-width: 330px;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 4px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  z-index: 10;
+  font-size: 0.75rem;
+  pointer-events: none;
+  padding: 0.35rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.markerPopoverEntry {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.markerPopoverSwatch {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.markerPopoverTime {
+  margin-left: auto;
+  color: var(--bs-secondary-color);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.7rem;
+}
+
+/* ── span popover ── */
+
+.spanPopover {
+  position: absolute;
+  width: 300px;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 4px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  z-index: 10;
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
+.spanPopoverHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  border-bottom: 1px solid var(--bs-border-color);
+  background: var(--bs-light-bg-subtle);
+  border-radius: 4px 4px 0 0;
+}
+
+.spanPopoverSwatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.spanPopoverTitle {
+  font-weight: 600;
+  font-family: var(--bs-font-monospace);
+  font-size: 0.72rem;
+}
+
+.spanPopoverTime {
+  margin-left: auto;
+  color: var(--bs-secondary-color);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.7rem;
+}
+
+.spanPopoverBody {
+  padding: 0.4rem 0.6rem;
+  color: var(--bs-body-color);
+}
+
+.spanPopoverFailed {
+  color: #b04a3c;
+}
+
+.spanPopoverHint {
+  color: var(--bs-secondary-color);
+}
+
+/* ── dark theme ── */
+
+:global([data-bs-theme="dark"]) .tokenSeries {
+  stroke: #adb5bd;
+}
+
+:global([data-bs-theme="dark"]) .hoverDotTokens {
+  fill: #adb5bd;
+}
+
+:global([data-bs-theme="dark"]) .contextSeries {
+  stroke: #6ea0dc;
+}
+
+:global([data-bs-theme="dark"]) .contextDot {
+  fill: #6ea0dc;
+}
+
+:global([data-bs-theme="dark"]) .hoverDotContext {
+  fill: #6ea0dc;
+}
+
+:global([data-bs-theme="dark"]) .compactionDrop {
+  stroke: #6ba3c9;
+}
+
+:global([data-bs-theme="dark"]) .compactionLabel {
+  fill: #8fbcd9;
+}
+
+:global([data-bs-theme="dark"]) .stallBracket {
+  stroke: #6c757d;
+}
+
+:global([data-bs-theme="dark"]) .stallBracketRetry {
+  stroke: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .stallLabelRetry {
+  fill: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .failedSpan {
+  fill: #322019;
+  stroke: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .retryBadge {
+  fill: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .densityFailure {
+  fill: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .burstLabel {
+  fill: #7ab8b3;
+}
+
+:global([data-bs-theme="dark"]) .rowLabelMuted {
+  fill: #6c757d;
+}
+
+:global([data-bs-theme="dark"]) .spanPopoverFailed {
+  color: #d98b7f;
+}

--- a/packages/inspect-components/src/sample-activity/ActivityChart.module.css
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.module.css
@@ -201,8 +201,18 @@
   outline: none;
 }
 
-.clusterCount {
-  font-size: 8px;
+/* Bordered count box above a clustered glyph (stroke/text take the
+   category hue inline) — the task timeline's ordinal-box token. */
+.clusterBoxRect {
+  fill: var(--bs-body-bg);
+  stroke-opacity: 0.55;
+  pointer-events: none;
+}
+
+.clusterBoxText {
+  font-family: var(--bs-font-monospace);
+  font-size: 9px;
+  pointer-events: none;
 }
 
 .markerPopover {

--- a/packages/inspect-components/src/sample-activity/ActivityChart.module.css
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.module.css
@@ -188,13 +188,17 @@
 
 /* ── marker rail ── */
 
+/* Only the hit rect is interactive — the group's stem line would
+   otherwise capture hovers meant for the bands beneath it. */
 .marker {
-  cursor: pointer;
-  outline: none;
+  pointer-events: none;
 }
 
 .markerHit {
   fill: transparent;
+  pointer-events: all;
+  cursor: pointer;
+  outline: none;
 }
 
 .clusterCount {

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -1000,7 +1000,9 @@ export const ActivityChart: FC<ActivityChartProps> = ({
         t += interval
       ) {
         const px = x(t);
-        if (px < plotLeft + 110 || px > plotRight - 60) continue;
+        // 80px right margin — the end tick renders with seconds, so it is
+        // wider than the task timeline's and a 60px skip lets them collide.
+        if (px < plotLeft + 110 || px > plotRight - 80) continue;
         ticks.push({ x: px, label: fmt(t), anchor: "middle" });
       }
     }

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -1,0 +1,1163 @@
+import clsx from "clsx";
+import {
+  FC,
+  Fragment,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  useRef,
+  useState,
+} from "react";
+
+import styles from "./ActivityChart.module.css";
+import {
+  ActivityData,
+  ActivityMarker,
+  ActivitySpan,
+  AgentRow,
+  fmtDay,
+  fmtDurationWords,
+  fmtTime,
+  fmtTimeSec,
+  fmtTokens,
+  kCategoryColor,
+  StallRegion,
+  TimeWindow,
+} from "./activityData";
+
+// Task-timeline parity geometry (handoff decision 6).
+const kBandHeight = 84;
+const kBandLabelY = 14;
+const kPlotTop = 22;
+const kPlotBottom = 72;
+const kAxisHeight = 28;
+const kYAxisWidth = 30;
+// Marks at the window end would otherwise sit on the svg edge and clip.
+const kPlotRightInset = 10;
+// The glyph rail above the bands (kMarkerHeadroom parity).
+const kMarkerHeadroom = 18;
+const kGlyphY = 12;
+// Markers closer than this cluster into one glyph + ×N badge.
+const kClusterGapPx = 10;
+// Label only the N longest stalls to avoid clutter (handoff decision 2).
+const kMaxStallLabels = 3;
+// Working blocks (16px tall, centred between plot top and baseline).
+const kWorkingBlockTop = 38;
+const kWorkingBlockHeight = 16;
+const kStallBracketTop = 58;
+const kStallLabelY = 70;
+// Merged model+tool band rows.
+const kAgentRowPitch = 24;
+const kAgentRowFirstLabelY = 28;
+const kAgentSpanOffset = 32;
+const kAgentSpanHeight = 11;
+const kSubLaneHeight = 3.25;
+// Density degrade: past ~1 span per 3px a row renders as occupancy columns.
+const kDensityPxPerSpan = 3;
+const kDensityColWidth = 2;
+// Hover/click bins on a dense row aggregate columns to a readable window.
+const kDensityHoverPx = 16;
+
+/** Crosshair + value readout for a hovered curve band. */
+interface LineHover {
+  bandId: string;
+  x: number;
+  dotY: number;
+  top: number;
+  label: string;
+}
+
+interface SpanHover {
+  x: number;
+  span: ActivitySpan;
+  row: AgentRow;
+}
+
+interface MarkerHover {
+  x: number;
+  members: ActivityMarker[];
+}
+
+interface BinHover {
+  x: number;
+  top: number;
+  label: string;
+  window: TimeWindow;
+}
+
+export interface ActivityChartProps {
+  data: ActivityData;
+  window: TimeWindow;
+  showWorking: boolean;
+  showMarkers: boolean;
+  showTokens: boolean;
+  showContext: boolean;
+  showModelTool: boolean;
+  /** Selected history-row key — its marker holds the active treatment. */
+  selectedKey: string | null;
+  /** Marker click: select + scroll to its history row (auto-widening). */
+  onSelectMarker: (key: string | null) => void;
+  /** Row hovered in the history list — its glyph lights up. */
+  hoveredRowKey?: string | null;
+  /** Hovering a glyph washes its history row(s); null clears. */
+  onHoverMarker?: (keys: string[] | null) => void;
+  /** Click-through to the Transcript via event uuid. */
+  onOpenEvent?: (uuid: string, event: ReactMouseEvent) => void;
+  /** Dense-band bin click: filter the history list to the bin's window. */
+  onFilterWindow?: (window: TimeWindow) => void;
+}
+
+export const ActivityChart: FC<ActivityChartProps> = ({
+  data,
+  window: timeWindow,
+  showWorking,
+  showMarkers,
+  showTokens,
+  showContext,
+  showModelTool,
+  selectedKey,
+  onSelectMarker,
+  hoveredRowKey,
+  onHoverMarker,
+  onOpenEvent,
+  onFilterWindow,
+}) => {
+  const [width, setWidth] = useState(0);
+  // Callback ref, not useResizeObserver — the chart renders null while every
+  // band is toggled off, so a mount-only effect could observe nothing.
+  const resizeObserver = useRef<ResizeObserver | null>(null);
+  const chartRef = (element: HTMLDivElement | null) => {
+    resizeObserver.current?.disconnect();
+    resizeObserver.current = null;
+    if (element) {
+      const observer = new ResizeObserver((entries) => {
+        if (entries[0]) {
+          setWidth(entries[0].contentRect.width);
+        }
+      });
+      observer.observe(element);
+      resizeObserver.current = observer;
+    }
+  };
+
+  const [lineHover, setLineHover] = useState<LineHover | null>(null);
+  const [spanHover, setSpanHover] = useState<SpanHover | null>(null);
+  const [markerHover, setMarkerHover] = useState<MarkerHover | null>(null);
+  const [binHover, setBinHover] = useState<BinHover | null>(null);
+
+  const plotLeft = kYAxisWidth;
+  const plotRight = Math.max(width - kPlotRightInset, plotLeft);
+  const plotWidth = plotRight - plotLeft;
+  const span = timeWindow.end - timeWindow.start;
+
+  const x = (t: number): number => {
+    const clamped = Math.min(Math.max(t, timeWindow.start), timeWindow.end);
+    return span > 0
+      ? plotLeft + ((clamped - timeWindow.start) / span) * plotWidth
+      : plotLeft;
+  };
+  const timeAt = (px: number): number =>
+    plotWidth > 0
+      ? timeWindow.start + ((px - plotLeft) / plotWidth) * span
+      : timeWindow.start;
+
+  // ── band stack ────────────────────────────────────────────────────────
+  interface Band {
+    kind: "working" | "tokens" | "context" | "modelTool";
+    top: number;
+    /** Plot baseline offset within the band (modelTool grows with rows). */
+    plotBottom: number;
+    height: number;
+  }
+
+  const agentRowCount = data.agentRows.length;
+  // The one variable-height band: grows with agent-row count (decision 6).
+  const modelToolPlotBottom = Math.max(
+    kPlotBottom,
+    kAgentRowFirstLabelY - 4 + agentRowCount * kAgentRowPitch + 4
+  );
+
+  const bands: Band[] = [];
+  let cursor = showMarkers && data.markers.length > 0 ? kMarkerHeadroom : 0;
+  const pushBand = (kind: Band["kind"], plotBottom: number) => {
+    const height = plotBottom + (kBandHeight - kPlotBottom);
+    bands.push({ kind, top: cursor, plotBottom, height });
+    cursor += height;
+  };
+  if (showWorking) pushBand("working", kPlotBottom);
+  if (showTokens && data.tokenSeries.length > 0)
+    pushBand("tokens", kPlotBottom);
+  if (showContext && data.contextSeries.length > 0) {
+    pushBand("context", kPlotBottom);
+  }
+  if (showModelTool && agentRowCount > 0) {
+    pushBand("modelTool", modelToolPlotBottom);
+  }
+
+  const axisY = (bands.length === 0 ? kMarkerHeadroom + 24 : cursor) + 6;
+  const height = axisY + kAxisHeight;
+
+  if (bands.length === 0 && (!showMarkers || data.markers.length === 0)) {
+    return null;
+  }
+
+  // ── shared band chrome ────────────────────────────────────────────────
+
+  const axisFrame = (band: Band) => (
+    <Fragment>
+      <line
+        className={styles.axisLine}
+        x1={plotLeft}
+        x2={plotLeft}
+        y1={band.top + kPlotTop - 4}
+        y2={band.top + band.plotBottom}
+      />
+      <line
+        className={styles.axisLine}
+        x1={plotLeft}
+        x2={plotRight}
+        y1={band.top + band.plotBottom}
+        y2={band.top + band.plotBottom}
+      />
+    </Fragment>
+  );
+
+  const bandLabel = (band: Band, text: string) => (
+    <text
+      className={styles.bandLabel}
+      x={0}
+      y={band.top + kBandLabelY}
+      letterSpacing="0.4"
+    >
+      {text}
+    </text>
+  );
+
+  const bandHeadline = (band: Band, text: string) => (
+    <text
+      className={styles.bandHeadline}
+      x={plotRight}
+      y={band.top + kBandLabelY}
+      textAnchor="end"
+    >
+      {text}
+    </text>
+  );
+
+  const cursorTime = (
+    event: ReactMouseEvent<SVGRectElement>
+  ): { px: number; t: number } => {
+    const left =
+      event.currentTarget.ownerSVGElement?.getBoundingClientRect().left ?? 0;
+    const px = Math.min(Math.max(event.clientX - left, plotLeft), plotRight);
+    return { px, t: timeAt(px) };
+  };
+
+  const crosshair = (band: Band, hover: LineHover, dotClass: string) => (
+    <Fragment>
+      <line
+        className={styles.crosshair}
+        x1={hover.x}
+        x2={hover.x}
+        y1={band.top + kPlotTop - 4}
+        y2={band.top + band.plotBottom}
+      />
+      <circle className={dotClass} cx={hover.x} cy={hover.dotY} r={3} />
+    </Fragment>
+  );
+
+  const lineHitRect = (
+    band: Band,
+    onMove: (event: ReactMouseEvent<SVGRectElement>) => void
+  ) => (
+    <rect
+      className={styles.lineHit}
+      x={plotLeft}
+      y={band.top + kPlotTop - 4}
+      width={Math.max(plotWidth, 0)}
+      height={band.plotBottom - kPlotTop + 4}
+      onMouseMove={onMove}
+      onMouseLeave={() => setLineHover(null)}
+    />
+  );
+
+  /** 0 / mid / max ticks in fmtTokens units. */
+  const yTicks = (yOf: (v: number) => number, max: number) => {
+    const values = [0, ...(max >= 4 ? [max / 2] : []), max];
+    return Array.from(new Set(values)).map((value) => (
+      <g key={`ytick-${value}`}>
+        <line
+          className={styles.axisLine}
+          x1={plotLeft - 3}
+          x2={plotLeft}
+          y1={yOf(value)}
+          y2={yOf(value)}
+        />
+        <text
+          className={styles.yTickLabel}
+          x={plotLeft - 5}
+          y={yOf(value) + (value === max ? 7 : 3)}
+          textAnchor="end"
+        >
+          {fmtTokens(value)}
+        </text>
+      </g>
+    ));
+  };
+
+  // ── WORKING / WAITING ─────────────────────────────────────────────────
+
+  const renderWorking = (band: Band) => {
+    // Only the N longest stalls get labels; brackets render for those same
+    // stalls so the annotation layer stays quiet (decision 2).
+    const labeled = [...data.stalls]
+      .sort((a, b) => b.duration - a.duration)
+      .slice(0, kMaxStallLabels)
+      .filter((stall) => x(stall.end) - x(stall.start) >= 24);
+    const stallLabel = (stall: StallRegion): string =>
+      stall.retries !== undefined && stall.retries > 0
+        ? `${fmtDurationWords(stall.duration)} · rate limit ×${stall.retries}`
+        : fmtDurationWords(stall.duration);
+    return (
+      <g key="band-working">
+        {bandLabel(band, "WORKING / WAITING")}
+        {bandHeadline(
+          band,
+          `working ${fmtDurationWords(data.workingTime)} · total ${fmtDurationWords(data.totalTime)}`
+        )}
+        {data.workingSegments.map((segment, i) => (
+          <rect
+            key={`w-${i}`}
+            className={styles.workingBlock}
+            x={x(segment.start)}
+            y={band.top + kWorkingBlockTop}
+            width={Math.max(x(segment.end) - x(segment.start), 1)}
+            height={kWorkingBlockHeight}
+            rx={1}
+          />
+        ))}
+        {labeled.map((stall, i) => {
+          const retry = stall.retries !== undefined && stall.retries > 0;
+          const x1 = x(stall.start) + 1;
+          const x2 = x(stall.end) - 1;
+          const yTop = band.top + kStallBracketTop;
+          return (
+            <Fragment key={`stall-${i}`}>
+              <path
+                className={
+                  retry ? styles.stallBracketRetry : styles.stallBracket
+                }
+                d={`M ${x1} ${yTop} V ${yTop + 3} H ${x2} V ${yTop}`}
+              />
+              <text
+                className={retry ? styles.stallLabelRetry : styles.stallLabel}
+                x={(x1 + x2) / 2}
+                y={band.top + kStallLabelY}
+                textAnchor="middle"
+              >
+                {stallLabel(stall)}
+              </text>
+            </Fragment>
+          );
+        })}
+        {axisFrame(band)}
+      </g>
+    );
+  };
+
+  // ── TOKEN BURN ────────────────────────────────────────────────────────
+
+  const tokenValueAt = (t: number): number => {
+    let value = 0;
+    for (const point of data.tokenSeries) {
+      if (point.time > t) break;
+      value = point.value;
+    }
+    return value;
+  };
+
+  const renderTokens = (band: Band) => {
+    const max = Math.max(data.totalTokens, 1);
+    const yMax = max * 1.05;
+    const y = (v: number): number =>
+      band.top + kPlotBottom - (v / yMax) * (kPlotBottom - kPlotTop);
+
+    // Cumulative step curve, decimated per pixel at scale.
+    let d = `M ${plotLeft} ${band.top + kPlotBottom}`;
+    let lastX = plotLeft;
+    for (const point of data.tokenSeries) {
+      const px = x(point.time);
+      if (
+        px - lastX >= 1 ||
+        point === data.tokenSeries[data.tokenSeries.length - 1]
+      ) {
+        d += ` H ${px.toFixed(1)} V ${y(point.value).toFixed(1)}`;
+        lastX = px;
+      }
+    }
+    d += ` H ${plotRight}`;
+
+    return (
+      <g key="band-tokens">
+        {bandLabel(band, "TOKEN BURN")}
+        {bandHeadline(band, `${fmtTokens(data.totalTokens)} total`)}
+        <path className={styles.tokenSeries} d={d} />
+        {axisFrame(band)}
+        {yTicks(y, max)}
+        {lineHover?.bandId === "tokens" &&
+          crosshair(band, lineHover, styles.hoverDotTokens)}
+        {lineHitRect(band, (event) => {
+          const { px, t } = cursorTime(event);
+          const value = tokenValueAt(t);
+          setLineHover({
+            bandId: "tokens",
+            x: px,
+            dotY: y(value),
+            top: band.top + kPlotTop,
+            label: `${value.toLocaleString()} tokens · ${fmtTimeSec(t)}`,
+          });
+        })}
+      </g>
+    );
+  };
+
+  // ── CONTEXT SIZE ──────────────────────────────────────────────────────
+
+  const renderContext = (band: Band) => {
+    const dropMax = data.compactions.reduce(
+      (m, c) => Math.max(m, c.before ?? 0),
+      0
+    );
+    const max = Math.max(data.contextPeak, dropMax, 1);
+    const yMax = max * 1.05;
+    const y = (v: number): number =>
+      band.top + kPlotBottom - (v / yMax) * (kPlotBottom - kPlotTop);
+
+    // Split the polyline at compaction drops so the line doesn't slope
+    // through the cliff — each drop restarts the run at tokens_after.
+    const runs: { x: number; y: number }[][] = [];
+    let run: { x: number; y: number }[] = [];
+    let compactionIndex = 0;
+    for (const point of data.contextSeries) {
+      while (
+        compactionIndex < data.compactions.length &&
+        (data.compactions[compactionIndex]?.time ?? Infinity) <= point.time
+      ) {
+        const drop = data.compactions[compactionIndex]!;
+        if (run.length > 0) runs.push(run);
+        run =
+          drop.after !== undefined
+            ? [{ x: x(drop.time), y: y(drop.after) }]
+            : [];
+        compactionIndex += 1;
+      }
+      run.push({ x: x(point.time), y: y(point.value) });
+    }
+    if (run.length > 0) runs.push(run);
+
+    // Dots only at sparse density — they'd smear into a rope at scale.
+    const sparse = data.contextSeries.length <= plotWidth / 8;
+
+    return (
+      <g key="band-context">
+        {bandLabel(band, "CONTEXT SIZE")}
+        {bandHeadline(band, `peak ${fmtTokens(data.contextPeak)}`)}
+        {runs.map((points, i) => (
+          <polyline
+            key={`ctx-run-${i}`}
+            className={styles.contextSeries}
+            points={points
+              .map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+              .join(" ")}
+          />
+        ))}
+        {sparse &&
+          data.contextSeries.map((point, i) => (
+            <circle
+              key={`ctx-dot-${i}`}
+              className={styles.contextDot}
+              cx={x(point.time)}
+              cy={y(point.value)}
+              r={2}
+            />
+          ))}
+        {data.compactions.map((drop, i) => {
+          if (drop.before === undefined || drop.after === undefined) {
+            return null;
+          }
+          const dx = x(drop.time);
+          return (
+            <Fragment key={`comp-${i}`}>
+              <line
+                className={styles.compactionDrop}
+                x1={dx}
+                x2={dx}
+                y1={y(drop.before)}
+                y2={y(drop.after)}
+              />
+              <text
+                className={styles.compactionLabel}
+                x={dx + 7}
+                y={y(drop.before) + 1}
+              >
+                {fmtTokens(drop.before)} → {fmtTokens(drop.after)}
+              </text>
+            </Fragment>
+          );
+        })}
+        {axisFrame(band)}
+        {yTicks(y, max)}
+        {lineHover?.bandId === "context" &&
+          crosshair(band, lineHover, styles.hoverDotContext)}
+        {lineHitRect(band, (event) => {
+          const { px, t } = cursorTime(event);
+          // Nearest point at or before the cursor.
+          let value = 0;
+          for (const point of data.contextSeries) {
+            if (point.time > t) break;
+            value = point.value;
+          }
+          setLineHover({
+            bandId: "context",
+            x: px,
+            dotY: y(value),
+            top: band.top + kPlotTop,
+            label: `${value.toLocaleString()} tokens · ${fmtTimeSec(t)}`,
+          });
+        })}
+      </g>
+    );
+  };
+
+  // ── MODEL & TOOL ACTIVITY ─────────────────────────────────────────────
+
+  const spanWidth = (s: ActivitySpan): number =>
+    Math.max(x(s.end) - x(s.start), 1.5);
+
+  const renderDiscreteRow = (row: AgentRow, rowTop: number): ReactNode => {
+    const spanY = rowTop + (kAgentSpanOffset - kAgentRowFirstLabelY);
+    const laneY = (s: ActivitySpan): number => {
+      if (s.subLane === undefined || s.subLaneCount === undefined) return spanY;
+      const count = Math.max(s.subLaneCount, 1);
+      const pitch =
+        count > 1 ? (kAgentSpanHeight + 1 - kSubLaneHeight) / (count - 1) : 0;
+      return spanY + s.subLane * pitch;
+    };
+    return (
+      <Fragment>
+        {row.spans.map((s, i) => {
+          const subLaned = s.subLane !== undefined;
+          const h = subLaned ? kSubLaneHeight : kAgentSpanHeight;
+          const failedTool = s.kind === "tool" && s.failed;
+          return (
+            <g key={`span-${i}`}>
+              {s.kind === "model" &&
+                s.retries !== undefined &&
+                s.retries > 0 && (
+                  <text
+                    className={styles.retryBadge}
+                    x={x(s.start) - 4}
+                    y={spanY + 9}
+                    textAnchor="end"
+                  >
+                    ×{s.retries}
+                  </text>
+                )}
+              <rect
+                className={clsx(
+                  s.kind === "model" ? styles.modelSpan : styles.toolSpan,
+                  failedTool && styles.failedSpan,
+                  s.pending && styles.pendingSpan,
+                  s.uuid && onOpenEvent && styles.clickableSpan
+                )}
+                x={x(s.start)}
+                y={laneY(s)}
+                width={spanWidth(s)}
+                height={h}
+                rx={1}
+                onMouseEnter={() =>
+                  setSpanHover({ x: x(s.start), span: s, row })
+                }
+                onMouseLeave={() => setSpanHover(null)}
+                onClick={
+                  s.uuid && onOpenEvent
+                    ? (event) => onOpenEvent(s.uuid!, event)
+                    : undefined
+                }
+              />
+            </g>
+          );
+        })}
+        {row.bursts.map((burst, i) => (
+          <text
+            key={`burst-${i}`}
+            className={styles.burstLabel}
+            x={(x(burst.start) + x(burst.end)) / 2}
+            y={rowTop - 4 + (kAgentSpanOffset - kAgentRowFirstLabelY)}
+            textAnchor="middle"
+          >
+            {burst.label} ×{burst.count}
+            {burst.failed > 0 ? ` · ${burst.failed} failed` : ""}
+            {burst.folded > 0 ? ` · +${burst.folded}` : ""}
+          </text>
+        ))}
+      </Fragment>
+    );
+  };
+
+  interface DensityColumn {
+    model: number;
+    tool: number;
+    failed: boolean;
+  }
+
+  const renderDenseRow = (
+    row: AgentRow,
+    rowTop: number,
+    band: Band
+  ): ReactNode => {
+    const spanY = rowTop + (kAgentSpanOffset - kAgentRowFirstLabelY);
+    const rowH = kAgentSpanHeight + 1;
+    const nCols = Math.max(1, Math.floor(plotWidth / kDensityColWidth));
+    const cols: DensityColumn[] = Array.from({ length: nCols }, () => ({
+      model: 0,
+      tool: 0,
+      failed: false,
+    }));
+    for (const s of row.spans) {
+      const c0 = Math.max(
+        0,
+        Math.floor((x(s.start) - plotLeft) / kDensityColWidth)
+      );
+      const c1 = Math.min(
+        nCols - 1,
+        Math.floor((x(s.end) - plotLeft) / kDensityColWidth)
+      );
+      for (let c = c0; c <= c1; c++) {
+        const col = cols[c]!;
+        if (s.kind === "model") col.model += 1;
+        else col.tool += 1;
+        if (s.failed) col.failed = true;
+      }
+    }
+
+    const binAt = (px: number): { label: string; window: TimeWindow } => {
+      const binStart =
+        plotLeft +
+        Math.floor((px - plotLeft) / kDensityHoverPx) * kDensityHoverPx;
+      const binEnd = Math.min(binStart + kDensityHoverPx, plotRight);
+      const c0 = Math.max(
+        0,
+        Math.floor((binStart - plotLeft) / kDensityColWidth)
+      );
+      const c1 = Math.min(
+        nCols - 1,
+        Math.floor((binEnd - plotLeft) / kDensityColWidth)
+      );
+      // Column counts overcount spans crossing bins — good enough for a
+      // hover readout, and O(width) like the strip itself.
+      let model = 0;
+      let tool = 0;
+      let failed = 0;
+      for (let c = c0; c <= c1; c++) {
+        const col = cols[c]!;
+        model = Math.max(model, col.model);
+        tool = Math.max(tool, col.tool);
+        if (col.failed) failed += 1;
+      }
+      const windowStart = timeAt(binStart);
+      const windowEnd = timeAt(binEnd);
+      const label =
+        `${fmtTime(windowStart)}–${fmtTime(windowEnd)} · ` +
+        `${model} model · ${tool} tool${failed > 0 ? ` (${failed} failed)` : ""}`;
+      return { label, window: { start: windowStart, end: windowEnd } };
+    };
+
+    return (
+      <Fragment>
+        {cols.map((col, i) => {
+          const total = col.model + col.tool;
+          if (total === 0) return null;
+          const share = col.tool / total;
+          return (
+            <rect
+              key={`col-${i}`}
+              x={plotLeft + i * kDensityColWidth}
+              y={spanY}
+              width={kDensityColWidth}
+              height={rowH}
+              fill={share > 0.5 ? "#4f8f8b" : "#64748b"}
+              opacity={0.3 + Math.min(0.6, total * 0.18)}
+            />
+          );
+        })}
+        {cols.map((col, i) =>
+          col.failed ? (
+            <rect
+              key={`fail-${i}`}
+              className={styles.densityFailure}
+              x={plotLeft + i * kDensityColWidth}
+              y={spanY}
+              width={1.5}
+              height={rowH}
+            />
+          ) : null
+        )}
+        <rect
+          className={styles.densityHit}
+          x={plotLeft}
+          y={spanY - 2}
+          width={Math.max(plotWidth, 0)}
+          height={rowH + 4}
+          onMouseMove={(event) => {
+            const { px } = cursorTime(event);
+            const bin = binAt(px);
+            setBinHover({
+              x: px,
+              top: band.top + kPlotTop,
+              label: bin.label,
+              window: bin.window,
+            });
+          }}
+          onMouseLeave={() => setBinHover(null)}
+          onClick={
+            onFilterWindow
+              ? (event) => {
+                  const { px } = cursorTime(event);
+                  onFilterWindow(binAt(px).window);
+                }
+              : undefined
+          }
+        />
+      </Fragment>
+    );
+  };
+
+  const renderModelTool = (band: Band) => {
+    const totalSpans = data.agentRows.reduce(
+      (sum, row) => sum + row.spans.length,
+      0
+    );
+    const totalTools = data.agentRows.reduce(
+      (sum, row) => sum + row.toolCount,
+      0
+    );
+    const totalModels = totalSpans - totalTools;
+    const anyDense = data.agentRows.some(
+      (row) => row.spans.length > plotWidth / kDensityPxPerSpan
+    );
+    return (
+      <g key="band-model-tool">
+        {bandLabel(band, "MODEL & TOOL ACTIVITY")}
+        {bandHeadline(
+          band,
+          anyDense
+            ? `${totalModels.toLocaleString()} model · ${totalTools.toLocaleString()} tool · per-pixel occupancy`
+            : `${totalModels.toLocaleString()} model · ${totalTools.toLocaleString()} tool`
+        )}
+        {data.agentRows.map((row, i) => {
+          const rowTop = band.top + kAgentRowFirstLabelY + i * kAgentRowPitch;
+          const dense = row.spans.length > plotWidth / kDensityPxPerSpan;
+          return (
+            <g
+              key={`row-${row.model}-${row.role ?? ""}`}
+              className={row.role ? styles.roleRow : undefined}
+            >
+              <text className={styles.rowLabel} x={kYAxisWidth + 4} y={rowTop}>
+                {row.model}{" "}
+                <tspan className={styles.rowLabelMuted}>
+                  {row.role
+                    ? `· ${row.role}`
+                    : row.toolCount > 0
+                      ? "+ tools"
+                      : ""}
+                </tspan>
+              </text>
+              {dense
+                ? renderDenseRow(row, rowTop, band)
+                : renderDiscreteRow(row, rowTop)}
+            </g>
+          );
+        })}
+        {axisFrame(band)}
+      </g>
+    );
+  };
+
+  // ── marker rail ───────────────────────────────────────────────────────
+
+  interface MarkerGroup {
+    x: number;
+    members: ActivityMarker[];
+  }
+
+  const glyph = (
+    category: ActivityMarker["category"],
+    cx: number
+  ): ReactNode => {
+    const color = kCategoryColor[category];
+    switch (category) {
+      case "error":
+        return (
+          <path
+            d={`M ${cx - 3.5} ${kGlyphY - 3.5} L ${cx + 3.5} ${kGlyphY + 3.5} M ${cx + 3.5} ${kGlyphY - 3.5} L ${cx - 3.5} ${kGlyphY + 3.5}`}
+            stroke={color}
+            strokeWidth={1.8}
+            strokeLinecap="round"
+            fill="none"
+          />
+        );
+      case "limit":
+        return (
+          <polygon
+            points={`${cx},${kGlyphY - 4.5} ${cx - 4.5},${kGlyphY + 3.5} ${cx + 4.5},${kGlyphY + 3.5}`}
+            fill={color}
+          />
+        );
+      case "approval":
+        return <circle cx={cx} cy={kGlyphY} r={4} fill={color} />;
+      case "input":
+        return (
+          <rect
+            x={cx - 3}
+            y={kGlyphY - 3}
+            width={6}
+            height={6}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.5}
+            transform={`rotate(45 ${cx} ${kGlyphY})`}
+          />
+        );
+      case "interrupt":
+        return (
+          <Fragment>
+            <rect
+              x={cx - 4}
+              y={kGlyphY - 4}
+              width={2.6}
+              height={8}
+              fill={color}
+            />
+            <rect
+              x={cx + 1.4}
+              y={kGlyphY - 4}
+              width={2.6}
+              height={8}
+              fill={color}
+            />
+          </Fragment>
+        );
+      case "compaction":
+        return (
+          <polygon
+            points={`${cx - 4.5},${kGlyphY - 4} ${cx + 4.5},${kGlyphY - 4} ${cx},${kGlyphY + 4}`}
+            fill={color}
+          />
+        );
+      case "score":
+        return (
+          <Fragment>
+            <circle
+              cx={cx}
+              cy={kGlyphY}
+              r={4.5}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.5}
+            />
+            <circle cx={cx} cy={kGlyphY} r={1.6} fill={color} />
+          </Fragment>
+        );
+    }
+  };
+
+  const renderMarkers = () => {
+    // Dense markers cluster within 10px into one glyph + ×N (decision 3).
+    const groups: MarkerGroup[] = [];
+    for (const marker of data.markers) {
+      const mx = x(marker.time);
+      const last = groups[groups.length - 1];
+      if (last && mx - last.x < kClusterGapPx) {
+        last.members.push(marker);
+        last.x = (x(last.members[0]!.time) + mx) / 2;
+      } else {
+        groups.push({ x: mx, members: [marker] });
+      }
+    }
+    return (
+      <g key="markers">
+        {groups.map((group, i) => {
+          const head = group.members[0]!;
+          const keys = group.members.map((m) => m.key);
+          const color = kCategoryColor[head.category];
+          const active =
+            (selectedKey !== null && keys.includes(selectedKey)) ||
+            (hoveredRowKey != null && keys.includes(hoveredRowKey));
+          const label =
+            group.members.length > 1
+              ? `${group.members.length} events: ${group.members
+                  .map((m) => m.label)
+                  .join("; ")}`
+              : head.label;
+          const activate = () => {
+            setMarkerHover({ x: group.x, members: group.members });
+            onHoverMarker?.(keys);
+          };
+          const deactivate = () => {
+            setMarkerHover(null);
+            onHoverMarker?.(null);
+          };
+          const selected = selectedKey !== null && keys.includes(selectedKey);
+          const toggle = () =>
+            onSelectMarker(selected ? null : (keys[0] ?? null));
+          return (
+            <g
+              key={`marker-${i}`}
+              className={styles.marker}
+              role="button"
+              tabIndex={0}
+              aria-label={label}
+              onClick={toggle}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  toggle();
+                }
+              }}
+              onMouseEnter={activate}
+              onMouseLeave={deactivate}
+              onFocus={activate}
+              onBlur={deactivate}
+            >
+              {/* Full-height stem in the hue at low opacity (decision 3). */}
+              <line
+                x1={group.x}
+                x2={group.x}
+                y1={kMarkerHeadroom}
+                y2={axisY}
+                stroke={color}
+                opacity={active ? 0.5 : 0.2}
+              />
+              {active && (
+                <circle
+                  cx={group.x}
+                  cy={kGlyphY}
+                  r={7.5}
+                  fill={color}
+                  opacity={0.18}
+                />
+              )}
+              {glyph(head.category, group.x)}
+              {group.members.length > 1 && (
+                <text
+                  className={styles.clusterCount}
+                  x={group.x + 6}
+                  y={9}
+                  fill={color}
+                >
+                  ×{group.members.length}
+                </text>
+              )}
+              {/* Generous invisible hit area — glyphs are small. */}
+              <rect
+                className={styles.markerHit}
+                x={group.x - 6}
+                y={2}
+                width={12 + (group.members.length > 1 ? 12 : 0)}
+                height={18}
+              />
+            </g>
+          );
+        })}
+      </g>
+    );
+  };
+
+  // ── axis (task-timeline tick logic) ───────────────────────────────────
+
+  const renderAxis = () => {
+    const ticks: {
+      x: number;
+      label: string;
+      anchor: "start" | "middle" | "end";
+    }[] = [
+      {
+        x: plotLeft,
+        label: `${fmtDay(timeWindow.start)}, ${fmtTime(timeWindow.start)}`,
+        anchor: "start",
+      },
+      { x: plotRight, label: fmtTimeSec(timeWindow.end), anchor: "end" },
+    ];
+    const intervals = [
+      15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 43200, 86400,
+    ];
+    const interval = intervals.find((i) => (i / span) * plotWidth >= 80);
+    if (interval) {
+      const fmt = interval < 60 ? fmtTimeSec : fmtTime;
+      for (
+        let t = Math.ceil(timeWindow.start / interval) * interval;
+        t < timeWindow.end;
+        t += interval
+      ) {
+        const px = x(t);
+        if (px < plotLeft + 110 || px > plotRight - 60) continue;
+        ticks.push({ x: px, label: fmt(t), anchor: "middle" });
+      }
+    }
+    return (
+      <g key="axis">
+        <line
+          className={styles.axisLine}
+          x1={plotLeft}
+          x2={plotRight}
+          y1={axisY}
+          y2={axisY}
+        />
+        {ticks.map((tick, i) => (
+          <g key={i}>
+            <line
+              className={styles.axisLine}
+              x1={tick.x}
+              x2={tick.x}
+              y1={axisY}
+              y2={axisY + 3}
+            />
+            <text
+              className={styles.axisLabel}
+              x={tick.x}
+              y={axisY + 14}
+              textAnchor={tick.anchor}
+            >
+              {tick.label}
+            </text>
+          </g>
+        ))}
+      </g>
+    );
+  };
+
+  // ── popovers / tooltips ───────────────────────────────────────────────
+
+  const renderSpanPopover = () => {
+    if (!spanHover) return null;
+    const { span: s, row } = spanHover;
+    const left = Math.min(
+      Math.max(spanHover.x - 24, 0),
+      Math.max(width - 300, 0)
+    );
+    // Find the band top for model/tool to anchor below the hovered row.
+    const band = bands.find((b) => b.kind === "modelTool");
+    const rowIndex = data.agentRows.indexOf(row);
+    const top =
+      (band?.top ?? 0) +
+      kAgentSpanOffset +
+      Math.max(rowIndex, 0) * kAgentRowPitch +
+      kAgentSpanHeight +
+      4;
+    return (
+      <div className={styles.spanPopover} style={{ left, top }}>
+        <div className={styles.spanPopoverHeader}>
+          <span
+            className={styles.spanPopoverSwatch}
+            style={{ background: s.kind === "model" ? "#64748b" : "#4f8f8b" }}
+          />
+          <span className={styles.spanPopoverTitle}>{s.label}</span>
+          <span className={styles.spanPopoverTime}>
+            {fmtTimeSec(s.start)}
+            {s.end > s.start
+              ? ` – ${s.pending ? "now" : fmtTimeSec(s.end)}`
+              : ""}
+          </span>
+        </div>
+        <div className={styles.spanPopoverBody}>
+          {s.kind === "model" ? "model call" : "tool call"}
+          {row.role ? ` · ${row.role}` : ""}
+          {` · ${fmtDurationWords(s.end - s.start)}`}
+          {s.retries !== undefined && s.retries > 0
+            ? ` · retried ×${s.retries}`
+            : ""}
+          {s.failed ? (
+            <span className={styles.spanPopoverFailed}> · failed</span>
+          ) : (
+            ""
+          )}
+          {s.uuid && onOpenEvent ? (
+            <span className={styles.spanPopoverHint}>
+              {" "}
+              · click to open in transcript
+            </span>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const renderMarkerPopover = () => {
+    if (!markerHover) return null;
+    const left = Math.min(
+      Math.max(markerHover.x - 24, 0),
+      Math.max(width - 300, 0)
+    );
+    return (
+      <div
+        className={styles.markerPopover}
+        style={{ left, top: kMarkerHeadroom + 8 }}
+      >
+        {markerHover.members.map((member, i) => (
+          <div key={i} className={styles.markerPopoverEntry}>
+            <span
+              className={styles.markerPopoverSwatch}
+              style={{ background: kCategoryColor[member.category] }}
+            />
+            <span>{member.label}</span>
+            <span className={styles.markerPopoverTime}>
+              {fmtTimeSec(member.time)}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div ref={chartRef} className={styles.chart} style={{ height }}>
+      {width > 0 && (
+        <svg className={styles.svg} width={width} height={height}>
+          {bands.map((band) => {
+            switch (band.kind) {
+              case "working":
+                return renderWorking(band);
+              case "tokens":
+                return renderTokens(band);
+              case "context":
+                return renderContext(band);
+              case "modelTool":
+                return renderModelTool(band);
+            }
+          })}
+          {renderAxis()}
+          {showMarkers && renderMarkers()}
+        </svg>
+      )}
+      {renderSpanPopover()}
+      {renderMarkerPopover()}
+      {(lineHover ?? binHover) && (
+        <div
+          className={styles.lineTooltip}
+          style={(() => {
+            const hover = lineHover ?? binHover!;
+            return hover.x > width - 180
+              ? {
+                  left: hover.x - 10,
+                  top: hover.top,
+                  transform: "translateX(-100%)",
+                }
+              : { left: hover.x + 10, top: hover.top };
+          })()}
+        >
+          {(lineHover ?? binHover!).label}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -607,7 +607,9 @@ export const ActivityChart: FC<ActivityChartProps> = ({
   interface DensityColumn {
     model: number;
     tool: number;
-    failed: boolean;
+    /** Failed calls overlapping this column (not a column-hit flag — the
+     *  bin readout takes a max like the model/tool counts). */
+    failed: number;
   }
 
   const renderDenseRow = (
@@ -621,7 +623,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
     const cols: DensityColumn[] = Array.from({ length: nCols }, () => ({
       model: 0,
       tool: 0,
-      failed: false,
+      failed: 0,
     }));
     for (const s of row.spans) {
       const c0 = Math.max(
@@ -636,7 +638,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
         const col = cols[c]!;
         if (s.kind === "model") col.model += 1;
         else col.tool += 1;
-        if (s.failed) col.failed = true;
+        if (s.failed) col.failed += 1;
       }
     }
 
@@ -662,7 +664,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
         const col = cols[c]!;
         model = Math.max(model, col.model);
         tool = Math.max(tool, col.tool);
-        if (col.failed) failed += 1;
+        failed = Math.max(failed, col.failed);
       }
       const windowStart = timeAt(binStart);
       const windowEnd = timeAt(binEnd);
@@ -691,7 +693,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
           );
         })}
         {cols.map((col, i) =>
-          col.failed ? (
+          col.failed > 0 ? (
             <rect
               key={`fail-${i}`}
               className={styles.densityFailure}

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -480,30 +480,41 @@ export const ActivityChart: FC<ActivityChartProps> = ({
               r={2}
             />
           ))}
-        {data.compactions.map((drop, i) => {
-          if (drop.before === undefined || drop.after === undefined) {
-            return null;
-          }
-          const dx = x(drop.time);
-          return (
-            <Fragment key={`comp-${i}`}>
-              <line
-                className={styles.compactionDrop}
-                x1={dx}
-                x2={dx}
-                y1={y(drop.before)}
-                y2={y(drop.after)}
-              />
-              <text
-                className={styles.compactionLabel}
-                x={dx + 7}
-                y={y(drop.before) + 1}
-              >
-                {fmtTokens(drop.before)} → {fmtTokens(drop.after)}
-              </text>
-            </Fragment>
-          );
-        })}
+        {(() => {
+          // Every drop draws its dashed cliff, but annotations declutter:
+          // a label only renders with enough horizontal room after the
+          // previously labeled drop (same philosophy as the N-longest
+          // stall labels) — dense compaction runs stay readable.
+          let lastLabelX = -Infinity;
+          return data.compactions.map((drop, i) => {
+            if (drop.before === undefined || drop.after === undefined) {
+              return null;
+            }
+            const dx = x(drop.time);
+            const labeled = dx - lastLabelX >= 60;
+            if (labeled) lastLabelX = dx;
+            return (
+              <Fragment key={`comp-${i}`}>
+                <line
+                  className={styles.compactionDrop}
+                  x1={dx}
+                  x2={dx}
+                  y1={y(drop.before)}
+                  y2={y(drop.after)}
+                />
+                {labeled && (
+                  <text
+                    className={styles.compactionLabel}
+                    x={dx + 7}
+                    y={y(drop.before) + 1}
+                  >
+                    {fmtTokens(drop.before)} → {fmtTokens(drop.after)}
+                  </text>
+                )}
+              </Fragment>
+            );
+          });
+        })()}
         {axisFrame(band)}
         {yTicks(y, max)}
         {lineHover?.bandId === "context" &&
@@ -913,24 +924,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
           const toggle = () =>
             onSelectMarker(selected ? null : (keys[0] ?? null));
           return (
-            <g
-              key={`marker-${i}`}
-              className={styles.marker}
-              role="button"
-              tabIndex={0}
-              aria-label={label}
-              onClick={toggle}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  toggle();
-                }
-              }}
-              onMouseEnter={activate}
-              onMouseLeave={deactivate}
-              onFocus={activate}
-              onBlur={deactivate}
-            >
+            <g key={`marker-${i}`} className={styles.marker}>
               {/* Full-height stem in the hue at low opacity (decision 3). */}
               <line
                 x1={group.x}
@@ -960,13 +954,30 @@ export const ActivityChart: FC<ActivityChartProps> = ({
                   ×{group.members.length}
                 </text>
               )}
-              {/* Generous invisible hit area — glyphs are small. */}
+              {/* The interactive element is this generous invisible rect on
+                  the rail, NOT the group: the group's bounding box includes
+                  the full-height stem, which would put its click point
+                  mid-chart and let stems steal hovers from the bands. */}
               <rect
                 className={styles.markerHit}
                 x={group.x - 6}
                 y={2}
                 width={12 + (group.members.length > 1 ? 12 : 0)}
                 height={18}
+                role="button"
+                tabIndex={0}
+                aria-label={label}
+                onClick={toggle}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    toggle();
+                  }
+                }}
+                onMouseEnter={activate}
+                onMouseLeave={deactivate}
+                onFocus={activate}
+                onBlur={deactivate}
               />
             </g>
           );

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -544,6 +544,11 @@ export const ActivityChart: FC<ActivityChartProps> = ({
   const spanWidth = (s: ActivitySpan): number =>
     Math.max(x(s.end) - x(s.start), 1.5);
 
+  /** The row label's full text ("model · grader" / "model + tools") — the
+   *  burst-label declutter reserves its extent. */
+  const rowLabelText = (row: AgentRow): string =>
+    `${row.model} ${row.role ? `· ${row.role}` : row.toolCount > 0 ? "+ tools" : ""}`;
+
   const renderDiscreteRow = (row: AgentRow, rowTop: number): ReactNode => {
     const spanY = rowTop + (kAgentSpanOffset - kAgentRowFirstLabelY);
     const laneY = (s: ActivitySpan): number => {
@@ -598,19 +603,37 @@ export const ActivityChart: FC<ActivityChartProps> = ({
             </g>
           );
         })}
-        {row.bursts.map((burst, i) => (
-          <text
-            key={`burst-${i}`}
-            className={styles.burstLabel}
-            x={(x(burst.start) + x(burst.end)) / 2}
-            y={rowTop - 4 + (kAgentSpanOffset - kAgentRowFirstLabelY)}
-            textAnchor="middle"
-          >
-            {burst.label} ×{burst.count}
-            {burst.failed > 0 ? ` · ${burst.failed} failed` : ""}
-            {burst.folded > 0 ? ` · +${burst.folded}` : ""}
-          </text>
-        ))}
+        {(() => {
+          // Burst labels declutter greedily: the "bash ×3 · 1 failed"
+          // annotation is designed for isolated bursts — with parallel tool
+          // calls every turn, dozens of them smear over each other and the
+          // row label. A label renders only with clear horizontal room
+          // (after the row label and the previous burst label); the span
+          // hover popover keeps the full detail for unlabeled bursts.
+          let lastLabelEnd =
+            kYAxisWidth + 4 + rowLabelText(row).length * 5 + 12;
+          return row.bursts.map((burst, i) => {
+            const text =
+              `${burst.label} ×${burst.count}` +
+              (burst.failed > 0 ? ` · ${burst.failed} failed` : "") +
+              (burst.folded > 0 ? ` · +${burst.folded}` : "");
+            const mid = (x(burst.start) + x(burst.end)) / 2;
+            const half = (text.length * 4.5) / 2;
+            if (mid - half < lastLabelEnd + 8) return null;
+            lastLabelEnd = mid + half;
+            return (
+              <text
+                key={`burst-${i}`}
+                className={styles.burstLabel}
+                x={mid}
+                y={rowTop - 4 + (kAgentSpanOffset - kAgentRowFirstLabelY)}
+                textAnchor="middle"
+              >
+                {text}
+              </text>
+            );
+          });
+        })()}
       </Fragment>
     );
   };
@@ -778,11 +801,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
               <text className={styles.rowLabel} x={kYAxisWidth + 4} y={rowTop}>
                 {row.model}{" "}
                 <tspan className={styles.rowLabelMuted}>
-                  {row.role
-                    ? `· ${row.role}`
-                    : row.toolCount > 0
-                      ? "+ tools"
-                      : ""}
+                  {rowLabelText(row).slice(row.model.length + 1)}
                 </tspan>
               </text>
               {dense

--- a/packages/inspect-components/src/sample-activity/ActivityChart.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityChart.tsx
@@ -160,6 +160,47 @@ export const ActivityChart: FC<ActivityChartProps> = ({
       ? timeWindow.start + ((px - plotLeft) / plotWidth) * span
       : timeWindow.start;
 
+  // ── marker clusters (computed before the bands: a cluster's count box
+  //    needs extra rail headroom, which shifts every band down) ──────────
+  interface MarkerGroup {
+    x: number;
+    members: ActivityMarker[];
+  }
+
+  /** Count-box width for a cluster ("×12" is wider than "×2"); singles
+   *  reserve just their glyph. */
+  const badgeWidth = (count: number): number =>
+    count > 1 ? `×${count}`.length * 5.5 + 8 : 9;
+
+  // Merge markers whose glyphs or count boxes would collide — pixel-based
+  // like the task timeline's ordinal boxes, so clusters dissolve on wider
+  // windows and boxes never overlap their neighbours.
+  const markerGroups: MarkerGroup[] = [];
+  for (const marker of data.markers) {
+    const mx = x(marker.time);
+    const last = markerGroups[markerGroups.length - 1];
+    const gap = last
+      ? Math.max(
+          kClusterGapPx,
+          (badgeWidth(last.members.length + 1) + 9) / 2 + 2
+        )
+      : kClusterGapPx;
+    if (last && mx - last.x < gap) {
+      last.members.push(marker);
+      last.x = (x(last.members[0]!.time) + mx) / 2;
+    } else {
+      markerGroups.push({ x: mx, members: [marker] });
+    }
+  }
+  const hasClusterBadges = markerGroups.some(
+    (group) => group.members.length > 1
+  );
+  // Clusters render a bordered count box ABOVE the glyph (task-timeline
+  // ordinal-box convention) — the rail grows to fit it; without clusters
+  // the handoff's 18px rail stands.
+  const markerHeadroom = hasClusterBadges ? 30 : kMarkerHeadroom;
+  const glyphY = hasClusterBadges ? 23 : kGlyphY;
+
   // ── band stack ────────────────────────────────────────────────────────
   interface Band {
     kind: "working" | "tokens" | "context" | "modelTool";
@@ -177,7 +218,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
   );
 
   const bands: Band[] = [];
-  let cursor = showMarkers && data.markers.length > 0 ? kMarkerHeadroom : 0;
+  let cursor = showMarkers && data.markers.length > 0 ? markerHeadroom : 0;
   const pushBand = (kind: Band["kind"], plotBottom: number) => {
     const height = plotBottom + (kBandHeight - kPlotBottom);
     bands.push({ kind, top: cursor, plotBottom, height });
@@ -193,7 +234,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
     pushBand("modelTool", modelToolPlotBottom);
   }
 
-  const axisY = (bands.length === 0 ? kMarkerHeadroom + 24 : cursor) + 6;
+  const axisY = (bands.length === 0 ? markerHeadroom + 24 : cursor) + 6;
   const height = axisY + kAxisHeight;
 
   if (bands.length === 0 && (!showMarkers || data.markers.length === 0)) {
@@ -817,21 +858,17 @@ export const ActivityChart: FC<ActivityChartProps> = ({
 
   // ── marker rail ───────────────────────────────────────────────────────
 
-  interface MarkerGroup {
-    x: number;
-    members: ActivityMarker[];
-  }
-
   const glyph = (
     category: ActivityMarker["category"],
-    cx: number
+    cx: number,
+    cy: number
   ): ReactNode => {
     const color = kCategoryColor[category];
     switch (category) {
       case "error":
         return (
           <path
-            d={`M ${cx - 3.5} ${kGlyphY - 3.5} L ${cx + 3.5} ${kGlyphY + 3.5} M ${cx + 3.5} ${kGlyphY - 3.5} L ${cx - 3.5} ${kGlyphY + 3.5}`}
+            d={`M ${cx - 3.5} ${cy - 3.5} L ${cx + 3.5} ${cy + 3.5} M ${cx + 3.5} ${cy - 3.5} L ${cx - 3.5} ${cy + 3.5}`}
             stroke={color}
             strokeWidth={1.8}
             strokeLinecap="round"
@@ -841,48 +878,36 @@ export const ActivityChart: FC<ActivityChartProps> = ({
       case "limit":
         return (
           <polygon
-            points={`${cx},${kGlyphY - 4.5} ${cx - 4.5},${kGlyphY + 3.5} ${cx + 4.5},${kGlyphY + 3.5}`}
+            points={`${cx},${cy - 4.5} ${cx - 4.5},${cy + 3.5} ${cx + 4.5},${cy + 3.5}`}
             fill={color}
           />
         );
       case "approval":
-        return <circle cx={cx} cy={kGlyphY} r={4} fill={color} />;
+        return <circle cx={cx} cy={cy} r={4} fill={color} />;
       case "input":
         return (
           <rect
             x={cx - 3}
-            y={kGlyphY - 3}
+            y={cy - 3}
             width={6}
             height={6}
             fill="none"
             stroke={color}
             strokeWidth={1.5}
-            transform={`rotate(45 ${cx} ${kGlyphY})`}
+            transform={`rotate(45 ${cx} ${cy})`}
           />
         );
       case "interrupt":
         return (
           <Fragment>
-            <rect
-              x={cx - 4}
-              y={kGlyphY - 4}
-              width={2.6}
-              height={8}
-              fill={color}
-            />
-            <rect
-              x={cx + 1.4}
-              y={kGlyphY - 4}
-              width={2.6}
-              height={8}
-              fill={color}
-            />
+            <rect x={cx - 4} y={cy - 4} width={2.6} height={8} fill={color} />
+            <rect x={cx + 1.4} y={cy - 4} width={2.6} height={8} fill={color} />
           </Fragment>
         );
       case "compaction":
         return (
           <polygon
-            points={`${cx - 4.5},${kGlyphY - 4} ${cx + 4.5},${kGlyphY - 4} ${cx},${kGlyphY + 4}`}
+            points={`${cx - 4.5},${cy - 4} ${cx + 4.5},${cy - 4} ${cx},${cy + 4}`}
             fill={color}
           />
         );
@@ -891,34 +916,22 @@ export const ActivityChart: FC<ActivityChartProps> = ({
           <Fragment>
             <circle
               cx={cx}
-              cy={kGlyphY}
+              cy={cy}
               r={4.5}
               fill="none"
               stroke={color}
               strokeWidth={1.5}
             />
-            <circle cx={cx} cy={kGlyphY} r={1.6} fill={color} />
+            <circle cx={cx} cy={cy} r={1.6} fill={color} />
           </Fragment>
         );
     }
   };
 
   const renderMarkers = () => {
-    // Dense markers cluster within 10px into one glyph + ×N (decision 3).
-    const groups: MarkerGroup[] = [];
-    for (const marker of data.markers) {
-      const mx = x(marker.time);
-      const last = groups[groups.length - 1];
-      if (last && mx - last.x < kClusterGapPx) {
-        last.members.push(marker);
-        last.x = (x(last.members[0]!.time) + mx) / 2;
-      } else {
-        groups.push({ x: mx, members: [marker] });
-      }
-    }
     return (
       <g key="markers">
-        {groups.map((group, i) => {
+        {markerGroups.map((group, i) => {
           const head = group.members[0]!;
           const keys = group.members.map((m) => m.key);
           const color = kCategoryColor[head.category];
@@ -942,13 +955,15 @@ export const ActivityChart: FC<ActivityChartProps> = ({
           const selected = selectedKey !== null && keys.includes(selectedKey);
           const toggle = () =>
             onSelectMarker(selected ? null : (keys[0] ?? null));
+          const cluster = group.members.length > 1;
+          const boxW = badgeWidth(group.members.length);
           return (
             <g key={`marker-${i}`} className={styles.marker}>
               {/* Full-height stem in the hue at low opacity (decision 3). */}
               <line
                 x1={group.x}
                 x2={group.x}
-                y1={kMarkerHeadroom}
+                y1={glyphY + 6}
                 y2={axisY}
                 stroke={color}
                 opacity={active ? 0.5 : 0.2}
@@ -956,22 +971,38 @@ export const ActivityChart: FC<ActivityChartProps> = ({
               {active && (
                 <circle
                   cx={group.x}
-                  cy={kGlyphY}
+                  cy={glyphY}
                   r={7.5}
                   fill={color}
                   opacity={0.18}
                 />
               )}
-              {glyph(head.category, group.x)}
-              {group.members.length > 1 && (
-                <text
-                  className={styles.clusterCount}
-                  x={group.x + 6}
-                  y={9}
-                  fill={color}
-                >
-                  ×{group.members.length}
-                </text>
+              {glyph(head.category, group.x, glyphY)}
+              {cluster && (
+                <Fragment>
+                  {/* Bordered count box centred above the glyph — the
+                      task timeline's ordinal-box convention, so the count
+                      reads as a badge on THIS mark rather than stray text
+                      floating between neighbours. */}
+                  <rect
+                    className={styles.clusterBoxRect}
+                    x={group.x - boxW / 2}
+                    y={2}
+                    width={boxW}
+                    height={13}
+                    rx={2}
+                    stroke={color}
+                  />
+                  <text
+                    className={styles.clusterBoxText}
+                    x={group.x}
+                    y={11.5}
+                    textAnchor="middle"
+                    fill={color}
+                  >
+                    ×{group.members.length}
+                  </text>
+                </Fragment>
               )}
               {/* The interactive element is this generous invisible rect on
                   the rail, NOT the group: the group's bounding box includes
@@ -979,10 +1010,10 @@ export const ActivityChart: FC<ActivityChartProps> = ({
                   mid-chart and let stems steal hovers from the bands. */}
               <rect
                 className={styles.markerHit}
-                x={group.x - 6}
-                y={2}
-                width={12 + (group.members.length > 1 ? 12 : 0)}
-                height={18}
+                x={group.x - Math.max(boxW, 12) / 2}
+                y={1}
+                width={Math.max(boxW, 12)}
+                height={glyphY + 6}
                 role="button"
                 tabIndex={0}
                 aria-label={label}
@@ -1135,7 +1166,7 @@ export const ActivityChart: FC<ActivityChartProps> = ({
     return (
       <div
         className={styles.markerPopover}
-        style={{ left, top: kMarkerHeadroom + 8 }}
+        style={{ left, top: markerHeadroom + 8 }}
       >
         {markerHover.members.map((member, i) => (
           <div key={i} className={styles.markerPopoverEntry}>

--- a/packages/inspect-components/src/sample-activity/ActivityHistoryList.module.css
+++ b/packages/inspect-components/src/sample-activity/ActivityHistoryList.module.css
@@ -1,0 +1,486 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.72rem;
+  flex-wrap: wrap;
+  padding-top: 0.25rem;
+}
+
+.caption {
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-right: 0.25rem;
+}
+
+/* Filled colour pills: fill + border + text in one hue per category — the
+   same hue the category's glyph uses on the rail, so the filter row doubles
+   as the rail's legend. */
+.filterPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 999px;
+  line-height: 1.2;
+  background: none;
+  font-size: 0.72rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.pillCount {
+  font-weight: 400;
+}
+
+.pillEmpty {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.pillAll {
+  color: var(--bs-body-color);
+}
+
+.pillAll.pillSelected {
+  background: #212529;
+  border-color: #212529;
+  color: #fff;
+}
+
+.pillError {
+  background: #fdf1ef;
+  border-color: #ecc8c1;
+  color: #a13b2c;
+}
+
+.pillLimit {
+  background: #fffaeb;
+  border-color: #e8d8a0;
+  color: #8a6d1a;
+}
+
+.pillApproval {
+  background: #f7f3fc;
+  border-color: #d9cfe8;
+  color: #4a2e73;
+}
+
+.pillInput {
+  background: #f2f7fc;
+  border-color: #cfe0f1;
+  color: #1d4f7c;
+}
+
+.pillInterrupt {
+  background: #f8f9fa;
+  border-color: #dee2e6;
+  color: #6c757d;
+}
+
+.pillCompaction {
+  background: #eef6fb;
+  border-color: #c3dcea;
+  color: #2b6a94;
+}
+
+/* The one palette addition (handoff): a green Scores hue. */
+.pillScore {
+  background: #f0f7f2;
+  border-color: #d3e3d8;
+  color: #2f8a52;
+}
+
+/* Selected = solid fill with white text; unselected pills stay tinted. */
+.pillError.pillSelected {
+  background: #b04a3c;
+  border-color: #b04a3c;
+  color: #fff;
+}
+
+.pillLimit.pillSelected {
+  background: #8a6d1a;
+  border-color: #8a6d1a;
+  color: #fff;
+}
+
+.pillApproval.pillSelected {
+  background: #6b4fa8;
+  border-color: #6b4fa8;
+  color: #fff;
+}
+
+.pillInput.pillSelected {
+  background: #1d4f7c;
+  border-color: #1d4f7c;
+  color: #fff;
+}
+
+.pillInterrupt.pillSelected {
+  background: #6c757d;
+  border-color: #6c757d;
+  color: #fff;
+}
+
+.pillCompaction.pillSelected {
+  background: #2b6a94;
+  border-color: #2b6a94;
+  color: #fff;
+}
+
+.pillScore.pillSelected {
+  background: #2f8a52;
+  border-color: #2f8a52;
+  color: #fff;
+}
+
+.pillSelected .pillCount {
+  color: inherit;
+}
+
+/* Dense-band time-window filter chip (click ✕ to clear). */
+.pillWindow {
+  background: var(--bs-secondary-bg);
+  border-color: var(--bs-secondary);
+  color: var(--bs-body-color);
+  font-family: var(--bs-font-monospace);
+}
+
+.search {
+  margin-left: auto;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  font-size: 0.72rem;
+  padding: 0.125rem 0.5rem;
+  width: 220px;
+}
+
+.search::placeholder {
+  color: var(--bs-secondary-color);
+}
+
+.list {
+  border: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem;
+}
+
+.empty {
+  padding: 0.75rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.8rem;
+}
+
+/* Four fixed columns — Time / Kind / Event / By (task-timeline parity). */
+.headerRow,
+.row {
+  display: grid;
+  grid-template-columns: 110px 64px minmax(0, 1fr) minmax(56px, max-content);
+  /* rem, not em — the header row's smaller font would shrink an em gap,
+     shifting its Kind/Event labels left of the row cells. */
+  column-gap: 1rem;
+  align-items: start;
+  padding: 0.4rem 0.25rem;
+}
+
+.headerRow {
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--bs-border-color);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.timeSort {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-transform: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-align: left;
+}
+
+.byHeader {
+  text-align: right;
+}
+
+.row {
+  border-bottom: 1px dotted var(--bs-border-color);
+  cursor: pointer;
+}
+
+/* Rows are virtualized (absolutely positioned), so :last-child would match
+   whatever row happens to render last — the bottom row is flagged by index. */
+.row.rowLast {
+  border-bottom: none;
+}
+
+.rowSelected {
+  background: var(--bs-secondary-bg);
+  outline: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+}
+
+/* Hover-linked wash while the row's glyph is hovered on the rail — the
+   inset bar carries the category hue. */
+.rowWash {
+  background: #faf8fd;
+}
+
+.washError {
+  box-shadow: inset 2px 0 0 #b04a3c;
+  background: #fdf6f5;
+}
+
+.washLimit {
+  box-shadow: inset 2px 0 0 #8a6d1a;
+  background: #fffaeb;
+}
+
+.washApproval {
+  box-shadow: inset 2px 0 0 #6b4fa8;
+}
+
+.washInput {
+  box-shadow: inset 2px 0 0 #1d4f7c;
+  background: #f7fafd;
+}
+
+.washInterrupt {
+  box-shadow: inset 2px 0 0 #6c757d;
+  background: #f8f9fa;
+}
+
+.washCompaction {
+  box-shadow: inset 2px 0 0 #2b6a94;
+  background: #f4f9fc;
+}
+
+.washScore {
+  box-shadow: inset 2px 0 0 #2f8a52;
+  background: #f4faf6;
+}
+
+.time {
+  font-family: var(--bs-font-monospace);
+  font-size: 0.72rem;
+  color: var(--bs-secondary-color);
+  padding-top: 2px;
+}
+
+/* Centers the pill on the row's first text line. */
+.kindCell {
+  display: flex;
+  align-items: center;
+  height: calc(0.8rem * 1.5);
+}
+
+/* Same filled pill as the filter row at 0.65rem uppercase, so a row's Kind
+   cell and its filter pill are visibly one object. */
+.kindPill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid;
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+/* Body: one size, one weight, two colours — mono separates values from
+   prose; no bold and no status colour anywhere in the cell. */
+.event {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--bs-body-color);
+  line-height: 1.5;
+}
+
+.muted {
+  color: var(--bs-secondary-color);
+}
+
+.mono {
+  font-family: var(--bs-font-monospace);
+  font-size: 0.75rem;
+}
+
+/* Author demoted to a right-aligned channel — user vs system at a glance. */
+.by {
+  font-size: 0.72rem;
+  font-weight: 400;
+  color: var(--bs-secondary-color);
+  text-align: right;
+  padding-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.openEvent {
+  font-size: 0.72rem;
+  color: var(--bs-link-color);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.openEvent:hover {
+  text-decoration: underline;
+}
+
+/* ── dark theme (mirrors the task timeline's pill overrides; Scores gets
+      its new dark variant per the handoff) ── */
+
+:global([data-bs-theme="dark"]) .pillAll.pillSelected {
+  background: #dee2e6;
+  border-color: #dee2e6;
+  color: #212529;
+}
+
+:global([data-bs-theme="dark"]) .pillError {
+  background: #322019;
+  border-color: #6b3a30;
+  color: #d98b7f;
+}
+
+:global([data-bs-theme="dark"]) .pillLimit {
+  background: #3a3220;
+  border-color: #5c512f;
+  color: #e8d8a0;
+}
+
+:global([data-bs-theme="dark"]) .pillApproval {
+  background: #2a2333;
+  border-color: #4a3d63;
+  color: #cbb8ec;
+}
+
+:global([data-bs-theme="dark"]) .pillInput {
+  background: #16222e;
+  border-color: #2c4a66;
+  color: #8db8dd;
+}
+
+:global([data-bs-theme="dark"]) .pillInterrupt {
+  background: #26282b;
+  border-color: #4a5056;
+  color: #9aa3ab;
+}
+
+:global([data-bs-theme="dark"]) .pillCompaction {
+  background: #16242e;
+  border-color: #2b4c66;
+  color: #8fbcd9;
+}
+
+:global([data-bs-theme="dark"]) .pillScore {
+  background: #1d2b22;
+  border-color: #2f4a3a;
+  color: #7fc79b;
+}
+
+:global([data-bs-theme="dark"]) .pillError.pillSelected,
+:global([data-bs-theme="dark"]) .pillLimit.pillSelected,
+:global([data-bs-theme="dark"]) .pillApproval.pillSelected,
+:global([data-bs-theme="dark"]) .pillInput.pillSelected,
+:global([data-bs-theme="dark"]) .pillInterrupt.pillSelected,
+:global([data-bs-theme="dark"]) .pillCompaction.pillSelected,
+:global([data-bs-theme="dark"]) .pillScore.pillSelected {
+  color: #fff;
+}
+
+:global([data-bs-theme="dark"]) .pillError.pillSelected {
+  background: #b04a3c;
+  border-color: #b04a3c;
+}
+
+:global([data-bs-theme="dark"]) .pillLimit.pillSelected {
+  background: #8a6d1a;
+  border-color: #8a6d1a;
+}
+
+:global([data-bs-theme="dark"]) .pillApproval.pillSelected {
+  background: #6b4fa8;
+  border-color: #6b4fa8;
+}
+
+:global([data-bs-theme="dark"]) .pillInput.pillSelected {
+  background: #1d4f7c;
+  border-color: #1d4f7c;
+}
+
+:global([data-bs-theme="dark"]) .pillInterrupt.pillSelected {
+  background: #6c757d;
+  border-color: #6c757d;
+}
+
+:global([data-bs-theme="dark"]) .pillCompaction.pillSelected {
+  background: #2b6a94;
+  border-color: #2b6a94;
+}
+
+:global([data-bs-theme="dark"]) .pillScore.pillSelected {
+  background: #2f8a52;
+  border-color: #2f8a52;
+}
+
+:global([data-bs-theme="dark"]) .rowWash {
+  background: #221d2b;
+}
+
+:global([data-bs-theme="dark"]) .washError {
+  background: #2b1f1b;
+}
+
+:global([data-bs-theme="dark"]) .washLimit {
+  background: #2b2619;
+}
+
+:global([data-bs-theme="dark"]) .washApproval {
+  background: #221d2b;
+}
+
+:global([data-bs-theme="dark"]) .washInput {
+  background: #1a222b;
+}
+
+:global([data-bs-theme="dark"]) .washInterrupt {
+  background: #222528;
+}
+
+:global([data-bs-theme="dark"]) .washCompaction {
+  background: #19242c;
+}
+
+:global([data-bs-theme="dark"]) .washScore {
+  background: #1c2620;
+}

--- a/packages/inspect-components/src/sample-activity/ActivityHistoryList.tsx
+++ b/packages/inspect-components/src/sample-activity/ActivityHistoryList.tsx
@@ -1,0 +1,286 @@
+import clsx from "clsx";
+import {
+  FC,
+  Fragment,
+  MouseEvent as ReactMouseEvent,
+  Ref,
+  RefObject,
+  useImperativeHandle,
+  useRef,
+} from "react";
+
+import { useLatestRef } from "@tsmono/react/hooks";
+import { VirtualList, type VirtualListHandle } from "@tsmono/react/virtual";
+
+import { fmtDayClock } from "../usage";
+
+import {
+  ActivityCategory,
+  ActivityHistoryRow,
+  fmtTime,
+  kActivityCategories,
+  kCategoryLong,
+  kCategoryShort,
+  rowHaystack,
+  TimeWindow,
+} from "./activityData";
+import styles from "./ActivityHistoryList.module.css";
+
+const kPillClass: Record<ActivityCategory, string> = {
+  error: styles.pillError,
+  limit: styles.pillLimit,
+  approval: styles.pillApproval,
+  input: styles.pillInput,
+  interrupt: styles.pillInterrupt,
+  compaction: styles.pillCompaction,
+  score: styles.pillScore,
+};
+
+/** Hover-link wash carries the category hue in its inset bar. */
+const kWashClass: Record<ActivityCategory, string> = {
+  error: styles.washError,
+  limit: styles.washLimit,
+  approval: styles.washApproval,
+  input: styles.washInput,
+  interrupt: styles.washInterrupt,
+  compaction: styles.washCompaction,
+  score: styles.washScore,
+};
+
+export interface ActivityHistoryListHandle {
+  /** Scroll the row with this key into view (after the next commit, so a
+   *  filter widened in the same event has already re-rendered the list). */
+  scrollToKey: (key: string) => void;
+}
+
+export interface ActivityHistoryListProps {
+  rows: ActivityHistoryRow[];
+  /** The tab's scroll container — rows virtualize against it. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Store-persisted VirtualList snapshot key, scoped per sample. */
+  persistenceKey: string;
+  /** Empty set = All; selection narrows additively. */
+  selectedCategories: Set<ActivityCategory>;
+  onToggleCategory: (category: ActivityCategory | "all") => void;
+  search: string;
+  onSearchChange: (search: string) => void;
+  timeDescending: boolean;
+  onToggleTimeSort: () => void;
+  selectedKey: string | null;
+  onSelectKey: (key: string | null) => void;
+  /** Rows washed while their glyph is hovered on the rail. */
+  washKeys: string[];
+  onHoverRow: (key: string | null) => void;
+  /** Click-through to the Transcript via event uuid. */
+  onOpenEvent?: (uuid: string, event: ReactMouseEvent) => void;
+  /** Dense-band bin click narrows the list to this window (clear chip). */
+  windowFilter?: TimeWindow | null;
+  onClearWindowFilter?: () => void;
+  ref?: Ref<ActivityHistoryListHandle>;
+}
+
+export const ActivityHistoryList: FC<ActivityHistoryListProps> = ({
+  rows,
+  scrollRef,
+  persistenceKey,
+  selectedCategories,
+  onToggleCategory,
+  search,
+  onSearchChange,
+  timeDescending,
+  onToggleTimeSort,
+  selectedKey,
+  onSelectKey,
+  washKeys,
+  onHoverRow,
+  onOpenEvent,
+  windowFilter,
+  onClearWindowFilter,
+  ref,
+}) => {
+  const counts = new Map<ActivityCategory, number>();
+  for (const row of rows) {
+    counts.set(row.category, (counts.get(row.category) ?? 0) + 1);
+  }
+
+  const query = search.trim().toLowerCase();
+  const visible = rows.filter(
+    (row) =>
+      (selectedCategories.size === 0 || selectedCategories.has(row.category)) &&
+      (query === "" || rowHaystack(row).toLowerCase().includes(query)) &&
+      (windowFilter == null ||
+        (row.time >= windowFilter.start && row.time <= windowFilter.end))
+  );
+  const ordered = timeDescending ? [...visible].reverse() : visible;
+
+  const listHandle = useRef<VirtualListHandle | null>(null);
+  const orderedRef = useLatestRef(ordered);
+  useImperativeHandle(ref, () => ({
+    scrollToKey: (key: string) => {
+      // After the commit triggered by the same click (filters widened,
+      // search cleared) — the index must come from the NEW ordered list.
+      requestAnimationFrame(() => {
+        const index = orderedRef.current.findIndex((row) => row.key === key);
+        if (index >= 0) {
+          listHandle.current?.scrollToIndex({ index, align: "center" });
+        }
+      });
+    },
+  }));
+
+  const renderRow = (index: number, row: ActivityHistoryRow) => {
+    const selected = selectedKey === row.key;
+    const washed = !selected && washKeys.includes(row.key);
+    return (
+      <div
+        className={clsx(
+          styles.row,
+          index === ordered.length - 1 && styles.rowLast,
+          selected && styles.rowSelected,
+          washed && styles.rowWash,
+          washed && kWashClass[row.category]
+        )}
+        role="button"
+        tabIndex={0}
+        onClick={() => onSelectKey(selected ? null : row.key)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelectKey(selected ? null : row.key);
+          }
+        }}
+        onMouseEnter={() => onHoverRow(row.key)}
+        onMouseLeave={() => onHoverRow(null)}
+      >
+        <div className={styles.time}>{fmtDayClock(row.time)}</div>
+        <div className={styles.kindCell}>
+          <span className={clsx(styles.kindPill, kPillClass[row.category])}>
+            {kCategoryShort[row.category]}
+          </span>
+        </div>
+        <div className={styles.event}>
+          {row.lead}
+          {row.mono !== undefined && (
+            <Fragment>
+              {" "}
+              <span className={styles.mono}>{row.mono}</span>
+            </Fragment>
+          )}
+          {row.tail !== undefined && ` ${row.tail}`}
+          {row.detail !== undefined && (
+            <span className={styles.muted}> · {row.detail}</span>
+          )}
+          {row.uuid !== undefined && onOpenEvent && (
+            <Fragment>
+              {" "}
+              <button
+                type="button"
+                className={styles.openEvent}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onOpenEvent(row.uuid!, event);
+                }}
+              >
+                open in transcript →
+              </button>
+            </Fragment>
+          )}
+        </div>
+        <div className={styles.by}>{row.by}</div>
+      </div>
+    );
+  };
+
+  const allSelected = selectedCategories.size === 0;
+  const sortIcon = timeDescending ? "bi-arrow-down" : "bi-arrow-up";
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.filterRow}>
+        <span className={styles.caption}>History</span>
+        <button
+          type="button"
+          className={clsx(
+            styles.filterPill,
+            styles.pillAll,
+            allSelected && styles.pillSelected
+          )}
+          onClick={() => onToggleCategory("all")}
+        >
+          All <span className={styles.pillCount}>{rows.length}</span>
+        </button>
+        {kActivityCategories.map((category) => {
+          const count = counts.get(category) ?? 0;
+          const selected = selectedCategories.has(category);
+          return (
+            <button
+              key={category}
+              type="button"
+              className={clsx(
+                styles.filterPill,
+                kPillClass[category],
+                selected && styles.pillSelected,
+                count === 0 && styles.pillEmpty
+              )}
+              onClick={() => onToggleCategory(category)}
+              // A selected pill stays clickable at count 0 (live counts can
+              // drop) — otherwise the filter would trap an empty list.
+              disabled={count === 0 && !selected}
+            >
+              {kCategoryLong[category]}{" "}
+              <span className={styles.pillCount}>{count}</span>
+            </button>
+          );
+        })}
+        {windowFilter != null && onClearWindowFilter && (
+          <button
+            type="button"
+            className={clsx(styles.filterPill, styles.pillWindow)}
+            onClick={onClearWindowFilter}
+            title="Clear the time-window filter"
+          >
+            {fmtTime(windowFilter.start)}–{fmtTime(windowFilter.end)}{" "}
+            <span aria-hidden="true">✕</span>
+          </button>
+        )}
+        <input
+          type="text"
+          className={styles.search}
+          placeholder="filter by event or detail"
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </div>
+      <div className={styles.list}>
+        <div className={styles.headerRow}>
+          {/* Time is the one sortable column (task-timeline parity). */}
+          <button
+            type="button"
+            className={styles.timeSort}
+            onClick={onToggleTimeSort}
+          >
+            Time
+            <i className={`bi ${sortIcon}`} aria-hidden="true" />
+          </button>
+          <span>Kind</span>
+          <span>Event</span>
+          <span className={styles.byHeader}>By</span>
+        </div>
+        {ordered.length === 0 ? (
+          <div className={styles.empty}>No events</div>
+        ) : (
+          <VirtualList<ActivityHistoryRow>
+            ref={listHandle}
+            persistenceKey={persistenceKey}
+            scrollRef={scrollRef}
+            embedded
+            data={ordered}
+            estimatedItemHeight={33}
+            overscan={10}
+            renderRow={renderRow}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.module.css
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.module.css
@@ -1,0 +1,67 @@
+.container {
+  padding: 0.5em 1em 1em 1em;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.pickerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.72rem;
+  flex-wrap: wrap;
+}
+
+.caption {
+  text-transform: uppercase;
+  color: var(--bs-secondary-color);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-right: 0.25rem;
+}
+
+.bandChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid var(--bs-border-color);
+  color: var(--bs-secondary-color);
+  border-radius: 999px;
+  line-height: 1.2;
+  background: none;
+  font-size: 0.72rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bandChipOn {
+  border-color: var(--bs-secondary);
+  background: var(--bs-secondary-bg);
+  color: var(--bs-body-color);
+}
+
+.bandChip i {
+  font-size: 0.7rem;
+}
+
+.legend {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  color: var(--bs-secondary-color);
+  white-space: nowrap;
+}
+
+.legendSwatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 1px;
+  background: #5b8ec4;
+  display: inline-block;
+}

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
@@ -170,6 +170,34 @@ describe("SampleActivityPanel band chips", () => {
     expect(container.querySelector("svg")).toBeNull();
     expect(screen.queryByText("History")).toBeNull();
   });
+
+  it("hides the working band for logs without a working clock", () => {
+    // Mid-vintage: timestamps present, working_start normalizer-filled 0,
+    // no working_time — the band would read as all-waiting.
+    mountPanel({
+      events: [
+        testModelEvent({
+          timestamp: iso(0),
+          completed: iso(10),
+          working_start: 0,
+          working_time: null,
+          output: testModelOutput({
+            usage: testModelUsage({
+              input_tokens: 100,
+              output_tokens: 10,
+              total_tokens: 110,
+            }),
+          }),
+        }),
+      ],
+    });
+    expect(
+      screen.queryByRole("button", { name: /Working \/ waiting/ })
+    ).toBeNull();
+    expect(screen.queryByText("WORKING / WAITING")).toBeNull();
+    // The rest of the panel still renders.
+    expect(screen.getByText("TOKEN BURN")).toBeTruthy();
+  });
 });
 
 describe("SampleActivityPanel history list", () => {

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { FC, useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  testCompactionEvent,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testScoreEvent,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
+import type { Event } from "@tsmono/inspect-common/types";
+import { ComponentStateProvider } from "@tsmono/react/state";
+import { makeReactiveStateStore } from "@tsmono/react/testing";
+
+import { SampleActivityPanel } from "./SampleActivityPanel";
+
+/** ResizeObserver that reports a real size synchronously on observe: the
+ *  chart renders nothing at width 0, and the virtualizer computes an empty
+ *  range from a zero-height scroll rect. jsdom provides neither. */
+class ImmediateResizeObserver implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: globalThis.Element) {
+    const size: ResizeObserverSize = { inlineSize: 1000, blockSize: 600 };
+    const rect = new DOMRectReadOnly(0, 0, 1000, 600);
+    this.callback(
+      [
+        {
+          target,
+          contentRect: rect,
+          borderBoxSize: [size],
+          contentBoxSize: [size],
+          devicePixelContentBoxSize: [size],
+        },
+      ],
+      this
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+const kRunStart = Date.parse("2025-01-15T10:00:00.000Z") / 1000;
+const iso = (sec: number): string =>
+  new Date((kRunStart + sec) * 1000).toISOString();
+
+const fixtureEvents = (): Event[] => [
+  testModelEvent({
+    uuid: "model-1",
+    timestamp: iso(0),
+    completed: iso(10),
+    working_start: 0,
+    working_time: 10,
+    model: "test-model",
+    output: testModelOutput({
+      usage: testModelUsage({
+        input_tokens: 1000,
+        output_tokens: 200,
+        total_tokens: 1200,
+      }),
+    }),
+  }),
+  testToolEvent({
+    uuid: "tool-fail",
+    timestamp: iso(10),
+    completed: iso(14),
+    working_start: 10,
+    working_time: 4,
+    function: "bash",
+    error: { type: "unknown", message: "exit 127" },
+  }),
+  testCompactionEvent({
+    uuid: "compact-1",
+    timestamp: iso(20),
+    working_start: 14,
+    tokens_before: 142_000,
+    tokens_after: 38_000,
+  }),
+  testScoreEvent({
+    uuid: "score-1",
+    timestamp: iso(30),
+    working_start: 15,
+    scorer: "test_scorer",
+  }),
+];
+
+interface HarnessProps {
+  events?: Event[];
+  onOpenEvent?: (uuid: string, event: unknown) => void;
+}
+
+const Harness: FC<HarnessProps> = ({
+  events = fixtureEvents(),
+  onOpenEvent,
+}) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div ref={scrollRef} style={{ height: 500, overflow: "auto" }}>
+      <SampleActivityPanel
+        events={events}
+        startedAt={iso(0)}
+        completedAt={iso(30)}
+        scrollRef={scrollRef}
+        persistScope="test-log:1:1"
+        onOpenEvent={onOpenEvent}
+      />
+    </div>
+  );
+};
+
+const mountPanel = (props: HarnessProps = {}) => {
+  const { hooks } = makeReactiveStateStore();
+  return render(
+    <ComponentStateProvider hooks={hooks}>
+      <Harness {...props} />
+    </ComponentStateProvider>
+  );
+};
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ImmediateResizeObserver);
+  // jsdom has no scrollTo; VirtualList calls it during mount.
+  Element.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("SampleActivityPanel band chips", () => {
+  it("lights the curated default band set", () => {
+    mountPanel();
+    // Default-on bands render in the chart.
+    expect(screen.getByText("WORKING / WAITING")).toBeTruthy();
+    expect(screen.getByText("TOKEN BURN")).toBeTruthy();
+    // Opt-in bands stay off until their chip is toggled.
+    expect(screen.queryByText("CONTEXT SIZE")).toBeNull();
+    expect(screen.queryByText("MODEL & TOOL ACTIVITY")).toBeNull();
+  });
+
+  it("toggles opt-in bands on and default bands off via chips", () => {
+    mountPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Context size" }));
+    expect(screen.getByText("CONTEXT SIZE")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Model & tool activity" })
+    );
+    expect(screen.getByText("MODEL & TOOL ACTIVITY")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Token burn/ }));
+    expect(screen.queryByText("TOKEN BURN")).toBeNull();
+  });
+
+  it("hides the whole panel for events without timestamps", () => {
+    const { container } = mountPanel({
+      events: [testModelEvent({ timestamp: "" })],
+    });
+    expect(container.querySelector("svg")).toBeNull();
+    expect(screen.queryByText("History")).toBeNull();
+  });
+});
+
+describe("SampleActivityPanel history list", () => {
+  it("renders one row per incident with category pills", () => {
+    mountPanel();
+    expect(screen.getByText(/exit 127/)).toBeTruthy();
+    expect(screen.getByText("142k → 38k")).toBeTruthy();
+    expect(screen.getByText(/scorer test_scorer/)).toBeTruthy();
+    // Filter pills carry live counts.
+    expect(screen.getByRole("button", { name: /Errors 1/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Compactions 1/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Scores 1/ })).toBeTruthy();
+  });
+
+  it("filters additively via category pills", () => {
+    mountPanel();
+    fireEvent.click(screen.getByRole("button", { name: /Errors 1/ }));
+    expect(screen.getByText(/exit 127/)).toBeTruthy();
+    expect(screen.queryByText(/scorer test_scorer/)).toBeNull();
+
+    // Additive: selecting Scores too widens rather than replaces.
+    fireEvent.click(screen.getByRole("button", { name: /Scores 1/ }));
+    expect(screen.getByText(/scorer test_scorer/)).toBeTruthy();
+    expect(screen.queryByText("142k → 38k")).toBeNull();
+
+    // All resets.
+    fireEvent.click(screen.getByRole("button", { name: /All 3/ }));
+    expect(screen.getByText("142k → 38k")).toBeTruthy();
+  });
+
+  it("filters by search text", () => {
+    mountPanel();
+    const search = screen.getByPlaceholderText("filter by event or detail");
+    fireEvent.change(search, { target: { value: "compacted" } });
+    expect(screen.getByText("142k → 38k")).toBeTruthy();
+    expect(screen.queryByText(/exit 127/)).toBeNull();
+  });
+
+  it("clicks through to the transcript via event uuid", () => {
+    const onOpenEvent = vi.fn();
+    mountPanel({ onOpenEvent });
+    const errorRow = screen.getByText(/exit 127/).closest("[role='button']");
+    if (!(errorRow instanceof HTMLElement)) {
+      throw new Error("expected the error row to render");
+    }
+    fireEvent.click(
+      within(errorRow).getByRole("button", {
+        name: "open in transcript →",
+      })
+    );
+    expect(onOpenEvent).toHaveBeenCalledWith("tool-fail", expect.anything());
+  });
+});
+
+describe("SampleActivityPanel marker ↔ list link", () => {
+  it("marker click widens a filter that would hide its row", () => {
+    mountPanel();
+    // Narrow to Scores — the error row disappears.
+    fireEvent.click(screen.getByRole("button", { name: /Scores 1/ }));
+    expect(screen.queryByText(/exit 127/)).toBeNull();
+
+    // Click the error glyph on the rail — the filter widens to include it.
+    fireEvent.click(screen.getByRole("button", { name: "Tool bash errored" }));
+    expect(screen.getByText(/exit 127/)).toBeTruthy();
+  });
+
+  it("hovering a glyph washes its history row", () => {
+    mountPanel();
+    const glyph = screen.getByRole("button", { name: "Tool bash errored" });
+    fireEvent.mouseEnter(glyph);
+    const row = screen.getByText(/exit 127/).closest("[role='button']");
+    expect(row?.className).toContain("washError");
+    fireEvent.mouseLeave(glyph);
+    const rowAfter = screen.getByText(/exit 127/).closest("[role='button']");
+    expect(rowAfter?.className).not.toContain("washError");
+  });
+});

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.test.tsx
@@ -252,6 +252,49 @@ describe("SampleActivityPanel history list", () => {
   });
 });
 
+describe("SampleActivityPanel burst labels", () => {
+  it("declutters burst labels when parallel-tool bursts crowd the row", () => {
+    // 40 turns of two overlapping tool calls each → 40 bursts across the
+    // stubbed 1000px chart. Labeling every burst would smear; only those
+    // with clear horizontal room render (hover keeps the rest).
+    const events: Event[] = [];
+    for (let i = 0; i < 40; i++) {
+      const t0 = i * 10;
+      events.push(
+        testModelEvent({
+          uuid: `m-${i}`,
+          timestamp: iso(t0),
+          completed: iso(t0 + 4),
+          working_start: t0,
+          working_time: 4,
+        }),
+        testToolEvent({
+          uuid: `t-${i}a`,
+          timestamp: iso(t0 + 4),
+          completed: iso(t0 + 9),
+          working_start: t0 + 4,
+          function: "python",
+        }),
+        testToolEvent({
+          uuid: `t-${i}b`,
+          timestamp: iso(t0 + 5),
+          completed: iso(t0 + 10),
+          working_start: t0 + 4,
+          function: "python",
+        })
+      );
+    }
+    const { container } = mountPanel({ events });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Model & tool activity" })
+    );
+
+    const labels = container.querySelectorAll("[class*='burstLabel']");
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels.length).toBeLessThan(40);
+  });
+});
+
 describe("SampleActivityPanel marker ↔ list link", () => {
   it("marker click widens a filter that would hide its row", () => {
     mountPanel();

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.tsx
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.tsx
@@ -1,0 +1,280 @@
+import clsx from "clsx";
+import {
+  FC,
+  MouseEvent as ReactMouseEvent,
+  RefObject,
+  useRef,
+  useState,
+} from "react";
+
+import type { Event } from "@tsmono/inspect-common/types";
+import { useProperty } from "@tsmono/react/hooks";
+
+import { ActivityChart } from "./ActivityChart";
+import {
+  ActivityCategory,
+  deriveActivityData,
+  rowHaystack,
+  TimeWindow,
+} from "./activityData";
+import {
+  ActivityHistoryList,
+  type ActivityHistoryListHandle,
+} from "./ActivityHistoryList";
+import styles from "./SampleActivityPanel.module.css";
+
+/** Property bag for the Activity tab's durable UI state, keyed per sample. */
+export const kSampleActivityBag = "sample-activity";
+
+export const sampleActivityBandId = (band: string): string => band;
+
+// Stable empty arrays — a fresh identity would re-render every row.
+const kNoKeys: string[] = [];
+const kNoCategories: ActivityCategory[] = [];
+
+export interface SampleActivityPanelProps {
+  events: Event[];
+  startedAt?: string | null;
+  completedAt?: string | null;
+  workingTime?: number | null;
+  totalTime?: number | null;
+  /** Live sample — pending spans render open-ended to now. */
+  running?: boolean;
+  /** The tab's scroll container — the history list virtualizes against it. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+  /** Durable-state scope (log + sample identity) for the property bag. */
+  persistScope: string;
+  /** Click-through to the Transcript via event uuid. */
+  onOpenEvent?: (uuid: string, event: ReactMouseEvent) => void;
+}
+
+interface BandChipProps {
+  label: string;
+  on: boolean;
+  onToggle: () => void;
+}
+
+const BandChip: FC<BandChipProps> = ({ label, on, onToggle }) => (
+  <button
+    type="button"
+    className={clsx(styles.bandChip, on && styles.bandChipOn)}
+    onClick={onToggle}
+  >
+    {on ? <i className="bi bi-check" aria-hidden="true" /> : null}
+    {label}
+  </button>
+);
+
+// Durable UI state (band overrides, filters, search, sort, selection) lives
+// in the property bag keyed per sample — the tab unmounts on tab switches.
+// Keying the body per sample resets the transient state (hover links,
+// popovers, window filter) when the sample in view changes.
+export const SampleActivityPanel: FC<SampleActivityPanelProps> = (props) => (
+  <SampleActivityPanelBody key={props.persistScope} {...props} />
+);
+
+const SampleActivityPanelBody: FC<SampleActivityPanelProps> = ({
+  events,
+  startedAt,
+  completedAt,
+  workingTime,
+  totalTime,
+  running = false,
+  scrollRef,
+  persistScope,
+  onOpenEvent,
+}) => {
+  // `now` deliberately defaults to the latest event timestamp inside the
+  // derivation: live samples re-render as polling delivers new events, so
+  // the open edge advances with the data (and render stays pure).
+  const data = deriveActivityData({
+    events,
+    startedAt,
+    completedAt,
+    workingTime,
+    totalTime,
+    running,
+  });
+
+  // ── band picker (curated default-on set, handoff decision 1) ─────────
+  const [bandOverrides, setBandOverrides] = useProperty<
+    Record<string, boolean>
+  >(kSampleActivityBag, `bands:${persistScope}`, { defaultValue: {} });
+  const bandOn = (id: string, fallback: boolean): boolean =>
+    bandOverrides[id] ?? fallback;
+  const toggleBand = (id: string, fallback: boolean) => {
+    setBandOverrides({ ...bandOverrides, [id]: !bandOn(id, fallback) });
+  };
+
+  const showWorking = bandOn("working", true);
+  const showMarkers = bandOn("markers", true) && data.markers.length > 0;
+  const showTokens = bandOn("tokens", true) && data.tokenSeries.length > 0;
+  const showContext = bandOn("context", false) && data.contextSeries.length > 0;
+  const showModelTool = bandOn("modelTool", false) && data.agentRows.length > 0;
+
+  // ── history filters (array, not Set — store persistence) ─────────────
+  const [categoryList, setCategoryList] = useProperty<ActivityCategory[]>(
+    kSampleActivityBag,
+    `filters:${persistScope}`,
+    { defaultValue: kNoCategories }
+  );
+  const selectedCategories = new Set(categoryList);
+  const toggleCategory = (category: ActivityCategory | "all") => {
+    if (category === "all") {
+      setCategoryList([]);
+      return;
+    }
+    setCategoryList(
+      categoryList.includes(category)
+        ? categoryList.filter((existing) => existing !== category)
+        : [...categoryList, category]
+    );
+  };
+
+  const [search, setSearch] = useProperty<string>(
+    kSampleActivityBag,
+    `search:${persistScope}`,
+    { defaultValue: "" }
+  );
+  // Time sort: descending by default while the sample is running so new
+  // events land at the top. The default is frozen at first view (a sample
+  // completing mid-view must not flip the list under the user).
+  const [timeSort, setTimeSort] = useProperty<"asc" | "desc">(
+    kSampleActivityBag,
+    `sort:${persistScope}`
+  );
+  const [initialRunning] = useState(running);
+  const timeDescending = timeSort ? timeSort === "desc" : initialRunning;
+
+  const [selectedKey, setSelectedKey] = useProperty<string | null>(
+    kSampleActivityBag,
+    `selected:${persistScope}`,
+    { defaultValue: null }
+  );
+
+  // Bidirectional glyph ↔ row hover link (transient).
+  const [hoverLink, setHoverLink] = useState<{
+    source: "marker" | "row";
+    keys: string[];
+  } | null>(null);
+  // Dense-band bin click narrows the list to the bin's window (transient).
+  const [windowFilter, setWindowFilter] = useState<TimeWindow | null>(null);
+
+  const listRef = useRef<ActivityHistoryListHandle | null>(null);
+
+  // Glyph click → select + scroll to its history row, clearing any filter
+  // that would hide it: the category filter widens to include the row, a
+  // non-matching search is dropped, and a window filter that excludes the
+  // row is cleared.
+  const selectMarker = (key: string | null) => {
+    setSelectedKey(key);
+    if (key === null) return;
+    const row = data.rows.find((r) => r.key === key);
+    if (row) {
+      if (categoryList.length > 0 && !categoryList.includes(row.category)) {
+        setCategoryList([...categoryList, row.category]);
+      }
+      const query = search.trim().toLowerCase();
+      if (query !== "" && !rowHaystack(row).toLowerCase().includes(query)) {
+        setSearch("");
+      }
+      if (
+        windowFilter !== null &&
+        (row.time < windowFilter.start || row.time > windowFilter.end)
+      ) {
+        setWindowFilter(null);
+      }
+    }
+    listRef.current?.scrollToKey(key);
+  };
+
+  if (!data.window) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.pickerRow}>
+        <span className={styles.caption}>Activity</span>
+        <BandChip
+          label="Working / waiting"
+          on={showWorking}
+          onToggle={() => toggleBand("working", true)}
+        />
+        {data.markers.length > 0 && (
+          <BandChip
+            label="Markers"
+            on={showMarkers}
+            onToggle={() => toggleBand("markers", true)}
+          />
+        )}
+        {data.tokenSeries.length > 0 && (
+          <BandChip
+            label="Token burn"
+            on={showTokens}
+            onToggle={() => toggleBand("tokens", true)}
+          />
+        )}
+        {data.contextSeries.length > 0 && (
+          <BandChip
+            label="Context size"
+            on={showContext}
+            onToggle={() => toggleBand("context", false)}
+          />
+        )}
+        {data.agentRows.length > 0 && (
+          <BandChip
+            label="Model & tool activity"
+            on={showModelTool}
+            onToggle={() => toggleBand("modelTool", false)}
+          />
+        )}
+        <span className={styles.legend}>
+          <span className={styles.legendSwatch} /> working · gap = waiting
+        </span>
+      </div>
+      <ActivityChart
+        data={data}
+        window={data.window}
+        showWorking={showWorking}
+        showMarkers={showMarkers}
+        showTokens={showTokens}
+        showContext={showContext}
+        showModelTool={showModelTool}
+        selectedKey={selectedKey}
+        onSelectMarker={selectMarker}
+        hoveredRowKey={
+          hoverLink?.source === "row" ? (hoverLink.keys[0] ?? null) : null
+        }
+        onHoverMarker={(keys) =>
+          setHoverLink(
+            keys && keys.length > 0 ? { source: "marker", keys } : null
+          )
+        }
+        onOpenEvent={onOpenEvent}
+        onFilterWindow={setWindowFilter}
+      />
+      <ActivityHistoryList
+        ref={listRef}
+        rows={data.rows}
+        scrollRef={scrollRef}
+        persistenceKey={`sample-activity-history:${persistScope}`}
+        selectedCategories={selectedCategories}
+        onToggleCategory={toggleCategory}
+        search={search}
+        onSearchChange={setSearch}
+        timeDescending={timeDescending}
+        onToggleTimeSort={() => setTimeSort(timeDescending ? "asc" : "desc")}
+        selectedKey={selectedKey}
+        onSelectKey={setSelectedKey}
+        washKeys={hoverLink?.source === "marker" ? hoverLink.keys : kNoKeys}
+        onHoverRow={(key) =>
+          setHoverLink(key !== null ? { source: "row", keys: [key] } : null)
+        }
+        onOpenEvent={onOpenEvent}
+        windowFilter={windowFilter}
+        onClearWindowFilter={() => setWindowFilter(null)}
+      />
+    </div>
+  );
+};

--- a/packages/inspect-components/src/sample-activity/SampleActivityPanel.tsx
+++ b/packages/inspect-components/src/sample-activity/SampleActivityPanel.tsx
@@ -26,8 +26,6 @@ import styles from "./SampleActivityPanel.module.css";
 /** Property bag for the Activity tab's durable UI state, keyed per sample. */
 export const kSampleActivityBag = "sample-activity";
 
-export const sampleActivityBandId = (band: string): string => band;
-
 // Stable empty arrays — a fresh identity would re-render every row.
 const kNoKeys: string[] = [];
 const kNoCategories: ActivityCategory[] = [];
@@ -106,7 +104,9 @@ const SampleActivityPanelBody: FC<SampleActivityPanelProps> = ({
     setBandOverrides({ ...bandOverrides, [id]: !bandOn(id, fallback) });
   };
 
-  const showWorking = bandOn("working", true);
+  // No working clock (mid-vintage logs) → no working band at all; an
+  // all-zero clock would render the whole run as waiting.
+  const showWorking = bandOn("working", true) && data.hasWorkingSignal;
   const showMarkers = bandOn("markers", true) && data.markers.length > 0;
   const showTokens = bandOn("tokens", true) && data.tokenSeries.length > 0;
   const showContext = bandOn("context", false) && data.contextSeries.length > 0;
@@ -196,11 +196,13 @@ const SampleActivityPanelBody: FC<SampleActivityPanelProps> = ({
     <div className={styles.container}>
       <div className={styles.pickerRow}>
         <span className={styles.caption}>Activity</span>
-        <BandChip
-          label="Working / waiting"
-          on={showWorking}
-          onToggle={() => toggleBand("working", true)}
-        />
+        {data.hasWorkingSignal && (
+          <BandChip
+            label="Working / waiting"
+            on={showWorking}
+            onToggle={() => toggleBand("working", true)}
+          />
+        )}
         {data.markers.length > 0 && (
           <BandChip
             label="Markers"
@@ -229,9 +231,11 @@ const SampleActivityPanelBody: FC<SampleActivityPanelProps> = ({
             onToggle={() => toggleBand("modelTool", false)}
           />
         )}
-        <span className={styles.legend}>
-          <span className={styles.legendSwatch} /> working · gap = waiting
-        </span>
+        {data.hasWorkingSignal && (
+          <span className={styles.legend}>
+            <span className={styles.legendSwatch} /> working · gap = waiting
+          </span>
+        )}
       </div>
       <ActivityChart
         data={data}

--- a/packages/inspect-components/src/sample-activity/activityData.test.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.test.ts
@@ -141,6 +141,27 @@ describe("working / waiting derivation", () => {
     });
   });
 
+  it("absorbs a working-clock reset without blanking later segments", () => {
+    // Real logs: init-scope events carry working_start from a different
+    // base (observed ~13 days) before it resets to ~0 for the run proper.
+    // A global monotone clamp latched onto the garbage and rendered the
+    // whole sample as waiting.
+    const events: Event[] = [
+      testModelEvent({
+        timestamp: iso(0),
+        completed: iso(2),
+        working_start: 1_147_553,
+        working_time: 2,
+      }),
+      modelCall({ start: 3, duration: 10, workingStart: 0.001 }),
+      modelCall({ start: 13, duration: 10, workingStart: 10.001 }),
+    ];
+    const data = deriveActivityData({ events });
+    // The run-proper work still renders: one merged block from 3s to 23s.
+    const last = data.workingSegments[data.workingSegments.length - 1];
+    expect(last).toEqual({ start: kRunStart + 3, end: kRunStart + 23 });
+  });
+
   it("merges working blocks separated by sub-threshold noise", () => {
     const events: Event[] = [
       modelCall({ start: 0, duration: 10, workingStart: 0 }),

--- a/packages/inspect-components/src/sample-activity/activityData.test.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.test.ts
@@ -1,0 +1,579 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  testApprovalEvent,
+  testCompactionEvent,
+  testErrorEvent,
+  testInputEvent,
+  testInterruptEvent,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testSampleLimitEvent,
+  testScoreEvent,
+  testToolEvent,
+} from "@tsmono/inspect-common/testing";
+import type { Event, ModelEvent } from "@tsmono/inspect-common/types";
+
+import {
+  deriveActivityData,
+  fmtDurationWords,
+  fmtTokens,
+  hasEventTimestamps,
+  rowHaystack,
+} from "./activityData";
+
+/** ISO timestamp `sec` seconds into a fixed run start. */
+const kRunStart = Date.parse("2025-01-15T10:00:00.000Z") / 1000;
+const iso = (sec: number): string =>
+  new Date((kRunStart + sec) * 1000).toISOString();
+
+/** A model call spanning [start, start+duration] wall seconds that worked
+ *  for `working` seconds (defaults to the whole span). */
+const modelCall = (opts: {
+  start: number;
+  duration: number;
+  working?: number;
+  workingStart: number;
+  input?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  output?: number;
+  retries?: number;
+  model?: string;
+  role?: string;
+  uuid?: string;
+  pending?: boolean;
+}): ModelEvent =>
+  testModelEvent({
+    timestamp: iso(opts.start),
+    completed: opts.pending ? undefined : iso(opts.start + opts.duration),
+    working_start: opts.workingStart,
+    working_time: opts.pending ? undefined : (opts.working ?? opts.duration),
+    model: opts.model ?? "test-model",
+    role: opts.role,
+    uuid: opts.uuid,
+    retries: opts.retries,
+    pending: opts.pending,
+    output: testModelOutput({
+      usage: testModelUsage({
+        input_tokens: opts.input ?? 0,
+        input_tokens_cache_read: opts.cacheRead,
+        input_tokens_cache_write: opts.cacheWrite,
+        output_tokens: opts.output ?? 0,
+        total_tokens:
+          (opts.input ?? 0) +
+          (opts.cacheRead ?? 0) +
+          (opts.cacheWrite ?? 0) +
+          (opts.output ?? 0),
+      }),
+    }),
+  });
+
+describe("hasEventTimestamps", () => {
+  it("is false for old logs whose events lack timestamps", () => {
+    const events: Event[] = [
+      testModelEvent({ timestamp: "" }),
+      testToolEvent({ timestamp: "" }),
+    ];
+    expect(hasEventTimestamps(events)).toBe(false);
+  });
+
+  it("is true when any event carries a timestamp", () => {
+    expect(hasEventTimestamps([testModelEvent()])).toBe(true);
+  });
+});
+
+describe("working / waiting derivation", () => {
+  it("derives working segments and a stall from working-time drift", () => {
+    // Call 1 works 0–10s; 20s of dead wall clock; call 2 works 30–40s.
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 10, workingStart: 0 }),
+      modelCall({ start: 30, duration: 10, workingStart: 10 }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.window).toEqual({ start: kRunStart, end: kRunStart + 40 });
+    expect(data.workingSegments).toEqual([
+      { start: kRunStart, end: kRunStart + 10 },
+      { start: kRunStart + 30, end: kRunStart + 40 },
+    ]);
+    expect(data.stalls).toHaveLength(1);
+    expect(data.stalls[0]).toMatchObject({
+      start: kRunStart + 10,
+      end: kRunStart + 30,
+      duration: 20,
+    });
+    // Not retry-attributable — no history row for it.
+    expect(data.stalls[0]?.retries).toBeUndefined();
+    expect(data.rows).toHaveLength(0);
+  });
+
+  it("attributes a stall to an adjacent retrying model call", () => {
+    // The retrying call's wall span [10, 40] contains the 25s of waiting
+    // (working_time 5 « wall 30).
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 10, workingStart: 0 }),
+      modelCall({
+        start: 10,
+        duration: 30,
+        working: 5,
+        workingStart: 10,
+        retries: 3,
+        uuid: "retry-uuid",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    const stall = data.stalls.find((s) => s.retries !== undefined);
+    expect(stall).toMatchObject({ retries: 3, uuid: "retry-uuid" });
+    expect(stall?.duration).toBe(25);
+
+    // Attributable stalls surface as an error history row with the model
+    // event's uuid as click-through target.
+    const stallRow = data.rows.find((r) => r.key.startsWith("stall:"));
+    expect(stallRow).toMatchObject({
+      category: "error",
+      uuid: "retry-uuid",
+      lead: "Model request rate-limited, retried ×3",
+      detail: "resumed after 25s",
+      by: "system",
+    });
+  });
+
+  it("merges working blocks separated by sub-threshold noise", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 10, workingStart: 0 }),
+      modelCall({ start: 10.4, duration: 10, workingStart: 10.4 }),
+    ];
+    const data = deriveActivityData({ events });
+    expect(data.workingSegments).toHaveLength(1);
+    expect(data.stalls).toHaveLength(0);
+  });
+
+  it("sums working time from segments when the sample scalar is absent", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 10, workingStart: 0 }),
+      modelCall({ start: 30, duration: 10, workingStart: 10 }),
+    ];
+    const data = deriveActivityData({ events });
+    expect(data.workingTime).toBe(20);
+    expect(data.totalTime).toBe(40);
+  });
+
+  it("prefers the sample's own scalars when present", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 10, workingStart: 0 }),
+    ];
+    const data = deriveActivityData({
+      events,
+      workingTime: 123,
+      totalTime: 456,
+    });
+    expect(data.workingTime).toBe(123);
+    expect(data.totalTime).toBe(456);
+  });
+});
+
+describe("token burn", () => {
+  it("accumulates input + cache read/write + output per model call", () => {
+    const events: Event[] = [
+      modelCall({
+        start: 0,
+        duration: 5,
+        workingStart: 0,
+        input: 100,
+        cacheRead: 50,
+        cacheWrite: 25,
+        output: 25,
+      }),
+      modelCall({
+        start: 10,
+        duration: 5,
+        workingStart: 5,
+        input: 300,
+        output: 100,
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.tokenSeries).toEqual([
+      { time: kRunStart + 5, value: 200 },
+      { time: kRunStart + 15, value: 600 },
+    ]);
+    expect(data.totalTokens).toBe(600);
+  });
+
+  it("skips model calls without usage (pending, errored)", () => {
+    const events: Event[] = [
+      testModelEvent({
+        timestamp: iso(0),
+        output: testModelOutput({ usage: undefined }),
+      }),
+    ];
+    const data = deriveActivityData({ events });
+    expect(data.tokenSeries).toHaveLength(0);
+    expect(data.totalTokens).toBe(0);
+  });
+});
+
+describe("context size", () => {
+  it("plots input-side tokens per call and tracks the peak", () => {
+    const events: Event[] = [
+      modelCall({
+        start: 0,
+        duration: 5,
+        workingStart: 0,
+        input: 1000,
+        cacheRead: 500,
+        output: 100,
+        uuid: "m1",
+      }),
+      modelCall({
+        start: 10,
+        duration: 5,
+        workingStart: 5,
+        input: 2000,
+        cacheWrite: 500,
+        output: 100,
+        uuid: "m2",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.contextSeries).toEqual([
+      { time: kRunStart, value: 1500, uuid: "m1" },
+      { time: kRunStart + 10, value: 2500, uuid: "m2" },
+    ]);
+    expect(data.contextPeak).toBe(2500);
+  });
+
+  it("derives compaction drops from tokens_before/tokens_after", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 5, workingStart: 0, input: 142_000 }),
+      testCompactionEvent({
+        timestamp: iso(6),
+        working_start: 5,
+        tokens_before: 142_000,
+        tokens_after: 38_000,
+        uuid: "comp-1",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.compactions).toEqual([
+      {
+        time: kRunStart + 6,
+        before: 142_000,
+        after: 38_000,
+        key: "comp-1",
+        uuid: "comp-1",
+      },
+    ]);
+    const row = data.rows.find((r) => r.category === "compaction");
+    expect(row?.mono).toBe("142k → 38k");
+  });
+
+  it("falls back to the last context value when tokens_before is absent", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 5, workingStart: 0, input: 90_000 }),
+      testCompactionEvent({
+        timestamp: iso(6),
+        working_start: 5,
+        tokens_after: 30_000,
+      }),
+    ];
+    const data = deriveActivityData({ events });
+    expect(data.compactions[0]).toMatchObject({
+      before: 90_000,
+      after: 30_000,
+    });
+  });
+});
+
+describe("model & tool activity", () => {
+  it("puts models and their tools on one row, graders on their own", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 5, workingStart: 0, model: "opus" }),
+      testToolEvent({
+        timestamp: iso(5),
+        completed: iso(8),
+        working_start: 5,
+        working_time: 3,
+        function: "bash",
+      }),
+      modelCall({
+        start: 20,
+        duration: 4,
+        workingStart: 8,
+        model: "sonnet",
+        role: "grader",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.agentRows).toHaveLength(2);
+    const [primary, grader] = data.agentRows;
+    expect(primary).toMatchObject({
+      model: "opus",
+      role: undefined,
+      modelCount: 1,
+      toolCount: 1,
+    });
+    expect(primary?.spans.map((s) => s.kind)).toEqual(["model", "tool"]);
+    expect(grader).toMatchObject({ model: "sonnet", role: "grader" });
+  });
+
+  it("splits concurrent tool calls into sub-lanes with a burst label", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 2, workingStart: 0, model: "opus" }),
+      testToolEvent({
+        timestamp: iso(2),
+        completed: iso(10),
+        working_start: 2,
+        function: "bash",
+      }),
+      testToolEvent({
+        timestamp: iso(3),
+        completed: iso(11),
+        working_start: 2,
+        function: "bash",
+        error: { type: "unknown", message: "exit 127" },
+      }),
+      testToolEvent({
+        timestamp: iso(4),
+        completed: iso(12),
+        working_start: 2,
+        function: "bash",
+      }),
+      // Not overlapping the burst — stays a full-height span.
+      testToolEvent({
+        timestamp: iso(20),
+        completed: iso(22),
+        working_start: 10,
+        function: "editor",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    const row = data.agentRows[0];
+    const burstSpans = row?.spans.filter((s) => s.subLane !== undefined) ?? [];
+    expect(burstSpans).toHaveLength(3);
+    expect(burstSpans.map((s) => s.subLane)).toEqual([0, 1, 2]);
+    expect(burstSpans.every((s) => s.subLaneCount === 3)).toBe(true);
+
+    expect(row?.bursts).toHaveLength(1);
+    expect(row?.bursts[0]).toMatchObject({
+      count: 3,
+      failed: 1,
+      label: "bash",
+      folded: 0,
+    });
+
+    const solo = row?.spans.find((s) => s.label === "editor");
+    expect(solo?.subLane).toBeUndefined();
+  });
+
+  it("caps sub-lanes at 4 and folds the rest", () => {
+    const tools: Event[] = Array.from({ length: 6 }, (_, i) =>
+      testToolEvent({
+        timestamp: iso(1 + i * 0.1),
+        completed: iso(10),
+        working_start: 1,
+        function: "bash",
+      })
+    );
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 1, workingStart: 0 }),
+      ...tools,
+    ];
+    const data = deriveActivityData({ events });
+
+    const row = data.agentRows[0];
+    const laned = row?.spans.filter((s) => s.subLane !== undefined) ?? [];
+    expect(laned).toHaveLength(4);
+    expect(row?.bursts[0]).toMatchObject({ count: 6, folded: 2 });
+  });
+
+  it("marks failed tool calls and emits an error marker + row", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 2, workingStart: 0 }),
+      testToolEvent({
+        timestamp: iso(2),
+        completed: iso(4),
+        working_start: 2,
+        function: "bash",
+        error: { type: "unknown", message: "exit 127" },
+        uuid: "tool-1",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.agentRows[0]?.failedCount).toBe(1);
+    const marker = data.markers.find((m) => m.category === "error");
+    expect(marker).toMatchObject({ key: "tool-1", uuid: "tool-1" });
+    const row = data.rows.find((r) => r.category === "error");
+    expect(row).toMatchObject({
+      lead: "Tool",
+      mono: "bash",
+      tail: "errored",
+      detail: "exit 127",
+    });
+  });
+});
+
+describe("markers and history rows", () => {
+  it("generates one marker + row per incident category", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 2, workingStart: 0 }),
+      testErrorEvent({ timestamp: iso(1), uuid: "e1" }),
+      testSampleLimitEvent({ timestamp: iso(2), type: "token", uuid: "e2" }),
+      testApprovalEvent({
+        timestamp: iso(3),
+        approver: "charles",
+        decision: "approve",
+        uuid: "e3",
+      }),
+      testInputEvent({ timestamp: iso(4), input: "wrap it up", uuid: "e4" }),
+      testInterruptEvent({ timestamp: iso(5), uuid: "e5" }),
+      testCompactionEvent({
+        timestamp: iso(6),
+        tokens_before: 100_000,
+        tokens_after: 20_000,
+        uuid: "e6",
+      }),
+      testScoreEvent({ timestamp: iso(7), uuid: "e7" }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.markers.map((m) => m.category)).toEqual([
+      "error",
+      "limit",
+      "approval",
+      "input",
+      "interrupt",
+      "compaction",
+      "score",
+    ]);
+    expect(data.rows.map((r) => r.category)).toEqual(
+      data.markers.map((m) => m.category)
+    );
+    // Rows keyed by event uuid for the marker ↔ row hover link.
+    expect(data.rows.map((r) => r.key)).toEqual([
+      "e1",
+      "e2",
+      "e3",
+      "e4",
+      "e5",
+      "e6",
+      "e7",
+    ]);
+    // By column: approvals carry the approver, inputs the user.
+    expect(data.rows.find((r) => r.category === "approval")?.by).toBe(
+      "charles"
+    );
+    expect(data.rows.find((r) => r.category === "input")?.by).toBe("user");
+  });
+
+  it("falls back to a synthetic key when an event has no uuid", () => {
+    const events: Event[] = [testErrorEvent({ timestamp: iso(0), uuid: null })];
+    const data = deriveActivityData({ events });
+    expect(data.markers[0]?.key).toBe("evt:0");
+    expect(data.markers[0]?.uuid).toBeUndefined();
+  });
+
+  it("markers and rows are time-sorted regardless of event order", () => {
+    const events: Event[] = [
+      testScoreEvent({ timestamp: iso(10), uuid: "late" }),
+      testErrorEvent({ timestamp: iso(1), uuid: "early" }),
+    ];
+    const data = deriveActivityData({ events });
+    expect(data.markers.map((m) => m.key)).toEqual(["early", "late"]);
+    expect(data.rows.map((r) => r.key)).toEqual(["early", "late"]);
+  });
+
+  it("builds a searchable haystack from every sentence part", () => {
+    const events: Event[] = [
+      testApprovalEvent({
+        timestamp: iso(0),
+        approver: "charles",
+        decision: "approve",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+    const haystack = rowHaystack(data.rows[0]!).toLowerCase();
+    expect(haystack).toContain("approval");
+    expect(haystack).toContain("test_tool");
+    expect(haystack).toContain("charles");
+  });
+});
+
+describe("pending / running samples", () => {
+  it("renders pending spans open-ended to now", () => {
+    const nowSec = kRunStart + 100;
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 5, workingStart: 0 }),
+      modelCall({ start: 10, duration: 0, workingStart: 5, pending: true }),
+    ];
+    const data = deriveActivityData({ events, running: true, now: nowSec });
+
+    expect(data.pending).toBe(true);
+    expect(data.window?.end).toBe(nowSec);
+    const open = data.agentRows[0]?.spans.find((s) => s.pending);
+    expect(open?.end).toBe(nowSec);
+    // The working band extends past the last checkpoint on a live sample.
+    const lastSegment = data.workingSegments[data.workingSegments.length - 1];
+    expect(lastSegment?.end).toBe(nowSec);
+  });
+
+  it("does not extend a completed sample past its last event", () => {
+    const events: Event[] = [
+      modelCall({ start: 0, duration: 5, workingStart: 0 }),
+    ];
+    const data = deriveActivityData({ events, now: kRunStart + 500 });
+    expect(data.window?.end).toBe(kRunStart + 5);
+  });
+});
+
+describe("zero-ModelEvent samples", () => {
+  it("keeps working/waiting and markers meaningful with empty curves", () => {
+    const events: Event[] = [
+      testErrorEvent({ timestamp: iso(1), uuid: "e1" }),
+      testScoreEvent({ timestamp: iso(9), uuid: "s1" }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.tokenSeries).toHaveLength(0);
+    expect(data.contextSeries).toHaveLength(0);
+    expect(data.agentRows).toHaveLength(0);
+    expect(data.window).toEqual({ start: kRunStart + 1, end: kRunStart + 9 });
+    expect(data.markers).toHaveLength(2);
+    expect(data.rows).toHaveLength(2);
+  });
+
+  it("returns an inert shape for a sample with no timestamped events", () => {
+    const data = deriveActivityData({
+      events: [testModelEvent({ timestamp: "" })],
+    });
+    expect(data.window).toBeUndefined();
+    expect(data.workingSegments).toHaveLength(0);
+    expect(data.markers).toHaveLength(0);
+  });
+});
+
+describe("formatting", () => {
+  it("formats durations in handoff style", () => {
+    expect(fmtDurationWords(45)).toBe("45s");
+    expect(fmtDurationWords(135)).toBe("2m 15s");
+    expect(fmtDurationWords(600)).toBe("10m");
+    expect(fmtDurationWords(3720)).toBe("1h 2m");
+    expect(fmtDurationWords(-1)).toBe("—");
+  });
+
+  it("formats token counts in handoff style", () => {
+    expect(fmtTokens(950)).toBe("950");
+    expect(fmtTokens(38_000)).toBe("38k");
+    expect(fmtTokens(183_400)).toBe("183k");
+    expect(fmtTokens(1_500_000)).toBe("1.5M");
+  });
+});

--- a/packages/inspect-components/src/sample-activity/activityData.test.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.test.ts
@@ -141,6 +141,52 @@ describe("working / waiting derivation", () => {
     });
   });
 
+  it("reports no working signal for mid-vintage logs (timestamps, no working clock)", () => {
+    // Real vintage: event timestamps exist but working_start predates the
+    // field (normalizer fills 0) and working_time is absent. An all-zero
+    // work clock must not render the whole run as waiting.
+    const events: Event[] = [
+      testModelEvent({
+        timestamp: iso(0),
+        completed: iso(10),
+        working_start: 0,
+        working_time: null,
+      }),
+      testModelEvent({
+        timestamp: iso(30),
+        completed: iso(40),
+        working_start: 0,
+        working_time: null,
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.hasWorkingSignal).toBe(false);
+    expect(data.workingSegments).toHaveLength(0);
+    expect(data.stalls).toHaveLength(0);
+    // The rest of the derivation still works off the timestamps.
+    expect(data.window).toEqual({ start: kRunStart, end: kRunStart + 40 });
+    expect(data.agentRows).toHaveLength(1);
+  });
+
+  it("reports a working signal from working_time or nonzero working_start", () => {
+    const viaWorkingTime = deriveActivityData({
+      events: [modelCall({ start: 0, duration: 10, workingStart: 0 })],
+    });
+    expect(viaWorkingTime.hasWorkingSignal).toBe(true);
+
+    const viaWorkingStart = deriveActivityData({
+      events: [
+        testModelEvent({
+          timestamp: iso(5),
+          working_start: 5,
+          working_time: null,
+        }),
+      ],
+    });
+    expect(viaWorkingStart.hasWorkingSignal).toBe(true);
+  });
+
   it("absorbs a working-clock reset without blanking later segments", () => {
     // Real logs: init-scope events carry working_start from a different
     // base (observed ~13 days) before it resets to ~0 for the run proper.
@@ -223,6 +269,61 @@ describe("token burn", () => {
       { time: kRunStart + 15, value: 600 },
     ]);
     expect(data.totalTokens).toBe(600);
+  });
+
+  it("time-sorts the series when overlapping calls complete out of order", () => {
+    // Call A spans the whole window and completes LAST; call B (a parallel
+    // subagent / concurrent scorer) completes first. Points pushed in event
+    // order would go backwards at A's completion.
+    const events: Event[] = [
+      modelCall({
+        start: 0,
+        duration: 100,
+        workingStart: 0,
+        input: 1000,
+        uuid: "outer",
+      }),
+      modelCall({
+        start: 10,
+        duration: 10,
+        workingStart: 0,
+        input: 500,
+        uuid: "inner",
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.tokenSeries).toEqual([
+      { time: kRunStart + 20, value: 500 },
+      { time: kRunStart + 100, value: 1500 },
+    ]);
+    expect(data.totalTokens).toBe(1500);
+  });
+
+  it("prefers the recorded total over the category composition", () => {
+    // OpenAI-style usage: input_tokens already includes the cached reads,
+    // so summing categories would double-count (1000+400+100 = 1500).
+    const events: Event[] = [
+      testModelEvent({
+        timestamp: iso(0),
+        completed: iso(5),
+        working_start: 0,
+        working_time: 5,
+        output: testModelOutput({
+          usage: testModelUsage({
+            input_tokens: 1000,
+            input_tokens_cache_read: 400,
+            output_tokens: 100,
+            total_tokens: 1100,
+          }),
+        }),
+      }),
+    ];
+    const data = deriveActivityData({ events });
+
+    expect(data.totalTokens).toBe(1100);
+    // Context (input side) derives from the same total minus output.
+    expect(data.contextSeries[0]?.value).toBe(1000);
   });
 
   it("skips model calls without usage (pending, errored)", () => {

--- a/packages/inspect-components/src/sample-activity/activityData.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.ts
@@ -682,16 +682,17 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
   };
 
   let prev: Checkpoint | undefined;
-  let workFloor = -Infinity;
   for (const point of checkpoints) {
-    // Clamp non-monotonic working offsets (clock skew, parallel writers).
-    const work = Math.max(point.work, workFloor);
-    workFloor = work;
+    const work = point.work;
     if (prev) {
       const wallDelta = point.wall - prev.wall;
       if (wallDelta > 0) {
         // Work-first convention: the worked share of the interval renders
         // from its left edge, waiting fills the remainder as a true gap.
+        // The per-pair clamp also absorbs working-clock resets: init-scope
+        // events can carry a working_start from a different base (observed
+        // in real logs), so a negative or over-wide delta degrades to 0 /
+        // wallDelta instead of poisoning a global monotone floor.
         const workDelta = Math.min(Math.max(work - prev.work, 0), wallDelta);
         if (workDelta > 0) pushWorking(prev.wall, prev.wall + workDelta);
         const gap = wallDelta - workDelta;

--- a/packages/inspect-components/src/sample-activity/activityData.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.ts
@@ -1,0 +1,828 @@
+import type {
+  Event,
+  ModelEvent,
+  ScoreEvent,
+} from "@tsmono/inspect-common/types";
+import { isoToEpoch } from "@tsmono/inspect-common/utils";
+
+/** Epoch seconds; same convention as the task timeline. */
+export interface TimeWindow {
+  start: number;
+  end: number;
+}
+
+// ── marker / history categories ─────────────────────────────────────────
+
+export type ActivityCategory =
+  | "error"
+  | "limit"
+  | "approval"
+  | "input"
+  | "interrupt"
+  | "compaction"
+  | "score";
+
+export const kActivityCategories: ActivityCategory[] = [
+  "error",
+  "limit",
+  "approval",
+  "input",
+  "interrupt",
+  "compaction",
+  "score",
+];
+
+/** One hue per category — glyphs, stems, pills, and row washes all share it
+ *  (handoff design tokens). */
+export const kCategoryColor: Record<ActivityCategory, string> = {
+  error: "#b04a3c",
+  limit: "#8a6d1a",
+  approval: "#6b4fa8",
+  input: "#1d4f7c",
+  interrupt: "#6c757d",
+  compaction: "#2b6a94",
+  score: "#2f8a52",
+};
+
+/** Filter-pill captions (long) and Kind-cell captions (short). */
+export const kCategoryLong: Record<ActivityCategory, string> = {
+  error: "Errors",
+  limit: "Limits",
+  approval: "Approvals",
+  input: "Inputs",
+  interrupt: "Interrupts",
+  compaction: "Compactions",
+  score: "Scores",
+};
+
+export const kCategoryShort: Record<ActivityCategory, string> = {
+  error: "error",
+  limit: "limit",
+  approval: "approval",
+  input: "input",
+  interrupt: "interrupt",
+  compaction: "compact",
+  score: "score",
+};
+
+// ── derived shapes ───────────────────────────────────────────────────────
+
+export interface WorkingSegment {
+  start: number;
+  end: number;
+}
+
+export interface StallRegion {
+  start: number;
+  end: number;
+  /** Seconds of wall clock with no working-time advance. */
+  duration: number;
+  /** Adjacent ModelEvent.retries when the stall is retry-attributable. */
+  retries?: number;
+  /** The attributed model event — the stall row's click-through target. */
+  uuid?: string;
+}
+
+export interface StepPoint {
+  time: number;
+  value: number;
+}
+
+export interface ContextPoint {
+  time: number;
+  value: number;
+  uuid?: string;
+}
+
+export interface CompactionDrop {
+  time: number;
+  /** tokens_before, falling back to the context value at the drop. */
+  before?: number;
+  after?: number;
+  key: string;
+  uuid?: string;
+}
+
+export interface ActivitySpan {
+  start: number;
+  end: number;
+  kind: "model" | "tool";
+  /** Model name or tool function. */
+  label: string;
+  failed: boolean;
+  /** Open-ended span on a running sample — end extends to "now". */
+  pending: boolean;
+  retries?: number;
+  uuid?: string;
+  /** Sub-lane index within a concurrent tool burst; undefined = full row. */
+  subLane?: number;
+  /** Sub-lane count of the burst this span belongs to (≤ kMaxSubLanes). */
+  subLaneCount?: number;
+}
+
+/** A run of concurrently-overlapping tool spans on one agent row. */
+export interface ToolBurst {
+  start: number;
+  end: number;
+  count: number;
+  failed: number;
+  /** Dominant tool name for the "bash ×3 · 1 failed" label. */
+  label: string;
+  /** Spans beyond the sub-lane cap folded into the "+N" count. */
+  folded: number;
+}
+
+export interface AgentRow {
+  model: string;
+  /** Secondary role (e.g. "grader") — rendered muted at 0.7 opacity. */
+  role?: string;
+  spans: ActivitySpan[];
+  bursts: ToolBurst[];
+  modelCount: number;
+  toolCount: number;
+  failedCount: number;
+}
+
+export interface ActivityMarker {
+  time: number;
+  category: ActivityCategory;
+  /** History-row link (uuid when present, synthetic otherwise). */
+  key: string;
+  /** Event uuid — the transcript click-through target. */
+  uuid?: string;
+  /** Tooltip / aria text. */
+  label: string;
+}
+
+/** One sentence per row: lead text, optional mono value, optional tail
+ *  after the value, muted parenthetical detail. */
+export interface ActivityHistoryRow {
+  time: number;
+  category: ActivityCategory;
+  key: string;
+  uuid?: string;
+  lead: string;
+  mono?: string;
+  tail?: string;
+  detail?: string;
+  /** Right-aligned By column ("system", approver, "user"). */
+  by: string;
+}
+
+export interface ActivityData {
+  /** Wall-clock window; undefined when no event carries a timestamp. */
+  window?: TimeWindow;
+  workingSegments: WorkingSegment[];
+  /** Chronological; the chart labels only the N longest. */
+  stalls: StallRegion[];
+  /** Seconds — sample scalar when present, else summed segments. */
+  workingTime: number;
+  totalTime: number;
+  /** Cumulative total-token step curve (one point per model call). */
+  tokenSeries: StepPoint[];
+  totalTokens: number;
+  /** Per-call input-side tokens at event time. */
+  contextSeries: ContextPoint[];
+  contextPeak: number;
+  compactions: CompactionDrop[];
+  agentRows: AgentRow[];
+  markers: ActivityMarker[];
+  rows: ActivityHistoryRow[];
+  /** Any open-ended span (running sample). */
+  pending: boolean;
+}
+
+// ── formatting (handoff style: "2m 15s", "183k") ─────────────────────────
+
+export const fmtDurationWords = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds < 0) return "—";
+  const t = Math.round(seconds);
+  if (t < 60) return `${t}s`;
+  if (t < 3600) {
+    const m = Math.floor(t / 60);
+    const s = t % 60;
+    return s > 0 ? `${m}m ${s}s` : `${m}m`;
+  }
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+};
+
+export const fmtTime = (sec: number): string =>
+  new Date(sec * 1000).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+export const fmtTimeSec = (sec: number): string =>
+  new Date(sec * 1000).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+export const fmtDay = (sec: number): string =>
+  new Date(sec * 1000).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+
+export const fmtTokens = (value: number): string => {
+  if (!Number.isFinite(value)) return "—";
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1000) return `${Math.round(value / 1000)}k`;
+  return String(Math.round(value));
+};
+
+// ── search haystack ──────────────────────────────────────────────────────
+
+export const rowHaystack = (row: ActivityHistoryRow): string =>
+  [
+    kCategoryLong[row.category],
+    kCategoryShort[row.category],
+    row.lead,
+    row.mono ?? "",
+    row.tail ?? "",
+    row.detail ?? "",
+    row.by,
+  ].join(" ");
+
+// ── internals ────────────────────────────────────────────────────────────
+
+/** Wall/working checkpoint (epoch seconds, working seconds). */
+interface Checkpoint {
+  wall: number;
+  work: number;
+}
+
+/** Gaps shorter than this are timing noise, not waiting. */
+const kMinGapSeconds = 1;
+
+/** Sub-lane cap for concurrent tool bursts (handoff decision 4). */
+export const kMaxSubLanes = 4;
+
+const truncate = (text: string, max = 120): string =>
+  text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
+/** Wall completion for duration-bearing events (model/tool/subtask/sandbox). */
+const completedEpoch = (event: Event): number | undefined =>
+  "completed" in event && typeof event.completed === "string"
+    ? isoToEpoch(event.completed)
+    : undefined;
+
+const scoreText = (score: ScoreEvent["score"]): string => {
+  const value = score.value;
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+};
+
+/** Input-side tokens for one model call (context occupancy). */
+const inputSideTokens = (event: ModelEvent): number | undefined => {
+  const usage = event.output.usage;
+  if (!usage) return undefined;
+  return (
+    usage.input_tokens +
+    (usage.input_tokens_cache_read ?? 0) +
+    (usage.input_tokens_cache_write ?? 0)
+  );
+};
+
+/** All tokens for one model call — the burn curve's increment. */
+const allTokens = (event: ModelEvent): number | undefined => {
+  const usage = event.output.usage;
+  if (!usage) return undefined;
+  const input = inputSideTokens(event) ?? 0;
+  return input + usage.output_tokens;
+};
+
+export interface ActivityInputs {
+  events: Event[];
+  startedAt?: string | null;
+  completedAt?: string | null;
+  workingTime?: number | null;
+  totalTime?: number | null;
+  /** Live sample — pending spans render open-ended to `now`. */
+  running?: boolean;
+  /** Epoch seconds for the open edge; defaults to the latest event time. */
+  now?: number;
+}
+
+/** True when any event carries a usable timestamp — old logs without them
+ *  hide the Activity tab entirely. */
+export const hasEventTimestamps = (events: Event[]): boolean =>
+  events.some((event) => isoToEpoch(event.timestamp) !== undefined);
+
+/**
+ * The single O(n) pass over sample.events producing every band series,
+ * stall region, marker, and history row (spec: Architecture).
+ */
+export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
+  const { events, running = false } = inputs;
+
+  const checkpoints: Checkpoint[] = [];
+  const tokenSeries: StepPoint[] = [];
+  const contextSeries: ContextPoint[] = [];
+  const compactions: CompactionDrop[] = [];
+  const markers: ActivityMarker[] = [];
+  const rows: ActivityHistoryRow[] = [];
+  /** Retry-bearing model-call windows for stall attribution. */
+  const retryWindows: {
+    start: number;
+    end: number;
+    retries: number;
+    uuid?: string;
+  }[] = [];
+  const rowsByKey = new Map<string, AgentRow>();
+  const agentRows: AgentRow[] = [];
+
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  let cumulativeTokens = 0;
+  let contextPeak = 0;
+  let lastContext = 0;
+  let pending = false;
+  /** Temporal tool → model-row attribution: the row of the model call that
+   *  most recently started. */
+  let currentRow: AgentRow | undefined;
+
+  const rowFor = (model: string, role: string | undefined): AgentRow => {
+    const key = `${model} ${role ?? ""}`;
+    let row = rowsByKey.get(key);
+    if (!row) {
+      row = {
+        model,
+        role,
+        spans: [],
+        bursts: [],
+        modelCount: 0,
+        toolCount: 0,
+        failedCount: 0,
+      };
+      rowsByKey.set(key, row);
+      agentRows.push(row);
+    }
+    return row;
+  };
+
+  // Pre-scan for the time extent so `now` has a fallback before the main
+  // pass needs it for open-ended spans.
+  for (const event of events) {
+    const t = isoToEpoch(event.timestamp);
+    if (t !== undefined) {
+      if (t < minTime) minTime = t;
+      if (t > maxTime) maxTime = t;
+    }
+    const completed = completedEpoch(event);
+    if (completed !== undefined && completed > maxTime) maxTime = completed;
+  }
+  if (minTime > maxTime) {
+    // No event timestamps at all — the caller hides the tab; still return
+    // an inert shape so downstream code never branches on undefined arrays.
+    return {
+      window: undefined,
+      workingSegments: [],
+      stalls: [],
+      workingTime: inputs.workingTime ?? 0,
+      totalTime: inputs.totalTime ?? 0,
+      tokenSeries: [],
+      totalTokens: 0,
+      contextSeries: [],
+      contextPeak: 0,
+      compactions: [],
+      agentRows: [],
+      markers: [],
+      rows: [],
+      pending: false,
+    };
+  }
+
+  const startEpoch = isoToEpoch(inputs.startedAt);
+  const endEpoch = isoToEpoch(inputs.completedAt);
+  const now = inputs.now ?? maxTime;
+  const windowStart =
+    startEpoch !== undefined ? Math.min(startEpoch, minTime) : minTime;
+  const windowEnd =
+    running && now > maxTime
+      ? now
+      : endEpoch !== undefined
+        ? Math.max(endEpoch, maxTime)
+        : maxTime;
+  const window: TimeWindow = { start: windowStart, end: windowEnd };
+
+  events.forEach((event, index) => {
+    const t = isoToEpoch(event.timestamp);
+    if (t === undefined) return;
+    const key = event.uuid ?? `evt:${index}`;
+    const uuid = event.uuid ?? undefined;
+
+    checkpoints.push({ wall: t, work: event.working_start });
+    const completed = completedEpoch(event);
+    const workingTime =
+      "working_time" in event && typeof event.working_time === "number"
+        ? event.working_time
+        : undefined;
+    if (completed !== undefined && workingTime !== undefined) {
+      checkpoints.push({
+        wall: completed,
+        work: event.working_start + workingTime,
+      });
+    }
+
+    switch (event.event) {
+      case "model": {
+        const isPending = event.pending === true && completed === undefined;
+        const end = completed ?? (isPending ? Math.max(windowEnd, t) : t);
+        if (isPending) pending = true;
+        const role = event.role ?? undefined;
+        const row = rowFor(event.model, role);
+        row.modelCount += 1;
+        row.spans.push({
+          start: t,
+          end,
+          kind: "model",
+          label: event.model,
+          failed: false,
+          pending: isPending,
+          retries: event.retries ?? undefined,
+          uuid,
+        });
+        // Tool calls that follow attribute to the primary row even when a
+        // grader ran in between — grader rows don't call tools.
+        if (!role) currentRow = row;
+        if ((event.retries ?? 0) > 0) {
+          retryWindows.push({
+            start: t,
+            end,
+            retries: event.retries ?? 0,
+            uuid,
+          });
+        }
+        const burned = allTokens(event);
+        if (burned !== undefined && burned > 0) {
+          cumulativeTokens += burned;
+          tokenSeries.push({ time: completed ?? t, value: cumulativeTokens });
+        }
+        const context = inputSideTokens(event);
+        if (context !== undefined && context > 0) {
+          contextSeries.push({ time: t, value: context, uuid });
+          lastContext = context;
+          if (context > contextPeak) contextPeak = context;
+        }
+        break;
+      }
+      case "tool": {
+        const failed = event.error != null || event.failed === true;
+        const isPending = event.pending === true && completed === undefined;
+        const end = completed ?? (isPending ? Math.max(windowEnd, t) : t);
+        if (isPending) pending = true;
+        const row = currentRow ?? rowFor("tools", undefined);
+        row.toolCount += 1;
+        if (failed) row.failedCount += 1;
+        row.spans.push({
+          start: t,
+          end,
+          kind: "tool",
+          label: event.function,
+          failed,
+          pending: isPending,
+          uuid,
+        });
+        if (failed) {
+          const at = completed ?? t;
+          markers.push({
+            time: at,
+            category: "error",
+            key,
+            uuid,
+            label: `Tool ${event.function} errored`,
+          });
+          rows.push({
+            time: at,
+            category: "error",
+            key,
+            uuid,
+            lead: "Tool",
+            mono: event.function,
+            tail: "errored",
+            detail: event.error?.message
+              ? truncate(event.error.message)
+              : undefined,
+            by: "system",
+          });
+        }
+        break;
+      }
+      case "error": {
+        markers.push({
+          time: t,
+          category: "error",
+          key,
+          uuid,
+          label: `Error · ${truncate(event.error.message, 80)}`,
+        });
+        rows.push({
+          time: t,
+          category: "error",
+          key,
+          uuid,
+          lead: "Error",
+          detail: truncate(event.error.message),
+          by: "system",
+        });
+        break;
+      }
+      case "sample_limit": {
+        markers.push({
+          time: t,
+          category: "limit",
+          key,
+          uuid,
+          label: `Sample hit ${event.type} limit`,
+        });
+        rows.push({
+          time: t,
+          category: "limit",
+          key,
+          uuid,
+          lead: "Sample hit",
+          mono: `${event.type} limit`,
+          detail: event.message ? truncate(event.message) : undefined,
+          by: "system",
+        });
+        break;
+      }
+      case "approval": {
+        markers.push({
+          time: t,
+          category: "approval",
+          key,
+          uuid,
+          label: `Approval · ${event.call.function} · ${event.decision}`,
+        });
+        rows.push({
+          time: t,
+          category: "approval",
+          key,
+          uuid,
+          lead: "Approval requested for",
+          mono: event.call.function,
+          detail: event.decision,
+          by: event.approver,
+        });
+        break;
+      }
+      case "input": {
+        markers.push({
+          time: t,
+          category: "input",
+          key,
+          uuid,
+          label: "Input provided",
+        });
+        rows.push({
+          time: t,
+          category: "input",
+          key,
+          uuid,
+          lead: "Input provided",
+          detail: event.input ? `“${truncate(event.input, 80)}”` : undefined,
+          by: "user",
+        });
+        break;
+      }
+      case "interrupt": {
+        markers.push({
+          time: t,
+          category: "interrupt",
+          key,
+          uuid,
+          label: `Interrupted (${event.interrupted})`,
+        });
+        rows.push({
+          time: t,
+          category: "interrupt",
+          key,
+          uuid,
+          lead: "Interrupted",
+          detail: `${event.interrupted} · ${event.source}`,
+          by: event.source === "user_cancel" ? "user" : "system",
+        });
+        break;
+      }
+      case "compaction": {
+        const before =
+          event.tokens_before ?? (lastContext > 0 ? lastContext : undefined);
+        const after = event.tokens_after ?? undefined;
+        compactions.push({ time: t, before, after, key, uuid });
+        markers.push({
+          time: t,
+          category: "compaction",
+          key,
+          uuid,
+          label:
+            before !== undefined && after !== undefined
+              ? `Context compacted ${fmtTokens(before)} → ${fmtTokens(after)}`
+              : "Context compacted",
+        });
+        rows.push({
+          time: t,
+          category: "compaction",
+          key,
+          uuid,
+          lead: "Context compacted",
+          mono:
+            before !== undefined && after !== undefined
+              ? `${fmtTokens(before)} → ${fmtTokens(after)}`
+              : undefined,
+          detail: "tokens",
+          by: "system",
+        });
+        if (after !== undefined) lastContext = after;
+        break;
+      }
+      case "score": {
+        const value = scoreText(event.score);
+        markers.push({
+          time: t,
+          category: "score",
+          key,
+          uuid,
+          label: `Scored ${value}${event.intermediate ? " (intermediate)" : ""}`,
+        });
+        rows.push({
+          time: t,
+          category: "score",
+          key,
+          uuid,
+          lead: event.intermediate ? "Scored (intermediate)" : "Scored",
+          mono: truncate(value, 40),
+          detail: event.scorer ? `scorer ${event.scorer}` : undefined,
+          by: "system",
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  // ── working segments + stalls from the checkpoint stream ─────────────
+  checkpoints.sort((a, b) => a.wall - b.wall || a.work - b.work);
+  const workingSegments: WorkingSegment[] = [];
+  const stalls: StallRegion[] = [];
+  const pushWorking = (start: number, end: number) => {
+    if (end <= start) return;
+    const last = workingSegments[workingSegments.length - 1];
+    // Merge blocks that touch (within noise) so the band reads as blocks.
+    if (last && start - last.end < kMinGapSeconds) {
+      last.end = Math.max(last.end, end);
+    } else {
+      workingSegments.push({ start, end });
+    }
+  };
+
+  let prev: Checkpoint | undefined;
+  let workFloor = -Infinity;
+  for (const point of checkpoints) {
+    // Clamp non-monotonic working offsets (clock skew, parallel writers).
+    const work = Math.max(point.work, workFloor);
+    workFloor = work;
+    if (prev) {
+      const wallDelta = point.wall - prev.wall;
+      if (wallDelta > 0) {
+        // Work-first convention: the worked share of the interval renders
+        // from its left edge, waiting fills the remainder as a true gap.
+        const workDelta = Math.min(Math.max(work - prev.work, 0), wallDelta);
+        if (workDelta > 0) pushWorking(prev.wall, prev.wall + workDelta);
+        const gap = wallDelta - workDelta;
+        if (gap >= kMinGapSeconds) {
+          const gapStart = prev.wall + workDelta;
+          const attributed = retryWindows.find(
+            (w) => gapStart < w.end && point.wall > w.start
+          );
+          stalls.push({
+            start: gapStart,
+            end: point.wall,
+            duration: gap,
+            retries: attributed?.retries,
+            uuid: attributed?.uuid,
+          });
+        }
+      }
+    } else if (
+      point.wall > windowStart &&
+      point.work >= point.wall - windowStart
+    ) {
+      // Work before the first checkpoint is real (working_start covers it).
+      pushWorking(windowStart, point.wall);
+    }
+    prev = { wall: point.wall, work };
+  }
+  // A running sample keeps working past its last checkpoint — open-ended.
+  if (running && prev && windowEnd > prev.wall) {
+    pushWorking(prev.wall, windowEnd);
+  }
+
+  // Attributable stalls become history rows (handoff mock: the rate-limit
+  // stall reads as an error row; unattributed waits stay chart-only).
+  for (const stall of stalls) {
+    if (stall.retries === undefined || stall.retries <= 0) continue;
+    rows.push({
+      time: stall.start,
+      category: "error",
+      key: `stall:${stall.start}`,
+      uuid: stall.uuid,
+      lead: `Model request rate-limited, retried ×${stall.retries}`,
+      detail: `resumed after ${fmtDurationWords(stall.duration)}`,
+      by: "system",
+    });
+  }
+
+  // ── per-row concurrent tool bursts → sub-lanes ────────────────────────
+  for (const row of agentRows) {
+    row.spans.sort((a, b) => a.start - b.start || a.end - b.end);
+    assignSubLanes(row);
+  }
+  // Primary rows first (in first-appearance order), role rows after.
+  agentRows.sort((a, b) => {
+    const roleRank = (row: AgentRow) => (row.role ? 1 : 0);
+    if (roleRank(a) !== roleRank(b)) return roleRank(a) - roleRank(b);
+    const first = (row: AgentRow) => row.spans[0]?.start ?? Infinity;
+    return first(a) - first(b);
+  });
+
+  markers.sort((a, b) => a.time - b.time);
+  rows.sort((a, b) => a.time - b.time);
+
+  const totalTime = inputs.totalTime ?? Math.max(0, windowEnd - windowStart);
+  const workingTime =
+    inputs.workingTime ??
+    workingSegments.reduce((sum, s) => sum + (s.end - s.start), 0);
+
+  return {
+    window,
+    workingSegments,
+    stalls,
+    workingTime,
+    totalTime,
+    tokenSeries,
+    totalTokens: cumulativeTokens,
+    contextSeries,
+    contextPeak,
+    compactions,
+    agentRows,
+    markers,
+    rows,
+    pending,
+  };
+};
+
+/** Splits overlapping tool spans into thin sub-lanes for the overlap
+ *  duration only (handoff 5a), capping at kMaxSubLanes with a "+N" fold. */
+const assignSubLanes = (row: AgentRow): void => {
+  const tools = row.spans.filter((span) => span.kind === "tool");
+  let burst: ActivitySpan[] = [];
+  let burstEnd = -Infinity;
+
+  const flush = () => {
+    if (burst.length > 1) {
+      const shown = burst.slice(0, kMaxSubLanes);
+      shown.forEach((span, lane) => {
+        span.subLane = lane;
+        span.subLaneCount = shown.length;
+      });
+      // Folded spans render nothing individually; the burst label counts
+      // them so nothing silently disappears.
+      const names = new Map<string, number>();
+      let failed = 0;
+      for (const span of burst) {
+        names.set(span.label, (names.get(span.label) ?? 0) + 1);
+        if (span.failed) failed += 1;
+      }
+      const dominant =
+        [...names.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "tools";
+      row.bursts.push({
+        start: burst[0]?.start ?? 0,
+        end: burstEnd,
+        count: burst.length,
+        failed,
+        label: dominant,
+        folded: Math.max(0, burst.length - kMaxSubLanes),
+      });
+    }
+    burst = [];
+    burstEnd = -Infinity;
+  };
+
+  for (const span of tools) {
+    if (burst.length > 0 && span.start < burstEnd) {
+      burst.push(span);
+      burstEnd = Math.max(burstEnd, span.end);
+    } else {
+      flush();
+      burst = [span];
+      burstEnd = span.end;
+    }
+  }
+  flush();
+};

--- a/packages/inspect-components/src/sample-activity/activityData.ts
+++ b/packages/inspect-components/src/sample-activity/activityData.ts
@@ -5,6 +5,11 @@ import type {
 } from "@tsmono/inspect-common/types";
 import { isoToEpoch } from "@tsmono/inspect-common/utils";
 
+// Direct file imports keep this module React-free (the usage barrel pulls
+// in component modules).
+import { fmtCompactDuration } from "../usage/timeFormat";
+import { usageTotal } from "../usage/tokenTotals";
+
 /** Epoch seconds; same convention as the task timeline. */
 export interface TimeWindow {
   start: number;
@@ -190,23 +195,17 @@ export interface ActivityData {
   rows: ActivityHistoryRow[];
   /** Any open-ended span (running sample). */
   pending: boolean;
+  /** False for mid-vintage logs whose events carry timestamps but no real
+   *  working clock (normalizer-filled working_start 0, no working_time) —
+   *  the working/waiting band would read as all-waiting, so it hides. */
+  hasWorkingSignal: boolean;
 }
 
 // ── formatting (handoff style: "2m 15s", "183k") ─────────────────────────
 
-export const fmtDurationWords = (seconds: number): string => {
-  if (!Number.isFinite(seconds) || seconds < 0) return "—";
-  const t = Math.round(seconds);
-  if (t < 60) return `${t}s`;
-  if (t < 3600) {
-    const m = Math.floor(t / 60);
-    const s = t % 60;
-    return s > 0 ? `${m}m ${s}s` : `${m}m`;
-  }
-  const h = Math.floor(t / 3600);
-  const m = Math.floor((t % 3600) / 60);
-  return m > 0 ? `${h}h ${m}m` : `${h}h`;
-};
+/** fmtCompactDuration with a guard: negative/NaN input is corrupt data. */
+export const fmtDurationWords = (seconds: number): string =>
+  !Number.isFinite(seconds) || seconds < 0 ? "—" : fmtCompactDuration(seconds);
 
 export const fmtTime = (sec: number): string =>
   new Date(sec * 1000).toLocaleTimeString(undefined, {
@@ -276,23 +275,23 @@ const scoreText = (score: ScoreEvent["score"]): string => {
   return String(value);
 };
 
-/** Input-side tokens for one model call (context occupancy). */
+/** Input-side tokens for one model call (context occupancy): the shared
+ *  total minus the output side. Summing input + cache categories directly
+ *  would double-count on providers whose input_tokens already includes
+ *  cached reads (OpenAI) — deriving from usageTotal keeps this surface
+ *  consistent with the Usage tab. */
 const inputSideTokens = (event: ModelEvent): number | undefined => {
   const usage = event.output.usage;
   if (!usage) return undefined;
-  return (
-    usage.input_tokens +
-    (usage.input_tokens_cache_read ?? 0) +
-    (usage.input_tokens_cache_write ?? 0)
-  );
+  return Math.max(0, usageTotal(usage) - usage.output_tokens);
 };
 
-/** All tokens for one model call — the burn curve's increment. */
+/** All tokens for one model call — the burn curve's increment. Shares
+ *  usageTotal with the Usage tab so the two surfaces always agree. */
 const allTokens = (event: ModelEvent): number | undefined => {
   const usage = event.output.usage;
   if (!usage) return undefined;
-  const input = inputSideTokens(event) ?? 0;
-  return input + usage.output_tokens;
+  return usageTotal(usage);
 };
 
 export interface ActivityInputs {
@@ -320,7 +319,11 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
   const { events, running = false } = inputs;
 
   const checkpoints: Checkpoint[] = [];
-  const tokenSeries: StepPoint[] = [];
+  /** Raw per-call burns — sorted by time then accumulated AFTER the pass:
+   *  overlapping calls (parallel subagents, concurrent scorers) complete
+   *  out of event order, and the step path/hover both consume the series
+   *  as time-ordered. */
+  const tokenPoints: { time: number; burned: number }[] = [];
   const contextSeries: ContextPoint[] = [];
   const compactions: CompactionDrop[] = [];
   const markers: ActivityMarker[] = [];
@@ -337,10 +340,17 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
 
   let minTime = Infinity;
   let maxTime = -Infinity;
-  let cumulativeTokens = 0;
   let contextPeak = 0;
   let lastContext = 0;
   let pending = false;
+  // Mid-vintage logs carry timestamps but predate working_start/working_time
+  // (the normalizer fills working_start with 0) — without a real working
+  // signal the working/waiting band would render the whole run as waiting.
+  const hasWorkingSignal = events.some(
+    (event) =>
+      ("working_time" in event && typeof event.working_time === "number") ||
+      event.working_start > 0
+  );
   /** Temporal tool → model-row attribution: the row of the model call that
    *  most recently started. */
   let currentRow: AgentRow | undefined;
@@ -393,6 +403,7 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
       markers: [],
       rows: [],
       pending: false,
+      hasWorkingSignal: false,
     };
   }
 
@@ -459,8 +470,7 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
         }
         const burned = allTokens(event);
         if (burned !== undefined && burned > 0) {
-          cumulativeTokens += burned;
-          tokenSeries.push({ time: completed ?? t, value: cumulativeTokens });
+          tokenPoints.push({ time: completed ?? t, burned });
         }
         const context = inputSideTokens(event);
         if (context !== undefined && context > 0) {
@@ -667,9 +677,13 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
   });
 
   // ── working segments + stalls from the checkpoint stream ─────────────
+  // Skipped entirely without a working signal: mid-vintage logs carry
+  // timestamps but no working_start/working_time (the normalizer fills 0),
+  // and an all-zero work clock would read as "the whole run was waiting".
   checkpoints.sort((a, b) => a.wall - b.wall || a.work - b.work);
   const workingSegments: WorkingSegment[] = [];
   const stalls: StallRegion[] = [];
+  if (!hasWorkingSignal) checkpoints.length = 0;
   const pushWorking = (start: number, end: number) => {
     if (end <= start) return;
     const last = workingSegments[workingSegments.length - 1];
@@ -724,6 +738,15 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
     pushWorking(prev.wall, windowEnd);
   }
 
+  // Overlapping calls complete out of event order — sort the raw burns by
+  // time, then accumulate into the cumulative step curve.
+  tokenPoints.sort((a, b) => a.time - b.time);
+  let cumulativeTokens = 0;
+  const tokenSeries: StepPoint[] = tokenPoints.map((point) => {
+    cumulativeTokens += point.burned;
+    return { time: point.time, value: cumulativeTokens };
+  });
+
   // Attributable stalls become history rows (handoff mock: the rate-limit
   // stall reads as an error row; unattributed waits stay chart-only).
   for (const stall of stalls) {
@@ -775,6 +798,7 @@ export const deriveActivityData = (inputs: ActivityInputs): ActivityData => {
     markers,
     rows,
     pending,
+    hasWorkingSignal,
   };
 };
 

--- a/packages/inspect-components/src/sample-activity/index.ts
+++ b/packages/inspect-components/src/sample-activity/index.ts
@@ -1,0 +1,4 @@
+export * from "./activityData";
+export * from "./ActivityChart";
+export * from "./ActivityHistoryList";
+export * from "./SampleActivityPanel";

--- a/packages/inspect-components/src/usage/ConnectionsView.tsx
+++ b/packages/inspect-components/src/usage/ConnectionsView.tsx
@@ -125,7 +125,7 @@ export const ConnectionsView: FC<ConnectionsViewProps> = ({
                 <button
                   type="button"
                   className={styles.actionLink}
-                  title="View on timeline"
+                  title="View on activity"
                   onClick={(event) => onViewTimeline(model, event)}
                 >
                   <i className="bi bi-graph-up" aria-hidden="true" />

--- a/packages/inspect-components/src/usage/ModelTokenTable.tsx
+++ b/packages/inspect-components/src/usage/ModelTokenTable.tsx
@@ -6,6 +6,7 @@ import { formatNumber } from "@tsmono/util";
 
 import styles from "./ModelTokenTable.module.css";
 import { ModelUsageData } from "./ModelUsagePanel";
+import { compositionTotal, usageTotal } from "./tokenTotals";
 
 interface ModelTokenTableProps {
   model_usage?: Record<string, ModelUsageData>;
@@ -59,12 +60,6 @@ const categoryValue = (usage: ModelUsageData, key: CategoryKey): number => {
       return usage.reasoning_tokens ?? 0;
   }
 };
-
-const compositionTotal = (usage: ModelUsageData): number =>
-  CAT_ORDER.reduce((a, k) => a + categoryValue(usage, k), 0);
-
-const usageTotal = (usage: ModelUsageData): number =>
-  usage.total_tokens || compositionTotal(usage);
 
 export const ModelTokenTable: FC<ModelTokenTableProps> = ({
   model_usage,

--- a/packages/inspect-components/src/usage/index.ts
+++ b/packages/inspect-components/src/usage/index.ts
@@ -1,4 +1,5 @@
 export { ModelTokenTable } from "./ModelTokenTable";
+export { compositionTotal, usageTotal } from "./tokenTotals";
 export { ModelUsagePanel } from "./ModelUsagePanel";
 export type { ModelUsageData, ModelUsageTiming } from "./ModelUsagePanel";
 export { UsagePanel } from "./UsagePanel";

--- a/packages/inspect-components/src/usage/tokenTotals.ts
+++ b/packages/inspect-components/src/usage/tokenTotals.ts
@@ -1,0 +1,17 @@
+import type { ModelUsageData } from "./ModelUsagePanel";
+
+/** Sum of the individual token categories — the fallback when a record
+ *  carries no total. */
+export const compositionTotal = (usage: ModelUsageData): number =>
+  (usage.input_tokens ?? 0) +
+  (usage.input_tokens_cache_read ?? 0) +
+  (usage.input_tokens_cache_write ?? 0) +
+  (usage.output_tokens ?? 0) +
+  (usage.reasoning_tokens ?? 0);
+
+/** One total for every token surface (Usage tab, Activity tab): prefer the
+ *  recorded total_tokens — providers disagree on composition (OpenAI's
+ *  input_tokens already includes cached reads, so summing categories
+ *  double-counts) — falling back to the composition when absent/zero. */
+export const usageTotal = (usage: ModelUsageData): number =>
+  usage.total_tokens || compositionTotal(usage);


### PR DESCRIPTION
## Summary

Implements the **Sample Activity view** per the approved design handoff bundle (`2026-08-31-sample-activity-design.md` + design canvas, integrated mock 2a):

- **New top-level `Activity` tab** in the sample display (peer of Transcript / Messages / Scoring / Metadata): a stacked-band operational timeline for a single sample on one shared wall-clock axis, with a filterable virtualized history list beneath.
  - **Working / waiting** — working blocks (`#5b8ec4`) with waiting rendered as true gaps; the N longest stalls get labeled brackets, red `2m 15s · rate limit ×3` when retry-attributable via the adjacent `ModelEvent.retries` (grey otherwise).
  - **Marker rail** — 18px rail with the 7 per-category glyphs from the handoff (error ✕, limit ▲, approval ●, input ◇, interrupt ‖, compaction ▼, score ◎), hue-tinted stems, ×N clustering within 10px. ◆ stays reserved for log-level config changes.
  - **Token burn** — cumulative step curve from `ModelEvent.output.usage` (input + cache read/write + output), 0/mid/max y-ticks, hover crosshair + tabular-nums tooltip.
  - **Context size** (opt-in) — per-call input-side tokens; `CompactionEvent`s render as dashed cliff drops annotated `142k → 38k`.
  - **Model & tool activity** (opt-in) — one row per agent/model (grader roles muted on their own row); model (grey) and tool (teal) spans interleave; concurrent tool calls split into ≤4 sub-lanes with a `bash ×3 · 1 failed` burst label and `+N` fold; failed tools render red-outlined. Past ~1 span/3px the row degrades to a per-pixel occupancy strip (O(width), red failure hairlines, hover reads the bin, click filters the history list to the bin's window).
  - **History list** — always present; additive category pills (incl. the new Scores hue with dark variants), free-text search, one sortable Time column, virtualized against the tab scroll container; bidirectional glyph ↔ row hover link; marker click auto-widens filters.
  - **Click-through to Transcript** from every span, glyph, and history row via event uuid (`/transcript?event=`); modifier-click opens a new tab.
  - Band chips with the curated default-on set (working/waiting + markers + token burn); band toggles, filters, search, sort, and selection persist per sample via the property-bag pattern.
  - Tab **hidden for old logs without event timestamps**; running samples render pending spans open-ended and the window extends to the latest event.
- **Companion label-only rename:** the log-level `Timeline` tab is now labeled **Activity** (internal tab id `timeline` and persisted keys unchanged). The two "View on timeline" affordance texts follow.
- Code lives in `packages/inspect-components/src/sample-activity/` (`activityData.ts` pure O(n) derivation, `SampleActivityPanel.tsx`, `ActivityChart.tsx`, `ActivityHistoryList.tsx`) — patterns borrowed as fresh code from the task timeline, which is untouched.

## Screenshots

| Before (light) | After — defaults (light) |
| --- | --- |
| ![before sample tabs](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/before-sample-tabs-light.png) | ![activity defaults](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-default-light.png) |

| After — all bands, 154-turn log (light) | After — all bands (dark) |
| --- | --- |
| ![all bands light](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-all-bands-light.png) | ![all bands dark](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-all-bands-dark.png) |

| Errors filter | Click-through lands on Transcript |
| --- | --- |
| ![errors filter](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-errors-filter.png) | ![click-through](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-clickthrough-transcript.png) |

| Before — log tab labeled "Timeline" | Discrete spans at moderate density (69-turn log) |
| --- | --- |
| ![before log tabs](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/before-log-tabs-light.png) | ![discrete spans](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/079d912343ce19c73c3785b0e6d48cee9808ff4d/sample-activity/sample-activity-69turn-discrete-light.png) |

(Screenshots live on the non-merging `ao/ts-mono-2/sample-activity-assets` branch.)

## Testing

- **Unit** (`activityData.test.ts`, 36 tests): stall detection + retry attribution, working-clock reset absorption (regression found against a real log), cumulative token math, context series + compaction drops, marker/history-row generation, sub-lane bursts + `+N` fold, pending/running handling, zero-ModelEvent samples, timestamp gating.
- **Component** (`SampleActivityPanel.test.tsx`): curated default chips, chip toggles, pill/search filtering, click-through callback, marker click filter-widening, glyph↔row hover wash.
- **E2E** (`apps/inspect/e2e/sample-activity.spec.ts`, 7 tests, MSW-mocked per suite convention): tab presence, band rendering + stall label, chip toggles, list filters, marker→row selection, click-through URL, tab hidden without timestamps, log-tab relabel.
- **Real-app verification** (verify-log-viewer skill, new `drive/sample-activity.spec.ts` + `features/sample-activity.md`): drove the tab against a real 154-turn `.eval` (light + dark) — this run surfaced and fixed a real-data bug (working-clock reset poisoning the working/waiting band).
- `pnpm check` and `pnpm test` green at repo root.

## Density / scale check logs

Three real agentic logs (paths on this machine) served as the realistic density/scale check; the verify-log-viewer drive (`drive/sample-activity.spec.ts`, pin a fixture with `VERIFY_ACTIVITY_LOG`) passes against each, light and dark:

- **79-turn log** (error-free; primary density check): 411 events — 80 model, 79 tool, 79 sandbox; message-limit termination (▲ limit marker) and a model-graded ScoreEvent (◎):
  `/Users/charlesteague/Development/test_evals/agentic/logs/2026-08-31T20-27-50-00-00_ascii-art-python_PvkSPg4TAnD8ZdgKmFyJbQ.eval`
- **69-turn flaky log** (failed-span styling + error markers): 403 events — 70 model, 89 tool with **12 deliberate ToolError failures** interleaved among 77 successes; the drive asserts the error ✕ rail glyphs and the red-outlined failed-span treatment (`#fdf1ef`/`#b04a3c`, hairlines in density mode):
  `/Users/charlesteague/Development/test_evals/agentic/logs/2026-08-31T20-49-58-00-00_ascii-art-flaky_N3SZHoUNQGGvCFbU3BTAih.eval`
- **154-turn flaky log** (density-degrade stress: per-pixel occupancy strip + marker clustering): 156 model calls, 197 tool calls (30 failed), token-limit termination, 3.0M tokens:
  `/Users/charlesteague/Development/test_evals/agentic/logs-sample-activity/2026-08-31T21-01-42-00-00_ascii-art-flaky_BkjQFttDtQrkhewD6JXVWh.eval`

- **225-turn compaction log** (compaction rendering): 1291 events with **18 threshold-triggered CompactionEvents** (~5k → ~1k each) plus a message-limit event. The drive asserts the context-band sawtooth with a dashed cliff drop per compaction and `Nk → M` annotations (labels declutter past 60px density), the ▼ rail markers with ×N clustering, `Compactions 18` pill, marker-click filter widening, and that the merged band's per-pixel density strip engages on its 478 spans:
  `/Users/charlesteague/Development/test_evals/agentic/logs-sample-activity/2026-08-31T21-45-21-00-00_ascii-art-compaction_RFyebqdnn4iTTcdWHxVpMP.eval`

None of these logs contain model-retry stalls (not cheaply forced against a real API), so **retry-attributed stall labeling is covered by unit-test fixtures** (`activityData.test.ts`) and the mocked e2e suite rather than these logs.

| 79-turn log (error-free) | 69-turn flaky log (12 tool failures) |
| --- | --- |
| ![79-turn log](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/8584dfd448f0a12576074077df473e4cf2757766/sample-activity/sample-activity-79turn-light.png) | ![69-turn flaky log](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/8584dfd448f0a12576074077df473e4cf2757766/sample-activity/sample-activity-69turn-failedspans-light.png) |


| Compaction log (18 cliff drops, ▼ clusters) | |
| --- | --- |
| ![compaction log](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/237cad0749ccd51b57161430af7d81b1c7d48b5c/sample-activity/sample-activity-compactions-light.png) | |

| Burst labels declutter at parallel-tool density | |
| --- | --- |
| ![burst labels](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/35d35a381c09a35fffd999037ca71175415b2932/sample-activity/sample-activity-burst-labels-decluttered.png) | |

| Marker cluster count: before (floating ×N) → after (count box above glyph) | |
| --- | --- |
| ![cluster badge before/after](https://raw.githubusercontent.com/meridianlabs-ai/ts-mono/491f2cf06afabfb917c6769a42af673c7a831047/sample-activity/cluster-badge-before-after.png) | |

## Known limits / follow-ups

- Span/marker hover popovers are informational (pointer-events none) with click as the navigation, per the handoff's interaction section; the dense-bin click narrows the history list via a clearable time-window chip.
- Deferred per spec: working-time axis toggle, zoom/minimap, swimlane unification, shared band-chart primitive extraction.
- `testInterruptEvent` fixture builder added to `@tsmono/inspect-common/testing` (fixture-placement rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
