### PR TITLE
Regenerate types for the stream_idle_timeout generate-config field

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -2150,6 +2150,8 @@ export interface components {
             seed?: number | null;
             /** Stop Seqs */
             stop_seqs?: string[] | null;
+            /** Stream Idle Timeout */
+            stream_idle_timeout?: number | null;
             /** System Message */
             system_message?: string | null;
             /** Temperature */

--- a/packages/inspect-common/src/utils/effectiveConfig.ts
+++ b/packages/inspect-common/src/utils/effectiveConfig.ts
@@ -76,6 +76,7 @@ const GENERATE_CONFIG_KEYS: Record<keyof GenerateConfig, true> = {
   response_schema: true,
   seed: true,
   stop_seqs: true,
+  stream_idle_timeout: true,
   system_message: true,
   temperature: true,
   timeout: true,


### PR DESCRIPTION
Regenerates the shared types for the new optional `stream_idle_timeout` field on `GenerateConfig`, and adds its entry to `effectiveConfig.ts`'s compile-time key record (the drift guard that keeps the unknown-field skip accurate).

Paired with UKGovernmentBEIS/inspect_ai#5096 ("Stalled streaming model calls now time out on chunk silence"), which adds the Python field. That PR's `check-schema-and-types` job is red until this merges.

Generated by `python src/inspect_ai/_view/schema.py` from the paired branch; `pnpm typecheck`, `pnpm test`, and `pnpm lint` all pass. The field is optional (Noneable), so the sibling scout app's duplicated types need no sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
