### PR TITLE
test(inspect-components): build fixture ModelEvent without a type cast so the timeline suite runs

### DIFF
--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -18,6 +18,14 @@ import { join } from "path";
 
 import { describe, expect, it } from "vitest";
 
+import {
+  testAssistantMessage,
+  testChatCompletionChoice,
+  testModelEvent,
+  testModelOutput,
+  testModelUsage,
+  testToolCall,
+} from "@tsmono/inspect-common/testing";
 import type {
   ChatCompletionChoice,
   ChatMessage,
@@ -197,40 +205,36 @@ function createEvent(data: JsonEvent): Event | null {
       const usage = data.output?.usage;
       const inputTokens = usage?.input_tokens ?? 0;
       const outputTokens = usage?.output_tokens ?? 0;
-      return {
+      return testModelEvent({
         ...baseFields,
-        event: "model",
         model,
         completed: data.completed ?? null,
         span_id: data.span_id ?? null,
         config: data.config ?? {},
-        tool_choice: "auto",
-        tools: [],
         input: data.input ?? [],
-        output: {
+        output: testModelOutput({
           model,
-          completion: "",
-          choices: (data.output?.choices ?? []).map((c) => ({
-            message: {
-              role: "assistant",
-              content: c.message.content,
-              tool_calls:
-                c.message.tool_calls?.map((tc) => ({
-                  ...tc,
-                  type: "function",
-                })) ?? null,
-            },
-            stop_reason: c.stop_reason ?? "unknown",
-          })),
+          choices: (data.output?.choices ?? []).map((c) =>
+            testChatCompletionChoice({
+              message: testAssistantMessage({
+                content: c.message.content,
+                tool_calls:
+                  c.message.tool_calls?.map((tc) => testToolCall(tc)) ?? null,
+              }),
+              ...(c.stop_reason !== undefined
+                ? { stop_reason: c.stop_reason }
+                : {}),
+            })
+          ),
           usage: usage
-            ? {
+            ? testModelUsage({
                 input_tokens: inputTokens,
                 output_tokens: outputTokens,
                 total_tokens: inputTokens + outputTokens,
-              }
+              })
             : null,
-        },
-      };
+        }),
+      });
     }
 
     case "tool": {

--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -18,7 +18,14 @@ import { join } from "path";
 
 import { describe, expect, it } from "vitest";
 
-import type { CompactionEvent, Event } from "@tsmono/inspect-common/types";
+import type {
+  ChatCompletionChoice,
+  ChatMessage,
+  CompactionEvent,
+  Event,
+  GenerateConfig,
+  ToolCall,
+} from "@tsmono/inspect-common/types";
 
 import {
   asTimelineEvent,
@@ -51,12 +58,7 @@ interface JsonEvent {
   source?: string;
   message_id?: string;
   from_anchor?: string;
-  input?: Array<{
-    role: string;
-    content: string;
-    tool_call_id?: string;
-    function?: string;
-  }>;
+  input?: ChatMessage[];
   output?: {
     usage?: {
       input_tokens?: number;
@@ -64,19 +66,14 @@ interface JsonEvent {
     };
     choices?: Array<{
       message: {
-        role: string;
         content: string;
-        tool_calls?: Array<{
-          id: string;
-          function: string;
-          arguments: Record<string, unknown>;
-        }>;
+        tool_calls?: Pick<ToolCall, "id" | "function" | "arguments">[];
       };
-      stop_reason?: string;
+      stop_reason?: ChatCompletionChoice["stop_reason"];
     }>;
   };
   events?: JsonEvent[];
-  config?: Record<string, unknown>;
+  config?: GenerateConfig;
 }
 
 interface ExpectedAgentSource {
@@ -196,50 +193,44 @@ function createEvent(data: JsonEvent): Event | null {
 
   switch (data.event) {
     case "model": {
-      const inputMsgs = (data.input ?? []).map((msg) => {
-        const mapped: Record<string, unknown> = {
-          role: msg.role,
-          content: msg.content,
-        };
-        if (msg.tool_call_id !== undefined) {
-          mapped.tool_call_id = msg.tool_call_id;
-        }
-        if (msg.function !== undefined) {
-          mapped.function = msg.function;
-        }
-        return mapped;
-      });
-      const modelFields = {
+      const model = data.model ?? "unknown";
+      const usage = data.output?.usage;
+      const inputTokens = usage?.input_tokens ?? 0;
+      const outputTokens = usage?.output_tokens ?? 0;
+      return {
         ...baseFields,
         event: "model",
-        model: data.model ?? "unknown",
+        model,
         completed: data.completed ?? null,
         span_id: data.span_id ?? null,
         config: data.config ?? {},
-        input: inputMsgs,
-        output: data.output
-          ? {
-              choices: data.output.choices
-                ? data.output.choices.map((c) => ({
-                    message: {
-                      role: c.message.role,
-                      content: c.message.content,
-                      tool_calls: c.message.tool_calls ?? null,
-                    },
-                    stop_reason: c.stop_reason ?? "stop",
-                  }))
-                : [],
-              usage: data.output.usage
-                ? {
-                    input_tokens: data.output.usage.input_tokens ?? 0,
-                    output_tokens: data.output.usage.output_tokens ?? 0,
-                  }
-                : null,
-            }
-          : null,
+        tool_choice: "auto",
+        tools: [],
+        input: data.input ?? [],
+        output: {
+          model,
+          completion: "",
+          choices: (data.output?.choices ?? []).map((c) => ({
+            message: {
+              role: "assistant",
+              content: c.message.content,
+              tool_calls:
+                c.message.tool_calls?.map((tc) => ({
+                  ...tc,
+                  type: "function",
+                })) ?? null,
+            },
+            stop_reason: c.stop_reason ?? "unknown",
+          })),
+          usage: usage
+            ? {
+                input_tokens: inputTokens,
+                output_tokens: outputTokens,
+                total_tokens: inputTokens + outputTokens,
+              }
+            : null,
+        },
       };
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- same boundary as loadFixture: the fixture JSON on disk is the shape this suite is written against
-      return modelFields as Event;
     }
 
     case "tool": {

--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -228,7 +228,7 @@ function createEvent(data: JsonEvent): Event | null {
                     },
                     stop_reason: c.stop_reason ?? "stop",
                   }))
-                : undefined,
+                : [],
               usage: data.output.usage
                 ? {
                     input_tokens: data.output.usage.input_tokens ?? 0,

--- a/suppressions.json
+++ b/suppressions.json
@@ -1709,7 +1709,7 @@
   },
   "packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts": {
     "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/inspect-components/src/transcript/timeline/hooks/useTranscriptTimeline.ts": {


### PR DESCRIPTION
`packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts` built a `ModelOutput` with `choices: undefined` when a fixture omitted `choices`, then asserted the literal to `Event`. `ModelOutput.choices` is a required array, so `hasToolCalls` (`core.ts:1359`) read `.length` off `undefined` and threw.

The `as Event` cast is what let that required-field violation type-check. Rather than patch the one field, this PR removes the cast and the accompanying eslint suppression so the compiler enforces the `ModelEvent` contract:

- The fixture's `input`, `stop_reason`, `tool_calls`, and `config` are typed with the shared API types (`ChatMessage`, `ChatCompletionChoice`, `ToolCall`, `GenerateConfig`). The single `loadFixture` cast remains the one place the on-disk contract is asserted. If `generated.ts` drifts, this file fails typecheck instead of silently constructing bad events.
- The model case returns a fully-formed `ModelEvent` literal: `choices` is always an array, `output` is non-null, and the remaining required fields (`tool_choice`, `tools`, `output.model`, `output.completion`, `usage.total_tokens`) are filled with defaults the timeline code never reads. Removing the cast is what surfaced these; `choices` was not the only gap.
- The untyped `Record<string, unknown>` message mapping is gone; fixture messages pass through as `ChatMessage[]`.

Why this repo's CI never saw it: the suite resolves fixtures nine directories up, in the **embedding parent repo**. Standalone ts-mono has no parent, so `FIXTURE_DIRS` is empty and `describe.runIf(FIXTURES_AVAILABLE)` skips the whole thing. The suite only runs when ts-mono is checked out inside inspect_scout or inspect_ai. That CI gap is real but out of scope here.

Measured from inside inspect_scout (50 fixtures at `tests/transcript/nodes/fixtures/events`):

```
before:  Test Files 1 failed | 95 passed    Tests 37 failed | 980 passed
after:   Test Files 1 passed (1)            Tests 52 passed (52)
```

`pnpm typecheck` (15/15), `eslint` and `prettier --check` on the file are clean.

Found while landing meridianlabs-ai/inspect_scout#602.

### Agent review

- Original one-line fix prepared by Claude Opus 5 via Claude Code; cast removal prepared by Claude Fable 5.1 via Claude Code.
- Verified by running the suite before and after on the same checkout, confirming the timeline code does not read any of the newly defaulted fields (`stop_reason`, `total_tokens`, `completion`, `tool_choice`, `tools`), and confirming `ModelOutput.choices` is non-optional in `generated.ts`.
