### PR TITLE
ci: disable automatic Claude review on PR open

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,45 +1,29 @@
 # Copy to .github/workflows/claude-review.yml in any Meridian repo to add the
-# read-only reviewer. Auto-reviews PRs when they open (drafts are skipped
-# until marked ready for review; release-please PRs are skipped too, gated in
-# the reusable workflow) and on demand via an @review comment.
-# Independent of the dev agent (claude.yml) — different trigger, different
-# (lower) permissions.
+# read-only reviewer. Reviews on demand via an @review comment. Independent of
+# the dev agent (claude.yml) — different trigger, different (lower)
+# permissions.
 #
-# Caveat: auto-review-on-open (the pull_request trigger) only fires where this
-# file exists on the PR's BASE branch — GitHub resolves pull_request-family
-# workflows from the PR's branches, not the default branch. On a pristine-base
-# mirror like the inspect_ai fork, PRs target a base that lacks this workflow,
-# so pull_request never fires; only the @review comment path works there, and
-# auto-review is instead driven by the dev agent posting @review on PR open.
+# ts-mono: automatic review-on-open is deliberately disabled here. The
+# upstream template also carries a `pull_request: [opened, reopened,
+# ready_for_review]` trigger (with a matching same-repo/non-draft clause in the
+# job `if:`); it was removed so PRs are only reviewed when someone asks.
+# Re-add that trigger and clause to restore auto-review.
 #
-# Caveat: PRs from forks are skipped by auto-review. GitHub issues no OIDC
-# token and only a read-only GITHUB_TOKEN to pull_request runs from forks, so
-# the job — which requests id-token: write for WIF auth — fails at startup.
-# A maintainer can still review a fork PR with an @review comment, which runs
-# as issue_comment in the base-repo context with full token access.
+# The @review comment path runs as issue_comment in the base-repo context with
+# full token access, so it works on fork PRs and drafts too.
 
 name: Review
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
 jobs:
   review:
-    # Run on PR events (skipping drafts — they get reviewed via
-    # ready_for_review when marked ready — and fork PRs, which get no OIDC
-    # token so the run would die at startup on id-token: write; the full_name
-    # check, not head.repo.fork, keeps same-repo PRs working on repos that are
-    # themselves forks), or on a PR comment containing @review. An explicit
-    # @review still works on a draft and on a fork PR. `@review` does not
-    # collide with the dev agent's `@claude` trigger.
+    # Run on a PR comment containing @review (works on drafts and fork PRs),
+    # or on an External-labeled issue comment containing @review. `@review`
+    # does not collide with the dev agent's `@claude` trigger.
     if: >
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft != true &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       github.actor != 'dependabot[bot]') ||
       (github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@review')) ||
       (github.event.issue.pull_request == null &&


### PR DESCRIPTION
## Summary

- Remove the `pull_request: [opened, reopened, ready_for_review]` trigger from `.github/workflows/claude-review.yml` and its matching clause in the job `if:`.
- The workflow now fires only on `issue_comment`, so a PR is reviewed only when someone comments `@review` (still works on drafts and fork PRs).
- Header comment updated to note that ts-mono deliberately diverges from the `meridianlabs-ai/agents` template here, and how to restore auto-review.

## Side effects

- PRs labeled `auto` will no longer get their review-then-fix round in `claude-auto.yml` without someone posting `@review` first, since that loop keys off the reviewer's summary comment.
- PRs opened by the dev agent (`claude.yml`) still trigger CI but are no longer auto-reviewed.

## Test plan

- [x] YAML parses; `prettier --check` passes
- [ ] After merge, open a PR and confirm no Review run starts
- [ ] Comment `@review` on that PR and confirm the Review workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)