### PR TITLE
Fix main typecheck: add score_explanation to Scout transcript columns

### DIFF
--- a/apps/scout/src/app/transcripts/columns.tsx
+++ b/apps/scout/src/app/transcripts/columns.tsx
@@ -34,6 +34,7 @@ export const COLUMN_LABELS: Record<keyof TranscriptInfo, string> = {
   agent: "Agent",
   agent_args: "Agent Args",
   score: "Score",
+  score_explanation: "Score Explanation",
   metadata: "Metadata",
   source_id: "Source ID",
   source_type: "Source Type",
@@ -60,6 +61,7 @@ export const COLUMN_HEADER_TITLES: Record<keyof TranscriptInfo, string> = {
   agent: "Agent used to to execute task.",
   agent_args: "Arguments passed to create agent.",
   score: "Value indicating score on task.",
+  score_explanation: "Explanation of the score on task.",
   metadata:
     "Transcript source specific metadata (e.g. model, task name, errors, epoch, dataset sample id, limits, etc.).",
   source_id:
@@ -429,6 +431,21 @@ export const ALL_COLUMNS: Record<keyof TranscriptInfo, TranscriptColumn> = {
       return String(value);
     },
   }),
+  score_explanation: createColumn({
+    accessorKey: "score_explanation",
+    header: "Score Explanation",
+    headerTitle: "Explanation of the score on task.",
+    size: 200,
+    minSize: 80,
+    maxSize: 500,
+    meta: {
+      filterable: true,
+      filterType: "string",
+    },
+    cell: (value) => {
+      return value || "-";
+    },
+  }),
   metadata: createObjectColumn({
     accessorKey: "metadata",
     header: "Metadata",
@@ -607,6 +624,7 @@ export const DEFAULT_COLUMN_ORDER: Array<keyof TranscriptInfo> = [
   "agent",
   "agent_args",
   "score",
+  "score_explanation",
   "metadata",
   "source_id",
   "source_type",


### PR DESCRIPTION
## Why main is red

The `typecheck` CI job has failed on every `main` commit since 3ccf7bf ("regenerate types"). That commit regenerated `apps/scout/src/types/generated.ts` and added an optional `score_explanation` field to `TranscriptInfo`, but `apps/scout/src/app/transcripts/columns.tsx` keeps three exhaustive `Record<keyof TranscriptInfo, ...>` maps (`COLUMN_LABELS`, `COLUMN_HEADER_TITLES`, `ALL_COLUMNS`), so `tsc` fails with TS2741 on each of them:

```
src/app/transcripts/columns.tsx(25,14): error TS2741: Property 'score_explanation' is missing in type '{ ... }' but required in type 'Record<"agent" | ... | "score_explanation" | ..., string>'.
```

## Fix

Register the field the same way every other transcript field is: a label, a header tooltip, a filterable string column (`value || "-"` cell, same shape as `error`/`limit`), and a slot in `DEFAULT_COLUMN_ORDER` right after `score`. It is deliberately **not** added to the default visible set, so the transcripts grid renders exactly as before until a user opts the column in via the column picker. No UI appearance change, so no screenshots.

The query builder in `src/query/transcriptColumns.ts` needs nothing: it is not exhaustive and its proxy already resolves unknown field names.

## Verification

- Reproduced the 3 TS2741 errors on the pre-fix file, then confirmed they are gone.
- `pnpm check` from the repo root: 33/33 tasks pass (manypkg, suppressions ledger, lint, typecheck, format).
- `pnpm --filter scout test`: 32 files, 280 tests pass.

No new suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5A9Hp44V9spvrx8MFjtiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5A9Hp44V9spvrx8MFjtiH)_