### PR TITLE
fix: stop log-authored keys from reaching Object.prototype in the viewer

### DIFF
--- a/apps/inspect/src/app/plan/PlanDetailView.test.tsx
+++ b/apps/inspect/src/app/plan/PlanDetailView.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { testEvalScore, testEvalSpec } from "@tsmono/inspect-common/testing";
+import type { EvalScore } from "@tsmono/inspect-common/types";
+import {
+  ComponentIconProvider,
+  ComponentNavigationProvider,
+} from "@tsmono/react/components";
+import { ComponentStateProvider } from "@tsmono/react/state";
+import { makeStateHooks, testIcons } from "@tsmono/react/testing";
+
+import { PlanDetailView } from "./PlanDetailView";
+
+afterEach(cleanup);
+
+const renderScores = (scores: EvalScore[]) =>
+  render(
+    <ComponentStateProvider hooks={makeStateHooks()}>
+      <ComponentIconProvider icons={testIcons}>
+        <ComponentNavigationProvider navigation={{ navigate: () => {} }}>
+          <PlanDetailView evaluation={testEvalSpec()} scores={scores} />
+        </ComponentNavigationProvider>
+      </ComponentIconProvider>
+    </ComponentStateProvider>
+  );
+
+describe("PlanDetailView scorers", () => {
+  it("groups scores by scorer", () => {
+    renderScores([
+      testEvalScore({ scorer: "match", name: "accuracy" }),
+      testEvalScore({ scorer: "match", name: "stderr" }),
+      testEvalScore({ scorer: "model_graded", name: "accuracy" }),
+    ]);
+    expect(screen.getByText("Scorers")).toBeInTheDocument();
+    expect(screen.getByText(/match/)).toBeInTheDocument();
+    expect(screen.getByText(/model_graded/)).toBeInTheDocument();
+  });
+
+  // Scorer names come from the log header; one that is an Object.prototype
+  // member must render as an ordinary group instead of throwing.
+  it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])(
+    "renders a scorer named %s as an ordinary group",
+    (scorer) => {
+      renderScores([
+        testEvalScore({ scorer, name: "accuracy" }),
+        testEvalScore({ scorer, name: "stderr" }),
+      ]);
+      expect(screen.getByText("Scorer")).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(scorer))).toBeInTheDocument();
+    }
+  );
+});

