### PR TITLE
Fix sample tab scroll position lost on quick tab switches; clean up effect/timer lifecycles flagged by react-doctor

### DIFF
--- a/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
+++ b/apps/inspect/src/app/log-view/tabs/timeline/TimelineChart.tsx
@@ -201,19 +201,15 @@ export const TimelineChart: FC<TimelineChartProps> = ({
   // Callback ref, not useResizeObserver — the chart renders null until
   // samples arrive (and while every band is toggled off), so a mount-only
   // effect observes nothing and the width would stay 0 forever.
-  const resizeObserver = useRef<ResizeObserver | null>(null);
   const chartRef = useCallback((element: HTMLDivElement | null) => {
-    resizeObserver.current?.disconnect();
-    resizeObserver.current = null;
-    if (element) {
-      const observer = new ResizeObserver((entries) => {
-        if (entries[0]) {
-          setWidth(entries[0].contentRect.width);
-        }
-      });
-      observer.observe(element);
-      resizeObserver.current = observer;
-    }
+    if (!element) return;
+    const observer = new ResizeObserver((entries) => {
+      if (entries[0]) {
+        setWidth(entries[0].contentRect.width);
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
   }, []);
   const [popover, setPopover] = useState<PopoverState | null>(null);
   const [lineHover, setLineHover] = useState<LineHover | null>(null);

--- a/packages/react/src/hooks/useScrollDirection.test.tsx
+++ b/packages/react/src/hooks/useScrollDirection.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { act, cleanup, render } from "@testing-library/react";
 import { useRef, type RefObject } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useScrollDirection } from "./useScrollDirection";
+import {
+  useScrollDirection,
+  type UseScrollDirectionResult,
+} from "./useScrollDirection";
 
-afterEach(cleanup);
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
 
 function Harness({
   elRef,
@@ -71,5 +77,72 @@ describe("useScrollDirection hidden state across scroller remounts", () => {
     // The loading→loaded swap on a deep-link mount must NOT wipe the forced
     // collapsed state — that painted the chrome expanded mid-landing.
     expect(hidden).toBe(true);
+  });
+});
+
+function LockHarness({
+  elRef,
+  onApi,
+}: {
+  elRef: RefObject<HTMLElement | null>;
+  onApi: (api: UseScrollDirectionResult) => void;
+}) {
+  const api = useScrollDirection(elRef);
+  onApi(api);
+  return null;
+}
+
+// A scroller jsdom treats as scrollable: the handler's at-bottom guard reads
+// scrollHeight/clientHeight, which jsdom reports as 0 by default.
+const makeScrollableEl = () => {
+  const el = makeEl();
+  Object.defineProperty(el, "scrollHeight", { value: 2000 });
+  Object.defineProperty(el, "clientHeight", { value: 500 });
+  return el;
+};
+
+describe("useScrollDirection transition lock semantics", () => {
+  it("a scroll-driven lock engaged after resetAnchor(true) + setHidden expires instead of self-extending", () => {
+    vi.useFakeTimers();
+    const el = makeScrollableEl();
+    const elRef: RefObject<HTMLElement | null> = { current: el };
+    let api: UseScrollDirectionResult | undefined;
+    render(<LockHarness elRef={elRef} onApi={(a) => (api = a)} />);
+
+    const scrollTo = (top: number) => {
+      el.scrollTop = top;
+      act(() => {
+        el.dispatchEvent(new Event("scroll"));
+      });
+    };
+
+    // The transcript search-next sequence: a self-extending programmatic
+    // lock, immediately superseded by an imperative setHidden.
+    act(() => api!.resetAnchor(true));
+    act(() => api!.setHidden(true));
+    expect(api!.hidden).toBe(true);
+
+    // Let that lock expire, then anchor mid-scroller (down, no state change).
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    scrollTo(1000);
+
+    // Upward direction change reveals and engages an ORDINARY transition
+    // lock — the one whose semantics are under test.
+    scrollTo(500);
+    expect(api!.hidden).toBe(false);
+
+    // Scroll steadily downward, each event past the threshold and inside
+    // 250ms of the last. A lock that wrongly inherited the programmatic
+    // flag re-arms its expiry on every event and never releases, so hidden
+    // would stay false for as long as scrolling continues.
+    for (let i = 1; i <= 6; i++) {
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      scrollTo(500 + i * 60);
+    }
+    expect(api!.hidden).toBe(true);
   });
 });

--- a/packages/react/src/hooks/useScrollDirection.ts
+++ b/packages/react/src/hooks/useScrollDirection.ts
@@ -9,8 +9,6 @@ import {
 
 import { isReadonlyArray } from "@tsmono/util";
 
-import { useUnmount } from "./useUnmount";
-
 const asArray = <T>(v: T | ReadonlyArray<T>): ReadonlyArray<T> =>
   isReadonlyArray(v) ? v : [v];
 
@@ -103,14 +101,34 @@ export function useScrollDirection(
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [hidden, setHidden] = useState(options?.initialHidden ?? false);
 
-  // A lock timer may be pending at unmount (set by the scroll handlers,
-  // resetAnchor, or setHidden — the latter two can fire even with no
-  // scroller attached).
-  useUnmount(() => {
+  const releaseLock = useCallback(() => {
+    transitionLockedRef.current = false;
+    programmaticLockRef.current = false;
     if (lockTimerRef.current !== null) {
       clearTimeout(lockTimerRef.current);
+      lockTimerRef.current = null;
     }
-  });
+  }, []);
+
+  // Engage the lock for one `transitionLockMs` window, replacing any pending
+  // expiry AND its programmatic flag — a transition lock that supersedes a
+  // resetAnchor lock must not inherit its self-extending debounce semantics.
+  const engageLock = useCallback(
+    (programmatic: boolean, onExpire?: () => void) => {
+      transitionLockedRef.current = true;
+      programmaticLockRef.current = programmatic;
+      if (lockTimerRef.current !== null) {
+        clearTimeout(lockTimerRef.current);
+      }
+      lockTimerRef.current = setTimeout(() => {
+        transitionLockedRef.current = false;
+        programmaticLockRef.current = false;
+        lockTimerRef.current = null;
+        onExpire?.();
+      }, transitionLockMs);
+    },
+    [transitionLockMs]
+  );
 
   // Normalize input to an array of refs.
   const refArray: ReadonlyArray<RefObject<HTMLElement | null>> = useMemo(
@@ -178,16 +196,10 @@ export function useScrollDirection(
   useEffect(() => {
     directionAnchorsRef.current = new WeakMap();
     lastDirectionsRef.current = new WeakMap();
-    transitionLockedRef.current = false;
-    programmaticLockRef.current = false;
-    // A timer pending from the previous scroller set would otherwise fire
-    // later and release a lock engaged after this re-attach.
-    if (lockTimerRef.current !== null) {
-      clearTimeout(lockTimerRef.current);
-      lockTimerRef.current = null;
-    }
-
-    if (scrollEls.length === 0) return;
+    // Lock state belongs to the previous scroller set — release it wholesale
+    // (a stale programmatic flag surviving the swap would make the next
+    // transition lock self-extend).
+    releaseLock();
 
     // Track previous suppression state to reset anchors when suppression ends.
     let wasSuppressed = suppressRef?.current ?? false;
@@ -245,13 +257,11 @@ export function useScrollDirection(
 
       if (transitionLockedRef.current) {
         if (programmaticLockRef.current && lockTimerRef.current !== null) {
-          clearTimeout(lockTimerRef.current);
-          lockTimerRef.current = setTimeout(() => {
-            transitionLockedRef.current = false;
-            programmaticLockRef.current = false;
-            lockTimerRef.current = null;
+          // Debounce: extend the programmatic lock until scrolling idles,
+          // then re-anchor at the settled position.
+          engageLock(true, () => {
             directionAnchorsRef.current.set(el, el.scrollTop);
-          }, transitionLockMs);
+          });
         }
         return;
       }
@@ -264,14 +274,7 @@ export function useScrollDirection(
       const shouldHide = direction === "down" && scrollTop > 10;
       setHidden((prev) => {
         if (prev === shouldHide) return prev;
-        transitionLockedRef.current = true;
-        if (lockTimerRef.current !== null) {
-          clearTimeout(lockTimerRef.current);
-        }
-        lockTimerRef.current = setTimeout(() => {
-          transitionLockedRef.current = false;
-          lockTimerRef.current = null;
-        }, transitionLockMs);
+        engageLock(false);
         return shouldHide;
       });
     };
@@ -285,9 +288,11 @@ export function useScrollDirection(
       for (const { el, handler } of handlers) {
         el.removeEventListener("scroll", handler);
       }
+      // Covers unmount too — no pending expiry timer outlives the hook.
+      releaseLock();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- suppressRef is a stable ref (read at event time, never during render); listing it trips react-hooks/refs
-  }, [scrollEls, threshold, transitionLockMs, stayHiddenOnUpScroll]);
+  }, [scrollEls, threshold, stayHiddenOnUpScroll, engageLock, releaseLock]);
 
   const resetAnchor = useCallback(
     (debounce?: boolean) => {
@@ -295,18 +300,9 @@ export function useScrollDirection(
       if (primary) {
         directionAnchorsRef.current.set(primary, primary.scrollTop);
       }
-      transitionLockedRef.current = true;
-      programmaticLockRef.current = !!debounce;
-      if (lockTimerRef.current !== null) {
-        clearTimeout(lockTimerRef.current);
-      }
-      lockTimerRef.current = setTimeout(() => {
-        transitionLockedRef.current = false;
-        programmaticLockRef.current = false;
-        lockTimerRef.current = null;
-      }, transitionLockMs);
+      engageLock(!!debounce);
     },
-    [primaryRef, transitionLockMs]
+    [primaryRef, engageLock]
   );
 
   const setHiddenExternal = useCallback(
@@ -315,18 +311,11 @@ export function useScrollDirection(
         if (prev === next) return prev;
         // Match the internal state-change path: engage the transition lock so
         // scroll events from the imminent imperative scroll don't fight us.
-        transitionLockedRef.current = true;
-        if (lockTimerRef.current !== null) {
-          clearTimeout(lockTimerRef.current);
-        }
-        lockTimerRef.current = setTimeout(() => {
-          transitionLockedRef.current = false;
-          lockTimerRef.current = null;
-        }, transitionLockMs);
+        engageLock(false);
         return next;
       });
     },
-    [transitionLockMs]
+    [engageLock]
   );
 
   return { hidden, resetAnchor, setHidden: setHiddenExternal };

--- a/packages/react/src/hooks/useScrollDirection.ts
+++ b/packages/react/src/hooks/useScrollDirection.ts
@@ -9,6 +9,8 @@ import {
 
 import { isReadonlyArray } from "@tsmono/util";
 
+import { useUnmount } from "./useUnmount";
+
 const asArray = <T>(v: T | ReadonlyArray<T>): ReadonlyArray<T> =>
   isReadonlyArray(v) ? v : [v];
 
@@ -101,6 +103,15 @@ export function useScrollDirection(
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [hidden, setHidden] = useState(options?.initialHidden ?? false);
 
+  // A lock timer may be pending at unmount (set by the scroll handlers,
+  // resetAnchor, or setHidden — the latter two can fire even with no
+  // scroller attached).
+  useUnmount(() => {
+    if (lockTimerRef.current !== null) {
+      clearTimeout(lockTimerRef.current);
+    }
+  });
+
   // Normalize input to an array of refs.
   const refArray: ReadonlyArray<RefObject<HTMLElement | null>> = useMemo(
     () => asArray(scrollRef),
@@ -168,6 +179,13 @@ export function useScrollDirection(
     directionAnchorsRef.current = new WeakMap();
     lastDirectionsRef.current = new WeakMap();
     transitionLockedRef.current = false;
+    programmaticLockRef.current = false;
+    // A timer pending from the previous scroller set would otherwise fire
+    // later and release a lock engaged after this re-attach.
+    if (lockTimerRef.current !== null) {
+      clearTimeout(lockTimerRef.current);
+      lockTimerRef.current = null;
+    }
 
     if (scrollEls.length === 0) return;
 

--- a/packages/react/src/hooks/useStatefulScrollPosition.test.tsx
+++ b/packages/react/src/hooks/useStatefulScrollPosition.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ComponentStateProvider } from "../state/ComponentStateContext";
+import { makeReactiveStateStore } from "../test/component-state-hooks";
+
+import { useStatefulScrollPosition } from "./useStatefulScrollPosition";
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+function Harness({
+  el,
+  elementKey,
+}: {
+  el: HTMLDivElement;
+  elementKey: string;
+}) {
+  const ref = useRef<HTMLDivElement | null>(el);
+  useStatefulScrollPosition(ref, elementKey, 1000);
+  return null;
+}
+
+const makeScrollable = () => {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  return el;
+};
+
+describe("useStatefulScrollPosition", () => {
+  it("stores the debounced scroll position under the element key", () => {
+    vi.useFakeTimers();
+    const { hooks, store } = makeReactiveStateStore();
+    const el = makeScrollable();
+    render(
+      <ComponentStateProvider hooks={hooks}>
+        <Harness el={el} elementKey="panel" />
+      </ComponentStateProvider>
+    );
+
+    el.scrollTop = 800;
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(store.get("scrollPosition::panel")).toBe(800);
+  });
+
+  it("stores the position captured at event time when the trailing tick lands after unmount", () => {
+    vi.useFakeTimers();
+    const { hooks, store } = makeReactiveStateStore();
+    const el = makeScrollable();
+    const { unmount } = render(
+      <ComponentStateProvider hooks={hooks}>
+        <Harness el={el} elementKey="panel" />
+      </ComponentStateProvider>
+    );
+
+    el.scrollTop = 800;
+    act(() => {
+      el.dispatchEvent(new Event("scroll"));
+    });
+    unmount();
+    // A detached element's scrollTop reads 0; the pending tick must store
+    // the value captured when the scroll event fired, not re-read it now.
+    el.scrollTop = 0;
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(store.get("scrollPosition::panel")).toBe(800);
+  });
+});

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -26,20 +26,29 @@ export function useStatefulScrollPosition<
     scrollPositionRef.current = scrollPosition;
   }, [scrollPosition]);
 
-  // Create debounced scroll handler
-  const handleScrollInner = useCallback(
-    (e: Event) => {
-      if (!(e.target instanceof Element)) return;
-      const position = e.target.scrollTop;
+  const storePosition = useCallback(
+    (position: number) => {
       log.debug(`Storing scroll position`, elementKey, position);
       setScrollPosition(position);
     },
     [elementKey, setScrollPosition]
   );
 
-  const handleScroll = useMemo(
-    () => debounce(handleScrollInner, delay),
-    [handleScrollInner, delay]
+  const debouncedStore = useMemo(
+    () => debounce(storePosition, delay),
+    [storePosition, delay]
+  );
+
+  // Debounce the position, not the Event: the trailing tick can land after
+  // unmount, when the detached element's scrollTop reads 0 — reading it at
+  // fire time would clobber the saved position with 0.
+  const handleScroll = useCallback(
+    (e: Event) => {
+      if (e.target instanceof Element) {
+        debouncedStore(e.target.scrollTop);
+      }
+    },
+    [debouncedStore]
   );
 
   // Function to manually restore scroll position
@@ -113,9 +122,9 @@ export function useStatefulScrollPosition<
     return () => {
       clearTimeout(pollTimer);
       // A debounce tick pending here is left to fire after unmount —
-      // deliberate: it writes the final scroll position to the app's state
-      // store (safe post-unmount), so a scroll made just before unmounting
-      // is still restorable.
+      // deliberate: it writes the position captured at event time to the
+      // app's state store (safe post-unmount), so a scroll made just before
+      // unmounting is still restorable.
       element.removeEventListener("scroll", handleScroll);
     };
   }, [elementKey, elementRef, handleScroll, scrollable]);

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -111,9 +111,7 @@ export function useStatefulScrollPosition<
     element.addEventListener("scroll", handleScroll);
 
     return () => {
-      if (pollTimer !== undefined) {
-        clearTimeout(pollTimer);
-      }
+      clearTimeout(pollTimer);
       // A debounce tick pending here is left to fire after unmount —
       // deliberate: it writes the final scroll position to the app's state
       // store (safe post-unmount), so a scroll made just before unmounting

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -119,6 +119,10 @@ export function useStatefulScrollPosition<
       if (pollTimer !== undefined) {
         clearTimeout(pollTimer);
       }
+      // A debounce tick pending here is left to fire after unmount —
+      // deliberate: it writes the final scroll position to the app's state
+      // store (safe post-unmount), so a scroll made just before unmounting
+      // is still restorable.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (element.removeEventListener) {
         element.removeEventListener("scroll", handleScroll);

--- a/packages/react/src/hooks/useStatefulScrollPosition.ts
+++ b/packages/react/src/hooks/useStatefulScrollPosition.ts
@@ -108,12 +108,7 @@ export function useStatefulScrollPosition<
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (element.addEventListener) {
-      element.addEventListener("scroll", handleScroll);
-    } else {
-      log.warn("Element has no way to add event listener", element);
-    }
+    element.addEventListener("scroll", handleScroll);
 
     return () => {
       if (pollTimer !== undefined) {
@@ -123,12 +118,7 @@ export function useStatefulScrollPosition<
       // deliberate: it writes the final scroll position to the app's state
       // store (safe post-unmount), so a scroll made just before unmounting
       // is still restorable.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (element.removeEventListener) {
-        element.removeEventListener("scroll", handleScroll);
-      } else {
-        log.warn("Element has no way to remove event listener", element);
-      }
+      element.removeEventListener("scroll", handleScroll);
     };
   }, [elementKey, elementRef, handleScroll, scrollable]);
 

--- a/suppressions.json
+++ b/suppressions.json
@@ -2009,12 +2009,6 @@
       "count": 1
     }
   },
-  "packages/react/src/hooks/useStatefulScrollPosition.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 2,
-      "undescribed": 2
-    }
-  },
   "packages/react/src/hooks/useWhyDidYouUpdate.ts": {
     "@typescript-eslint/no-explicit-any (file-wide)": {
       "count": 1,


### PR DESCRIPTION
## What

A react-doctor `effect-needs-cleanup` pass over the five flagged sites. Each finding was verified against the rule's fix/false-positive recipe; the pass surfaced two real bugs (one user-facing), two cleanups, and three verified false positives.

**Bug fixes**

- **`useStatefulScrollPosition` — scroll position lost on quick tab switches** (user-facing). The debounced save stored the scroll *Event* and read `e.target.scrollTop` when the trailing tick fired, so switching sample tabs within 1s of scrolling let the tick read 0 from the detached/collapsed scroller and clobber the saved position — flipping back landed at the top. The position is now captured at event time (debounce a number, not the Event). Regression test added; it fails against `main`.
- **`useScrollDirection` — transition locks inheriting programmatic debounce semantics.** Both `setHidden` lock-engage paths cancelled a pending `resetAnchor` timer but left `programmaticLockRef` stuck `true`, so a later ordinary transition lock silently self-extended on every scroll event (deterministically triggered by the transcript search-next sequence; a fast flick to top could leave the header chrome stuck collapsed). Lock state now lives in shared `engageLock`/`releaseLock` helpers owning all three lock refs (replacing six inline copies of the clear-timer dance); pending expiry timers are cleared on scroller re-attach and unmount.

**Cleanups**

- **`TimelineChart`**: the ResizeObserver's disposal is now an explicit cleanup returned from the callback ref (React 19) instead of relying on the null invocation; drops the observer-holding ref.
- **`useStatefulScrollPosition`**: removed dead `element.addEventListener` guards (deleting 2 ledger suppressions) and an unnecessary `pollTimer` conditional; documented the deliberate post-unmount debounce flush.

**Verified false positives (no change)**: `useSidebarScrollCoupling`'s wheel listeners and `ScannerResultDetailView`'s callback-ref listener already clean up correctly; the rule's own docs name these as matcher blind spots (loop-based and callback-ref cleanups).

Note for anyone tracking scanner counts: react-doctor still reports all 5 sites — its cleanup matcher cannot see loop/conditional/callback-ref cleanups — so the detector count does not drop. The remaining hits are documented false positives per the rule's validation recipe; nothing is suppressed.

## Verification

- `pnpm check` and `pnpm turbo run test --filter=...@tsmono/react` green, re-run after rebasing onto current `main`.
- Both bug fixes carry regression tests that fail against the pre-fix code (A/B-verified by swapping `main`'s hook in): `useStatefulScrollPosition.test.tsx` proves the post-unmount tick stores the event-time position, and `useScrollDirection.test.tsx` proves a scroll-driven transition lock engaged after `resetAnchor(true)` + `setHidden` expires on schedule instead of self-extending.
- Browser verification against a real `inspect view` server reading real `.eval` logs (Playwright, no mocks):
  - Scroll-restore across a quick tab flip passes on this branch and **fails with `main`'s hook swapped in** (position clobbered to 0 while the scroller sat collapsed on the other tab).
  - Headroom collapse/reveal behavior is unchanged vs `main` (A/B run), including `stayHiddenOnUpScroll`. One pre-existing quirk found on both: an at-top scroll event landing inside the 250ms transition lock misses the reveal and never retries — out of scope here.
  - Timeline chart tracks container resize correctly, including after a tab unmount/remount.

Suppressions ledger: net removal of 2 entries; no new suppressions.

### Agent review

- Reviewer: Claude Fable 5 via `/code-review` (fresh context, same model as author), 1 multi-agent pass: 8 finder angles, 6 adversarial verifications.
- Findings: 5 — 4 fixed (post-unmount debounce clobber, stuck programmatic-lock flag, two misleading comments, redundant dual timer cleanup), 1 deferred with reason (a shared callback-ref resize hook to retire ~10 hand-rolled ResizeObserver sites is follow-up scope, not a defect in this change).
- 3 candidate findings refuted during verification (useUnmount ordering, removed listener guards, setWidth rounding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
