### PR TITLE
fix: validate element shapes at the eval-log normalization boundary

### DIFF
--- a/apps/inspect/src/client/utils/normalize.test.ts
+++ b/apps/inspect/src/client/utils/normalize.test.ts
@@ -49,6 +49,24 @@ describe("normalizeEvalHeader", () => {
     expect(header.metadata).toEqual({ from: "log" });
   });
 
+  it("fills stats usage defaults and drops malformed usage entries", () => {
+    const header = normalizeEvalHeader({
+      eval: minimalEval,
+      stats: {
+        model_usage: {
+          "openai/gpt-4": { input_tokens: 1, output_tokens: 2 },
+          "openai/gpt-3.5": null,
+        },
+      },
+    });
+    expect(header.stats?.model_usage).toEqual({
+      "openai/gpt-4": { input_tokens: 1, output_tokens: 2, total_tokens: 0 },
+    });
+    expect(header.stats?.role_usage).toEqual({});
+    expect(header.stats?.started_at).toBe("");
+    expect(normalizeEvalHeader({ eval: minimalEval }).stats).toBeUndefined();
+  });
+
   it("preserves fields it doesn't model (future schema growth)", () => {
     const header = normalizeEvalHeader({
       eval: minimalEval,

--- a/apps/inspect/src/client/utils/normalize.ts
+++ b/apps/inspect/src/client/utils/normalize.ts
@@ -4,12 +4,12 @@ import {
   normalizeEvalResults,
   normalizeEvalSample,
   normalizeEvalSpec,
+  normalizeEvalStats,
 } from "@tsmono/inspect-common/normalize";
 import {
   ConfigUpdate,
   EvalError,
   EvalLog,
-  EvalStats,
   LogUpdate,
 } from "@tsmono/inspect-common/types";
 import { isRecord } from "@tsmono/util";
@@ -41,7 +41,7 @@ export const normalizeEvalHeader = (raw: unknown): EvalHeader => {
     eval: evalSpec,
     plan: normalizeEvalPlan(raw["plan"]),
     results: normalizeEvalResults(raw["results"]),
-    stats: raw["stats"] as EvalStats | undefined,
+    stats: normalizeEvalStats(raw["stats"]),
     error: raw["error"] as EvalError | null | undefined,
     tags: (raw["tags"] ?? evalSpec.tags ?? []) as string[],
     metadata: (raw["metadata"] ?? evalSpec.metadata ?? {}) as Record<

--- a/apps/inspect/src/log_data/logsContent.test.ts
+++ b/apps/inspect/src/log_data/logsContent.test.ts
@@ -5,6 +5,7 @@
 import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { testLogDetails, testSampleSummary } from "../client/api/testClientApi";
 import { DB_NAME } from "../client/database/schema";
 import {
   createDatabaseService,
@@ -12,7 +13,12 @@ import {
 } from "../client/database/service";
 import { queryClient } from "../state/queryClient";
 
-import { clearFile, writeListing, writePreviews } from "./logsContent";
+import {
+  clearFile,
+  writeDetails,
+  writeListing,
+  writePreviews,
+} from "./logsContent";
 
 const invalidateListings = vi.hoisted(() => vi.fn());
 vi.mock("./databaseListings", async (importOriginal) => ({
@@ -58,6 +64,54 @@ describe("writeListing", () => {
     // ...and nothing was persisted where no scoped read could reach it.
     expect(await db.readLogs({ prefix: "~/logs" })).toHaveLength(0);
     expect(await db.getSyncScope("~/logs")).toBeUndefined();
+  });
+});
+
+describe("writeDetails", () => {
+  let db: DatabaseService;
+
+  beforeEach(async () => {
+    db = createDatabaseService();
+    await db.openDatabase();
+  });
+
+  afterEach(async () => {
+    queryClient.clear();
+    await db.closeDatabase();
+    await Dexie.delete(DB_NAME);
+    vi.restoreAllMocks();
+  });
+
+  test("a payload whose derivation throws is skipped without taking the rest of the batch with it", async () => {
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A score whose value cannot be read stands in for any derivation
+    // failure the normalizers don't anticipate.
+    const poisoned = testSampleSummary({
+      scores: {
+        match: {
+          get value(): string {
+            throw new Error("derive failed");
+          },
+          history: [],
+        },
+      },
+    });
+
+    await writeDetails(db, "file:///logs", {
+      "file:///logs/bad.eval": testLogDetails({ sampleSummaries: [poisoned] }),
+      "file:///logs/good.eval": testLogDetails({
+        sampleSummaries: [testSampleSummary({ id: "s1" })],
+      }),
+    });
+
+    const rows = await db.readLogs({ prefix: "file:///logs" });
+    expect(rows?.map((row) => [row.name, row.depth])).toEqual([
+      ["file:///logs/good.eval", "detailed"],
+    ]);
+    expect(
+      await db.readSampleSummaries({ file: "file:///logs/good.eval" })
+    ).toHaveLength(1);
+    expect(logError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/inspect/src/log_data/logsContent.test.ts
+++ b/apps/inspect/src/log_data/logsContent.test.ts
@@ -5,12 +5,15 @@
 import Dexie from "dexie";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { testEvalSpec } from "@tsmono/inspect-common/testing";
+
 import { testLogDetails, testSampleSummary } from "../client/api/testClientApi";
 import { DB_NAME } from "../client/database/schema";
 import {
   createDatabaseService,
   DatabaseService,
 } from "../client/database/service";
+import { normalizeEvalHeader } from "../client/utils/normalize";
 import { queryClient } from "../state/queryClient";
 
 import {
@@ -84,21 +87,15 @@ describe("writeDetails", () => {
 
   test("a payload whose derivation throws is skipped without taking the rest of the batch with it", async () => {
     const logError = vi.spyOn(console, "error").mockImplementation(() => {});
-    // A score whose value cannot be read stands in for any derivation
-    // failure the normalizers don't anticipate.
-    const poisoned = testSampleSummary({
-      scores: {
-        match: {
-          get value(): string {
-            throw new Error("derive failed");
-          },
-          history: [],
-        },
-      },
+    // Wire data the normalizers pass through but derivation rejects: the
+    // spec normalizer does not validate model_roles, and modelRoleNames
+    // dereferences each role's config.
+    const poisoned = normalizeEvalHeader({
+      eval: { ...testEvalSpec(), model_roles: { grader: null } },
     });
 
     await writeDetails(db, "file:///logs", {
-      "file:///logs/bad.eval": testLogDetails({ sampleSummaries: [poisoned] }),
+      "file:///logs/bad.eval": testLogDetails(poisoned),
       "file:///logs/good.eval": testLogDetails({
         sampleSummaries: [testSampleSummary({ id: "s1" })],
       }),

--- a/apps/inspect/src/log_data/logsContent.ts
+++ b/apps/inspect/src/log_data/logsContent.ts
@@ -11,6 +11,7 @@ import {
 import { DatabaseService, scopePrefix } from "../client/database";
 import {
   maxDepth,
+  PreparedLogDetails,
   prepareLogDetails,
   previewTier,
 } from "../client/utils/type-utils";
@@ -292,6 +293,26 @@ export const writePreviews = async (
 };
 
 /**
+ * Prepare each payload of a flush batch on its own. A payload the normalizers
+ * let through but derivation still rejects is skipped and reported, not
+ * allowed to keep every unrelated log in the same flush out of the stores.
+ * The skipped log stays at its current depth.
+ */
+const prepareBatch = (
+  details: Record<string, LogDetails>
+): (readonly [string, PreparedLogDetails])[] => {
+  const prepared: (readonly [string, PreparedLogDetails])[] = [];
+  for (const [name, payload] of Object.entries(details)) {
+    try {
+      prepared.push([name, prepareLogDetails(payload)]);
+    } catch (error) {
+      log.error(`Skipping details ingestion for ${name}`, error);
+    }
+  }
+  return prepared;
+};
+
+/**
  * Details INGESTION: normalize each transport payload into the entity
  * stores — the detailed tier onto the log row, sample summaries into their
  * own store. Cache updates land synchronously; samples rows land BEFORE the
@@ -308,9 +329,7 @@ export const writeDetails = async (
   logDir: string,
   details: Record<string, LogDetails>
 ): Promise<void> => {
-  const prepared = Object.entries(details).map(
-    ([name, payload]) => [name, prepareLogDetails(payload)] as const
-  );
+  const prepared = prepareBatch(details);
   await Promise.all(
     prepared.map(([name, file]) =>
       pushFileSamples(

--- a/packages/inspect-common/src/normalize/index.ts
+++ b/packages/inspect-common/src/normalize/index.ts
@@ -23,6 +23,7 @@ export {
   normalizeEvalPlan,
   normalizeEvalResults,
   normalizeEvalSpec,
+  normalizeEvalStats,
 } from "./log";
 export { normalizeEvalSample } from "./sample";
 export { normalizeSampleSummaries, normalizeSampleSummary } from "./summary";

--- a/packages/inspect-common/src/normalize/log.ts
+++ b/packages/inspect-common/src/normalize/log.ts
@@ -1,6 +1,13 @@
 import { isRecord } from "@tsmono/util";
 
-import type { ConfigUpdate, EvalPlan, EvalResults, EvalSpec } from "../types";
+import type {
+  ConfigUpdate,
+  EvalMetric,
+  EvalPlan,
+  EvalResults,
+  EvalScore,
+  EvalSpec,
+} from "../types";
 
 /**
  * Normalize a raw EvalSpec: apply the same legacy migrations as pydantic's
@@ -58,6 +65,69 @@ export const normalizeEvalPlan = (raw: unknown): EvalPlan => {
   return plan as unknown as EvalPlan;
 };
 
+const isEvalMetric = (value: unknown): value is EvalMetric =>
+  isRecord(value) &&
+  typeof value["name"] === "string" &&
+  typeof value["value"] === "number" &&
+  isRecord(value["params"]);
+
+const isEvalMetricMap = (value: unknown): value is Record<string, EvalMetric> =>
+  isRecord(value) && Object.values(value).every(isEvalMetric);
+
+// Metrics are keyed by name in the map, so a missing name fills from the key;
+// `params` postdates `options` (the 2024 shape) and defaults to {} upstream.
+const normalizeEvalMetrics = (raw: unknown): Record<string, EvalMetric> => {
+  if (!isRecord(raw)) {
+    return {};
+  }
+  if (isEvalMetricMap(raw)) {
+    return raw;
+  }
+  const metrics: Record<string, EvalMetric> = {};
+  for (const [name, entry] of Object.entries(raw)) {
+    if (!isRecord(entry)) continue;
+    const filled = {
+      ...entry,
+      name: typeof entry["name"] === "string" ? entry["name"] : name,
+      params: isRecord(entry["params"]) ? entry["params"] : {},
+    };
+    if (isEvalMetric(filled)) metrics[name] = filled;
+  }
+  return metrics;
+};
+
+const isEvalScore = (value: unknown): value is EvalScore =>
+  isRecord(value) &&
+  typeof value["name"] === "string" &&
+  typeof value["scorer"] === "string" &&
+  isRecord(value["metrics"]) &&
+  isRecord(value["params"]);
+
+/**
+ * Normalize raw per-scorer results. Entries without a name drop (pydantic
+ * has no default); `scorer` predates multi-scorer logs and backfills from
+ * the name, as the v1 migration does; `metrics`/`params` default to {}.
+ */
+const normalizeEvalScores = (raw: unknown): EvalScore[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const entries = raw as unknown[];
+  const scores: EvalScore[] = [];
+  for (const entry of entries) {
+    if (!isRecord(entry) || typeof entry["name"] !== "string") continue;
+    const filled = {
+      ...entry,
+      scorer:
+        typeof entry["scorer"] === "string" ? entry["scorer"] : entry["name"],
+      metrics: normalizeEvalMetrics(entry["metrics"]),
+      params: isRecord(entry["params"]) ? entry["params"] : {},
+    };
+    if (isEvalScore(filled)) scores.push(filled);
+  }
+  return scores;
+};
+
 /**
  * Normalize raw EvalResults. Returns null for absent results (in-progress
  * logs legitimately have none).
@@ -71,7 +141,7 @@ export const normalizeEvalResults = (raw: unknown): EvalResults | null => {
     results["total_samples"] = 0;
   if (typeof results["completed_samples"] !== "number")
     results["completed_samples"] = 0;
-  if (!Array.isArray(results["scores"])) results["scores"] = [];
+  results["scores"] = normalizeEvalScores(results["scores"]);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary lift (#555): required fields are filled above; the rest is wire data TypeScript can't verify
   return results as unknown as EvalResults;
 };

--- a/packages/inspect-common/src/normalize/log.ts
+++ b/packages/inspect-common/src/normalize/log.ts
@@ -2,12 +2,16 @@ import { isRecord } from "@tsmono/util";
 
 import type {
   ConfigUpdate,
+  ConnectionLimitChange,
   EvalMetric,
   EvalPlan,
   EvalResults,
   EvalScore,
   EvalSpec,
+  EvalStats,
 } from "../types";
+
+import { normalizeModelUsageMap } from "./summary";
 
 /**
  * Normalize a raw EvalSpec: apply the same legacy migrations as pydantic's
@@ -126,6 +130,48 @@ const normalizeEvalScores = (raw: unknown): EvalScore[] => {
     if (isEvalScore(filled)) scores.push(filled);
   }
   return scores;
+};
+
+const kLimitChangeReasons: ReadonlySet<unknown> = new Set([
+  "slow_start",
+  "steady_state_up",
+  "rate_limit",
+  "manual",
+]);
+
+const isConnectionLimitChange = (
+  value: unknown
+): value is ConnectionLimitChange =>
+  isRecord(value) &&
+  typeof value["model"] === "string" &&
+  typeof value["new_limit"] === "number" &&
+  typeof value["old_limit"] === "number" &&
+  kLimitChangeReasons.has(value["reason"]) &&
+  typeof value["timestamp"] === "number";
+
+/**
+ * Normalize raw EvalStats, mirroring pydantic's field defaults. Usage
+ * entries are filled inside the maps (their token fields are read unguarded
+ * by the tokens column). Absent or non-object stats stay absent: journal
+ * headers legitimately carry none.
+ */
+export const normalizeEvalStats = (raw: unknown): EvalStats | undefined => {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const history = raw["connection_limit_history"];
+  return {
+    ...raw,
+    started_at: typeof raw["started_at"] === "string" ? raw["started_at"] : "",
+    completed_at:
+      typeof raw["completed_at"] === "string" ? raw["completed_at"] : "",
+    model_usage: normalizeModelUsageMap(raw["model_usage"]),
+    role_usage: normalizeModelUsageMap(raw["role_usage"]),
+    // Limit changes have no pydantic defaults, so malformed entries drop.
+    connection_limit_history: Array.isArray(history)
+      ? (history as unknown[]).filter(isConnectionLimitChange)
+      : [],
+  };
 };
 
 /**

--- a/packages/inspect-common/src/normalize/normalize.test.ts
+++ b/packages/inspect-common/src/normalize/normalize.test.ts
@@ -279,6 +279,18 @@ describe("normalizeEvalSample input validation", () => {
     ]);
   });
 
+  it("drops malformed model_fallbacks elements", () => {
+    const sample = normalizeEvalSample({
+      id: 1,
+      epoch: 1,
+      input: "q",
+      model_fallbacks: [null, 1, { model: "a", fallback_model: "b" }],
+    });
+    expect(sample.model_fallbacks).toEqual([
+      { model: "a", fallback_model: "b", count: 1 },
+    ]);
+  });
+
   it("normalizes retry-error events recursively", () => {
     const sample = normalizeEvalSample({
       id: 1,

--- a/packages/inspect-common/src/normalize/normalize.test.ts
+++ b/packages/inspect-common/src/normalize/normalize.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { expectEvent } from "../testing";
+import {
+  expectEvent,
+  testEvalMetric,
+  testEvalScore,
+  testUserMessage,
+} from "../testing";
 import type { ModelEvent } from "../types";
 import { inputString } from "../utils";
 
@@ -88,13 +93,12 @@ describe("normalize header pieces on a real Nov-2024 log", () => {
       ],
     })!;
     expect(results.scores).toEqual([
-      { name: "legacy", scorer: "legacy", metrics: {}, params: {} },
-      {
+      testEvalScore({ name: "legacy", scorer: "legacy" }),
+      testEvalScore({
         name: "match",
         scorer: "match",
-        params: {},
-        metrics: { accuracy: { name: "accuracy", value: 1, params: {} } },
-      },
+        metrics: { accuracy: testEvalMetric({ value: 1 }) },
+      }),
     ]);
   });
 
@@ -318,7 +322,7 @@ describe("normalizeEvalSample input validation", () => {
       epoch: 1,
       input: [1, null, { role: "user" }, { role: "user", content: "q" }],
     });
-    expect(sample.input).toEqual([{ role: "user", content: "q" }]);
+    expect(sample.input).toEqual([testUserMessage({ content: "q" })]);
     expect(inputString(sample.input)).toEqual(["q"]);
   });
 

--- a/packages/inspect-common/src/normalize/normalize.test.ts
+++ b/packages/inspect-common/src/normalize/normalize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { expectEvent } from "../testing";
 import type { ModelEvent } from "../types";
+import { inputString } from "../utils";
 
 import legacyHeader from "./fixtures/legacy-header-2024-11.json";
 import legacySample from "./fixtures/legacy-sample-2024-11.json";
@@ -63,6 +64,38 @@ describe("normalize header pieces on a real Nov-2024 log", () => {
     expect(results?.scores.length).toBe(legacyHeader.results.scores.length);
     const plan = normalizeEvalPlan(legacyHeader.plan);
     expect(plan.name).toBe(legacyHeader.plan.name);
+  });
+
+  it("drops malformed results.scores entries and fills score defaults", () => {
+    const results = normalizeEvalResults({
+      total_samples: 1,
+      completed_samples: 1,
+      scores: [
+        null,
+        1,
+        { scorer: "nameless" },
+        { name: "legacy" },
+        {
+          name: "match",
+          scorer: "match",
+          params: {},
+          metrics: {
+            gone: null,
+            text: { name: "text", value: "1" },
+            accuracy: { name: "accuracy", value: 1, params: {} },
+          },
+        },
+      ],
+    })!;
+    expect(results.scores).toEqual([
+      { name: "legacy", scorer: "legacy", metrics: {}, params: {} },
+      {
+        name: "match",
+        scorer: "match",
+        params: {},
+        metrics: { accuracy: { name: "accuracy", value: 1, params: {} } },
+      },
+    ]);
   });
 
   it("returns null results for in-progress logs", () => {
@@ -277,6 +310,16 @@ describe("normalizeEvalSample input validation", () => {
     expect(sample.error_retries).toEqual([
       { message: "boom", traceback: "", traceback_ansi: "" },
     ]);
+  });
+
+  it("drops malformed input messages so inputString stays unguarded", () => {
+    const sample = normalizeEvalSample({
+      id: 1,
+      epoch: 1,
+      input: [1, null, { role: "user" }, { role: "user", content: "q" }],
+    });
+    expect(sample.input).toEqual([{ role: "user", content: "q" }]);
+    expect(inputString(sample.input)).toEqual(["q"]);
   });
 
   it("drops malformed model_fallbacks elements", () => {

--- a/packages/inspect-common/src/normalize/sample.ts
+++ b/packages/inspect-common/src/normalize/sample.ts
@@ -3,7 +3,7 @@ import { isRecord } from "@tsmono/util";
 import type { EvalSample } from "../types";
 
 import { normalizeEvents, normalizeModelOutput } from "./events";
-import { normalizeModelUsageMap } from "./summary";
+import { normalizeModelFallbacks, normalizeModelUsageMap } from "./summary";
 
 /**
  * Normalize a raw EvalSample of any vintage into the current shape:
@@ -59,12 +59,12 @@ export const normalizeEvalSample = (raw: unknown): EvalSample => {
 
   // `count` on fallbacks and the traceback pair on retry errors default
   // upstream; fill them so their renderers can read them unguarded.
-  if (Array.isArray(sample["model_fallbacks"])) {
-    sample["model_fallbacks"] = sample["model_fallbacks"].map(
-      (fallback: unknown) =>
-        isRecord(fallback) && typeof fallback["count"] !== "number"
-          ? { ...fallback, count: 1 }
-          : fallback
+  if (
+    sample["model_fallbacks"] !== undefined &&
+    sample["model_fallbacks"] !== null
+  ) {
+    sample["model_fallbacks"] = normalizeModelFallbacks(
+      sample["model_fallbacks"]
     );
   }
   if (Array.isArray(sample["error_retries"])) {

--- a/packages/inspect-common/src/normalize/sample.ts
+++ b/packages/inspect-common/src/normalize/sample.ts
@@ -3,7 +3,11 @@ import { isRecord } from "@tsmono/util";
 import type { EvalSample } from "../types";
 
 import { normalizeEvents, normalizeModelOutput } from "./events";
-import { normalizeModelFallbacks, normalizeModelUsageMap } from "./summary";
+import {
+  normalizeModelFallbacks,
+  normalizeModelUsageMap,
+  normalizeSampleInput,
+} from "./summary";
 
 /**
  * Normalize a raw EvalSample of any vintage into the current shape:
@@ -36,9 +40,7 @@ export const normalizeEvalSample = (raw: unknown): EvalSample => {
     delete sample["score"];
   }
 
-  if (typeof sample["input"] !== "string" && !Array.isArray(sample["input"])) {
-    sample["input"] = "";
-  }
+  sample["input"] = normalizeSampleInput(sample["input"]);
   if (
     typeof sample["target"] !== "string" &&
     !Array.isArray(sample["target"])

--- a/packages/inspect-common/src/normalize/summary.test.ts
+++ b/packages/inspect-common/src/normalize/summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { modelFallbackLines, totalModelFallbacks } from "../utils";
+import { inputString, modelFallbackLines, totalModelFallbacks } from "../utils";
 
 import { normalizeSampleSummaries, normalizeSampleSummary } from "./index";
 
@@ -60,6 +60,46 @@ describe("normalizeSampleSummary", () => {
     })!;
     expect(arrays.input).toEqual([{ role: "user", content: "q" }]);
     expect(arrays.target).toEqual(["a", "b"]);
+  });
+
+  it("drops non-record score values so score readers stay unguarded", () => {
+    const summary = normalizeSampleSummary({
+      ...vintageRow,
+      scores: { a: null, b: 1, c: "C", match: { value: "C" } },
+    })!;
+    expect(summary.scores).toEqual({ match: { value: "C" } });
+    expect(Object.values(summary.scores!).map((s) => s.value)).toEqual(["C"]);
+  });
+
+  it.each([
+    ["a null element", [null]],
+    ["a number element", [1]],
+    ["a bare string element", ["not a message"]],
+    ["a message without content", [{ role: "user" }]],
+    ["a message with non-text content", [{ role: "user", content: 5 }]],
+  ])("drops %s from a message-list input", (_label, malformed) => {
+    const summary = normalizeSampleSummary({
+      ...vintageRow,
+      input: [...malformed, { role: "user", content: "q" }],
+    })!;
+    expect(summary.input).toEqual([{ role: "user", content: "q" }]);
+    expect(inputString(summary.input)).toEqual(["q"]);
+  });
+
+  it("drops malformed content items inside an input message", () => {
+    const summary = normalizeSampleSummary({
+      ...vintageRow,
+      input: [
+        {
+          role: "user",
+          content: [null, { text: "untyped" }, { type: "text", text: "hi" }],
+        },
+      ],
+    })!;
+    expect(summary.input).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+    expect(inputString(summary.input)).toEqual(["hi"]);
   });
 
   it("fills model_fallbacks counts while preserving complete entries", () => {

--- a/packages/inspect-common/src/normalize/summary.test.ts
+++ b/packages/inspect-common/src/normalize/summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { testUserMessage } from "../testing";
 import { inputString, modelFallbackLines, totalModelFallbacks } from "../utils";
 
 import { normalizeSampleSummaries, normalizeSampleSummary } from "./index";
@@ -58,7 +59,7 @@ describe("normalizeSampleSummary", () => {
       input: [{ role: "user", content: "q" }],
       target: ["a", "b"],
     })!;
-    expect(arrays.input).toEqual([{ role: "user", content: "q" }]);
+    expect(arrays.input).toEqual([testUserMessage({ content: "q" })]);
     expect(arrays.target).toEqual(["a", "b"]);
   });
 
@@ -82,7 +83,7 @@ describe("normalizeSampleSummary", () => {
       ...vintageRow,
       input: [...malformed, { role: "user", content: "q" }],
     })!;
-    expect(summary.input).toEqual([{ role: "user", content: "q" }]);
+    expect(summary.input).toEqual([testUserMessage({ content: "q" })]);
     expect(inputString(summary.input)).toEqual(["q"]);
   });
 
@@ -97,7 +98,7 @@ describe("normalizeSampleSummary", () => {
       ],
     })!;
     expect(summary.input).toEqual([
-      { role: "user", content: [{ type: "text", text: "hi" }] },
+      testUserMessage({ content: [{ type: "text", text: "hi" }] }),
     ]);
     expect(inputString(summary.input)).toEqual(["hi"]);
   });

--- a/packages/inspect-common/src/normalize/summary.test.ts
+++ b/packages/inspect-common/src/normalize/summary.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { modelFallbackLines, totalModelFallbacks } from "../utils";
+
 import { normalizeSampleSummaries, normalizeSampleSummary } from "./index";
 
 // The shape real vintage summaries.json rows carry (2024-era writers).
@@ -72,6 +74,38 @@ describe("normalizeSampleSummary", () => {
       { model: "a", fallback_model: "b", count: 1 },
       { model: "c", fallback_model: "d", count: 3 },
     ]);
+  });
+
+  it.each([
+    ["a null element", [null]],
+    ["a number element", [1]],
+    ["a string element", ["openai/gpt-4"]],
+    ["a record missing model names", [{ count: 2 }]],
+  ])(
+    "drops %s from model_fallbacks so fallback readers stay unguarded",
+    (_label, malformed) => {
+      const summary = normalizeSampleSummary({
+        ...vintageRow,
+        model_fallbacks: [...malformed, { model: "a", fallback_model: "b" }],
+      })!;
+      expect(summary.model_fallbacks).toEqual([
+        { model: "a", fallback_model: "b", count: 1 },
+      ]);
+      expect(totalModelFallbacks(summary.model_fallbacks)).toBe(1);
+      expect(modelFallbackLines(summary.model_fallbacks)).toEqual(["a → b"]);
+    }
+  );
+
+  it("nulls a non-array model_fallbacks and resets a non-numeric count", () => {
+    expect(
+      normalizeSampleSummary({ ...vintageRow, model_fallbacks: "bad" })!
+        .model_fallbacks
+    ).toBeNull();
+    const summary = normalizeSampleSummary({
+      ...vintageRow,
+      model_fallbacks: [{ model: "a", fallback_model: "b", count: "3" }],
+    })!;
+    expect(totalModelFallbacks(summary.model_fallbacks)).toBe(1);
   });
 
   it("returns undefined for non-object entries", () => {

--- a/packages/inspect-common/src/normalize/summary.ts
+++ b/packages/inspect-common/src/normalize/summary.ts
@@ -1,6 +1,6 @@
 import { isRecord } from "@tsmono/util";
 
-import type { EvalSampleSummary, ModelUsage } from "../types";
+import type { EvalSampleSummary, ModelFallback, ModelUsage } from "../types";
 
 import { normalizeModelUsage } from "./events";
 
@@ -28,6 +28,38 @@ export const normalizeModelUsageMap = (
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary lift (#555): every entry round-tripped unchanged, so raw already satisfies the type
   return changed ? usage : (raw as Record<string, ModelUsage>);
+};
+
+const isModelFallback = (value: unknown): value is ModelFallback =>
+  isRecord(value) &&
+  typeof value["model"] === "string" &&
+  typeof value["fallback_model"] === "string" &&
+  typeof value["count"] === "number";
+
+/**
+ * Normalize a raw model-fallbacks rollup: `count` defaults to 1 the way
+ * pydantic fills it; entries without both model names are dropped (pydantic
+ * would refuse them); a non-array becomes null, the "no fallbacks" value.
+ * Identity-preserving on clean input.
+ */
+export const normalizeModelFallbacks = (
+  raw: unknown
+): ModelFallback[] | null => {
+  if (!Array.isArray(raw)) {
+    return null;
+  }
+  const entries = raw as unknown[];
+  if (entries.every(isModelFallback)) {
+    return entries;
+  }
+  const fallbacks: ModelFallback[] = [];
+  for (const entry of entries) {
+    if (!isRecord(entry)) continue;
+    const filled =
+      typeof entry["count"] === "number" ? entry : { ...entry, count: 1 };
+    if (isModelFallback(filled)) fallbacks.push(filled);
+  }
+  return fallbacks;
 };
 
 /**
@@ -79,18 +111,11 @@ export const normalizeSampleSummary = (
   // current writers) set the field explicitly, so only vintage settled
   // rows hit this fill.
   if (typeof raw["completed"] !== "boolean") fix("completed", true);
-  if (Array.isArray(raw["model_fallbacks"])) {
-    let changed = false;
-    const fallbacks: unknown[] = [];
-    for (const fallback of raw["model_fallbacks"] as unknown[]) {
-      if (isRecord(fallback) && typeof fallback["count"] !== "number") {
-        changed = true;
-        fallbacks.push({ ...fallback, count: 1 });
-      } else {
-        fallbacks.push(fallback);
-      }
-    }
-    if (changed) fix("model_fallbacks", fallbacks);
+  // Absent stays absent (the field is optional); anything present must be a
+  // clean rollup or null.
+  if (raw["model_fallbacks"] !== undefined && raw["model_fallbacks"] !== null) {
+    const fallbacks = normalizeModelFallbacks(raw["model_fallbacks"]);
+    if (fallbacks !== raw["model_fallbacks"]) fix("model_fallbacks", fallbacks);
   }
 
   const summary = fixes ? { ...raw, ...fixes } : raw;

--- a/packages/inspect-common/src/normalize/summary.ts
+++ b/packages/inspect-common/src/normalize/summary.ts
@@ -1,6 +1,13 @@
 import { isRecord } from "@tsmono/util";
 
-import type { EvalSampleSummary, ModelFallback, ModelUsage } from "../types";
+import type {
+  ChatMessage,
+  Content,
+  EvalSampleSummary,
+  ModelFallback,
+  ModelUsage,
+  Score,
+} from "../types";
 
 import { normalizeModelUsage } from "./events";
 
@@ -28,6 +35,84 @@ export const normalizeModelUsageMap = (
   }
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary lift (#555): every entry round-tripped unchanged, so raw already satisfies the type
   return changed ? usage : (raw as Record<string, ModelUsage>);
+};
+
+const isContent = (value: unknown): value is Content =>
+  isRecord(value) && typeof value["type"] === "string";
+
+// `role` is not checked: every pydantic message subclass defaults it, so its
+// absence is legal wire data; only the content shape the readers walk is.
+const isChatMessage = (value: unknown): value is ChatMessage =>
+  isRecord(value) &&
+  (typeof value["content"] === "string" ||
+    (Array.isArray(value["content"]) &&
+      (value["content"] as unknown[]).every(isContent)));
+
+const normalizeInputMessage = (raw: unknown): ChatMessage | undefined => {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const content = raw["content"];
+  if (Array.isArray(content)) {
+    const kept = (content as unknown[]).filter(isContent);
+    const message =
+      kept.length === content.length ? raw : { ...raw, content: kept };
+    return isChatMessage(message) ? message : undefined;
+  }
+  return isChatMessage(raw) ? raw : undefined;
+};
+
+/**
+ * Normalize a raw sample input: a string passes through; a message list
+ * drops entries pydantic would refuse (non-records, content that is neither
+ * a string nor a list of typed content items); anything else becomes "".
+ * Identity-preserving on clean input.
+ */
+export const normalizeSampleInput = (raw: unknown): string | ChatMessage[] => {
+  if (typeof raw === "string") {
+    return raw;
+  }
+  if (!Array.isArray(raw)) {
+    return "";
+  }
+  const entries = raw as unknown[];
+  if (entries.every(isChatMessage)) {
+    return entries;
+  }
+  const messages: ChatMessage[] = [];
+  for (const entry of entries) {
+    const message = normalizeInputMessage(entry);
+    if (message !== undefined) messages.push(message);
+  }
+  return messages;
+};
+
+// A score without a value is not a score — pydantic has no default for it.
+const isScore = (value: unknown): value is Score =>
+  isRecord(value) && value["value"] !== undefined;
+
+const isScoreMap = (value: unknown): value is Record<string, Score> =>
+  isRecord(value) && Object.values(value).every(isScore);
+
+/**
+ * Normalize a raw sample scores map (scorer name → Score): non-record and
+ * value-less entries drop; a non-record map becomes null, the "unscored"
+ * value. Identity-preserving on clean input.
+ */
+export const normalizeSampleScores = (
+  raw: unknown
+): Record<string, Score> | null => {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  if (isScoreMap(raw)) {
+    return raw;
+  }
+  const scores: Record<string, Score> = {};
+  for (const [name, score] of Object.entries(raw)) {
+    if (isScore(score)) scores[name] = score;
+  }
+  return scores;
 };
 
 const isModelFallback = (value: unknown): value is ModelFallback =>
@@ -89,13 +174,13 @@ export const normalizeSampleSummary = (
     fixes[field] = value;
   };
 
-  if (typeof raw["input"] !== "string" && !Array.isArray(raw["input"])) {
-    fix("input", "");
-  }
+  const input = normalizeSampleInput(raw["input"]);
+  if (input !== raw["input"]) fix("input", input);
   if (typeof raw["target"] !== "string" && !Array.isArray(raw["target"])) {
     fix("target", "");
   }
-  if (!isRecord(raw["scores"]) && raw["scores"] !== null) fix("scores", null);
+  const scores = normalizeSampleScores(raw["scores"]);
+  if (scores !== raw["scores"]) fix("scores", scores);
   if (!isRecord(raw["metadata"])) fix("metadata", {});
   // Usage entries carry their own required-with-default token fields, read
   // unguarded by the tokens column — fill inside, not just the map.


### PR DESCRIPTION
The normalizers in `@tsmono/inspect-common/normalize` are the point after which raw eval-log JSON is treated as typed data and read unguarded (#555). They checked container types but not element shapes, so a log author could ship arrays and maps whose elements the generated types rule out and pydantic would refuse, and those elements reached readers written to the normalized contract:

- `model_fallbacks` with a null, number, or string element crashed `totalModelFallbacks` / `modelFallbackLines`. For a running eval under the local view server that threw while building the samples descriptor, replacing the whole viewer with the root error panel; for a settled log it threw inside `deriveSampleFields` during details ingestion.
- `results.scores` with a null or metrics-less entry, a sample `scores` map with a null value, or a message-list `input` with a non-message element threw in `deriveLogFields` / `deriveSampleFields` / `inputString` at ingestion.
- A full sample whose `input` array held a non-message element threw in `inputString` when the Scoring tab or the print view rendered.

The ingestion throws had a wider blast radius than the one file: `writeDetails` prepared every payload of a flush batch synchronously before any cache push or database write, so one malformed log kept every unrelated log in the same 250 ms flush window from reaching detailed depth, and the backfill re-enqueued them all together to fail the same way.

Changes, following the existing normalizer conventions (drop what pydantic would refuse, fill what it defaults, keep identity on clean input):

- A shared `normalizeModelFallbacks` drops elements without string `model` / `fallback_model`, fills a non-numeric `count` with 1, and turns a non-array into null. Used by both the summary and the full-sample normalizers.
- A shared `normalizeSampleInput` keeps string inputs, and for message lists drops entries whose `content` is neither a string nor a list of typed content items, dropping untyped items inside a message rather than the whole message.
- `normalizeSampleScores` drops score-map entries that aren't records with a `value`; a non-record map becomes null.
- `normalizeEvalResults` now requires each score to carry a string `name` (`scorer` backfills from it, as the v1 migration already does), fills `metrics` / `params` with `{}`, and drops metric entries without a numeric `value` (filling `name` from the map key and `params` with `{}`, since 2024-era logs wrote `options` instead).
- `writeDetails` prepares each payload of a batch on its own: a payload whose derivation still throws is logged and skipped while the rest of the batch lands.

No read-site guards were added; the readers keep trusting the normalized types. No new lint suppressions: the new checks are type predicates, and the per-file directive counts are unchanged.

Tests: table-driven cases in `summary.test.ts` and `normalize.test.ts` feed each malformed shape through the normalizer and then through the reader that used to throw; `logsContent.test.ts` writes a two-log batch where one log's derivation throws and asserts the other still reaches the database at detailed depth. Each test failed against the previous code.

Not in this PR: the skipped log is still re-enqueued by the next backfill (it is never recorded as a failed fetch, since attempt bookkeeping lives in the fetch engine), and a throw from `toLogPreview` inside `onDetailsComplete` can still end a queue worker. Both need engine-side changes and are left as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)