### PR TITLE
Harden Scout project-config save and state-diff synthesis against prototype pollution

### DIFF
--- a/apps/scout/src/app/project/SettingsContent.tsx
+++ b/apps/scout/src/app/project/SettingsContent.tsx
@@ -23,7 +23,7 @@ import {
   TextField,
 } from "./components/FormFields";
 import fieldStyles from "./components/FormFields.module.css";
-import { filterNullValues } from "./configUtils";
+import { filterNullValues, ownField } from "./configUtils";
 import { useBatchConfig, useNestedConfig } from "./hooks/useNestedConfig";
 import styles from "./SettingsContent.module.css";
 
@@ -101,7 +101,7 @@ export const SettingsContent: FC<SettingsContentProps> = ({
 
   // Cache config hook
   const cache = useNestedConfig<CachePolicy>(
-    generateConfig.cache,
+    ownField(generateConfig, "cache"),
     useCallback(
       (value) => updateGenerateConfig({ cache: value }),
       [updateGenerateConfig]
@@ -110,7 +110,7 @@ export const SettingsContent: FC<SettingsContentProps> = ({
 
   // Batch config hook
   const batch = useBatchConfig<BatchConfig>(
-    generateConfig.batch,
+    ownField(generateConfig, "batch"),
     useCallback(
       (value) => updateGenerateConfig({ batch: value }),
       [updateGenerateConfig]

--- a/apps/scout/src/app/project/configUtils.test.ts
+++ b/apps/scout/src/app/project/configUtils.test.ts
@@ -2,7 +2,123 @@ import { describe, expect, it } from "vitest";
 
 import { ProjectConfigInput } from "../../types/api-types";
 
-import { mergeInFlightEdits } from "./configUtils";
+import {
+  computeConfigToSave,
+  filterNullValues,
+  initializeEditedConfig,
+  mergeInFlightEdits,
+} from "./configUtils";
+
+// A rendered transcript could once write onto Object.prototype (a JSON-pointer
+// state diff through `/__proto__/...`). The config builders must never turn
+// such inherited members into own keys of the PUT body, so these tests
+// pollute the real prototype for the duration of one call and clean up.
+const withPollutedPrototype = (
+  key: string,
+  value: unknown,
+  run: () => void
+): void => {
+  Object.defineProperty(Object.prototype, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+  try {
+    run();
+  } finally {
+    Reflect.deleteProperty(Object.prototype, key);
+  }
+};
+
+describe("filterNullValues", () => {
+  it("drops null and undefined values", () => {
+    expect(filterNullValues({ a: 1, b: null, c: undefined, d: "x" })).toEqual({
+      a: 1,
+      d: "x",
+    });
+  });
+
+  it("copies own properties only", () => {
+    withPollutedPrototype("system_message", "attacker prompt", () => {
+      const result = filterNullValues({ temperature: 0.5 });
+      expect(Object.keys(result)).toEqual(["temperature"]);
+      expect(Object.hasOwn(result, "system_message")).toBe(false);
+    });
+  });
+});
+
+describe("computeConfigToSave", () => {
+  const serverConfig: ProjectConfigInput = {
+    filter: "kind == 'eval'",
+    model: "openai/gpt-5.4",
+    validation: {},
+  };
+
+  it("sends the fields the editor owns and drops unchanged empty ones", () => {
+    const edited = initializeEditedConfig(serverConfig);
+    const original = structuredClone(edited);
+    expect(computeConfigToSave(edited, original, serverConfig)).toEqual({
+      filter: "kind == 'eval'",
+      model: "openai/gpt-5.4",
+    });
+  });
+
+  it("does not read a server-only key through the prototype chain", () => {
+    // `validation` is always an own key of the server config, so it is always
+    // in the key set but never in the editor's state.
+    withPollutedPrototype("validation", { planted: "x == 1" }, () => {
+      const edited = initializeEditedConfig(serverConfig);
+      const original = structuredClone(edited);
+      const result = computeConfigToSave(edited, original, serverConfig);
+      expect(Object.hasOwn(result, "validation")).toBe(false);
+      expect(JSON.stringify(result)).not.toContain("planted");
+    });
+  });
+
+  it("does not persist a planted model_roles the user never set", () => {
+    const planted = {
+      grader: { model: "openai/gpt-4o", base_url: "https://attacker.example" },
+    };
+    withPollutedPrototype("model_roles", planted, () => {
+      const withRoles: ProjectConfigInput = {
+        ...serverConfig,
+        model_roles: { grader: "openai/gpt-5.4" },
+      };
+      const edited = initializeEditedConfig(withRoles);
+      const original = structuredClone(edited);
+      const result = computeConfigToSave(edited, original, withRoles);
+      expect(Object.hasOwn(result, "model_roles")).toBe(false);
+      expect(JSON.stringify(result)).not.toContain("attacker.example");
+    });
+  });
+
+  it("still sends a value the user actually set on that key", () => {
+    withPollutedPrototype("model_roles", { grader: "planted" }, () => {
+      const edited = {
+        ...initializeEditedConfig(serverConfig),
+        model_roles: { grader: "openai/gpt-5.4" },
+      };
+      const original = structuredClone(initializeEditedConfig(serverConfig));
+      const result = computeConfigToSave(edited, original, serverConfig);
+      expect(result.model_roles).toEqual({ grader: "openai/gpt-5.4" });
+    });
+  });
+
+  it("treats a generate_config key absent from the original as unset", () => {
+    withPollutedPrototype("system_message", "planted", () => {
+      const edited = {
+        ...initializeEditedConfig(serverConfig),
+        generate_config: { system_message: null },
+      };
+      const original = structuredClone(initializeEditedConfig(serverConfig));
+      const result = computeConfigToSave(edited, original, serverConfig);
+      // Clearing a field the original never had is a no-op, not a `null`
+      // write that only exists because the original read the planted value.
+      expect(result.generate_config).toBeUndefined();
+    });
+  });
+});
 
 describe("mergeInFlightEdits", () => {
   const persisted: Partial<ProjectConfigInput> = {

--- a/apps/scout/src/app/project/configUtils.test.ts
+++ b/apps/scout/src/app/project/configUtils.test.ts
@@ -43,8 +43,21 @@ describe("filterNullValues", () => {
     withPollutedPrototype("system_message", "attacker prompt", () => {
       const result = filterNullValues({ temperature: 0.5 });
       expect(Object.keys(result)).toEqual(["temperature"]);
-      expect(Object.hasOwn(result, "system_message")).toBe(false);
     });
+  });
+});
+
+describe("initializeEditedConfig", () => {
+  it("treats a field the server omitted as unset, not as the prototype's", () => {
+    withPollutedPrototype(
+      "generate_config",
+      { system_message: "planted" },
+      () => {
+        const edited = initializeEditedConfig({ filter: "kind == 'eval'" });
+        expect(edited.generate_config).toBeNull();
+        expect(edited.model).toBeNull();
+      }
+    );
   });
 });
 
@@ -93,15 +106,36 @@ describe("computeConfigToSave", () => {
     });
   });
 
+  it("falls back to the server filter, not the prototype's, when unset", () => {
+    withPollutedPrototype("filter", "planted == 1", () => {
+      // An empty-array filter is dropped from the payload as unchanged and
+      // empty, so the fallback read must not find a planted value instead.
+      const emptyFilter: ProjectConfigInput = { ...serverConfig, filter: [] };
+      const edited = initializeEditedConfig(emptyFilter);
+      const original = structuredClone(edited);
+      const result = computeConfigToSave(edited, original, emptyFilter);
+      expect(result.filter).toEqual([]);
+    });
+  });
+
   it("still sends a value the user actually set on that key", () => {
-    withPollutedPrototype("model_roles", { grader: "planted" }, () => {
+    withPollutedPrototype("model_base_url", "https://attacker.example", () => {
       const edited = {
         ...initializeEditedConfig(serverConfig),
-        model_roles: { grader: "openai/gpt-5.4" },
+        model_base_url: "https://proxy.internal/v1",
       };
       const original = structuredClone(initializeEditedConfig(serverConfig));
       const result = computeConfigToSave(edited, original, serverConfig);
-      expect(result.model_roles).toEqual({ grader: "openai/gpt-5.4" });
+      expect(result.model_base_url).toBe("https://proxy.internal/v1");
+    });
+  });
+
+  it("does not send a planted value for an editable field the server omitted", () => {
+    withPollutedPrototype("model_base_url", "https://attacker.example", () => {
+      const edited = initializeEditedConfig(serverConfig);
+      const original = structuredClone(edited);
+      const result = computeConfigToSave(edited, original, serverConfig);
+      expect(Object.hasOwn(result, "model_base_url")).toBe(false);
     });
   });
 

--- a/apps/scout/src/app/project/configUtils.ts
+++ b/apps/scout/src/app/project/configUtils.ts
@@ -30,9 +30,7 @@ export function isEmpty(value: unknown): boolean {
 
 /**
  * Filter out null and undefined values from an object. Own properties only:
- * for-in also walks inherited enumerable keys, so anything a rendered
- * transcript managed to plant on Object.prototype would otherwise become an
- * own key of the config and ride along to the server.
+ * for-in also walks inherited (polluted-prototype) keys, see `ownField`.
  */
 export function filterNullValues<T extends Record<string, unknown>>(
   obj: T
@@ -58,14 +56,16 @@ export function deepCopy<T>(obj: T): T {
 }
 
 /**
- * Own-property read of a config record. The config builders look up keys
- * taken from one object's key set on another, so a key can be absent from the
- * record being read. A plain bracket read would then fall through to
- * Object.prototype and hand back whatever a polluted prototype holds; an
- * absent key must read as undefined.
+ * Own-property read. The config builders read keys that may be absent from
+ * the object at hand (server responses omit unset fields; key sets are taken
+ * from one object and read on another), and a plain read of an absent key
+ * falls through to Object.prototype. A page-lifetime pollution of that
+ * prototype must read as "unset", not as configuration the user entered.
  */
-const ownField = (record: Record<string, unknown>, key: string): unknown =>
-  Object.hasOwn(record, key) ? record[key] : undefined;
+export const ownField = <T extends object, K extends keyof T>(
+  obj: T,
+  key: K
+): T[K] | undefined => (Object.hasOwn(obj, key) ? obj[key] : undefined);
 
 /**
  * Clean nested config (cache/batch) for saving.
@@ -171,6 +171,30 @@ function cleanGenerateConfig(
 }
 
 /**
+ * The fields the settings editor owns. Only these are read from the server
+ * config and only these can appear in the saved payload: a field the editor
+ * has no control for is never the editor's to send back.
+ */
+const kEditableConfigKeys = [
+  "transcripts",
+  "filter",
+  "scans",
+  "max_transcripts",
+  "max_processes",
+  "limit",
+  "shuffle",
+  "tags",
+  "metadata",
+  "log_level",
+  "model",
+  "model_base_url",
+  "model_args",
+  "generate_config",
+] as const satisfies readonly (keyof ProjectConfigInput)[];
+
+type EditableConfigKey = (typeof kEditableConfigKeys)[number];
+
+/**
  * Compute the config to save by comparing edited values against original server state.
  * Only includes values that have changed or have content.
  */
@@ -181,14 +205,9 @@ export function computeConfigToSave(
 ): ProjectConfigInput {
   const result: Record<string, unknown> = {};
 
-  const allKeys = new Set([
-    ...Object.keys(edited),
-    ...Object.keys(serverConfig),
-  ]);
-
-  for (const key of allKeys) {
-    const editedValue = configField(edited, key);
-    const originalValue = configField(original, key);
+  for (const key of kEditableConfigKeys) {
+    const editedValue = ownField(edited, key);
+    const originalValue = ownField(original, key);
 
     // Handle generate_config specially
     if (key === "generate_config") {
@@ -215,7 +234,7 @@ export function computeConfigToSave(
   // cleared in the editor (the change survives as undefined). Either way the
   // server's own value stands — a required field can't be cleared, so an
   // emptied filter reverts on save rather than producing an invalid config.
-  const filter = result["filter"];
+  const filter = ownField(result, "filter");
   return {
     ...result,
     filter: isFilter(filter) ? filter : serverConfig.filter,
@@ -227,42 +246,30 @@ const isFilter = (value: unknown): value is string | string[] =>
   (Array.isArray(value) && value.every((entry) => typeof entry === "string"));
 
 /**
- * Reads a config field by name. The key set is the union of the edited and
- * server configs' keys, which the declared interface can't index.
- */
-const configField = (
-  config: Partial<ProjectConfigInput>,
-  key: string
-): unknown => {
-  const record: Record<string, unknown> = config;
-  return ownField(record, key);
-};
-
-/**
  * Initialize edited config from server config.
  * Extracts the relevant fields for editing.
- * All fields are normalized to null (not undefined) for consistent comparison.
+ * Optional fields are normalized to null (not undefined) for consistent
+ * comparison; the required `filter` stays undefined if the server omits it.
  */
 export function initializeEditedConfig(
   serverConfig: ProjectConfigInput
 ): Partial<ProjectConfigInput> {
   return {
-    transcripts: serverConfig.transcripts ?? null,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    filter: serverConfig.filter ?? null,
-    scans: serverConfig.scans ?? null,
-    max_transcripts: serverConfig.max_transcripts ?? null,
-    max_processes: serverConfig.max_processes ?? null,
-    limit: serverConfig.limit ?? null,
-    shuffle: serverConfig.shuffle ?? null,
-    tags: serverConfig.tags ?? null,
-    metadata: serverConfig.metadata ?? null,
-    log_level: serverConfig.log_level ?? null,
-    model: serverConfig.model ?? null,
-    model_base_url: serverConfig.model_base_url ?? null,
-    model_args: serverConfig.model_args ?? null,
-    generate_config: serverConfig.generate_config ?? null,
-  };
+    transcripts: ownField(serverConfig, "transcripts") ?? null,
+    filter: ownField(serverConfig, "filter"),
+    scans: ownField(serverConfig, "scans") ?? null,
+    max_transcripts: ownField(serverConfig, "max_transcripts") ?? null,
+    max_processes: ownField(serverConfig, "max_processes") ?? null,
+    limit: ownField(serverConfig, "limit") ?? null,
+    shuffle: ownField(serverConfig, "shuffle") ?? null,
+    tags: ownField(serverConfig, "tags") ?? null,
+    metadata: ownField(serverConfig, "metadata") ?? null,
+    log_level: ownField(serverConfig, "log_level") ?? null,
+    model: ownField(serverConfig, "model") ?? null,
+    model_base_url: ownField(serverConfig, "model_base_url") ?? null,
+    model_args: ownField(serverConfig, "model_args") ?? null,
+    generate_config: ownField(serverConfig, "generate_config") ?? null,
+  } satisfies Record<EditableConfigKey, unknown>;
 }
 
 /**

--- a/apps/scout/src/app/project/configUtils.ts
+++ b/apps/scout/src/app/project/configUtils.ts
@@ -29,13 +29,17 @@ export function isEmpty(value: unknown): boolean {
 }
 
 /**
- * Filter out null and undefined values from an object.
+ * Filter out null and undefined values from an object. Own properties only:
+ * for-in also walks inherited enumerable keys, so anything a rendered
+ * transcript managed to plant on Object.prototype would otherwise become an
+ * own key of the config and ride along to the server.
  */
 export function filterNullValues<T extends Record<string, unknown>>(
   obj: T
 ): Partial<T> {
   const result: Partial<T> = {};
   for (const key in obj) {
+    if (!Object.hasOwn(obj, key)) continue;
     const value = obj[key];
     if (value !== null && value !== undefined) {
       result[key] = value;
@@ -52,6 +56,16 @@ export function filterNullValues<T extends Record<string, unknown>>(
 export function deepCopy<T>(obj: T): T {
   return structuredClone(obj);
 }
+
+/**
+ * Own-property read of a config record. The config builders look up keys
+ * taken from one object's key set on another, so a key can be absent from the
+ * record being read. A plain bracket read would then fall through to
+ * Object.prototype and hand back whatever a polluted prototype holds; an
+ * absent key must read as undefined.
+ */
+const ownField = (record: Record<string, unknown>, key: string): unknown =>
+  Object.hasOwn(record, key) ? record[key] : undefined;
 
 /**
  * Clean nested config (cache/batch) for saving.
@@ -78,7 +92,7 @@ function cleanNestedConfig(
   const originalObj = isRecord(original) ? original : {};
 
   for (const [key, value] of Object.entries(edited)) {
-    const origValue = originalObj[key];
+    const origValue = ownField(originalObj, key);
     const valueChanged = JSON.stringify(value) !== JSON.stringify(origValue);
 
     if (valueChanged) {
@@ -122,7 +136,7 @@ function cleanGenerateConfig(
 
   for (const key of Object.keys(edited)) {
     const editedValue = edited[key];
-    const originalValue = originalObj[key];
+    const originalValue = ownField(originalObj, key);
 
     // Handle nested cache/batch configs
     if (key === "cache" || key === "batch") {
@@ -221,7 +235,7 @@ const configField = (
   key: string
 ): unknown => {
   const record: Record<string, unknown> = config;
-  return record[key];
+  return ownField(record, key);
 };
 
 /**
@@ -271,7 +285,7 @@ export function mergeInFlightEdits(
   for (const key of Object.keys(currentRecord)) {
     const changedSinceSave =
       JSON.stringify(currentRecord[key]) !==
-      JSON.stringify(snapshotRecord[key]);
+      JSON.stringify(ownField(snapshotRecord, key));
     if (changedSinceSave) {
       mergedRecord[key] = currentRecord[key];
     }

--- a/apps/scout/src/app/project/hooks/useNestedConfig.ts
+++ b/apps/scout/src/app/project/hooks/useNestedConfig.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import { filterNullValues } from "../configUtils";
+import { filterNullValues, ownField } from "../configUtils";
 
 /**
  * The nested-config editors send a patch: the fields the user touched merged
@@ -93,7 +93,9 @@ export function useBatchConfig<T extends Record<string, unknown>>(
           ? filterNullValues(configValue)
           : {};
       const size =
-        typeof configValue === "number" ? configValue : existingConfig.size;
+        typeof configValue === "number"
+          ? configValue
+          : ownField(existingConfig, "size");
       updateParent(
         asNestedConfig<T>({
           ...(size !== undefined ? { size } : {}),

--- a/packages/inspect-components/src/transcript/state/StateEventView.test.ts
+++ b/packages/inspect-components/src/transcript/state/StateEventView.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { JsonChange } from "@tsmono/inspect-common/types";
 
@@ -77,16 +77,20 @@ describe("synthesizeComparable", () => {
   });
 });
 
-// Paths come straight from the log. A `__proto__` or `constructor/prototype`
-// segment must become an ordinary key in the synthesized tree, never a step
-// into Object.prototype — a write there would outlive the event that made it
-// and be read back by every plain object in the page.
+// Paths come straight from the log. A `__proto__` segment must become an
+// ordinary key in the synthesized tree, never a step into Object.prototype:
+// a write there would be read back by every plain object in the page.
 describe("synthesizeComparable prototype safety", () => {
-  const planted = ["planted_add", "planted_replace", "planted_ctor"];
-
+  // If the code under test regresses, remove whatever it planted so the
+  // leak doesn't poison later tests in this worker.
+  let prototypeKeys: Set<string>;
+  beforeEach(() => {
+    prototypeKeys = new Set(Object.getOwnPropertyNames(Object.prototype));
+  });
   afterEach(() => {
-    for (const key of planted) {
-      Reflect.deleteProperty(Object.prototype, key);
+    for (const key of Object.getOwnPropertyNames(Object.prototype)) {
+      if (!prototypeKeys.has(key))
+        Reflect.deleteProperty(Object.prototype, key);
     }
   });
 
@@ -95,9 +99,7 @@ describe("synthesizeComparable prototype safety", () => {
       add("/__proto__/planted_add", "x"),
     ]);
     expect(Object.hasOwn(Object.prototype, "planted_add")).toBe(false);
-    expect("planted_add" in {}).toBe(false);
-    expect(Object.getPrototypeOf(after)).toBe(Object.prototype);
-    expect(Object.hasOwn(after, "__proto__")).toBe(true);
+    // A re-parented `after` would serialize as {}.
     expect(JSON.stringify(after)).toBe('{"__proto__":{"planted_add":"x"}}');
     expect(JSON.stringify(before)).toBe('{"__proto__":{}}');
   });
@@ -114,6 +116,8 @@ describe("synthesizeComparable prototype safety", () => {
     expect(Object.hasOwn(Object.prototype, "planted_replace")).toBe(false);
   });
 
+  // Never a vector (a function fails the container check), kept as a guard
+  // on the own-property walk should that check ever loosen.
   it("does not reach Object.prototype through constructor/prototype", () => {
     const [, after] = synthesizeComparable([
       add("/constructor/prototype/planted_ctor", "x"),

--- a/packages/inspect-components/src/transcript/state/StateEventView.test.ts
+++ b/packages/inspect-components/src/transcript/state/StateEventView.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { JsonChange } from "@tsmono/inspect-common/types";
 
@@ -74,5 +74,53 @@ describe("synthesizeComparable", () => {
     ]);
     expect(before).toEqual({ a: { name: "y" } });
     expect(after).toEqual({ a: { 0: "m" } });
+  });
+});
+
+// Paths come straight from the log. A `__proto__` or `constructor/prototype`
+// segment must become an ordinary key in the synthesized tree, never a step
+// into Object.prototype — a write there would outlive the event that made it
+// and be read back by every plain object in the page.
+describe("synthesizeComparable prototype safety", () => {
+  const planted = ["planted_add", "planted_replace", "planted_ctor"];
+
+  afterEach(() => {
+    for (const key of planted) {
+      Reflect.deleteProperty(Object.prototype, key);
+    }
+  });
+
+  it("stores a __proto__ segment as an own key instead of writing the prototype", () => {
+    const [before, after] = synthesizeComparable([
+      add("/__proto__/planted_add", "x"),
+    ]);
+    expect(Object.hasOwn(Object.prototype, "planted_add")).toBe(false);
+    expect("planted_add" in {}).toBe(false);
+    expect(Object.getPrototypeOf(after)).toBe(Object.prototype);
+    expect(Object.hasOwn(after, "__proto__")).toBe(true);
+    expect(JSON.stringify(after)).toBe('{"__proto__":{"planted_add":"x"}}');
+    expect(JSON.stringify(before)).toBe('{"__proto__":{}}');
+  });
+
+  it("keeps a replace through __proto__ off the prototype on both sides", () => {
+    synthesizeComparable([
+      {
+        op: "replace",
+        path: "/__proto__/planted_replace",
+        value: "new",
+        replaced: "old",
+      },
+    ]);
+    expect(Object.hasOwn(Object.prototype, "planted_replace")).toBe(false);
+  });
+
+  it("does not reach Object.prototype through constructor/prototype", () => {
+    const [, after] = synthesizeComparable([
+      add("/constructor/prototype/planted_ctor", "x"),
+    ]);
+    expect(Object.hasOwn(Object.prototype, "planted_ctor")).toBe(false);
+    expect(JSON.stringify(after)).toBe(
+      '{"constructor":{"prototype":{"planted_ctor":"x"}}}'
+    );
   });
 });

--- a/packages/inspect-components/src/transcript/state/StateEventView.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventView.tsx
@@ -200,10 +200,9 @@ type PathContainer = Record<string, unknown> | unknown[];
 const isPathContainer = (value: unknown): value is PathContainer =>
   typeof value === "object" && value !== null;
 
-// Path segments come straight from the log, so the walk must stay on the
-// synthesized tree's own properties: a `__proto__` or `constructor` segment
-// read through the prototype chain would step into Object.prototype, and the
-// write that follows would land there for the rest of the page's life.
+// Path segments come from the log, so reads stay on the synthesized tree's
+// own properties: a `/__proto__/x` path read through the prototype chain
+// would step into Object.prototype and the write below would land there.
 const getChild = (container: PathContainer, key: string): unknown => {
   if (Array.isArray(container)) {
     const index = Number(key);
@@ -219,16 +218,18 @@ const setChild = (
 ): void => {
   if (Array.isArray(container)) {
     container[Number(key)] = value;
-  } else {
-    // `container["__proto__"] = value` hits the inherited setter and
-    // re-parents the container instead of storing a key; defineProperty
-    // always creates an own, enumerable key so the segment renders as data.
+  } else if (key === "__proto__") {
+    // Assignment would hit the inherited setter and re-parent the container.
+    // defineProperty stores an own key instead (jsondiffpatch skips the key
+    // when diffing, so the change is dropped from the view, not rendered).
     Object.defineProperty(container, key, {
       value,
       enumerable: true,
       writable: true,
       configurable: true,
     });
+  } else {
+    container[key] = value;
   }
 };
 

--- a/packages/inspect-components/src/transcript/state/StateEventView.tsx
+++ b/packages/inspect-components/src/transcript/state/StateEventView.tsx
@@ -200,8 +200,17 @@ type PathContainer = Record<string, unknown> | unknown[];
 const isPathContainer = (value: unknown): value is PathContainer =>
   typeof value === "object" && value !== null;
 
-const getChild = (container: PathContainer, key: string): unknown =>
-  Array.isArray(container) ? container[Number(key)] : container[key];
+// Path segments come straight from the log, so the walk must stay on the
+// synthesized tree's own properties: a `__proto__` or `constructor` segment
+// read through the prototype chain would step into Object.prototype, and the
+// write that follows would land there for the rest of the page's life.
+const getChild = (container: PathContainer, key: string): unknown => {
+  if (Array.isArray(container)) {
+    const index = Number(key);
+    return Object.hasOwn(container, index) ? container[index] : undefined;
+  }
+  return Object.hasOwn(container, key) ? container[key] : undefined;
+};
 
 const setChild = (
   container: PathContainer,
@@ -211,7 +220,15 @@ const setChild = (
   if (Array.isArray(container)) {
     container[Number(key)] = value;
   } else {
-    container[key] = value;
+    // `container["__proto__"] = value` hits the inherited setter and
+    // re-parents the container instead of storing a key; defineProperty
+    // always creates an own, enumerable key so the segment renders as data.
+    Object.defineProperty(container, key, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
 };
 

--- a/suppressions.json
+++ b/suppressions.json
@@ -905,12 +905,6 @@
       "count": 2
     }
   },
-  "apps/scout/src/app/project/configUtils.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 1,
-      "undescribed": 1
-    }
-  },
   "apps/scout/src/app/project/hooks/useNestedConfig.ts": {
     "@typescript-eslint/no-unsafe-type-assertion": {
       "count": 1


### PR DESCRIPTION
## Summary

A transcript or scan-result author could write onto `Object.prototype`: `StateEventView`'s JSON-pointer synthesis walked a `/__proto__/<key>` path through the inherited prototype and assigned the log's value there during render. Scout's project-config builders then read those inherited members as if they were user edits and sent them in `PUT /api/v2/project/config`, which rewrites `scout.yaml` on the server (`model_roles`/`base_url`, `generate_config.system_message`, `scanners`, `results`, `validation`, ...).

This closes both ends independently, so either fix alone breaks the chain.

### `packages/inspect-components` — the pollution primitive

- `getChild` reads own properties only, for arrays and objects alike, so a `__proto__` segment can no longer step into `Object.prototype`.
- `setChild` uses `Object.defineProperty` for the one key whose inherited setter re-parents the target (`__proto__`); plain assignment elsewhere keeps the synthesizer at its previous cost. jsondiffpatch skips `__proto__` keys when diffing, so such a change is dropped from the diff view rather than rendered; the comment says so.

### `apps/scout` — the config save path

- `filterNullValues` skips inherited keys in its `for...in`.
- `initializeEditedConfig` read all 14 editor fields with plain property access, so a field the server omitted took the prototype's value as an own key of the editor state. It now uses own-property reads.
- `computeConfigToSave` no longer iterates the union of edited and server key sets. It walks one declared list of editable keys (`kEditableConfigKeys`), tied to `initializeEditedConfig` with a `satisfies` check, so a server-only key such as `model_roles` or `validation` is never read at all. The `filter` fallback read is own-only too.
- `useBatchConfig`'s `size` read and `SettingsContent`'s `cache`/`batch` reads feed the saved patch and are now own-only.
- One `no-unnecessary-condition` suppression went away with the read that made it unnecessary (`suppressions.json` shrinks by one entry; no new suppressions).

Behavior on unpolluted data is unchanged: the editor only ever writes the 14 keys in the list, and server-only keys were already dropped as unchanged-and-empty.

## Test plan

- [x] New tests pollute the real `Object.prototype` inside `try/finally` / `afterEach` and assert that no planted key reaches the save payload (`validation`, `model_roles`, `model_base_url`, `filter`, `generate_config`, `system_message`), that a value the user actually set on an editable key still saves, and that synthesizing a `/__proto__/...` change leaves `Object.prototype` untouched.
- [x] Confirmed the 7 new scout tests and 2 new StateEventView tests fail against the pre-fix source and pass with the fix.
- [x] `pnpm check` passes (manypkg, suppressions ledger, lint, typecheck, format; 33/33 tasks).
- [x] Full `pnpm test` in `apps/scout` (280 tests) and `packages/inspect-components` (968 tests) pass.

## Follow-ups (not in this PR)

- A huge numeric JSON-pointer index in a state event pads an array with that many entries and freezes the tab (`initializeArray` in `StateEventView.tsx`).
- Several places rebuild records from log-derived keys with bracket assignment (`store.ts`, `configsForUsage.ts`, `ModelEventView.tsx`, `useSampleScans.ts`, `attachments.ts`, `JsonPanel.tsx`); a key literally named `__proto__` re-parents the new object and vanishes from the UI. Local, not global pollution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qezbsm6zVMVcfuzjLvtzHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qezbsm6zVMVcfuzjLvtzHK)_