### PR TITLE
test: replace hand-built partial fixtures with shared builders

### DIFF
--- a/apps/inspect/src/app/shared/data-grid/findMatches.test.ts
+++ b/apps/inspect/src/app/shared/data-grid/findMatches.test.ts
@@ -17,18 +17,19 @@ const rows: Row[] = [
   { id: "r2", task: "swe-bench" },
 ];
 
-const col = (def: Partial<ExtendedColumnDef<Row>>): ExtendedColumnDef<Row> =>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberately partial: findMatches reads only id/accessorFn, and a full TanStack column def would be noise here
-  def as ExtendedColumnDef<Row>;
-
-const taskCol = col({ id: "task", accessorFn: (row: Row) => row.task });
-const modelCol = col({ id: "model", accessorFn: (row: Row) => row.model });
-const scoreCol = col({
+const taskCol: ExtendedColumnDef<Row> = {
+  id: "task",
+  accessorFn: (row) => row.task,
+};
+const modelCol: ExtendedColumnDef<Row> = {
+  id: "model",
+  accessorFn: (row) => row.model,
+};
+const scoreCol: ExtendedColumnDef<Row> = {
   id: "score",
-  accessorFn: (row: Row) => row.score,
-  textValue: (row: Row) =>
-    row.score === undefined ? null : row.score.toFixed(2),
-});
+  accessorFn: (row) => row.score,
+  textValue: (row) => (row.score === undefined ? null : row.score.toFixed(2)),
+};
 
 const getRowId = (row: Row) => row.id;
 
@@ -69,10 +70,10 @@ describe("buildSearchIndex / findMatches", () => {
   });
 
   it("ignores non-primitive accessor values", () => {
-    const objCol = col({
+    const objCol: ExtendedColumnDef<Row> = {
       id: "log",
-      accessorFn: (row: Row) => (row.id === "r0" ? { handle: 1 } : undefined),
-    });
+      accessorFn: (row) => (row.id === "r0" ? { handle: 1 } : undefined),
+    };
     const index = buildSearchIndex(rows, [objCol], getRowId);
     expect(findMatches(index, "object")).toEqual([]);
   });

--- a/apps/inspect/src/log_data/chunkedAttachments.test.ts
+++ b/apps/inspect/src/log_data/chunkedAttachments.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { ChunkByteStore, SequenceReader, type ChunkedSample } from "./chunked";
+import type { ChatMessage } from "@tsmono/inspect-common/types";
+
+import {
+  ChunkByteStore,
+  SequenceReader,
+  type ChunkedEvent,
+  type ChunkedSample,
+} from "./chunked";
 import { resolvedEventsReader } from "./chunkedAttachments";
