### PR TITLE
deps: override @xmldom/xmldom to ^0.9.12 (dependabot alert 76)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   nanoid@3: ^3.3.18
   dompurify: ^3.4.13
   '@babel/core': ^7.29.6
+  '@xmldom/xmldom': ^0.9.12
   minimatch@3: ^5.1.9
   brace-expansion@2: ^2.1.4
   brace-expansion@5: ^5.0.9
@@ -2745,10 +2746,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6572,7 +6572,7 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
@@ -8447,7 +8447,7 @@ snapshots:
 
   speech-rule-engine@4.1.4:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,8 @@ overrides:
   # Reached only via eslint-plugin-react-hooks and storybook's react-docgen,
   # both of which parse with babel. Nothing here builds with babel.
   "@babel/core": ^7.29.6
+  # speech-rule-engine (via mathjax-full) pins this exactly.
+  "@xmldom/xmldom": ^0.9.12 # GHSA-6gmq-8vp8-gcm6
 
   # Together these evict brace-expansion 1.x and its ReDoS advisories.
   # eslint-plugin-react, eslint-plugin-jsx-a11y and postcss-url all still ask


### PR DESCRIPTION
Routine dependabot-fix run: force a patched transitive dependency via a `pnpm-workspace.yaml` override.

## Alerts fixed

- [dependabot alert 76](https://github.com/meridianlabs-ai/ts-mono/security/dependabot/76) — `@xmldom/xmldom` (medium, GHSA-6gmq-8vp8-gcm6): XML fragment injection during `requireWellFormed` serialization. Vulnerable `>= 0.9.0, <= 0.9.11`; override forces `^0.9.12`.

`@xmldom/xmldom` enters the tree only through `speech-rule-engine@4.1.4` → `mathjax-full@3.2.2` (devDependencies of `@meridianlabs/log-viewer`, `@tsmono/react`, `scout`). speech-rule-engine pins it exactly at `0.9.10`, so it cannot pick up the patch on its own. 0.9.12 was published 2026-08-21, outside the 7-day `minimumReleaseAge` soak window, so no `minimumReleaseAgeExclude` entry was needed.

## Alerts deferred

None. Alert 76 was the only open alert.

## Verification

- `pnpm audit`: no known vulnerabilities
- `pnpm check`: 33/33 tasks passed
- `pnpm build`: 8/8 tasks passed
- `pnpm test`: 120 files, 1234 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
