### PR TITLE
Regenerate types for the logged_samples EvalResults field

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1614,6 +1614,8 @@ export interface components {
             completed_samples: number;
             early_stopping?: components["schemas"]["EarlyStoppingSummary"] | null;
             headline?: components["schemas"]["HeadlineMetric"] | null;
+            /** Logged Samples */
+            logged_samples?: number | null;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;


### PR DESCRIPTION
Regenerates the shared types for the new optional `logged_samples` field on `EvalResults`.

Paired with UKGovernmentBEIS/inspect_ai#5093 ("inspect ctl: task drain — stop dispatching new samples, let in-flight finish"), which adds the Python field. That PR's `check-schema-and-types` job is red until this merges.

Generated by `python src/inspect_ai/_view/schema.py` from the paired branch (synced with inspect_ai `main`); `pnpm typecheck` and `pnpm test` (1234 tests) pass. The field is optional (Noneable), so the sibling scout app's duplicated types need no sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)