+import { sequenceReaderOver, testChunkedSample } from "./testFixtures";
 
 // Wiring test for boundary normalization (#555): fails if the per-entry
 // normalize step is removed from the windowed events transform.
 describe("resolvedEventsReader", () => {
   const encoder = new TextEncoder();
 
+  // The chunk bytes are whatever an older writer put on disk, so the reader
+  // is typed as the contract (`ChunkedEvent`) while the items are not.
   const chunkedWithEvents = (chunkItems: unknown[]): ChunkedSample => {
-    const events = new SequenceReader(
+    const events = new SequenceReader<ChunkedEvent>(
       new ChunkByteStore({
         readFile: () =>
           Promise.resolve(encoder.encode(JSON.stringify(chunkItems))),
@@ -18,8 +28,10 @@ describe("resolvedEventsReader", () => {
       [0],
       chunkItems.length
     );
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberately partial: only `events` is read when the chunk carries no attachment:// refs
-    return { events } as unknown as ChunkedSample;
+    return {
+      ...testChunkedSample(sequenceReaderOver<ChatMessage>([])),
+      events,
+    };
   };
 
   it("normalizes legacy events while preserving chunk item count", async () => {

--- a/apps/inspect/src/log_data/runningSampleQuery.test.ts
+++ b/apps/inspect/src/log_data/runningSampleQuery.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { expectEvent, testEvalSample } from "@tsmono/inspect-common/testing";
+import {
+  expectEvent,
+  testEvalSample,
+  testInfoEvent,
+} from "@tsmono/inspect-common/testing";
 import { EvalSample } from "@tsmono/inspect-common/types";
 
 import { initAppConfig } from "../app_config";
 import { SampleHandle } from "../app/types";
 import {
+  EventData,
   SampleData,
   SampleDataResponse,
   SampleSummary,
@@ -50,13 +55,12 @@ const okResponse = (
   ...extra,
 });
 
-const eventData = (id: number, eventId: string, data: string) => ({
+const eventData = (id: number, eventId: string, data: string): EventData => ({
   id,
   event_id: eventId,
   sample_id: "sample-1",
   epoch: 1,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/consistent-type-assertions -- deliberately partial: the query under test only reads the event's discriminant and data
-  event: { event: "info", data } as never,
+  event: testInfoEvent({ data }),
 });
 
 const makeHandle = (logFile: string): SampleHandle => ({

--- a/apps/inspect/src/log_data/sampleData.test.ts
+++ b/apps/inspect/src/log_data/sampleData.test.ts
@@ -8,7 +8,7 @@ import {
   testInfoEvent,
   testUserMessage,
 } from "@tsmono/inspect-common/testing";
-import { EvalSample } from "@tsmono/inspect-common/types";
+import { ChatMessage, EvalSample } from "@tsmono/inspect-common/types";
 import { data, loading } from "@tsmono/util";
 
 import { SampleHandle } from "../app/types";
@@ -21,7 +21,11 @@ import {
   usePassiveEvalSampleData,
 } from "./sampleData";
 import { sampleQueryKey } from "./sampleQuery";
-import { testSampleSummary } from "./testFixtures";
+import {
+  sequenceReaderOver,
+  testChunkedSample,
+  testSampleSummary,
+} from "./testFixtures";
 
 const handle: SampleHandle = { logFile: "run.eval", id: "s1", epoch: 1 };
 
@@ -147,8 +151,9 @@ describe("deriveSampleData", () => {
 
   test("chunked path: a chunked sample serves its shell and never touches the monolith path", () => {
     const evalSample = sample({ events: [] });
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/consistent-type-assertions -- deliberately minimal: the case asserts the shell is served without the monolith path ever reading the rest
-    const chunkedSample = { shell: {} } as never;
+    const chunkedSample = testChunkedSample(
+      sequenceReaderOver<ChatMessage>([])
+    );
     const result = deriveSampleData(
       inputs({
         chunked: data({ chunked: chunkedSample, evalSample }),

--- a/apps/inspect/src/log_data/sampleStream.test.ts
+++ b/apps/inspect/src/log_data/sampleStream.test.ts
@@ -1,12 +1,13 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return --
-   Mock event fixtures are intentionally minimal `any` stubs, and the
-   assertions reach into their dynamically-shaped fields. (The unsafe-*
-   rules only fire under TSMONO_TYPED_LINT=1, the workspace lint mode.) */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { expectEvent } from "@tsmono/inspect-common/testing";
+import {
+  expectEvent,
+  testInfoEvent,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
 
-import { SampleData, SampleDataResponse } from "../client/api/types";
+import { EventData, SampleData, SampleDataResponse } from "../client/api/types";
 
 import {
   createSampleStreamSession,
@@ -31,16 +32,27 @@ const okResponse = (
   ...extra,
 });
 
-const eventData = (id: number, eventId: string, event: unknown) => ({
+const eventData = (
+  id: number,
+  eventId: string,
+  event: EventData["event"]
+): EventData => ({
   id,
   event_id: eventId,
   sample_id: "sample-1",
   epoch: 1,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberately partial: these cases feed the stream decoder events built inline below
-  event: event as never,
+  event,
 });
 
-const infoEvent = (data: string) => ({ event: "info", data });
+const infoEvent = (data: string) => testInfoEvent({ data });
+
+/**
+ * A skewed (older) live server can stream events of an older schema; the
+ * cases that cover the normalizer's handling of those opt in here.
+ */
+const legacyEvent = (value: unknown): EventData["event"] =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberately out of contract: see above
+  value as EventData["event"];
 
 const attachment = (id: number, hash: string, content: string) => ({
   id,
@@ -175,10 +187,13 @@ describe("createSampleStreamSession", () => {
     const session = makeSession();
     const first = await session.tick(false);
     expect(first.done).toBe(false);
-    expect(first.events.map((e: any) => e.data)).toEqual(["first", "second"]);
+    expect(first.events.map((e) => expectEvent(e, "info").data)).toEqual([
+      "first",
+      "second",
+    ]);
 
     const second = await session.tick(false);
-    expect(second.events.map((e: any) => e.data)).toEqual([
+    expect(second.events.map((e) => expectEvent(e, "info").data)).toEqual([
       "first-updated",
       "second",
       "third",
@@ -193,7 +208,11 @@ describe("createSampleStreamSession", () => {
     mockApi.get_log_sample_data.mockResolvedValueOnce(
       okResponse({
         events: [
-          eventData(1, "e1", { event: "model", timestamp: "t", model: "m" }),
+          eventData(
+            1,
+            "e1",
+            legacyEvent({ event: "model", timestamp: "t", model: "m" })
+          ),
         ],
       })
     );
@@ -241,11 +260,11 @@ describe("createSampleStreamSession", () => {
         ],
         events: [
           eventData(1, "e1", infoEvent("attachment://direct")),
-          eventData(2, "e2", {
-            event: "model",
-            input: [],
-            input_refs: [[0, 1]],
-          }),
+          eventData(
+            2,
+            "e2",
+            testModelEvent({ input: [], input_refs: [[0, 1]] })
+          ),
         ],
       })
     );
@@ -268,14 +287,17 @@ describe("createSampleStreamSession", () => {
         okResponse({
           events: [
             eventData(1, "e1", infoEvent("attachment://missing")),
-            eventData(2, "e2", {
-              event: "info",
-              data: {
-                a: "attachment://missing",
-                b: "attachment://missing",
-                c: "attachment://also-missing",
-              },
-            }),
+            eventData(
+              2,
+              "e2",
+              testInfoEvent({
+                data: {
+                  a: "attachment://missing",
+                  b: "attachment://missing",
+                  c: "attachment://also-missing",
+                },
+              })
+            ),
           ],
         })
       )
@@ -309,11 +331,11 @@ describe("createSampleStreamSession", () => {
           ),
         ],
         events: [
-          eventData(1, "e1", {
-            event: "model",
-            input: [],
-            input_refs: [[0, 1]],
-          }),
+          eventData(
+            1,
+            "e1",
+            testModelEvent({ input: [], input_refs: [[0, 1]] })
+          ),
         ],
       })
     );
@@ -358,22 +380,22 @@ describe("createSampleStreamSession", () => {
           callPoolEntry(3, assistant),
         ],
         events: [
-          eventData(1, "model-event-1", {
-            event: "model",
-            input: [],
-            input_refs: [[0, 3]],
-            model: "test",
-            tools: [],
-            tool_choice: "auto",
-            config: {},
-            output: { model: "test", choices: [] },
-            call: {
-              request: { model: "test" },
-              response: null,
-              call_refs: [[0, 3]],
-              call_key: "messages",
-            },
-          }),
+          eventData(
+            1,
+            "model-event-1",
+            testModelEvent({
+              input: [],
+              input_refs: [[0, 3]],
+              model: "test",
+              output: testModelOutput({ model: "test" }),
+              call: {
+                request: { model: "test" },
+                response: null,
+                call_refs: [[0, 3]],
+                call_key: "messages",
+              },
+            })
+          ),
         ],
       })
     );
@@ -414,14 +436,17 @@ describe("createSampleStreamSession", () => {
     // One segment per tick: the partial backlog paints instead of waiting
     // for the full drain; the signals tell the caller to re-tick immediately.
     expect(mockApi.get_log_sample_data).toHaveBeenCalledTimes(1);
-    expect(first.events.map((e: any) => e.data)).toEqual(["a"]);
+    expect(first.events.map((e) => expectEvent(e, "info").data)).toEqual(["a"]);
     expect(first.hasMore).toBe(true);
     expect(first.advanced).toBe(true);
     expect(first.done).toBe(false);
 
     const second = await session.tick(false);
     expect(cursorArgs(1)?.[0]).toBe(1);
-    expect(second.events.map((e: any) => e.data)).toEqual(["a", "b"]);
+    expect(second.events.map((e) => expectEvent(e, "info").data)).toEqual([
+      "a",
+      "b",
+    ]);
     expect(second.hasMore).toBe(false);
     expect(second.done).toBe(false);
   });
@@ -521,7 +546,9 @@ describe("createSampleStreamSession", () => {
     const after = await session.tick(false);
 
     expect(cursorArgs(1)).toEqual([-1, -1, -1, -1]);
-    expect(after.events.map((e: any) => e.data)).toEqual(["fresh"]);
+    expect(after.events.map((e) => expectEvent(e, "info").data)).toEqual([
+      "fresh",
+    ]);
     expect(after.events).not.toBe(before.events);
   });
 

--- a/packages/inspect-common/src/testing/index.ts
+++ b/packages/inspect-common/src/testing/index.ts
@@ -29,6 +29,7 @@ import type {
   Event,
   InfoEvent,
   InputEvent,
+  InterruptEvent,
   LoggerEvent,
   ModelConfig,
   ModelEvent,
@@ -38,6 +39,8 @@ import type {
   SampleLimitEvent,
   SandboxEvent,
   Score,
+  ScoreEdit,
+  ScoreEditEvent,
   ScoreEvent,
   SpanBeginEvent,
   SpanEndEvent,
@@ -248,6 +251,36 @@ export const testScoreEvent = (
   working_start: 0,
   intermediate: false,
   score: testScore(),
+  ...overrides,
+});
+
+export const testScoreEdit = (
+  overrides: Partial<ScoreEdit> = {}
+): ScoreEdit => ({
+  value: 1,
+  metadata: {},
+  ...overrides,
+});
+
+export const testScoreEditEvent = (
+  overrides: Partial<ScoreEditEvent> = {}
+): ScoreEditEvent => ({
+  event: "score_edit",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  score_name: "scorer",
+  edit: testScoreEdit(),
+  ...overrides,
+});
+
+export const testInterruptEvent = (
+  overrides: Partial<InterruptEvent> = {}
+): InterruptEvent => ({
+  event: "interrupt",
+  timestamp: TEST_TIMESTAMP,
+  working_start: 0,
+  source: "user_cancel",
+  interrupted: "between_turns",
   ...overrides,
 });
 

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, it, test } from "vitest";
 
 import {
+  testApprovalEvent,
   testAssistantMessage,
   testChatCompletionChoice,
+  testCompactionEvent,
+  testErrorEvent,
+  testEvalError,
+  testInfoEvent,
+  testInputEvent,
+  testInterruptEvent,
+  testLoggerEvent,
   testModelEvent,
   testModelOutput,
+  testSampleInitEvent,
+  testSampleLimitEvent,
+  testSandboxEvent,
+  testScore,
+  testScoreEdit,
+  testScoreEditEvent,
+  testScoreEvent,
+  testSpanBeginEvent,
+  testSpanEndEvent,
   testStateEvent,
+  testStepEvent,
+  testStoreEvent,
+  testSubtaskEvent,
+  testToolCall,
   testToolEvent,
 } from "@tsmono/inspect-common/testing";
 import type {
@@ -13,6 +34,7 @@ import type {
   ContentImage,
   ContentReasoning,
   ContentToolUse,
+  Event,
   JsonValue,
   ModelEvent,
   StateEvent,
@@ -165,14 +187,26 @@ describe("eventsToStr — multimodal content placeholders", () => {
 
   it("emits placeholders for audio/video/data/document", () => {
     const out = eventsToStr([
-      /* eslint-disable @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/consistent-type-assertions -- deliberately partial: these cover the placeholder path for content parts whose payload eventsToStr must never inline */
       modelEventWith([
-        { type: "audio", audio: "data:audio/mp3;base64,_AUDIO_BLOB_" } as never,
-        { type: "video", video: "data:video/mp4;base64,_VIDEO_BLOB_" } as never,
-        { type: "data", data: { huge: "_DATA_BLOB_" } } as never,
-        { type: "document", document: "_DOC_BLOB_" } as never,
+        {
+          type: "audio",
+          audio: "data:audio/mp3;base64,_AUDIO_BLOB_",
+          format: "mp3",
+        },
+        {
+          type: "video",
+          video: "data:video/mp4;base64,_VIDEO_BLOB_",
+          format: "mp4",
+        },
+        { type: "data", data: { huge: "_DATA_BLOB_" } },
+        {
+          type: "document",
+          document: "_DOC_BLOB_",
+          filename: "doc.pdf",
+          mime_type: "application/pdf",
+          citations: false,
+        },
       ]),
-      /* eslint-enable @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/consistent-type-assertions */
     ]);
     expect(out).toContain("<audio />");
     expect(out).toContain("<video />");
@@ -336,21 +370,38 @@ describe("eventsToStr — compaction event", () => {
   });
 });
 
-const makeNode = (event: Record<string, unknown>): EventNode => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the search-text cases below feed deliberately partial events; eventSearchText reads defensively
-  return new EventNode("test-id", event as never, 0);
-};
+const makeNode = (event: Event): EventNode =>
+  new EventNode("test-id", event, 0);
+
+/**
+ * `extractToolResultText` takes `unknown` and must survive result shapes
+ * the schema forbids (nested `tool` blocks, `data` parts, bare objects);
+ * the cases that exercise that path opt in here, one at a time.
+ */
+const outOfContractResult = (value: unknown): ToolEvent["result"] =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- deliberately out of contract: see above
+  value as ToolEvent["result"];
+
+const toolView = (title: string): ToolEvent["view"] => ({
+  title,
+  content: "",
+  format: "text",
+});
 
 describe("eventSearchText", () => {
   test("score: includes answer, explanation, and value", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "score",
-        score: { answer: "yes", explanation: "partial", value: 0.5 },
-        target: "correct answer",
-        intermediate: true,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testScoreEvent({
+          score: testScore({
+            answer: "yes",
+            explanation: "partial",
+            value: 0.5,
+          }),
+          target: "correct answer",
+          intermediate: true,
+        })
+      )
     );
     expect(texts).toContain("yes");
     expect(texts).toContain("partial");
@@ -360,13 +411,13 @@ describe("eventSearchText", () => {
 
   test("score: includes array target", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "score",
-        score: { answer: null, explanation: null, value: 1 },
-        target: ["a", "b"],
-        intermediate: false,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testScoreEvent({
+          score: testScore({ answer: null, explanation: null, value: 1 }),
+          target: ["a", "b"],
+          intermediate: false,
+        })
+      )
     );
     expect(texts).toContain("a");
     expect(texts).toContain("b");
@@ -374,16 +425,16 @@ describe("eventSearchText", () => {
 
   test("score_edit: includes score_name and edit fields", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "score_edit",
-        score_name: "accuracy",
-        edit: {
-          answer: "new answer",
-          explanation: "fixed reasoning",
-          provenance: null,
-        },
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testScoreEditEvent({
+          score_name: "accuracy",
+          edit: testScoreEdit({
+            answer: "new answer",
+            explanation: "fixed reasoning",
+            provenance: null,
+          }),
+        })
+      )
     );
     expect(texts).toContain("accuracy");
     expect(texts).toContain("new answer");
@@ -392,16 +443,16 @@ describe("eventSearchText", () => {
 
   test("score_edit: excludes UNCHANGED fields", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "score_edit",
-        score_name: "accuracy",
-        edit: {
-          answer: "UNCHANGED",
-          explanation: "UNCHANGED",
-          provenance: null,
-        },
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testScoreEditEvent({
+          score_name: "accuracy",
+          edit: testScoreEdit({
+            answer: "UNCHANGED",
+            explanation: "UNCHANGED",
+            provenance: null,
+          }),
+        })
+      )
     );
     expect(texts).toContain("accuracy");
     expect(texts).not.toContain("UNCHANGED");
@@ -409,16 +460,16 @@ describe("eventSearchText", () => {
 
   test("sample_init: includes target and metadata", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "sample_init",
-        sample: {
-          target: "expected output",
-          metadata: { category: "math" },
-          input: "question",
-        },
-        state: {},
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSampleInitEvent({
+          sample: {
+            target: "expected output",
+            metadata: { category: "math" },
+            input: "question",
+          },
+          state: {},
+        })
+      )
     );
     expect(texts).toContain("expected output");
     expect(texts.some((t) => t.includes("math"))).toBe(true);
@@ -426,12 +477,9 @@ describe("eventSearchText", () => {
 
   test("sample_limit: includes message and type", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "sample_limit",
-        message: "Token limit exceeded",
-        type: "token",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSampleLimitEvent({ message: "Token limit exceeded", type: "token" })
+      )
     );
     expect(texts).toContain("Token limit exceeded");
     expect(texts).toContain("token");
@@ -439,26 +487,26 @@ describe("eventSearchText", () => {
 
   test("input: includes input text", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "input",
-        input: "user typed this",
-        input_ansi: "user typed this",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testInputEvent({
+          input: "user typed this",
+          input_ansi: "user typed this",
+        })
+      )
     );
     expect(texts).toContain("user typed this");
   });
 
   test("interrupt: includes source and interrupted, plus optional ids", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "interrupt",
-        source: "user_cancel",
-        interrupted: "tool_call",
-        interrupted_tool_call_id: "tc-xyz",
-        interrupted_model_event_id: "me-abc",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testInterruptEvent({
+          source: "user_cancel",
+          interrupted: "tool_call",
+          interrupted_tool_call_id: "tc-xyz",
+          interrupted_model_event_id: "me-abc",
+        })
+      )
     );
     expect(texts).toContain("user_cancel");
     expect(texts).toContain("tool_call");
@@ -468,12 +516,9 @@ describe("eventSearchText", () => {
 
   test("interrupt: required fields only", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "interrupt",
-        source: "limit",
-        interrupted: "between_turns",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testInterruptEvent({ source: "limit", interrupted: "between_turns" })
+      )
     );
     expect(texts).toContain("limit");
     expect(texts).toContain("between_turns");
@@ -482,15 +527,15 @@ describe("eventSearchText", () => {
 
   test("approval: includes decision, explanation, and approver", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "approval",
-        decision: "approve",
-        explanation: "looks safe",
-        approver: "human-in-loop",
-        message: "Allow file write?",
-        call: {},
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testApprovalEvent({
+          decision: "approve",
+          explanation: "looks safe",
+          approver: "human-in-loop",
+          message: "Allow file write?",
+          call: testToolCall(),
+        })
+      )
     );
     expect(texts).toContain("approve");
     expect(texts).toContain("looks safe");
@@ -499,14 +544,14 @@ describe("eventSearchText", () => {
 
   test("sandbox: includes action, cmd, output, and file", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "sandbox",
-        action: "exec",
-        cmd: "ls -la",
-        output: "total 42",
-        file: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSandboxEvent({
+          action: "exec",
+          cmd: "ls -la",
+          output: "total 42",
+          file: null,
+        })
+      )
     );
     expect(texts).toContain("exec");
     expect(texts).toContain("ls -la");
@@ -515,14 +560,14 @@ describe("eventSearchText", () => {
 
   test("sandbox: includes file for read/write actions", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "sandbox",
-        action: "read_file",
-        cmd: null,
-        output: "file contents",
-        file: "/tmp/test.txt",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSandboxEvent({
+          action: "read_file",
+          cmd: null,
+          output: "file contents",
+          file: "/tmp/test.txt",
+        })
+      )
     );
     expect(texts).toContain("read_file");
     expect(texts).toContain("/tmp/test.txt");
@@ -530,14 +575,19 @@ describe("eventSearchText", () => {
 
   test("state: includes change paths and values", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "state",
-        changes: [
-          { op: "replace", path: "/messages/0/content", value: "hello" },
-          { op: "add", path: "/count", value: 42 },
-        ],
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testStateEvent({
+          changes: [
+            {
+              op: "replace",
+              path: "/messages/0/content",
+              value: "hello",
+              replaced: null,
+            },
+            { op: "add", path: "/count", value: 42, replaced: null },
+          ],
+        })
+      )
     );
     expect(texts).toContain("/messages/0/content");
     expect(texts).toContain("hello");
@@ -547,11 +597,11 @@ describe("eventSearchText", () => {
 
   test("store: includes change paths and values", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "store",
-        changes: [{ op: "add", path: "/key", value: "val" }],
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testStoreEvent({
+          changes: [{ op: "add", path: "/key", value: "val", replaced: null }],
+        })
+      )
     );
     expect(texts).toContain("/key");
     expect(texts).toContain("val");
@@ -559,30 +609,26 @@ describe("eventSearchText", () => {
 
   test("model: includes model name", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "model",
-        model: "gpt-4",
-        role: "assistant",
-        output: { choices: [] },
-        input: [],
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testModelEvent({ model: "gpt-4", role: "assistant" }))
     );
     expect(texts).toContain("gpt-4");
   });
 
   test("model: extracts text from output choices", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "model",
-        model: "gpt-4",
-        role: null,
-        output: {
-          choices: [{ message: { content: "hello world", role: "assistant" } }],
-        },
-        input: [],
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testModelEvent({
+          model: "gpt-4",
+          role: null,
+          output: testModelOutput({
+            choices: [
+              testChatCompletionChoice({
+                message: testAssistantMessage({ content: "hello world" }),
+              }),
+            ],
+          }),
+        })
+      )
     );
     expect(texts).toContain("gpt-4");
     expect(texts).toContain("hello world");
@@ -590,12 +636,7 @@ describe("eventSearchText", () => {
 
   test("step: includes name and type as separate values", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "step",
-        name: "generate",
-        type: "solver",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testStepEvent({ name: "generate", type: "solver" }))
     );
     expect(texts).toContain("generate");
     expect(texts).toContain("solver");
@@ -603,39 +644,24 @@ describe("eventSearchText", () => {
 
   test("step: includes name when no type", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "step",
-        name: "my_step",
-        type: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testStepEvent({ name: "my_step", type: null }))
     );
     expect(texts).toContain("my_step");
   });
 
   test("subtask: includes name and type", () => {
     const fork = eventSearchText(
-      makeNode({
-        event: "subtask",
-        name: "parallel",
-        type: "fork",
-        input: null,
-        result: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSubtaskEvent({ name: "parallel", type: "fork", result: null })
+      )
     );
     expect(fork).toContain("parallel");
     expect(fork).toContain("fork");
 
     const sub = eventSearchText(
-      makeNode({
-        event: "subtask",
-        name: "check",
-        type: "subtask",
-        input: null,
-        result: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testSubtaskEvent({ name: "check", type: "subtask", result: null })
+      )
     );
     expect(sub).toContain("check");
     expect(sub).toContain("subtask");
@@ -643,39 +669,37 @@ describe("eventSearchText", () => {
 
   test("tool: includes view title and function name", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "tool",
-        function: "search",
-        view: { title: "Web Search" },
-        arguments: null,
-        result: null,
-        error: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testToolEvent({
+          function: "search",
+          view: toolView("Web Search"),
+          error: null,
+        })
+      )
     );
     expect(texts).toContain("Web Search");
     expect(texts).toContain("search");
   });
 
   test("tool: array result yields one ordered search segment per rendered block", () => {
-    const node = makeNode({
-      event: "tool",
-      function: "browser",
-      view: { title: "Browser" },
-      arguments: { action: "get_page_text" },
-      result: [
-        { type: "text", text: "Revenue Recognition in policy docs" },
-        {
-          type: "tool",
-          content: [
-            { type: "text", text: "Revenue Recognition in extracted page" },
-          ],
-        },
-        { type: "image", image: "data:image/png;base64,abc123" },
-      ],
-      error: null,
-      timestamp: "2024-01-01T00:00:00Z",
-    });
+    const node = makeNode(
+      testToolEvent({
+        function: "browser",
+        view: toolView("Browser"),
+        arguments: { action: "get_page_text" },
+        result: outOfContractResult([
+          { type: "text", text: "Revenue Recognition in policy docs" },
+          {
+            type: "tool",
+            content: [
+              { type: "text", text: "Revenue Recognition in extracted page" },
+            ],
+          },
+          { type: "image", image: "data:image/png;base64,abc123" },
+        ]),
+        error: null,
+      })
+    );
 
     const resultSegments = extractEventFields(node.event)
       .filter(([key]) => key === "result")
@@ -691,23 +715,31 @@ describe("eventSearchText", () => {
   });
 
   test("tool: array document renders its filename; audio/video render no text", () => {
-    const node = makeNode({
-      event: "tool",
-      function: "fetch",
-      arguments: null,
-      result: [
-        {
-          type: "document",
-          filename: "report.pdf",
-          document: "data:application/pdf;base64,_DOC_BLOB_",
-          mime_type: "application/pdf",
-        },
-        { type: "audio", audio: "data:audio/mp3;base64,_AUDIO_BLOB_" },
-        { type: "video", video: "data:video/mp4;base64,_VIDEO_BLOB_" },
-      ],
-      error: null,
-      timestamp: "2024-01-01T00:00:00Z",
-    });
+    const node = makeNode(
+      testToolEvent({
+        function: "fetch",
+        result: [
+          {
+            type: "document",
+            filename: "report.pdf",
+            document: "data:application/pdf;base64,_DOC_BLOB_",
+            mime_type: "application/pdf",
+            citations: false,
+          },
+          {
+            type: "audio",
+            audio: "data:audio/mp3;base64,_AUDIO_BLOB_",
+            format: "mp3",
+          },
+          {
+            type: "video",
+            video: "data:video/mp4;base64,_VIDEO_BLOB_",
+            format: "mp4",
+          },
+        ],
+        error: null,
+      })
+    );
     const resultSegments = extractEventFields(node.event)
       .filter(([key]) => key === "result")
       .map(([, value]) => value);
@@ -719,34 +751,37 @@ describe("eventSearchText", () => {
   });
 
   test("tool: excluded hard cases stay safe (no payload leak), not renderer-exact", () => {
-    const imageNode = makeNode({
-      event: "tool",
-      function: "view_image",
-      arguments: null,
-      result: { type: "image", image: "data:image/png;base64,_HUGE_BLOB_" },
-      error: null,
-      timestamp: "2024-01-01T00:00:00Z",
-    });
+    const imageNode = makeNode(
+      testToolEvent({
+        function: "view_image",
+        result: {
+          type: "image",
+          image: "data:image/png;base64,_HUGE_BLOB_",
+          detail: "auto",
+        },
+        error: null,
+      })
+    );
     expect(eventSearchText(imageNode).join("\n")).not.toContain("_HUGE_BLOB_");
 
-    const dataNode = makeNode({
-      event: "tool",
-      function: "fetch",
-      arguments: null,
-      result: [{ type: "data", data: { secret: "_DATA_VALUE_" } }],
-      error: null,
-      timestamp: "2024-01-01T00:00:00Z",
-    });
+    const dataNode = makeNode(
+      testToolEvent({
+        function: "fetch",
+        result: outOfContractResult([
+          { type: "data", data: { secret: "_DATA_VALUE_" } },
+        ]),
+        error: null,
+      })
+    );
     expect(eventSearchText(dataNode).join("\n")).not.toContain("_DATA_VALUE_");
 
-    const objectNode = makeNode({
-      event: "tool",
-      function: "calc",
-      arguments: null,
-      result: { answer: 42, label: "ok" },
-      error: null,
-      timestamp: "2024-01-01T00:00:00Z",
-    });
+    const objectNode = makeNode(
+      testToolEvent({
+        function: "calc",
+        result: outOfContractResult({ answer: 42, label: "ok" }),
+        error: null,
+      })
+    );
     const objectSegments = extractEventFields(objectNode.event)
       .filter(([key]) => key === "result")
       .map(([, value]) => value);
@@ -755,26 +790,27 @@ describe("eventSearchText", () => {
 
   test("error: includes error message", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "error",
-        error: { message: "something broke", traceback: null },
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testErrorEvent({ error: testEvalError({ message: "something broke" }) })
+      )
     );
     expect(texts).toContain("something broke");
   });
 
   test("logger: includes message and filename", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "logger",
-        message: {
-          level: "WARNING",
-          message: "disk space low",
-          filename: "main.py",
-        },
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testLoggerEvent({
+          message: {
+            level: "warning",
+            message: "disk space low",
+            filename: "main.py",
+            created: 0,
+            module: "main",
+            lineno: 1,
+          },
+        })
+      )
     );
     expect(texts).toContain("disk space low");
     expect(texts).toContain("main.py");
@@ -782,12 +818,7 @@ describe("eventSearchText", () => {
 
   test("info: includes source and data", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "info",
-        source: "system",
-        data: "startup complete",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testInfoEvent({ source: "system", data: "startup complete" }))
     );
     expect(texts).toContain("system");
     expect(texts).toContain("startup complete");
@@ -795,24 +826,14 @@ describe("eventSearchText", () => {
 
   test("info: includes data without source", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "info",
-        source: null,
-        data: "startup complete",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testInfoEvent({ source: null, data: "startup complete" }))
     );
     expect(texts).toContain("startup complete");
   });
 
   test("span_begin: includes name and type as separate values", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "span_begin",
-        name: "evaluate",
-        type: "solver",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testSpanBeginEvent({ name: "evaluate", type: "solver" }))
     );
     expect(texts).toContain("evaluate");
     expect(texts).toContain("solver");
@@ -820,25 +841,20 @@ describe("eventSearchText", () => {
 
   test("span_begin: includes name when no type", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "span_begin",
-        name: "init",
-        type: null,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(testSpanBeginEvent({ name: "init", type: null }))
     );
     expect(texts).toContain("init");
   });
 
   test("compaction: emits tokens and omits default 'inspect' source", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "compaction",
-        source: "inspect",
-        tokens_before: 1000,
-        tokens_after: 500,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testCompactionEvent({
+          source: "inspect",
+          tokens_before: 1000,
+          tokens_after: 500,
+        })
+      )
     );
     expect(texts).toContain("1000");
     expect(texts).toContain("500");
@@ -847,24 +863,19 @@ describe("eventSearchText", () => {
 
   test("compaction: includes non-default source", () => {
     const texts = eventSearchText(
-      makeNode({
-        event: "compaction",
-        source: "agent",
-        tokens_before: 1000,
-        tokens_after: 500,
-        timestamp: "2024-01-01T00:00:00Z",
-      })
+      makeNode(
+        testCompactionEvent({
+          source: "agent",
+          tokens_before: 1000,
+          tokens_after: 500,
+        })
+      )
     );
     expect(texts).toContain("agent");
   });
 
   test("unknown event: returns empty array", () => {
-    const texts = eventSearchText(
-      makeNode({
-        event: "span_end",
-        timestamp: "2024-01-01T00:00:00Z",
-      })
-    );
+    const texts = eventSearchText(makeNode(testSpanEndEvent()));
     expect(texts).toEqual([]);
   });
 });

--- a/packages/inspect-components/src/transcript/eventText.test.ts
+++ b/packages/inspect-components/src/transcript/eventText.test.ts
@@ -324,23 +324,21 @@ describe("eventsToStr — extractEventFields sanitization", () => {
 
 const compactionEvent = (
   partial: Partial<CompactionEvent> = {}
-): CompactionEvent => ({
-  event: "compaction",
-  uuid: "VYVv8bWPCmD5fJYzrYq5MT",
-  span_id: "SPJ9XpwBYA3GuLzkGwmdwR",
-  timestamp: "2026-04-25T03:12:30.042596+00:00",
-  working_start: 4195.599,
-  source: "inspect",
-  type: "summary",
-  tokens_before: 263089,
-  tokens_after: 1923,
-  metadata: {
-    strategy: "CompactionSummary",
-    messages_before: 190,
-    messages_after: 3,
-  },
-  ...partial,
-});
+): CompactionEvent =>
+  testCompactionEvent({
+    uuid: "VYVv8bWPCmD5fJYzrYq5MT",
+    span_id: "SPJ9XpwBYA3GuLzkGwmdwR",
+    working_start: 4195.599,
+    source: "inspect",
+    tokens_before: 263089,
+    tokens_after: 1923,
+    metadata: {
+      strategy: "CompactionSummary",
+      messages_before: 190,
+      messages_after: 3,
+    },
+    ...partial,
+  });
 
 describe("eventsToStr — compaction event", () => {
   it("renders only UI-visible fields (tokens + metadata), not full event JSON", () => {

--- a/suppressions.json
+++ b/suppressions.json
@@ -382,11 +382,6 @@
       "count": 3
     }
   },
-  "apps/inspect/src/app/shared/data-grid/findMatches.test.ts": {
-    "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 1
-    }
-  },
   "apps/inspect/src/app/shared/data-grid/findMatches.ts": {
     "@typescript-eslint/no-unnecessary-condition": {
       "count": 1,
@@ -549,11 +544,6 @@
       "count": 1
     }
   },
-  "apps/inspect/src/log_data/chunkedAttachments.test.ts": {
-    "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 1
-    }
-  },
   "apps/inspect/src/log_data/databaseListings.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 1,
@@ -592,22 +582,6 @@
       "count": 1
     }
   },
-  "apps/inspect/src/log_data/runningSampleQuery.test.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 1
-    }
-  },
-  "apps/inspect/src/log_data/sampleData.test.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 1
-    }
-  },
   "apps/inspect/src/log_data/sampleData.ts": {
     "@typescript-eslint/no-unnecessary-condition": {
       "count": 1,
@@ -637,18 +611,6 @@
     }
   },
   "apps/inspect/src/log_data/sampleStream.test.ts": {
-    "@typescript-eslint/no-explicit-any (file-wide)": {
-      "count": 1,
-      "undescribed": 1
-    },
-    "@typescript-eslint/no-unsafe-member-access (file-wide)": {
-      "count": 1,
-      "undescribed": 1
-    },
-    "@typescript-eslint/no-unsafe-return (file-wide)": {
-      "count": 1,
-      "undescribed": 1
-    },
     "@typescript-eslint/no-unsafe-type-assertion": {
       "count": 1
     }
@@ -1557,13 +1519,7 @@
     }
   },
   "packages/inspect-components/src/transcript/eventText.test.ts": {
-    "@typescript-eslint/consistent-type-assertions (file-wide)": {
-      "count": 1
-    },
     "@typescript-eslint/no-unsafe-type-assertion": {
-      "count": 1
-    },
-    "@typescript-eslint/no-unsafe-type-assertion (file-wide)": {
       "count": 1
     }
   },


### PR DESCRIPTION
Follow-up to #610. That PR removed an `as Event` cast on a hand-built fixture that had hidden a required-field bug. This audits the remaining `no-unsafe-type-assertion` suppressions in ts-mono test files and removes the ones that follow the same pattern: partial domain data written by hand and cast to the full type, where a shared builder (or a plain annotation) already produces a schema-valid value.

Casts that are the *point* of a test (feeding deliberately invalid input to a runtime guard) and casts at a genuine boundary (fixture JSON off disk, library type quirks) are left alone.

### Changes, one commit each

- **inspect-common/testing:** add `testScoreEdit`, `testScoreEditEvent`, `testInterruptEvent`, the last two `Event` discriminants without a builder.
- **inspect-components `eventText.test.ts`:** `makeNode` took `Record<string, unknown>` and cast to `Event`; ~35 partial events behind the `eventSearchText` cases never had to satisfy the schema. Each now goes through its builder and `makeNode` is typed `(event: Event)`. The audio/video/data/document placeholder case fills in the fields its content parts were missing. Three tool-result cases deliberately feed shapes `ToolEvent.result` forbids (nested `tool` blocks, `data` parts, bare objects) because `extractToolResultText` takes `unknown`; they opt in through one labelled `outOfContractResult` helper.
- **inspect `runningSampleQuery.test.ts` / `sampleStream.test.ts`:** info and model events go through `testInfoEvent` / `testModelEvent`, the `eventData` helpers are typed `EventData`, and the `(e: any) => e.data` assertion lambdas become `expectEvent(e, "info").data`, which retires the file-level lint header. The one case that streams an older-schema model event to exercise the normalizer keeps a labelled `legacyEvent` cast.
- **inspect `findMatches.test.ts`:** the column defs satisfy `ExtendedColumnDef<Row>` as written, so a plain annotation replaces the `Partial` + cast helper. No production change.
- **inspect `chunkedAttachments.test.ts` / `sampleData.test.ts`:** use the existing `testChunkedSample` fixture instead of casting a one-field object to `ChunkedSample`. The attachments test still feeds older-writer bytes through the reader; that boundary is now the reader's type parameter rather than a cast on the whole sample.
- **suppressions ledger** regenerated (deletions only).

### Deliberately left as-is

- `logSlice.test.ts` / `logsSlice.test.ts` (`{} as StoreState`): a zustand harness where the slice under test writes before it reads. Same bet in miniature, but low risk and a different shape of fix.
- Mock/spy seams (`SamplesGrid.state`, `resolveBackend`, `databaseListing`, `logsListingRead`): fixable by typing the `vi.fn` or passing the generic, but not the hand-built-data pattern this PR is about.
- All "deliberately out of contract" and boundary-parse suppressions.

### Verification

- `pnpm check`: 33/33 tasks
- `pnpm test`: all packages green (log-viewer 1234/1234, inspect-components 1017/1017, inspect-common 141/141)
- `pnpm build`: 8/8

### Agent review

- Prepared by Claude Fable 5.1 via Claude Code. Each commit was typechecked, linted, formatted, and its affected test files run before committing; the full workspace check, test, and build ran before pushing.
- For each removed cast I read the consuming production code to confirm the test still exercises the same path (e.g. `extractToolResultText` takes `unknown`, `resolvedEventsReader` reads only `events`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
