### PR TITLE
test(inspect-components): fail the fixture timeline suite when a parent repo says its corpus is present

### DIFF
--- a/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
+++ b/packages/inspect-components/src/transcript/timeline/fixtureTimeline.test.ts
@@ -8,7 +8,9 @@
  * tests/timeline/fixtures/events/.
  *
  * These tests only run when ts-mono is embedded inside a parent repo that
- * provides fixtures; when used standalone the suite is skipped.
+ * provides fixtures; when used standalone the suite is skipped. A parent repo
+ * that owns a corpus sets TSMONO_REQUIRE_FIXTURES=1 in the job that runs this
+ * suite, which turns "found nothing" from a skip into a failure.
  */
 
 /// <reference types="node" />
@@ -185,6 +187,17 @@ const FIXTURE_NAMES = [
   ),
 ];
 const FIXTURES_AVAILABLE = FIXTURE_NAMES.length > 0;
+
+// Skipping is right for a bare clone and wrong for a parent repo that has a
+// corpus: on its own this file cannot tell the two apart, so a broken path
+// climb or a moved fixtures directory would report green over zero tests. The
+// parent's job supplies the missing half by setting TSMONO_REQUIRE_FIXTURES=1.
+if (!FIXTURES_AVAILABLE && process.env.TSMONO_REQUIRE_FIXTURES === "1") {
+  throw new Error(
+    "TSMONO_REQUIRE_FIXTURES is set but no fixtures were found. Looked in:\n" +
+      FIXTURE_DIR_CANDIDATES.map((dir) => `  ${dir}`).join("\n")
+  );
+}
 
 // =============================================================================
 // Event Deserialization


### PR DESCRIPTION
`fixtureTimeline.test.ts` loads its corpus from the embedding parent repo and
skips itself when it finds nothing. That is right for a bare clone and wrong for
a parent repo that does have a corpus — and this file cannot tell the two apart.
A wrong `../..` count in the nine-level climb, a moved fixtures directory, or a
renamed candidate path all produce the same "no fixtures" result, so a parent's
job would report green over zero tests.

This lets the caller supply the missing half. A parent's `viewer-tests` job sets
`TSMONO_REQUIRE_FIXTURES=1` to assert "the corpus is here"; if the suite then
finds none, it throws and names both directories it looked in. Nothing changes
for a bare clone or for this repo's own CI, which do not set it.

All three states, measured on this branch (rebased onto `1ec898af`):

```
fixtures present, variable set
 Test Files  96 passed (96)
      Tests  975 passed (975)

fixtures absent, variable unset
 Test Files  95 passed | 1 skipped (96)
      Tests  965 passed | 2 skipped (967)

fixtures absent, variable set
Error: TSMONO_REQUIRE_FIXTURES is set but no fixtures were found. Looked in:
  <root>/tests/transcript/nodes/fixtures/events
  <root>/tests/timeline/fixtures/events
 Test Files  1 failed | 95 passed (96)
```

Run in a checkout laid out like inspect_ai (`src/inspect_ai/_view/ts-mono` with
`tests/timeline/fixtures/events` at the root), moving the fixtures aside to get
the absent cases. Also clean: `turbo run lint typecheck`, `format:check`, and
the suppressions check — the change adds no suppression.

## What this is and is not

It is **not** a guard against #610's defect. There the fixtures were present and
readable the whole time; the test helper was wrong, and no fixture-discovery
check could have noticed. What #610 exposed is that the suite had been running
nowhere for 11 days — skipped in this repo's CI, and inspect_scout had no job
running it at all. inspect_scout meridianlabs-ai/inspect_scout#610 adds that
missing job. This PR stops that job from going quiet later without saying so.

Companion one-line changes set the variable in the two parents'
`viewer-tests` jobs: meridianlabs-ai/inspect_scout#610 and
meridianlabs-ai/inspect_ai#403. Order does not matter — until this merges and
each parent's submodule pointer moves, the variable is ignored and both are
no-ops.

### Agent review
- Verified by execution rather than a separate review pass: all three states
  above, before and after rebasing onto the merged #610, plus
  `turbo run lint typecheck`, `format:check` and the suppressions check. The
  companion inspect_scout workflow change had 2 fresh-context review passes
  (1 finding, fixed).
- Prepared by Claude Opus 5 (1M context) via Claude Code.
