### PR TITLE
ci: compare suppression ledger after merge

### DIFF
--- a/.github/workflows/suppressions-comment.yml
+++ b/.github/workflows/suppressions-comment.yml
@@ -16,16 +16,17 @@
 #      out the base branch: the delta script and the base ledger are the
 #      base repo's own trusted copies. A PR's changes to the script take
 #      effect only after a maintainer merges them.
-#   2. PR content is data, never code. The PR's suppressions.json is read
-#      with `git show` on the fetched head ref — that reads a blob and
-#      executes nothing. The PR head is never checked out.
+#   2. PR content is data, never code. The PR head is fetched but never
+#      checked out. `git merge-tree` computes the post-merge tree without
+#      touching the worktree or index, then `git show` reads only its
+#      suppressions.json blob.
 #   3. No dependency installs. The delta script is node-builtins-only by
 #      design; running `pnpm install` would execute PR-controllable
 #      dependency and lifecycle scripts.
 #
-# Do NOT "fix" this workflow by checking out the PR head, running any
-# script from it, or adding an install step — any of those breaks the
-# security model.
+# Do NOT "fix" this workflow by checking out the PR head or computed merge
+# tree, running any script from it, or adding an install step — any of those
+# breaks the security model.
 name: Suppressions comment
 
 on:
@@ -47,8 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # No `ref`: on pull_request_target this checks out the BASE branch
-      # (trusted script + base ledger). Never add ref: pull_request.head.
+      # (trusted script + base ledger). Full history lets merge-tree find the
+      # PR's merge base without ever checking out PR-controlled content.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -61,20 +65,31 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          # The PR's ledger is fetched and read as DATA: `git show` reads
-          # a blob and executes nothing. The PR head is never checked out.
-          git fetch --depth=1 origin "pull/$PR/head"
-          git show FETCH_HEAD:suppressions.json > /tmp/head-suppressions.json 2>/dev/null \
-            || echo '{}' > /tmp/head-suppressions.json
           # The workspace is the base branch, so its ledger is the base side.
           if [ -f suppressions.json ]; then
             cp suppressions.json /tmp/base-suppressions.json
           else
             echo '{}' > /tmp/base-suppressions.json
           fi
-          # Base script, node builtins only — no installs (see the security
-          # model above).
-          body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json /tmp/head-suppressions.json)
+          # Compute the post-merge ledger as DATA without checking out or
+          # executing anything from the PR. GitHub's synthetic merge ref can be
+          # stale, while comparing the raw head misreports base-only burn-downs.
+          git fetch origin "refs/pull/$PR/head"
+          if merge_tree=$(git merge-tree --write-tree HEAD FETCH_HEAD); then
+            git show "$merge_tree:suppressions.json" > /tmp/merged-suppressions.json 2>/dev/null \
+              || echo '{}' > /tmp/merged-suppressions.json
+            # Base script, node builtins only — no installs (see the security
+            # model above).
+            body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json /tmp/merged-suppressions.json)
+          else
+            merge_status=$?
+            if [ "$merge_status" -ne 1 ]; then
+              exit "$merge_status"
+            fi
+            body=$(printf '%s\n%s' \
+              '<!-- suppressions-delta -->' \
+              'Suppression delta unavailable because this PR does not merge cleanly with the current base. Resolve the merge conflicts and update the PR to rerun this check.')
+          fi
           # Sticky comment: match on the marker, not --edit-last, so other
           # bot comments on the PR are never clobbered.
           cid=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \

--- a/.github/workflows/suppressions-comment.yml
+++ b/.github/workflows/suppressions-comment.yml
@@ -75,20 +75,26 @@ jobs:
           # executing anything from the PR. GitHub's synthetic merge ref can be
           # stale, while comparing the raw head misreports base-only burn-downs.
           git fetch origin "refs/pull/$PR/head"
-          if merge_tree=$(git merge-tree --write-tree HEAD FETCH_HEAD); then
+          if merge_output=$(git merge-tree --write-tree --name-only --no-messages HEAD FETCH_HEAD); then
+            merge_status=0
+          else
+            merge_status=$?
+          fi
+          if [ "$merge_status" -ne 0 ] && [ "$merge_status" -ne 1 ]; then
+            exit "$merge_status"
+          fi
+          merge_tree="${merge_output%%$'\n'*}"
+          conflicted_paths="${merge_output#"$merge_tree"}"
+          if grep -Fqx 'suppressions.json' <<< "$conflicted_paths"; then
+            body=$(printf '%s\n%s' \
+              '<!-- suppressions-delta -->' \
+              'Suppression delta unavailable because suppressions.json does not merge cleanly with the current base. Resolve the conflict and update the PR to rerun this check.')
+          else
             git show "$merge_tree:suppressions.json" > /tmp/merged-suppressions.json 2>/dev/null \
               || echo '{}' > /tmp/merged-suppressions.json
             # Base script, node builtins only — no installs (see the security
             # model above).
             body=$(node scripts/suppressions-pr-delta.mjs /tmp/base-suppressions.json /tmp/merged-suppressions.json)
-          else
-            merge_status=$?
-            if [ "$merge_status" -ne 1 ]; then
-              exit "$merge_status"
-            fi
-            body=$(printf '%s\n%s' \
-              '<!-- suppressions-delta -->' \
-              'Suppression delta unavailable because this PR does not merge cleanly with the current base. Resolve the merge conflicts and update the PR to rerun this check.')
           fi
           # Sticky comment: match on the marker, not --edit-last, so other
           # bot comments on the PR are never clobbered.


### PR DESCRIPTION
I had a PR that only affected markdown files, but [a comment was left](https://github.com/meridianlabs-ai/ts-mono/pull/606#issuecomment-5498194181) about suppression changes. My PR's branch was slightly out of date with `main`, and CI was comparing my branch to the latest `main`.

Instead we'll compare the current branch with the simulated post-merge commit.