### PR TITLE
chore: regenerate scout types for GenerateConfig.stream_idle_timeout

### DIFF
--- a/apps/scout/src/types/generated.ts
+++ b/apps/scout/src/types/generated.ts
@@ -1655,6 +1655,8 @@ export interface components {
             seed?: number | null;
             /** Stop Seqs */
             stop_seqs?: string[] | null;
+            /** Stream Idle Timeout */
+            stream_idle_timeout?: number | null;
             /** System Message */
             system_message?: string | null;
             /** Temperature */
@@ -1742,6 +1744,8 @@ export interface components {
             seed?: number | null;
             /** Stop Seqs */
             stop_seqs?: string[] | null;
+            /** Stream Idle Timeout */
+            stream_idle_timeout?: number | null;
             /** System Message */
             system_message?: string | null;
             /** Temperature */


### PR DESCRIPTION
Upstream inspect_ai #5096 added `GenerateConfig.stream_idle_timeout`. Scout's `apps/scout/src/types/generated.ts` declares `GenerateConfig-Input` / `GenerateConfig-Output` inline instead of importing them from `@tsmono/inspect-common`, so #604's regeneration of `packages/inspect-common` did not cover it.

This commit is the output of `.venv/bin/python scripts/export_openapi_schema.py`, run from the embedding inspect_scout checkout against inspect_ai installed from main (`0.3.262.dev66+g76f1aa761`). No hand edits.

Without it, inspect_scout's `check-schema-and-types` job stays red on every PR and push to its `main` (first failure: [run 33607936645](https://github.com/meridianlabs-ai/inspect_scout/actions/runs/33607936645)).

Paired PR: meridianlabs-ai/inspect_scout#602 — merge this one first. Its `submodule-on-main` gate then needs the gitlink re-pointed at the squash SHA, since ts-mono has merge commits disabled.

### Checks

Run from the ts-mono root inside the inspect_scout submodule: `pnpm check` 33/33, `pnpm typecheck` 15/15, `pnpm test` 7/9.

`pnpm test` fails `@tsmono/inspect-components`, identically with and without this commit. Its `fixtureTimeline.test.ts` reads fixtures from the embedding parent repo, so inspect_scout's 50 fixtures activate a suite that standalone ts-mono CI skips (no parent repo, empty `FIXTURE_DIRS`). Pre-existing and unrelated, but worth a look separately.

### Agent review

- Prepared by Claude Opus 5 (1M context) via Claude Code.
- No separate reviewer pass. The diff is four lines of generator output in a generated file, so verification went to the generator rather than the text: the drift was reproduced against inspect_ai main before the change, and re-running the generator after committing is a no-op.