--- a/apps/inspect/src/app/plan/PlanDetailView.tsx
+++ b/apps/inspect/src/app/plan/PlanDetailView.tsx
@@ -45,37 +45,35 @@ export const PlanDetailView: FC<PlanDetailViewProps> = ({
   }
 
   if (scores) {
-    const scorers = scores.reduce<
-      Record<string, { scores: string[]; params: Record<string, unknown> }>
-    >((accum, score) => {
-      const existing = accum[score.scorer];
+    // Map, not a plain object: scorer names come from the log header, and a
+    // name such as "constructor" would otherwise read an inherited member as
+    // an existing group.
+    const scorers = new Map<
+      string,
+      { scores: string[]; params: Record<string, unknown> }
+    >();
+    for (const score of scores) {
+      const existing = scorers.get(score.scorer);
       if (existing === undefined) {
-        accum[score.scorer] = {
+        scorers.set(score.scorer, {
           scores: [score.name],
           params: score.params,
-        };
+        });
       } else {
         existing.scores.push(score.name);
       }
-      return accum;
-    }, {});
+    }
 
-    if (Object.keys(scorers).length > 0) {
-      const label = Object.keys(scorers).length === 1 ? "Scorer" : "Scorers";
-      const scorerPanels = Object.keys(scorers).map((key) => {
-        const scorer = scorers[key];
-        if (scorer === undefined) {
-          return null;
-        }
-        return (
-          <ScorerDetailView
-            key={key}
-            name={key}
-            scores={scorer.scores}
-            params={scorer.params}
-          />
-        );
-      });
+    if (scorers.size > 0) {
+      const label = scorers.size === 1 ? "Scorer" : "Scorers";
+      const scorerPanels = [...scorers].map(([key, scorer]) => (
+        <ScorerDetailView
+          key={key}
+          name={key}
+          scores={scorer.scores}
+          params={scorer.params}
+        />
+      ));
 
       taskColumns.push({
         title: label,

--- a/apps/inspect/src/app/samples/scans/scanReferencePreviews.test.ts
+++ b/apps/inspect/src/app/samples/scans/scanReferencePreviews.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  testAssistantMessage,
+  testInfoEvent,
+  testModelEvent,
+  testModelOutput,
+} from "@tsmono/inspect-common/testing";
+import type { Event } from "@tsmono/inspect-common/types";
+
+import { buildScanReferencePreviews } from "./scanReferencePreviews";
+import { buildScoreMarkdownRefs } from "./scanReferences";
+
+const makeUrl = () => undefined;
+
+const previewFor = (
+  events: Event[],
+  id: string,
+  type: "message" | "event" = "event"
+) =>
+  buildScoreMarkdownRefs(
+    { scanner_references: [{ type, id, cite: "[X1]" }] },
+    makeUrl,
+    buildScanReferencePreviews(events)
+  )[0]?.citePreview;
+
+const prototypeNames = [
+  "constructor",
+  "valueOf",
+  "__proto__",
+  "__defineGetter__",
+  "hasOwnProperty",
+  "toString",
+];
+
+// Reference ids, event uuids and message ids are all log-authored. An id
+// that names an Object.prototype member must yield a preview only when the
+// sample really contains an event or message with that id.
+describe("buildScanReferencePreviews", () => {
+  const events = [testInfoEvent({ uuid: "e1" })];
+
+  it("previews an event that is present and nothing for one that is not", () => {
+    expect(previewFor(events, "e1")).toBeTypeOf("function");
+    expect(previewFor(events, "missing")).toBeUndefined();
+  });
+
+  it.each(prototypeNames)(
+    "yields no preview for reference id %s when no such event exists",
+    (id) => {
+      expect(previewFor(events, id)).toBeUndefined();
+      expect(previewFor([], id)).toBeUndefined();
+    }
+  );
+
+  it.each(prototypeNames)("previews an event whose uuid is %s", (uuid) => {
+    expect(previewFor([testInfoEvent({ uuid })], uuid)).toBeTypeOf("function");
+  });
+
+  it.each(prototypeNames)(
+    "previews a model output message whose id is %s",
+    (id) => {
+      const event = testModelEvent({
+        uuid: "m1",
+        output: testModelOutput({
+          choices: [
+            { message: testAssistantMessage({ id }), stop_reason: "stop" },
+          ],
+        }),
+      });
+      expect(previewFor([event], id, "message")).toBeTypeOf("function");
+    }
+  );
+});

--- a/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
+++ b/apps/inspect/src/app/samples/scans/scanReferencePreviews.tsx
@@ -29,6 +29,8 @@ const TranscriptPreview: FC<{ id: string; events: Event[] }> = ({
   );
 };
 
+export type ScanReferencePreviews = ReadonlyMap<string, () => ReactNode>;
+
 /**
  * Walk events and build a lookup of reference id → preview renderer.
  *
@@ -36,35 +38,39 @@ const TranscriptPreview: FC<{ id: string; events: Event[] }> = ({
  * Event previews render the event inline via a transcript view; message
  * previews render the message inline via a chat view. Messages can live
  * inside ModelEvent input/output, so those are harvested here too.
+ *
+ * A Map, not a plain object: ids are log-authored, and a reference id such
+ * as "constructor" must resolve only to a message or event that really
+ * carries that id.
  */
 export function buildScanReferencePreviews(
   events: readonly Event[] | undefined
-): Record<string, () => ReactNode> {
-  if (!events || events.length === 0) return {};
-  const table: Record<string, () => ReactNode> = {};
+): ScanReferencePreviews {
+  const table = new Map<string, () => ReactNode>();
+  if (!events || events.length === 0) return table;
 
   const addMessage = (msg: ChatMessage | null | undefined) => {
-    if (!msg?.id || table[msg.id]) return;
+    if (!msg?.id || table.has(msg.id)) return;
     const captured = msg;
-    table[msg.id] = () => (
+    table.set(msg.id, () => (
       <ChatView
         id={`ref-preview-${captured.id}`}
         messages={[captured]}
         labels={{ show: false }}
         tools={{ collapseToolMessages: false }}
       />
-    );
+    ));
   };
 
   for (const event of events) {
-    if (event.uuid && !table[event.uuid]) {
+    if (event.uuid && !table.has(event.uuid)) {
       const captured = event;
-      table[event.uuid] = () => (
+      table.set(event.uuid, () => (
         <TranscriptPreview
           id={`ref-preview-${captured.uuid}`}
           events={[captured]}
         />
-      );
+      ));
     }
 
     if (event.event === "model") {

--- a/apps/inspect/src/app/samples/scans/scanReferences.ts
+++ b/apps/inspect/src/app/samples/scans/scanReferences.ts
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback } from "react";
+import { useCallback } from "react";
 
 import type { MarkdownReference } from "@tsmono/react/components";
 import {
@@ -14,18 +14,20 @@ import {
   useSampleUrlBuilder,
 } from "../../routing/url";
 
+import type { ScanReferencePreviews } from "./scanReferencePreviews";
+
 type Metadata = Record<string, unknown> | null | undefined;
 
 export function buildScoreMarkdownRefs(
   metadata: Metadata,
   makeUrl: (id: string, type: ScannerRefType) => string | undefined,
-  previewTable?: Record<string, () => ReactNode>
+  previewTable?: ScanReferencePreviews
 ): MarkdownReference[] {
   return readScannerReferences(metadata).map((ref) => ({
     id: ref.id,
     cite: ref.cite,
     citeUrl: makeUrl(ref.id, ref.type),
-    citePreview: previewTable?.[ref.id],
+    citePreview: previewTable?.get(ref.id),
   }));
 }
 

--- a/apps/inspect/src/app/shared/samples-grid/columns.test.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.test.tsx
@@ -4,13 +4,22 @@ import { testScore } from "@tsmono/inspect-common/testing";
 
 import { testSampleSummary } from "../../../client/api/testClientApi";
 import type { SampleSummary } from "../../../client/api/types";
-import { testSamplesDescriptor } from "../../samples/descriptor/testDescriptors";
+import {
+  testEvalDescriptor,
+  testSamplesDescriptor,
+  testScoreDescriptor,
+} from "../../samples/descriptor/testDescriptors";
 import {
   buildSampleFilterSpecRegistry,
   samplesOperatorsForKind,
 } from "../../samples/sample-tools/filterSpecRegistry";
 
-import { buildSampleColumns, SCORE_FIELD_RAW_PREFIX } from "./columns";
+import type { WireScoreColorScale } from "./colorScale";
+import {
+  buildSampleColumns,
+  SCORE_FIELD_PER_SCORER_PREFIX,
+  SCORE_FIELD_RAW_PREFIX,
+} from "./columns";
 import type { SampleRow } from "./types";
 
 const kField = `${SCORE_FIELD_RAW_PREFIX}quality`;
@@ -176,5 +185,77 @@ describe("buildSampleColumns non-resizable columns", () => {
     expect(cols.find((c) => c.id === "sampleId")?.enableResizing).not.toBe(
       false
     );
+  });
+});
+
+// Score names are the keys of each sample's `scores` record, written by the
+// log author. Names that are Object.prototype members must build ordinary
+// columns instead of dereferencing an inherited builtin.
+describe("buildSampleColumns prototype-named scores", () => {
+  const names = ["constructor", "__proto__", "toString", "hasOwnProperty"];
+  // A `constructor:` literal property is not contextually typed, so the
+  // scale value is declared separately.
+  const goodHigh: WireScoreColorScale = "good-high";
+
+  const sampleWith = (
+    scores: Record<string, ReturnType<typeof testScore>>
+  ): SampleSummary => testSampleSummary({ id: 1, target: "target", scores });
+
+  it.each(names)("discovers a raw-mode score column named %s", (name) => {
+    const cols = buildSampleColumns({
+      viewMode: "grid",
+      multiLog: true,
+      samples: [
+        sampleWith({ [name]: testScore({ value: 1 }) }),
+        sampleWith({ [name]: testScore({ value: 3 }) }),
+      ],
+      scoreColorScales: {},
+    });
+    const col = cols.find((c) => c.id === `${SCORE_FIELD_RAW_PREFIX}${name}`);
+    expect(col?.header).toBe(name);
+    expect(col?.meta?.sortComparator).toBeDefined();
+  });
+
+  it.each(names)(
+    "labels a per-scorer column named %s with its own name",
+    (name) => {
+      const cols = buildSampleColumns({
+        viewMode: "grid",
+        multiLog: false,
+        descriptor: testSamplesDescriptor({
+          evalDescriptor: testEvalDescriptor({
+            scoreDescriptor: () => testScoreDescriptor(),
+          }),
+        }),
+        scores: [
+          { name, scorer: "scorer" },
+          { name: "other", scorer: "scorer" },
+        ],
+        scoreLabels: {},
+        scoreColorScales: {},
+      });
+      const col = cols.find(
+        (c) => c.id === `${SCORE_FIELD_PER_SCORER_PREFIX}scorer__${name}`
+      );
+      expect(col?.header).toBe(name);
+    }
+  );
+
+  it("still applies an own label and colour scale for such a name", () => {
+    const cols = buildSampleColumns({
+      viewMode: "grid",
+      multiLog: true,
+      samples: [
+        sampleWith({ constructor: testScore({ value: 0 }) }),
+        sampleWith({ constructor: testScore({ value: 10 }) }),
+      ],
+      scoreLabels: { constructor: "Constructor" },
+      scoreColorScales: { constructor: goodHigh },
+    });
+    const col = cols.find(
+      (c) => c.id === `${SCORE_FIELD_RAW_PREFIX}constructor`
+    );
+    expect(col?.header).toBe("Constructor");
+    expect(col?.meta?.cellStyle).toBeDefined();
   });
 });

--- a/apps/inspect/src/app/shared/samples-grid/columns.tsx
+++ b/apps/inspect/src/app/shared/samples-grid/columns.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from "react";
 
 import { inputString, modelFallbackLines } from "@tsmono/inspect-common/utils";
 import type { FilterType } from "@tsmono/inspect-components/columnFilter";
-import { arrayToString, filename, formatNumber } from "@tsmono/util";
+import { arrayToString, filename, formatNumber, getOwn } from "@tsmono/util";
 
 import { ScoreLabel } from "../../../app/types";
 import { SampleSummary } from "../../../client/api/types";
@@ -518,8 +518,9 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
   // Resolve a metric name through the eval-author's label overrides,
   // falling back to the raw name. Used for the visible header text;
   // the column `id` is still keyed off the raw name so filter / sort /
-  // visibility stay stable across label changes.
-  const labelFor = (name: string): string => scoreLabels?.[name] ?? name;
+  // visibility stay stable across label changes. Own-key reads: score
+  // names are log-authored, and "constructor" must not read a builtin.
+  const labelFor = (name: string): string => getOwn(scoreLabels, name) ?? name;
 
   // Build a value→style resolver for the score column whose metric is
   // `name`, given its bounds. Returns undefined when no scale is
@@ -529,7 +530,7 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
     name: string,
     bounds: { min?: number; max?: number }
   ): ((value: unknown) => CSSProperties | undefined) | undefined => {
-    const wire = scoreColorScales?.[name];
+    const wire = getOwn(scoreColorScales, name);
     if (!wire) return undefined;
     const resolved = resolveScale(wire, bounds);
     if (!resolved) return undefined;
@@ -609,16 +610,21 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
   // type collisions so a name with mixed value types falls back to text.
   // Also tally numeric min/max per column so colour-scale gradients have
   // something to anchor against (no descriptor exists in raw mode).
-  const types: Record<string, Set<string>> = {};
-  const ranges: Record<string, { min: number; max: number }> = {};
+  // Maps, not plain objects: the names are the log's own score keys.
+  const types = new Map<string, Set<string>>();
+  const ranges = new Map<string, { min: number; max: number }>();
   for (const sample of samples ?? []) {
     if (!sample.scores) continue;
     for (const [name, score] of Object.entries(sample.scores)) {
-      if (!types[name]) types[name] = new Set();
-      types[name].add(typeof score.value);
+      let nameTypes = types.get(name);
+      if (!nameTypes) {
+        nameTypes = new Set();
+        types.set(name, nameTypes);
+      }
+      nameTypes.add(typeof score.value);
       if (typeof score.value === "number" && Number.isFinite(score.value)) {
-        const r = ranges[name];
-        if (!r) ranges[name] = { min: score.value, max: score.value };
+        const r = ranges.get(name);
+        if (!r) ranges.set(name, { min: score.value, max: score.value });
         else {
           if (score.value < r.min) r.min = score.value;
           if (score.value > r.max) r.max = score.value;
@@ -626,11 +632,11 @@ function buildScoreColumns(ctx: SampleGridContext): SampleColumn[] {
       }
     }
   }
-  const scoreNames = Object.keys(types).sort((a, b) => a.localeCompare(b));
+  const scoreNames = [...types.keys()].sort((a, b) => a.localeCompare(b));
   return scoreNames.map((name): SampleColumn => {
-    const nameTypes = types[name];
+    const nameTypes = types.get(name);
     const isUniformNumber = nameTypes?.size === 1 && nameTypes.has("number");
-    const valueToStyle = cellStyleFor(name, ranges[name] ?? {});
+    const valueToStyle = cellStyleFor(name, ranges.get(name) ?? {});
     return {
       id: rawScoreFieldKey(name),
       header: labelFor(name),

--- a/apps/inspect/src/log_data/chunked/format.test.ts
+++ b/apps/inspect/src/log_data/chunked/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  at,
   chunkEntryName,
   chunkIndexOf,
   classifySampleShape,
@@ -60,5 +61,15 @@ describe("chunk math", () => {
     expect(chunkIndexOf(starts, 999)).toBe(0);
     expect(chunkIndexOf(starts, 1000)).toBe(1);
     expect(chunkIndexOf(starts, 2209)).toBe(2);
+  });
+});
+
+describe("at", () => {
+  it("returns own elements", () => {
+    expect(at(["a", "b"], 1)).toBe("b");
+  });
+
+  it.each([-1, 0.5, 2, Number.NaN])("throws for index %s", (i) => {
+    expect(() => at(["a", "b"], i)).toThrow(/out of range/);
   });
 });

--- a/apps/inspect/src/log_data/chunked/format.ts
+++ b/apps/inspect/src/log_data/chunked/format.ts
@@ -93,9 +93,14 @@ export const sequenceChunkStarts = (
   return starts.sort((a, b) => a - b);
 };
 
-/** Bounds-checked index (an out-of-range index is a coding error). */
+/**
+ * Bounds-checked index (an out-of-range index is a coding error). Only an
+ * own integer position counts: a key that resolves through the array's
+ * prototype ("__proto__", "constructor") must not pass as an element.
+ */
 export const at = <T>(items: readonly T[], i: number): T => {
-  const item = items[i];
+  const item =
+    Number.isInteger(i) && i >= 0 && i < items.length ? items[i] : undefined;
   if (item === undefined) {
     throw new Error(`Index ${i} out of range (length ${items.length})`);
   }

--- a/apps/inspect/src/log_data/chunked/skeletonIndex.test.ts
+++ b/apps/inspect/src/log_data/chunked/skeletonIndex.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SkeletonIndex } from "./skeletonIndex";
+import type { SampleSkeleton, SkeletonSpan } from "./types";
+
+const span = (id: string, begin: number, parent?: number): SkeletonSpan => ({
+  id,
+  ...(parent !== undefined ? { parent } : {}),
+  name: id,
+  begin,
+  extent: [begin, begin + 1],
+  t: ["2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00"],
+  working: [0, 0],
+  events: 2,
+  models: 0,
+  gap_models: [0],
+  children: {},
+});
+
+const skeletonOf = (spans: SkeletonSpan[]): SampleSkeleton => ({
+  version: 1,
+  counts: { events: 0, models: 0 },
+  spans,
+  notables: [],
+  overflow: {},
+});
+
+// skeleton.json is JSON.parse'd straight into SampleSkeleton, so `parent`
+// can hold any JSON value at runtime. Reflect.set plants such a value on a
+// well-typed span without lying to the compiler about the type.
+const withRawParent = (s: SkeletonSpan, parent: unknown): SkeletonSpan => {
+  const copy = { ...s };
+  Reflect.set(copy, "parent", parent);
+  return copy;
+};
+
+describe("SkeletonIndex", () => {
+  afterEach(() => {
+    // A leaked push onto Array.prototype would poison every later test:
+    // reset before asserting so the failure stays contained.
+    const leaked = Array.prototype.length;
+    Array.prototype.length = 0;
+    expect(leaked).toBe(0);
+    expect([][0]).toBeUndefined();
+  });
+
+  it("indexes children under their parent and roots at the top", () => {
+    const skel = new SkeletonIndex(
+      skeletonOf([span("root", 0), span("child", 1, 0), span("other", 4)])
+    );
+    expect(skel.roots).toEqual([0, 2]);
+    expect(skel.childrenOf).toEqual([[1], [], []]);
+    expect(skel.spanStackAt(1)).toEqual([0, 1]);
+  });
+
+  it.each([
+    ["__proto__", "__proto__"],
+    ["constructor", "constructor"],
+    ["length", "length"],
+    ["a negative index", -1],
+    ["a fractional index", 0.5],
+    ["a self reference", 1],
+    ["a forward reference", 2],
+    ["an out-of-range index", 99],
+    ["null", null],
+  ])(
+    "rejects a span whose parent is %s without touching Array.prototype",
+    (_, parent) => {
+      const spans = [
+        span("root", 0),
+        withRawParent(span("child", 1), parent),
+        span("tail", 4),
+      ];
+      expect(() => new SkeletonIndex(skeletonOf(spans))).toThrow(/parent/);
+      expect(Object.hasOwn(Array.prototype, "0")).toBe(false);
+    }
+  );
+});

--- a/apps/inspect/src/log_data/chunked/skeletonIndex.ts
+++ b/apps/inspect/src/log_data/chunked/skeletonIndex.ts
@@ -7,6 +7,27 @@
 import { at } from "./format";
 import type { SampleSkeleton, SkeletonSpan } from "./types";
 
+// `parent` is typed number but arrives via JSON.parse of a log-authored
+// sidecar. Anything other than an earlier span's index would index
+// `childrenOf` through its prototype (a "__proto__" parent reaches
+// Array.prototype.push), so the value is checked before it is used as a key.
+const parentIndex = (parent: unknown, i: number): number | undefined => {
+  if (parent === undefined) {
+    return undefined;
+  }
+  if (
+    typeof parent !== "number" ||
+    !Number.isInteger(parent) ||
+    parent < 0 ||
+    parent >= i
+  ) {
+    throw new Error(
+      `Skeleton span ${i} has an invalid parent ${JSON.stringify(parent)}`
+    );
+  }
+  return parent;
+};
+
 export class SkeletonIndex {
   readonly spans: SkeletonSpan[];
   readonly childrenOf: number[][];
@@ -20,10 +41,11 @@ export class SkeletonIndex {
     this.roots = [];
     this.spans.forEach((span, i) => {
       this.byBegin.set(span.begin, i);
-      if (span.parent === undefined) {
+      const parent = parentIndex(span.parent, i);
+      if (parent === undefined) {
         this.roots.push(i);
       } else {
-        at(this.childrenOf, span.parent).push(i);
+        at(this.childrenOf, parent).push(i);
       }
     });
     this.spanIds = new Set(this.spans.map((span) => span.id));

--- a/apps/inspect/src/state/appSlice.test.ts
+++ b/apps/inspect/src/state/appSlice.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { testStoreState } from "./testStore";
+
+// Property bags are named by component ids, and transcript panels use the
+// event uuid straight from the log. A bag name or key that is an
+// Object.prototype member must be an ordinary own entry, never a read of or
+// write to the shared prototype.
+describe("appSlice property bags prototype safety", () => {
+  const prototypeKeys = new Set(Object.getOwnPropertyNames(Object.prototype));
+
+  afterEach(() => {
+    for (const key of Object.getOwnPropertyNames(Object.prototype)) {
+      if (!prototypeKeys.has(key))
+        Reflect.deleteProperty(Object.prototype, key);
+    }
+  });
+
+  it.each(["__proto__", "constructor", "toString"])(
+    "stores a value under bag %s without touching Object.prototype",
+    (bagName) => {
+      const { appActions } = testStoreState();
+
+      appActions.setPropertyValue(bagName, "selectedNav", "planted-nav");
+
+      expect(Object.hasOwn(Object.prototype, "selectedNav")).toBe(false);
+      expect(appActions.getPropertyValue(bagName, "selectedNav")).toBe(
+        "planted-nav"
+      );
+      expect(
+        appActions.getPropertyValue("another-bag", "selectedNav", "default")
+      ).toBe("default");
+    }
+  );
+
+  it("stores a __proto__ key inside a bag as an own entry", () => {
+    const { appActions } = testStoreState();
+
+    appActions.setPropertyValue("bag", "__proto__", { planted_key: 1 });
+
+    expect(Object.hasOwn(Object.prototype, "planted_key")).toBe(false);
+    expect(appActions.getPropertyValue("bag", "__proto__")).toEqual({
+      planted_key: 1,
+    });
+  });
+
+  it.each(["constructor", "toString", "hasOwnProperty", "__proto__"])(
+    "reads an absent %s key as the default",
+    (key) => {
+      const { appActions } = testStoreState();
+      appActions.setPropertyValue("bag", "other", 1);
+
+      expect(appActions.getPropertyValue("bag", key, "default")).toBe(
+        "default"
+      );
+      expect(appActions.getPropertyValue(key, "other", "default")).toBe(
+        "default"
+      );
+    }
+  );
+
+  it("ignores keys planted on Object.prototype", () => {
+    const { appActions } = testStoreState();
+    appActions.setPropertyValue("bag", "other", 1);
+    Object.defineProperty(Object.prototype, "planted_read", {
+      value: "polluted",
+      configurable: true,
+      writable: true,
+    });
+
+    expect(appActions.getPropertyValue("bag", "planted_read", "default")).toBe(
+      "default"
+    );
+    expect(appActions.getPropertyValue("missing", "x", "default")).toBe(
+      "default"
+    );
+  });
+
+  it("removes values and bags named after prototype members", () => {
+    const { appActions } = testStoreState();
+    appActions.setPropertyValue("__proto__", "a", 1);
+    appActions.setPropertyValue("__proto__", "b", 2);
+
+    appActions.removePropertyValue("__proto__", "a");
+    expect(appActions.getPropertyValue("__proto__", "a", "gone")).toBe("gone");
+    expect(appActions.getPropertyValue("__proto__", "b")).toBe(2);
+
+    appActions.removeByPrefix("__proto__", "b");
+    expect(appActions.getPropertyValue("__proto__", "b", "gone")).toBe("gone");
+
+    appActions.setPropertyValue("constructor", "a", 1);
+    appActions.removeAllProperties("constructor");
+    expect(appActions.getPropertyValue("constructor", "a", "gone")).toBe(
+      "gone"
+    );
+    expect(Object.hasOwn(Object.prototype, "a")).toBe(false);
+    expect(Object.hasOwn(Object.prototype, "b")).toBe(false);
+  });
+});

--- a/apps/inspect/src/state/appSlice.ts
+++ b/apps/inspect/src/state/appSlice.ts
@@ -1,5 +1,5 @@
 import type { VirtualListStateSnapshot } from "@tsmono/react/virtual";
-import { clearDocumentSelection } from "@tsmono/util";
+import { clearDocumentSelection, getOwn } from "@tsmono/util";
 
 import { AppState } from "../app/types";
 import { Capabilities } from "../client/api/types";
@@ -294,28 +294,42 @@ export const createAppSlice = (
         key: string,
         defaultValue?: T
       ): T => {
-        const state = get();
-        const bag = state.app.propertyBags[bagName] || {};
+        const bag = getOwn(get().app.propertyBags, bagName);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- unsound-by-design generic accessor: property bags hold unknown, and T is the caller's claim about their own property
-        return (key in bag ? bag[key] : defaultValue) as T;
+        return (
+          bag !== undefined && Object.hasOwn(bag, key) ? bag[key] : defaultValue
+        ) as T;
       },
 
       setPropertyValue: <T>(bagName: string, key: string, value: T) => {
         set((state) => {
-          // Create the bag if it doesn't exist
-          if (!state.app.propertyBags[bagName]) {
-            state.app.propertyBags[bagName] = {};
+          const bags = state.app.propertyBags;
+          const bag = getOwn(bags, bagName);
+          if (bag !== undefined && key !== "__proto__") {
+            bag[key] = value;
+            return;
           }
-          // Only update the specific key
-          state.app.propertyBags[bagName][key] = value;
+          // Bag names are component ids (transcript panels use the log's
+          // event uuid). A computed-key literal defines an own property,
+          // whereas assigning a "__proto__" name or key reaches the
+          // inherited setter, which immer's draft turns into a
+          // setPrototypeOf error.
+          state.app.propertyBags = {
+            ...bags,
+            [bagName]: { ...bag, [key]: value },
+          };
         });
       },
 
       removePropertyValue: (bagName: string, key: string) => {
         set((state) => {
-          if (state.app.propertyBags[bagName]) {
-            const { [key]: _, ...rest } = state.app.propertyBags[bagName];
-            state.app.propertyBags[bagName] = rest;
+          const bag = getOwn(state.app.propertyBags, bagName);
+          if (bag !== undefined) {
+            const { [key]: _, ...rest } = bag;
+            state.app.propertyBags = {
+              ...state.app.propertyBags,
+              [bagName]: rest,
+            };
           }
         });
       },
@@ -342,7 +356,7 @@ export const createAppSlice = (
 
       removeByPrefix: (bagName: string, prefix: string) => {
         set((state) => {
-          const bag = state.app.propertyBags[bagName];
+          const bag = getOwn(state.app.propertyBags, bagName);
           if (!bag) return;
           let changed = false;
           const next = { ...bag };
@@ -357,7 +371,10 @@ export const createAppSlice = (
               const { [bagName]: _, ...rest } = state.app.propertyBags;
               state.app.propertyBags = rest;
             } else {
-              state.app.propertyBags[bagName] = next;
+              state.app.propertyBags = {
+                ...state.app.propertyBags,
+                [bagName]: next,
+              };
             }
           }
         });

--- a/apps/inspect/src/state/componentStateAdapter.ts
+++ b/apps/inspect/src/state/componentStateAdapter.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { ComponentStateHooks } from "@tsmono/react/state";
+import { getOwn } from "@tsmono/util";
 
 import { useStore } from "./store";
 
@@ -16,7 +17,7 @@ export const inspectStateHooks: ComponentStateHooks = {
   useRemoveValue: () =>
     useStore((state) => state.appActions.removePropertyValue),
   useEntries: (id: string) =>
-    useStore(useCallback((state) => state.app.propertyBags[id], [id])),
+    useStore(useCallback((state) => getOwn(state.app.propertyBags, id), [id])),
   useRemoveAll: () => useStore((state) => state.appActions.removeAllProperties),
   useRemoveByPrefix: () => useStore((state) => state.appActions.removeByPrefix),
 };

--- a/apps/inspect/src/utils/attachments.test.ts
+++ b/apps/inspect/src/utils/attachments.test.ts
@@ -85,3 +85,46 @@ describe("resolveAttachments", () => {
     expect(resolveAttachments(undefined, attachments)).toBeUndefined();
   });
 });
+
+// Attachment ids are the suffix of a log-authored string; one that names an
+// Object.prototype member is a miss, never the inherited builtin.
+describe("resolveAttachments prototype-named ids", () => {
+  it.each([
+    "constructor",
+    "__proto__",
+    "toString",
+    "valueOf",
+    "hasOwnProperty",
+  ])("treats attachment://%s as a miss", (id) => {
+    const onFailedResolve = vi.fn();
+    const ref = `attachment://${id}`;
+    expect(resolveAttachments(ref, attachments, onFailedResolve)).toBe(ref);
+    expect(onFailedResolve).toHaveBeenCalledWith(id);
+    expect(
+      resolveAttachments({ content: [ref] }, attachments, onFailedResolve)
+    ).toEqual({ content: [ref] });
+  });
+
+  it("resolves an own attachment stored under such an id", () => {
+    expect(
+      resolveAttachments("attachment://constructor", {
+        constructor: "own content",
+      })
+    ).toBe("own content");
+  });
+
+  it("ignores attachments planted on Object.prototype", () => {
+    Object.defineProperty(Object.prototype, "planted_attachment", {
+      value: "polluted",
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(
+        resolveAttachments("attachment://planted_attachment", attachments)
+      ).toBe("attachment://planted_attachment");
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "planted_attachment");
+    }
+  });
+});

--- a/apps/inspect/src/utils/attachments.ts
+++ b/apps/inspect/src/utils/attachments.ts
@@ -1,3 +1,5 @@
+import { getOwn } from "@tsmono/util";
+
 const CONTENT_PROTOCOL = "tc://";
 const ATTACHMENT_PROTOCOL = "attachment://";
 
@@ -14,7 +16,9 @@ const resolveString = (
     return value;
   }
   const attachmentId = ref.slice(ATTACHMENT_PROTOCOL.length);
-  const attachment = attachments[attachmentId];
+  // Own-key read: the id is log-authored, and "constructor" must be a miss
+  // rather than the inherited builtin.
+  const attachment = getOwn(attachments, attachmentId);
   if (attachment === undefined) {
     onFailedResolve?.(attachmentId);
     // A miss keeps the original (un-rewritten) string

--- a/apps/scout/src/state/componentStateAdapter.ts
+++ b/apps/scout/src/state/componentStateAdapter.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { ComponentStateHooks } from "@tsmono/react/state";
+import { getOwn } from "@tsmono/util";
 
 import { useStore } from "./store";
 
@@ -15,7 +16,7 @@ export const scoutStateHooks: ComponentStateHooks = {
   useSetValue: () => useStore((state) => state.setPropertyValue),
   useRemoveValue: () => useStore((state) => state.removePropertyValue),
   useEntries: (id: string) =>
-    useStore(useCallback((state) => state.properties[id], [id])),
+    useStore(useCallback((state) => getOwn(state.properties, id), [id])),
   useRemoveAll: () => useStore((state) => state.removeAllProperties),
   useRemoveByPrefix: () => useStore((state) => state.removeByPrefix),
 };

--- a/apps/scout/src/state/store.test.ts
+++ b/apps/scout/src/state/store.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { apiScoutServer } from "../api/api-scout-server";
+
+import { createStore } from "./store";
+
+// Property groups are named by component ids, and transcript panels use the
+// event uuid straight from the log. An id or property name that is an
+// Object.prototype member must be an ordinary own entry, never a read of or
+// write to the shared prototype.
+describe("store properties prototype safety", () => {
+  const prototypeKeys = new Set(Object.getOwnPropertyNames(Object.prototype));
+
+  afterEach(() => {
+    for (const key of Object.getOwnPropertyNames(Object.prototype)) {
+      if (!prototypeKeys.has(key))
+        Reflect.deleteProperty(Object.prototype, key);
+    }
+  });
+
+  const actions = () => createStore(apiScoutServer()).getState();
+
+  it.each(["__proto__", "constructor", "toString"])(
+    "stores a value under id %s without touching Object.prototype",
+    (id) => {
+      const store = actions();
+
+      store.setPropertyValue(id, "selectedNav", "planted-nav");
+
+      expect(Object.hasOwn(Object.prototype, "selectedNav")).toBe(false);
+      expect(store.getPropertyValue(id, "selectedNav")).toBe("planted-nav");
+      expect(
+        store.getPropertyValue("another-id", "selectedNav", "default")
+      ).toBe("default");
+    }
+  );
+
+  it("stores a __proto__ property inside a group as an own entry", () => {
+    const store = actions();
+
+    store.setPropertyValue("id", "__proto__", { planted_key: 1 });
+
+    expect(Object.hasOwn(Object.prototype, "planted_key")).toBe(false);
+    expect(store.getPropertyValue("id", "__proto__")).toEqual({
+      planted_key: 1,
+    });
+  });
+
+  it.each(["constructor", "toString", "hasOwnProperty", "__proto__"])(
+    "reads an absent %s property as the default",
+    (name) => {
+      const store = actions();
+      store.setPropertyValue("id", "other", 1);
+
+      expect(store.getPropertyValue("id", name, "default")).toBe("default");
+      expect(store.getPropertyValue(name, "other", "default")).toBe("default");
+    }
+  );
+
+  it("removes properties and groups named after prototype members", () => {
+    const store = actions();
+    store.setPropertyValue("__proto__", "a", 1);
+    store.setPropertyValue("__proto__", "b", 2);
+
+    store.removePropertyValue("__proto__", "a");
+    expect(store.getPropertyValue("__proto__", "a", "gone")).toBe("gone");
+    expect(store.getPropertyValue("__proto__", "b")).toBe(2);
+
+    store.removeByPrefix("__proto__", "b");
+    expect(store.getPropertyValue("__proto__", "b", "gone")).toBe("gone");
+
+    store.setPropertyValue("constructor", "a", 1);
+    store.removeAllProperties("constructor");
+    expect(store.getPropertyValue("constructor", "a", "gone")).toBe("gone");
+    expect(Object.hasOwn(Object.prototype, "a")).toBe(false);
+  });
+});

--- a/apps/scout/src/state/store.ts
+++ b/apps/scout/src/state/store.ts
@@ -16,7 +16,7 @@ import {
   type SearchPanelState,
 } from "@tsmono/inspect-components/transcript-search";
 import type { VirtualListStateSnapshot } from "@tsmono/react/virtual";
-import { debounce } from "@tsmono/util";
+import { debounce, getOwn } from "@tsmono/util";
 
 import { ScoutApiV2 } from "../api/api";
 import { ColumnSizingStrategyKey } from "../app/components/columnSizing";
@@ -433,10 +433,20 @@ export const createStore = (api: ScoutApiV2) =>
           },
           setPropertyValue(id: string, propertyName: string, value: unknown) {
             set((state) => {
-              if (!state.properties[id]) {
-                state.properties[id] = {};
+              const group = getOwn(state.properties, id);
+              if (group !== undefined && propertyName !== "__proto__") {
+                group[propertyName] = value;
+                return;
               }
-              state.properties[id][propertyName] = value;
+              // Ids are component ids (transcript panels use the log's event
+              // uuid). A computed-key literal defines an own property,
+              // whereas assigning a "__proto__" id or name reaches the
+              // inherited setter, which immer's draft turns into a
+              // setPrototypeOf error.
+              state.properties = {
+                ...state.properties,
+                [id]: { ...group, [propertyName]: value },
+              };
             });
           },
           getPropertyValue(
@@ -444,15 +454,23 @@ export const createStore = (api: ScoutApiV2) =>
             propertyName: string,
             defaultValue: unknown
           ): unknown {
-            const value = get().properties[id]?.[propertyName];
+            const group = getOwn(get().properties, id);
+            const value =
+              group !== undefined && Object.hasOwn(group, propertyName)
+                ? group[propertyName]
+                : undefined;
             return value !== undefined ? value : defaultValue;
           },
           removePropertyValue(id: string, propertyName: string) {
             set((state) => {
-              const propertyGroup = state.properties[id];
+              const propertyGroup = getOwn(state.properties, id);
 
               // No property, go ahead and return
-              if (!propertyGroup || !propertyGroup[propertyName]) {
+              if (
+                !propertyGroup ||
+                !Object.hasOwn(propertyGroup, propertyName) ||
+                !propertyGroup[propertyName]
+              ) {
                 return;
               }
 
@@ -469,7 +487,10 @@ export const createStore = (api: ScoutApiV2) =>
               }
 
               // Update to the delete properties
-              state.properties[id] = remainingProperties;
+              state.properties = {
+                ...state.properties,
+                [id]: remainingProperties,
+              };
             });
           },
           removeAllProperties(id: string) {
@@ -480,7 +501,7 @@ export const createStore = (api: ScoutApiV2) =>
           },
           removeByPrefix(id: string, prefix: string) {
             set((state) => {
-              const bag = state.properties[id];
+              const bag = getOwn(state.properties, id);
               if (!bag) return;
               let changed = false;
               const next = { ...bag };
@@ -495,7 +516,7 @@ export const createStore = (api: ScoutApiV2) =>
                   const { [id]: _, ...remaining } = state.properties;
                   state.properties = remaining;
                 } else {
-                  state.properties[id] = next;
+                  state.properties = { ...state.properties, [id]: next };
                 }
               }
             });

--- a/packages/inspect-components/src/chat/ChatMessageRow.tsx
+++ b/packages/inspect-components/src/chat/ChatMessageRow.tsx
@@ -3,6 +3,7 @@ import { FC, memo, ReactNode } from "react";
 
 import type { ChatMessageTool } from "@tsmono/inspect-common/types";
 import type { MarkdownReference } from "@tsmono/react/components";
+import { getOwn } from "@tsmono/util";
 
 import { ChatMessage } from "./ChatMessage";
 import styles from "./ChatMessageRow.module.css";
@@ -69,7 +70,7 @@ export const ChatMessageRow = memo(function ChatMessageRow({
     blockId: string | null | undefined,
     blockNumber: number
   ): string | undefined =>
-    labelValues && blockId ? labelValues[blockId] : String(blockNumber);
+    labelValues && blockId ? getOwn(labelValues, blockId) : String(blockNumber);
 
   const hasToolCalls =
     toolCallStyle !== "omit" &&

--- a/packages/inspect-components/src/transcript/ToolEventView.tsx
+++ b/packages/inspect-components/src/transcript/ToolEventView.tsx
@@ -9,6 +9,7 @@ import {
   substituteToolCallContent,
   type ChatViewLabelOptions,
 } from "@tsmono/inspect-components/chat";
+import { getOwn } from "@tsmono/util";
 
 import { computeMaxLabelLength } from "../chat/labelLength";
 import { MessageLabel } from "../chat/MessageLabel";
@@ -87,12 +88,13 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
 
   const toolLabels = useMemo<ChatViewLabelOptions>(() => {
     const messageLabels = context?.messageLabels;
+    const toolLabelMap = context?.toolLabels;
     if (!messageLabels) return { show: false };
 
     const directLabel = event.message_id
-      ? messageLabels[event.message_id]
+      ? getOwn(messageLabels, event.message_id)
       : undefined;
-    const label = directLabel ?? context.toolLabels?.[event.id];
+    const label = directLabel ?? getOwn(toolLabelMap, event.id);
     return { messageLabels: label ? { [event.id]: label } : {} };
   }, [context?.messageLabels, context?.toolLabels, event.id, event.message_id]);
 

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.test.tsx
@@ -160,3 +160,34 @@ describe("renderTranscriptFooter", () => {
     expect(container.firstChild).toBeNull();
   });
 });
+
+// Event labels are keyed by the log's event uuid. A uuid that names an
+// Object.prototype member must read as "no label", not as the builtin.
+describe("TranscriptVirtualList event labels", () => {
+  const renderLabeled = (nodes: EventNode[]) =>
+    render(
+      <ComponentStateProvider hooks={stateHooks}>
+        <TranscriptVirtualList
+          id="labels-test"
+          listHandle={createRef<VirtualListHandle | null>()}
+          eventNodes={nodes}
+          disableVirtualization={true}
+          eventNodeContext={{ eventLabels: { labeled: "[E1]" } }}
+        />
+      </ComponentStateProvider>
+    );
+
+  it("shows the label of a cited event", () => {
+    renderLabeled([node("labeled", 0)]);
+    expect(screen.getAllByText("E1")).toHaveLength(1);
+  });
+
+  it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])(
+    "renders an event with uuid %s unlabeled",
+    (uuid) => {
+      const { container } = renderLabeled([node("labeled", 0), node(uuid, 0)]);
+      expect(container.querySelector(`[id="${uuid}"]`)).not.toBeNull();
+      expect(screen.getAllByText("E1")).toHaveLength(1);
+    }
+  );
+});

--- a/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
+++ b/packages/inspect-components/src/transcript/TranscriptVirtualListComponent.tsx
@@ -14,6 +14,7 @@ import {
 
 import { VirtualList } from "@tsmono/react/virtual";
 import type { VirtualListHandle } from "@tsmono/react/virtual";
+import { getOwn } from "@tsmono/util";
 
 import { GeneratingIndicator } from "../indicators/GeneratingIndicator";
 import { LoadingEventsIndicator } from "../indicators/LoadingEventsIndicator";
@@ -194,7 +195,7 @@ export const TranscriptVirtualListComponent: FC<
       const context = contextMap.get(item.id);
       const isLast = index === eventNodes.length - 1;
       const renderedNode = (
-        <EventLabelContext.Provider value={eventLabels?.[item.id]}>
+        <EventLabelContext.Provider value={getOwn(eventLabels, item.id)}>
           <RenderedEventNode
             node={item}
             next={next}

--- a/packages/inspect-components/src/transcript/transform/labels.ts
+++ b/packages/inspect-components/src/transcript/transform/labels.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Event } from "@tsmono/inspect-common/types";
+import { getOwn } from "@tsmono/util";
 
 /**
  * Derive tool-event labels from message labels.
@@ -22,13 +23,13 @@ export const buildToolLabels = (
   for (const event of events) {
     if (event.event === "tool") {
       const label = event.message_id
-        ? messageLabels[event.message_id]
+        ? getOwn(messageLabels, event.message_id)
         : undefined;
       if (label) toolLabels[event.id] = label;
     } else if (event.event === "model") {
       for (const message of event.input) {
         if (message.role !== "tool" || !message.id) continue;
-        const label = messageLabels[message.id];
+        const label = getOwn(messageLabels, message.id);
         if (label && message.tool_call_id) {
           toolLabels[message.tool_call_id] = label;
         }

--- a/packages/inspect-components/src/usage/configsForUsage.test.ts
+++ b/packages/inspect-components/src/usage/configsForUsage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { testEvalSpec, testModelConfig } from "@tsmono/inspect-common/testing";
 import type { ModelConfig } from "@tsmono/inspect-common/types";
@@ -99,4 +99,103 @@ describe("buildArgsByRole", () => {
       grader: { chain_of_thought: true, seed: 2 },
     });
   });
+});
+
+// Model names, role names and model_args keys come straight from the log
+// header. A name that is an Object.prototype member must become an ordinary
+// entry, never a write onto Object.prototype or the Object constructor.
+describe("prototype safety", () => {
+  const prototypeKeys = new Set(Object.getOwnPropertyNames(Object.prototype));
+  const objectStatics = new Set(Object.getOwnPropertyNames(Object));
+  const objectKeys = Object.keys;
+
+  afterEach(() => {
+    for (const key of Object.getOwnPropertyNames(Object.prototype)) {
+      if (!prototypeKeys.has(key))
+        Reflect.deleteProperty(Object.prototype, key);
+    }
+    for (const key of Object.getOwnPropertyNames(Object)) {
+      if (!objectStatics.has(key)) Reflect.deleteProperty(Object, key);
+    }
+    Object.keys = objectKeys;
+  });
+
+  it("keeps a __proto__ model's args and config off Object.prototype", () => {
+    const spec = testEvalSpec({
+      model: "__proto__",
+      model_args: { planted_args: 1 },
+      model_generate_config: { temperature: 0.5 },
+    });
+
+    const args = buildArgsByModel(spec);
+    const configs = buildConfigsByModel(spec);
+
+    expect(Object.hasOwn(Object.prototype, "planted_args")).toBe(false);
+    expect(Object.hasOwn(Object.prototype, "temperature")).toBe(false);
+    expect(args && Object.entries(args)).toEqual([
+      ["__proto__", { planted_args: 1 }],
+    ]);
+    expect(configs && Object.entries(configs)).toEqual([
+      ["__proto__", { temperature: 0.5 }],
+    ]);
+  });
+
+  it("keeps a constructor model's args off the Object constructor", () => {
+    const spec = testEvalSpec({
+      model: "constructor",
+      model_args: { keys: "clobbered" },
+    });
+
+    const args = buildArgsByModel(spec);
+
+    expect(Object.keys).toBe(objectKeys);
+    expect(Object.hasOwn(Object, "keys")).toBe(true);
+    expect(args && Object.entries(args)).toEqual([
+      ["constructor", { keys: "clobbered" }],
+    ]);
+  });
+
+  it.each(["__proto__", "constructor", "toString"])(
+    "keeps a role named %s as an ordinary entry",
+    (role) => {
+      const spec = testEvalSpec({
+        model_roles: {
+          [role]: config("mockllm/model", { temperature: 1 }, { planted: 1 }),
+        },
+      });
+
+      expect(buildConfigsByRole(spec)).toEqual({ [role]: { temperature: 1 } });
+      expect(buildArgsByRole(spec)).toEqual({ [role]: { planted: 1 } });
+      expect(Object.hasOwn(Object.prototype, "planted")).toBe(false);
+      expect(Object.hasOwn(Object.prototype, "temperature")).toBe(false);
+    }
+  );
+
+  it("does not let a __proto__ key in model_args re-parent the record", () => {
+    const spec = testEvalSpec({
+      model: "mockllm/model",
+      model_args: { ["__proto__"]: { planted_inner: 1 }, seed: 1 },
+    });
+
+    const args = buildArgsByModel(spec)?.["mockllm/model"];
+
+    expect(Object.hasOwn(Object.prototype, "planted_inner")).toBe(false);
+    expect(args && Object.entries(args)).toEqual([
+      ["__proto__", { planted_inner: 1 }],
+      ["seed", 1],
+    ]);
+  });
+
+  it.each(["constructor", "toString", "hasOwnProperty"])(
+    "reads an absent %s entry as undefined",
+    (name) => {
+      const spec = testEvalSpec({
+        model: "mockllm/model",
+        model_args: { seed: 1 },
+      });
+      const args = buildArgsByModel(spec);
+      expect(args?.[name]).toBeUndefined();
+      expect(args?.["mockllm/model"]?.[name]).toBeUndefined();
+    }
+  );
 });

--- a/packages/inspect-components/src/usage/configsForUsage.ts
+++ b/packages/inspect-components/src/usage/configsForUsage.ts
@@ -1,39 +1,51 @@
 import type { EvalSpec } from "@tsmono/inspect-common/types";
 import { modelRoleConfigs } from "@tsmono/inspect-common/utils";
+import { nullProtoRecord } from "@tsmono/util";
 
 type Dict = Record<string, unknown>;
 type DictMap = Record<string, Dict>;
 
-const mergeDefined = (target: Dict, source: Dict): Dict => {
+// Maps, not plain objects — model names, role names and model_args keys all
+// come from the log header, so "__proto__" or "constructor" must be ordinary
+// keys, never a write through the prototype chain.
+type Accumulator = Map<string, Map<string, unknown>>;
+
+const mergeDefined = (target: Map<string, unknown>, source: Dict): void => {
   for (const [k, v] of Object.entries(source)) {
-    if (v !== null && v !== undefined) target[k] = v;
+    if (v !== null && v !== undefined) target.set(k, v);
   }
-  return target;
 };
 
-const finalize = (acc: DictMap): DictMap | undefined => {
-  const out: DictMap = {};
-  for (const [k, v] of Object.entries(acc)) {
-    if (Object.keys(v).length > 0) out[k] = v;
+const addTo = (
+  acc: Accumulator,
+  key: string | null | undefined,
+  dict: Dict | null | undefined
+): void => {
+  if (!key || !dict) return;
+  const target = acc.get(key) ?? new Map<string, unknown>();
+  mergeDefined(target, dict);
+  acc.set(key, target);
+};
+
+const finalize = (acc: Accumulator): DictMap | undefined => {
+  const out = new Map<string, Dict>();
+  for (const [k, v] of acc) {
+    if (v.size > 0) out.set(k, nullProtoRecord(v));
   }
-  return Object.keys(out).length > 0 ? out : undefined;
+  return out.size > 0 ? nullProtoRecord(out) : undefined;
 };
 
 export const buildConfigsByModel = (
   evalSpec?: EvalSpec
 ): DictMap | undefined => {
   if (!evalSpec) return undefined;
-  const acc: DictMap = {};
-  const add = (modelId?: string | null, cfg?: Dict | null) => {
-    if (!modelId || !cfg) return;
-    acc[modelId] = mergeDefined(acc[modelId] ?? {}, cfg);
-  };
-  add(evalSpec.model, evalSpec.model_generate_config);
+  const acc: Accumulator = new Map();
+  addTo(acc, evalSpec.model, evalSpec.model_generate_config);
   if (evalSpec.model_roles) {
     for (const rc of Object.values(evalSpec.model_roles).flatMap(
       modelRoleConfigs
     )) {
-      add(rc.model, rc.config);
+      addTo(acc, rc.model, rc.config);
     }
   }
   return finalize(acc);
@@ -43,13 +55,12 @@ export const buildConfigsByRole = (
   evalSpec?: EvalSpec
 ): DictMap | undefined => {
   if (!evalSpec?.model_roles) return undefined;
-  const acc: DictMap = {};
+  const acc: Accumulator = new Map();
   for (const [role, value] of Object.entries(evalSpec.model_roles)) {
     // a role bound to a list of models merges its configs (later models
     // override earlier ones), mirroring how buildConfigsByModel accumulates
     for (const rc of modelRoleConfigs(value)) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (rc.config) acc[role] = mergeDefined(acc[role] ?? {}, rc.config);
+      addTo(acc, role, rc.config);
     }
   }
   return finalize(acc);
@@ -57,17 +68,13 @@ export const buildConfigsByRole = (
 
 export const buildArgsByModel = (evalSpec?: EvalSpec): DictMap | undefined => {
   if (!evalSpec) return undefined;
-  const acc: DictMap = {};
-  const add = (modelId?: string | null, args?: Dict | null) => {
-    if (!modelId || !args) return;
-    acc[modelId] = mergeDefined(acc[modelId] ?? {}, args);
-  };
-  add(evalSpec.model, evalSpec.model_args);
+  const acc: Accumulator = new Map();
+  addTo(acc, evalSpec.model, evalSpec.model_args);
   if (evalSpec.model_roles) {
     for (const rc of Object.values(evalSpec.model_roles).flatMap(
       modelRoleConfigs
     )) {
-      add(rc.model, rc.args);
+      addTo(acc, rc.model, rc.args);
     }
   }
   return finalize(acc);
@@ -75,11 +82,10 @@ export const buildArgsByModel = (evalSpec?: EvalSpec): DictMap | undefined => {
 
 export const buildArgsByRole = (evalSpec?: EvalSpec): DictMap | undefined => {
   if (!evalSpec?.model_roles) return undefined;
-  const acc: DictMap = {};
+  const acc: Accumulator = new Map();
   for (const [role, value] of Object.entries(evalSpec.model_roles)) {
     for (const rc of modelRoleConfigs(value)) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (rc.args) acc[role] = mergeDefined(acc[role] ?? {}, rc.args);
+      addTo(acc, role, rc.args);
     }
   }
   return finalize(acc);

--- a/packages/inspect-components/src/usage/connectionHistory.ts
+++ b/packages/inspect-components/src/usage/connectionHistory.ts
@@ -4,6 +4,7 @@ import type {
   ConnectionLimitChange,
 } from "@tsmono/inspect-common/types";
 import { formatConfigValue, isoToEpoch } from "@tsmono/inspect-common/utils";
+import { nullProtoRecord } from "@tsmono/util";
 
 export interface ConnectionWindow {
   start: number;
@@ -22,17 +23,6 @@ export interface ConnectionLaneData {
 }
 
 const kAdaptiveDefaultMax = 100;
-
-// fromEntries alone only makes *present* keys own properties — an absent
-// prototype-named key ("constructor" with no retunes) would still resolve
-// through Object.prototype at read sites. A null prototype closes both.
-const nullProtoRecord = <T>(entries: Map<string, T>): Record<string, T> => {
-  // setPrototypeOf rather than Object.create + assign: fromEntries already
-  // gives a correctly typed record, and Object.create returns `any`.
-  const record = Object.fromEntries(entries);
-  Object.setPrototypeOf(record, null);
-  return record;
-};
 
 // History timestamps are epoch seconds while started_at/completed_at are ISO
 // strings; normalize here. The window expands to cover any events outside the

--- a/packages/util/src/object.test.ts
+++ b/packages/util/src/object.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { getOwn, nullProtoRecord } from "./object";
+
+const prototypeNames = [
+  "__proto__",
+  "constructor",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "__defineGetter__",
+];
+
+describe("getOwn", () => {
+  it("returns own values and undefined for absent keys", () => {
+    expect(getOwn({ a: 1 }, "a")).toBe(1);
+    expect(getOwn({ a: 1 }, "b")).toBeUndefined();
+    expect(getOwn(undefined, "a")).toBeUndefined();
+  });
+
+  it.each(prototypeNames)(
+    "does not resolve %s through the prototype chain",
+    (name) => {
+      expect(getOwn<unknown>({ a: 1 }, name)).toBeUndefined();
+    }
+  );
+
+  it("returns an own value stored under a prototype member name", () => {
+    expect(
+      getOwn({ constructor: "mine", ["__proto__"]: "also mine" }, "constructor")
+    ).toBe("mine");
+    expect(getOwn({ ["__proto__"]: "also mine" }, "__proto__")).toBe(
+      "also mine"
+    );
+  });
+
+  it("ignores keys planted on Object.prototype", () => {
+    Object.defineProperty(Object.prototype, "planted_getOwn", {
+      value: "polluted",
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(getOwn<unknown>({}, "planted_getOwn")).toBeUndefined();
+    } finally {
+      Reflect.deleteProperty(Object.prototype, "planted_getOwn");
+    }
+    expect(Object.hasOwn(Object.prototype, "planted_getOwn")).toBe(false);
+  });
+});
+
+describe("nullProtoRecord", () => {
+  it("keeps every entry as an own property, including __proto__", () => {
+    const record = nullProtoRecord(
+      new Map<string, number>([
+        ["a", 1],
+        ["__proto__", 2],
+        ["constructor", 3],
+      ])
+    );
+    expect(Object.getPrototypeOf(record)).toBeNull();
+    expect(Object.entries(record)).toEqual([
+      ["a", 1],
+      ["__proto__", 2],
+      ["constructor", 3],
+    ]);
+    expect(Object.hasOwn(Object.prototype, "a")).toBe(false);
+  });
+
+  it.each(prototypeNames)("reads absent %s as undefined", (name) => {
+    const record = nullProtoRecord(new Map<string, number>([["a", 1]]));
+    expect(record[name]).toBeUndefined();
+  });
+});

--- a/packages/util/src/object.ts
+++ b/packages/util/src/object.ts
@@ -67,3 +67,32 @@ export const printObject = (val: object, size: number = 50): string => {
   const allItems = [...headItems, ...tailItems];
   return envelope[0] + allItems.join(separator) + envelope[1];
 };
+
+/**
+ * Own-property read of a string-keyed record. Plain indexing walks the
+ * prototype chain, so a key taken from untrusted data (a log's uuid, score
+ * name, attachment id, ...) that happens to be `constructor`, `toString` or
+ * `__proto__` resolves to a builtin instead of "absent"; this returns
+ * `undefined` for any key the record does not own.
+ */
+export const getOwn = <T>(
+  record: Readonly<Record<string, T>> | undefined,
+  key: string
+): T | undefined =>
+  record !== undefined && Object.hasOwn(record, key) ? record[key] : undefined;
+
+/**
+ * Record with a null prototype built from a Map. `Object.fromEntries` alone
+ * only makes *present* keys own properties; an absent prototype-named key
+ * would still resolve through Object.prototype at read sites, and a present
+ * `__proto__` key could not be assigned onto a plain object at all.
+ */
+export const nullProtoRecord = <T>(
+  entries: ReadonlyMap<string, T>
+): Record<string, T> => {
+  // setPrototypeOf rather than Object.create + assign: fromEntries already
+  // gives a correctly typed record, and Object.create returns `any`.
+  const record = Object.fromEntries(entries);
+  Object.setPrototypeOf(record, null);
+  return record;
+};

--- a/suppressions.json
+++ b/suppressions.json
@@ -1715,12 +1715,6 @@
       "undescribed": 1
     }
   },
-  "packages/inspect-components/src/usage/configsForUsage.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 2,
-      "undescribed": 2
-    }
-  },
   "packages/inspect-components/src/usage/connectionHistory.test.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1


### PR DESCRIPTION
## Summary

Several places in the inspect viewer (and one in Scout) used strings written by the log author — event uuids, model and role names, score and scorer names, scanner reference ids, skeleton span parents, attachment ids — as keys on plain objects or arrays. A name such as `__proto__`, `constructor` or `toString` then either resolved through the prototype chain to a builtin, or worse, wrote through it. Two of these were session-wide prototype pollution; the rest were deterministic render crashes to the root error panel.

Session-wide pollution:

- **Chunked skeleton index** — a span whose `parent` was `"__proto__"` indexed `childrenOf` through `Array.prototype` and pushed onto it, changing every past-the-end array read in the viewer (chunk bounds, cursor buffers, outline rows) for the rest of the session, including for other logs opened afterwards. `SkeletonIndex` now requires `parent` to be an integer index of an earlier span and throws otherwise; `at` accepts only own integer positions.
- **Usage config builders** — a model or role named `__proto__` wrote every key of the log's `model_args` / generate config onto `Object.prototype`; one named `constructor` overwrote statics on `Object` (`model_args: {"keys": ...}` broke `Object.keys`). Reached from the Models tab, every sample's Usage tab and the Timeline tab. The builders now accumulate in Maps and return null-prototype records.
- **Property bags (inspect app slice and Scout store)** — transcript event panels store per-panel UI state in a bag named by the event uuid. Creating a bag named `__proto__` inside the immer recipe assigned the tab selection onto the real `Object.prototype`, and because reads used `key in bag`, every other event panel then inherited it and rendered empty until reload. Both stores now read bags and keys as own properties only and create a missing bag with a computed-key literal (plain assignment of a `__proto__` name goes to the inherited setter, which immer turns into a `setPrototypeOf` error). The bags stay plain records because the slice is persisted as JSON.

Inherited-key reads that crashed the viewer or substituted a builtin:

- **Info tab** — a scorer named after an `Object.prototype` member made `PlanDetailView` call `.push` on the inherited member. Grouping is now a Map.
- **Samples grids** — a score named `constructor` made the column builder call `.add` on the `Object` function while discovering cross-log columns, so one such log broke the directory's Samples view; label and colour-scale overrides were read the same way. Tallies are Maps; the override maps are read as own properties.
- **Scan reference previews** — a scanner reference id naming a prototype member yielded a builtin as `citePreview`, and hovering the cite called it during render. The preview table is a Map.
- **Transcript event labels** — an event uuid naming a prototype member got the builtin as its label whenever a search result supplied any event citation, and `label.replace` threw. Event, message and tool label maps are read as own properties.
- **attachment:// resolution** — `attachment://constructor` resolved to the `Object` function and was substituted into message content, which the chat renderer then tried to iterate. Attachment lookups are own-key only, so these are ordinary misses.

## Approach

A small `getOwn` helper (own-property read of a string-keyed record) and `nullProtoRecord` (moved from `connectionHistory.ts`, which already did this) live in `@tsmono/util`; keyed accumulation uses `Map`. Each change has a test that fails on the previous source: tests plant keys on the real `Object.prototype` / `Array.prototype` / `Object` inside `try`/`finally` or `afterEach`, assert that nothing leaks, and assert that lookups of `constructor` / `toString` / `__proto__` read as absent rather than as a builtin.

Two `no-unnecessary-condition` suppressions in `configsForUsage.ts` became unnecessary and were removed (`suppressions.json` shrinks by two entries).

## Verification

`pnpm check`, `pnpm test`, and `pnpm build` all pass from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
