### PR TITLE
chore: regenerate scout types for the widened search event enum

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1786,7 +1786,7 @@ export interface components {
          */
         GrepSearchRequest: {
             /** Events */
-            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "span_begin" | "span_end") | string)[] | null;
+            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "input" | "sample_init" | "sample_limit" | "score" | "score_edit" | "state" | "anchor" | "checkpoint" | "interrupt" | "span_begin" | "span_end") | string)[] | null;
             /**
              * Ignore Case
              * @default true
@@ -2111,7 +2111,7 @@ export interface components {
          */
         LlmSearchRequest: {
             /** Events */
-            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "span_begin" | "span_end") | string)[] | null;
+            events?: "all" | (("model" | "tool" | "compaction" | "branch" | "approval" | "sandbox" | "info" | "store" | "logger" | "error" | "input" | "sample_init" | "sample_limit" | "score" | "score_edit" | "state" | "anchor" | "checkpoint" | "interrupt" | "span_begin" | "span_end") | string)[] | null;
             /** Messages */
             messages?: "all" | ("system" | "user" | "assistant" | "tool")[] | null;
             /** Model */


### PR DESCRIPTION
Regenerated `apps/scout/src/types/generated.ts` for the `EventType` widening in [inspect_scout#492](https://github.com/meridianlabs-ai/inspect_scout/pull/492).

`GrepSearchRequest.events` and `LlmSearchRequest.events` gain the event names the `llm_scanner` can now be shown: `input`, `sample_init`, `sample_limit`, `score`, `score_edit`, `state`, `anchor`, `checkpoint`, `interrupt`.

Generated by `scripts/export_openapi_schema.py` in inspect_scout; two lines, no hand edits. Based on `86bdc2af` (the commit inspect_scout currently pins) rather than ts-mono `main`, so the paired gitlink bump adds only erased types and leaves the checked-in viewer bundle byte-identical.

Pairs with inspect_scout#492 — that PR's `check-schema-and-types` stays red until this merges.

### Agent review
- Author: Claude Opus 5 (Claude Code). Generated artifact, not hand-written.
- No review pass was run on this diff — it is the verbatim output of the generator, verified byte-identical to a regeneration run twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)