### PR TITLE
fix: harden rendered-HTML sanitizer and link hrefs against log-authored content

### DIFF
--- a/apps/inspect/e2e/chat-components.spec.ts
+++ b/apps/inspect/e2e/chat-components.spec.ts
@@ -83,6 +83,38 @@ async function openSample(
 // ---------------------------------------------------------------------------
 
 test.describe("chat message rendering", () => {
+  for (const { layout, content } of [
+    { layout: "inline", content: "Before $x+1$ after." },
+    { layout: "display", content: "Before\n\n$$x+1$$\n\nafter." },
+  ]) {
+    test(`keeps ${layout} math in selected message text`, async ({
+      page,
+      network,
+    }) => {
+      await openSample(page, network, [
+        { role: "assistant", content, source: "generate" },
+      ]);
+
+      const messagesArea = page.locator("#messages-contents");
+      await expect(messagesArea.locator("mjx-container > svg")).toBeVisible();
+      await expect(messagesArea.locator("mjx-assistive-mml")).toHaveCSS(
+        "clip",
+        "rect(1px, 1px, 1px, 1px)"
+      );
+
+      const selected = await messagesArea.evaluate((element) => {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return selection?.toString();
+      });
+
+      expect(selected?.replace(/\s+/g, "")).toContain("Before𝑥+1after.");
+    });
+  }
+
   test("renders user and assistant messages", async ({ page, network }) => {
     await openSample(page, network, [
       {

--- a/packages/inspect-components/src/chat/MessageCitations.tsx
+++ b/packages/inspect-components/src/chat/MessageCitations.tsx
@@ -7,6 +7,8 @@ import type {
 } from "@tsmono/inspect-common/types";
 import { decodeHtmlEntities } from "@tsmono/util";
 
+import { ExternalLink } from "../content/ExternalLink";
+
 import styles from "./MessageCitations.module.css";
 
 export interface MessageCitationsProps {
@@ -54,10 +56,8 @@ const UrlCitation: FC<PropsWithChildren<{ citation: UrlCitationType }>> = ({
   children,
   citation,
 }): ReactElement => (
-  <a
+  <ExternalLink
     href={citation.url}
-    target="_blank"
-    rel="noopener noreferrer"
     className={clsx(styles.citationLink)}
     title={
       citation.cited_text && typeof citation.cited_text === "string"
@@ -66,7 +66,7 @@ const UrlCitation: FC<PropsWithChildren<{ citation: UrlCitationType }>> = ({
     }
   >
     {children}
-  </a>
+  </ExternalLink>
 );
 
 const OtherCitation: FC<PropsWithChildren> = ({ children }): ReactElement => (

--- a/packages/inspect-components/src/chat/MessageContent.test.tsx
+++ b/packages/inspect-components/src/chat/MessageContent.test.tsx
@@ -1,19 +1,29 @@
 // @vitest-environment jsdom
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { ComponentProps } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { ContentText } from "@tsmono/inspect-common/types";
+import type {
+  ContentData,
+  ContentText,
+  ContentToolUse,
+} from "@tsmono/inspect-common/types";
 import {
   ComponentIconProvider,
   ComponentNavigationProvider,
 } from "@tsmono/react/components";
 import { ComponentStateProvider } from "@tsmono/react/state";
-import { makeStateHooks, testIcons } from "@tsmono/react/testing";
+import {
+  makeStateHooks,
+  ResizeObserverStub,
+  testIcons,
+} from "@tsmono/react/testing";
 
 import { DisplayModeContext } from "../content/DisplayModeContext";
 
 import { MessageContent } from "./MessageContent";
+
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
 
 type Contents = ComponentProps<typeof MessageContent>["contents"];
 
@@ -93,5 +103,80 @@ describe("MessageContent evidence fidelity", () => {
 
     expect(container.querySelector("pre")?.textContent).toBe(content.text);
     expect(container.querySelector("sup")).toBeNull();
+  });
+});
+
+// Every href a log author can place in a chat message must be an absolute
+// http(s) URL; anything else renders as inert text rather than handing the
+// reviewer a link to a local file or a custom protocol handler.
+describe("MessageContent log-supplied link hrefs", () => {
+  const rejectedUrls = [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "file:///etc/passwd",
+    "blob:https://example.test/id",
+    "vscode://file/etc/passwd",
+    "ms-msdt:/id",
+    "custom://asset/1",
+    "/relative/path",
+    "//example.test/protocol-relative",
+  ];
+
+  const citationText = (url: string): ContentText => ({
+    type: "text",
+    text: "cited text",
+    citations: [{ type: "url", url, title: "Source" }],
+  });
+
+  const webSearchToolUse = (url: string): ContentToolUse => ({
+    type: "tool_use",
+    id: "srvtoolu_1",
+    name: "web_search",
+    tool_type: "web_search",
+    arguments: JSON.stringify({ query: "q" }),
+    result: JSON.stringify([
+      { type: "web_search_result", title: "Result", url },
+    ]),
+  });
+
+  const webSearchToolResult = (url: string): ContentData => ({
+    type: "data",
+    data: {
+      type: "web_search_tool_result",
+      content: [{ title: "Result", url, page_age: "1 day ago" }],
+    },
+  });
+
+  const sinks = [
+    ["citation", citationText, "Source"],
+    ["web_search tool result", webSearchToolUse, "Result"],
+    ["web_search_tool_result data", webSearchToolResult, "Result"],
+  ] as const;
+
+  describe.each(sinks)("%s", (_label, build, label) => {
+    it("links an absolute http(s) URL in a new tab", async () => {
+      const { container } = renderMessage([
+        build("https://example.test/source?q=1"),
+      ]);
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(label);
+      });
+      const anchor = container.querySelector("a");
+      expect(anchor?.getAttribute("href")).toBe(
+        "https://example.test/source?q=1"
+      );
+      expect(anchor?.getAttribute("target")).toBe("_blank");
+      expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer");
+    });
+
+    it.each(rejectedUrls)("renders %s as text, not a link", async (url) => {
+      const { container } = renderMessage([build(url)]);
+
+      await waitFor(() => {
+        expect(container.textContent).toContain(label);
+      });
+      expect(container.querySelector("a")).toBeNull();
+    });
   });
 });

--- a/packages/inspect-components/src/chat/content-data/WebSearchResults.tsx
+++ b/packages/inspect-components/src/chat/content-data/WebSearchResults.tsx
@@ -3,6 +3,8 @@ import { FC } from "react";
 
 import { isRecord } from "@tsmono/util";
 
+import { ExternalLink } from "../../content/ExternalLink";
+
 import styles from "./WebSearchResults.module.css";
 
 export interface WebSearchContentData {
@@ -40,17 +42,15 @@ export const WebSearchResults: FC<{ results: WebSearchContentData[] }> = ({
             key={index}
             className={clsx(styles.result, "text-style-secondary")}
           >
-            <a
+            <ExternalLink
               href={result.url}
-              target="_blank"
-              rel="noopener noreferrer"
               title={
                 result.url +
                 (result.page_age ? `\n(Age: ${result.page_age})` : "")
               }
             >
               {result.title}
-            </a>
+            </ExternalLink>
           </li>
         ))}
       </ol>

--- a/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
+++ b/packages/inspect-components/src/chat/server-tools/ServerToolCall.tsx
@@ -5,6 +5,7 @@ import type { ContentToolUse } from "@tsmono/inspect-common/types";
 import { ExpandablePanel } from "@tsmono/react/components";
 import { asJsonObjArray, isJson, isRecord } from "@tsmono/util";
 
+import { ExternalLink } from "../../content/ExternalLink";
 import { RecordTree } from "../../content/RecordTree";
 import { RenderedContent } from "../../content/RenderedContent";
 import { iconForTool } from "../tools/tool";
@@ -144,9 +145,7 @@ const WebSearchResults: FC<{ id?: string; results: WebResult[] }> = ({
     >
       {results.map((result, index) => (
         <div key={index}>
-          <a href={result.url} target="_blank" rel="noopener noreferrer">
-            {result.title}
-          </a>
+          <ExternalLink href={result.url}>{result.title}</ExternalLink>
         </div>
       ))}
     </ExpandablePanel>

--- a/packages/inspect-components/src/content/ExternalLink.test.tsx
+++ b/packages/inspect-components/src/content/ExternalLink.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { cleanup, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ExternalLink } from "./ExternalLink";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExternalLink", () => {
+  it.each(["https://example.test/a?b=1", "http://example.test/"])(
+    "links %s in a new tab with opener protection",
+    (href) => {
+      const { container } = render(
+        <ExternalLink href={href} className="cls" title="tip">
+          label
+        </ExternalLink>
+      );
+
+      const link = within(container).getByRole("link", { name: "label" });
+      expect(link.getAttribute("href")).toBe(href);
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+      expect(link.getAttribute("class")).toBe("cls");
+      expect(link.getAttribute("title")).toBe("tip");
+    }
+  );
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "file:///etc/passwd",
+    "blob:https://example.test/id",
+    "vscode://file/etc/passwd",
+    "ms-msdt:/id",
+    "custom://asset/1",
+    "mailto:someone@example.test",
+    "/relative/path",
+    "//example.test/protocol-relative",
+    "https://",
+    "not a url",
+  ])("renders %s as inert text", (href) => {
+    const { container } = render(
+      <ExternalLink href={href} title="tip">
+        label
+      </ExternalLink>
+    );
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("label");
+    expect(container.querySelector("span")?.getAttribute("title")).toBe("tip");
+  });
+});

--- a/packages/inspect-components/src/content/ExternalLink.tsx
+++ b/packages/inspect-components/src/content/ExternalLink.tsx
@@ -1,0 +1,45 @@
+import { FC, ReactNode } from "react";
+
+import { parseAbsoluteHttpUrl } from "@tsmono/util";
+
+interface ExternalLinkProps {
+  /** URL taken from log content; linked only when it is absolute http(s). */
+  href: string;
+  className?: string;
+  title?: string;
+  children: ReactNode;
+}
+
+/**
+ * Renders a log-supplied URL as a new-tab link when it is an absolute http(s)
+ * URL, and as inert text otherwise. Log content is the only source of these
+ * hrefs, and the markdown and media paths already refuse every other scheme
+ * (file:, blob:, custom protocol handlers); this keeps the React-rendered
+ * anchors on the same policy.
+ */
+export const ExternalLink: FC<ExternalLinkProps> = ({
+  href,
+  className,
+  title,
+  children,
+}) => {
+  const safeHref = parseAbsoluteHttpUrl(href);
+  if (safeHref === undefined) {
+    return (
+      <span className={className} title={title}>
+        {children}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={safeHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      title={title}
+    >
+      {children}
+    </a>
+  );
+};

--- a/packages/react/src/components/MarkdownDivWithReferences.test.ts
+++ b/packages/react/src/components/MarkdownDivWithReferences.test.ts
@@ -139,3 +139,38 @@ describe("injectReferenceLinks", () => {
     expect(result).toBe(`An array [1, 2, 3] and [${link("M1", "msg-1")}]`);
   });
 });
+
+describe("injectReferenceLinks attribute escaping", () => {
+  const parse = (html: string): Element =>
+    new DOMParser().parseFromString(`<div>${html}</div>`, "text/html").body
+      .firstElementChild!;
+
+  it.each([
+    ["closes the attribute and injects markup", '"><style>x</style><a x="'],
+    ["injects a style attribute", 'x" style="position:fixed" x="'],
+    ["injects an event handler", 'x" onmouseover="alert(1)'],
+    ["single quotes and ampersands", "a'b&c"],
+  ])("renders a ref id that %s as a single anchor", (_label, id) => {
+    const refs = [makeRef("M1", id)];
+    const html = injectReferenceLinks("See [M1]", refs, CITE_CLASS);
+    const root = parse(html);
+
+    const anchors = root.querySelectorAll("a");
+    expect(anchors).toHaveLength(1);
+    expect(root.querySelectorAll("*")).toHaveLength(1);
+    expect(anchors[0]?.getAttribute("data-ref-id")).toBe(id);
+    expect(anchors[0]?.attributes).toHaveLength(3);
+    expect(root.textContent).toBe("See [M1]");
+  });
+
+  it("escapes the href so the cite URL round-trips as a single attribute", () => {
+    const citeUrl = '#/messages/m1?a=1&b="2"';
+    const refs = [makeRef("M1", "msg-1", citeUrl)];
+    const root = parse(injectReferenceLinks("See [M1]", refs, CITE_CLASS));
+
+    const anchor = root.querySelector("a");
+    expect(root.querySelectorAll("*")).toHaveLength(1);
+    expect(anchor?.getAttribute("href")).toBe(citeUrl);
+    expect(anchor?.attributes).toHaveLength(3);
+  });
+});

--- a/packages/react/src/components/MarkdownDivWithReferences.tsx
+++ b/packages/react/src/components/MarkdownDivWithReferences.tsx
@@ -13,6 +13,7 @@ import { useProperty } from "../hooks/useProperty";
 import { useComponentNavigation } from "./ComponentNavigationContext";
 import { MarkdownDiv, type MarkdownRenderer } from "./MarkdownDiv";
 import styles from "./MarkdownDivWithReferences.module.css";
+import { escapeHtmlCharacters } from "./markdownRendering";
 import { NoContentsPanel } from "./NoContentsPanel";
 import { PopOver } from "./PopOver";
 
@@ -259,8 +260,11 @@ export function injectReferenceLinks(
     return bracketMatch.replace(/\b[ME]\d+\b/g, (ordinal) => {
       const ref = refByOrdinal.get(ordinal);
       if (!ref) return ordinal;
-      const href = ref.citeUrl || "javascript:void(0)";
-      return `<a href="${href}" class="${citeClass}" data-ref-id="${ref.id}">${ordinal}</a>`;
+      // The id and URL come from log content; escaping keeps them inside the
+      // attribute rather than leaving DOMPurify to repair a quote breakout.
+      const href = escapeHtmlCharacters(ref.citeUrl || "javascript:void(0)");
+      const id = escapeHtmlCharacters(ref.id);
+      return `<a href="${href}" class="${escapeHtmlCharacters(citeClass)}" data-ref-id="${id}">${ordinal}</a>`;
     });
   });
 }

--- a/packages/react/src/components/mathjaxStyles.LICENSE
+++ b/packages/react/src/components/mathjaxStyles.LICENSE
@@ -1,5 +1,5 @@
 MathJax SVG styles, adapted into a fixed, per-formula stylesheet.
-The fixed-position status rule is omitted.
+Runtime tooltip/status rules are omitted and assistive MathML is clipped.
 
 
                                  Apache License

--- a/packages/react/src/components/mathjaxStyles.LICENSE
+++ b/packages/react/src/components/mathjaxStyles.LICENSE
@@ -1,0 +1,231 @@
+MathJax SVG styles, adapted into a fixed, per-formula stylesheet.
+The fixed-position status rule is omitted.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+markdown-it-mathjax3 / mathxyjax3 wrapper styles:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Waylon Flinn
+Copyright (c) 2020 TANIGUCHI Masaya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/src/components/mathjaxStyles.ts
+++ b/packages/react/src/components/mathjaxStyles.ts
@@ -1,15 +1,11 @@
 // Third-party notices: mathjaxStyles.LICENSE.
 // Fixed SVG styles from markdown-it-mathjax3 5.2.0 / mathxyjax3 0.8.3.
 // Log-authored CSS must never supply selectors or positioning declarations.
-// The unused fixed-position mjx-status rule is deliberately omitted.
+// Runtime tooltips/status are omitted: static SVG uses native title elements.
+// Assistive MathML stays clipped even when a log forges its contents.
 const MATHJAX_STYLES = `
 :scope {
   display: contents;
-}
-:scope mjx-assistive-mml {
-  color: rgba(0, 0, 0, 0);
-  user-select: text !important;
-  clip: auto !important;
 }
 :scope mjx-container[jax="SVG"] {
   direction: ltr;
@@ -26,7 +22,7 @@ const MATHJAX_STYLES = `
 :scope mjx-assistive-mml {
   top: 0px;
   left: 0px;
-  clip: rect(1px, 1px, 1px, 1px);
+  clip: rect(1px, 1px, 1px, 1px) !important;
   user-select: none;
   position: absolute !important;
   padding: 1px 0px 0px !important;
@@ -77,26 +73,6 @@ const MATHJAX_STYLES = `
 }
 :scope g[data-mml-node="mtable"] > g > svg {
   overflow: visible;
-}
-:scope [jax="SVG"] mjx-tool {
-  display: inline-block;
-  position: relative;
-  width: 0px;
-  height: 0px;
-}
-:scope [jax="SVG"] mjx-tool > mjx-tip {
-  position: absolute;
-  top: 0px;
-  left: 0px;
-}
-:scope mjx-tool > mjx-tip {
-  display: inline-block;
-  padding: 0.2em;
-  border: 1px solid rgb(136, 136, 136);
-  font-size: 70%;
-  background-color: rgb(248, 248, 248);
-  color: black;
-  box-shadow: rgb(170, 170, 170) 2px 2px 5px;
 }
 :scope g[data-mml-node="maction"][data-toggle] {
   cursor: pointer;

--- a/packages/react/src/components/mathjaxStyles.ts
+++ b/packages/react/src/components/mathjaxStyles.ts
@@ -1,0 +1,121 @@
+// Third-party notices: mathjaxStyles.LICENSE.
+// Fixed SVG styles from markdown-it-mathjax3 5.2.0 / mathxyjax3 0.8.3.
+// Log-authored CSS must never supply selectors or positioning declarations.
+// The unused fixed-position mjx-status rule is deliberately omitted.
+const MATHJAX_STYLES = `
+:scope {
+  display: contents;
+}
+:scope mjx-assistive-mml {
+  color: rgba(0, 0, 0, 0);
+  user-select: text !important;
+  clip: auto !important;
+}
+:scope mjx-container[jax="SVG"] {
+  direction: ltr;
+}
+:scope mjx-container[jax="SVG"] > svg {
+  overflow: visible;
+  min-height: 1px;
+  min-width: 1px;
+}
+:scope mjx-container[jax="SVG"] > svg a {
+  fill: blue;
+  stroke: blue;
+}
+:scope mjx-assistive-mml {
+  top: 0px;
+  left: 0px;
+  clip: rect(1px, 1px, 1px, 1px);
+  user-select: none;
+  position: absolute !important;
+  padding: 1px 0px 0px !important;
+  border: 0px !important;
+  display: block !important;
+  width: auto !important;
+  overflow: hidden !important;
+}
+:scope mjx-assistive-mml[display="block"] {
+  width: 100% !important;
+}
+:scope mjx-container[jax="SVG"][display="true"] {
+  display: block;
+  text-align: center;
+  margin: 1em 0px;
+}
+:scope mjx-container[jax="SVG"][display="true"][width="full"] {
+  display: flex;
+}
+:scope mjx-container[jax="SVG"][justify="left"] {
+  text-align: left;
+}
+:scope mjx-container[jax="SVG"][justify="right"] {
+  text-align: right;
+}
+:scope g[data-mml-node="merror"] > g {
+  fill: red;
+  stroke: red;
+}
+:scope g[data-mml-node="merror"] > rect[data-background] {
+  fill: yellow;
+  stroke: none;
+}
+:scope g[data-mml-node="mtable"] > line[data-line], :scope svg[data-table] > g > line[data-line] {
+  stroke-width: 70px;
+  fill: none;
+}
+:scope g[data-mml-node="mtable"] > rect[data-frame], :scope svg[data-table] > g > rect[data-frame] {
+  stroke-width: 70px;
+  fill: none;
+}
+:scope g[data-mml-node="mtable"] > .mjx-dashed, :scope svg[data-table] > g > .mjx-dashed {
+  stroke-dasharray: 140;
+}
+:scope g[data-mml-node="mtable"] > .mjx-dotted, :scope svg[data-table] > g > .mjx-dotted {
+  stroke-linecap: round;
+  stroke-dasharray: 0, 140;
+}
+:scope g[data-mml-node="mtable"] > g > svg {
+  overflow: visible;
+}
+:scope [jax="SVG"] mjx-tool {
+  display: inline-block;
+  position: relative;
+  width: 0px;
+  height: 0px;
+}
+:scope [jax="SVG"] mjx-tool > mjx-tip {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+}
+:scope mjx-tool > mjx-tip {
+  display: inline-block;
+  padding: 0.2em;
+  border: 1px solid rgb(136, 136, 136);
+  font-size: 70%;
+  background-color: rgb(248, 248, 248);
+  color: black;
+  box-shadow: rgb(170, 170, 170) 2px 2px 5px;
+}
+:scope g[data-mml-node="maction"][data-toggle] {
+  cursor: pointer;
+}
+:scope foreignobject[data-mjx-xml] {
+  font-family: initial;
+  line-height: normal;
+  overflow: visible;
+}
+:scope mjx-container[jax="SVG"] path[data-c], :scope mjx-container[jax="SVG"] use[data-c] {
+  stroke-width: 3;
+}
+:scope g[data-mml-node="xypic"] path {
+  stroke-width: inherit;
+}
+:scope .MathJax g[data-mml-node="xypic"] path {
+  stroke-width: inherit;
+}
+`;
+
+export const mathJaxStyles = (scopeId: string): string =>
+  MATHJAX_STYLES.replaceAll(":scope", `#${scopeId}`).trim();

--- a/packages/react/src/components/mathjaxStyles.ts
+++ b/packages/react/src/components/mathjaxStyles.ts
@@ -3,6 +3,7 @@
 // Log-authored CSS must never supply selectors or positioning declarations.
 // Runtime tooltips/status are omitted: static SVG uses native title elements.
 // Assistive MathML stays clipped even when a log forges its contents.
+// Keep the clipped MathML selectable so copied text includes the formula.
 const MATHJAX_STYLES = `
 :scope {
   display: contents;
@@ -23,7 +24,7 @@ const MATHJAX_STYLES = `
   top: 0px;
   left: 0px;
   clip: rect(1px, 1px, 1px, 1px) !important;
-  user-select: none;
+  user-select: text !important;
   position: absolute !important;
   padding: 1px 0px 0px !important;
   border: 0px !important;

--- a/packages/react/src/components/renderedHtmlSanitizer.test.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.test.ts
@@ -102,7 +102,7 @@ describe("sanitizeRenderedHtml MathJax stylesheet", () => {
     [
       "a property outside the allowlist",
       "#mjx-a1{ & div { background-image: none; content: 'x' } }",
-      /background|content/,
+      /background-image:|content:/,
     ],
     [
       "fixed positioning",
@@ -136,21 +136,27 @@ describe("sanitizeRenderedHtml MathJax stylesheet", () => {
       "a literal url()",
       "#mjx-a1{ & div { fill: url(https://attacker.example/x) } }",
     ],
-  ])("removes the element entirely for %s", (_label, css) => {
-    expect(sanitizedCss(css)).toBeUndefined();
-  });
+  ])(
+    "replaces %s with the same trusted styles as ordinary math",
+    (_label, css) => {
+      const clean = parse(sanitizeRenderedHtml(mathHtml)).querySelector(
+        "style"
+      );
+      const id = clean?.parentElement?.id ?? "";
+      expect(sanitizedCss(css)).toBe(
+        clean?.textContent.replaceAll(id, "mjx-a1")
+      );
+      expect(sanitizedCss(css)).not.toMatch(/attacker|url\(|@import/);
+    }
+  );
 
-  // Browsers enumerate the shorthands MathJax writes as longhands.
-  it("keeps box longhands MathJax relies on", () => {
-    const css = sanitizedCss(
-      "#mjx-a1{ & svg { overflow-x: visible; overflow-y: visible; margin-top: 1em; padding-left: 1px; border-top-width: 1px; border-top-style: solid; border-top-color: #888 } }"
-    );
-    expect(css).toContain("overflow-x: visible");
-    expect(css).toContain("overflow-y: visible");
-    expect(css).toContain("margin-top: 1em");
-    expect(css).toContain("padding-left: 1px");
-    expect(css).toContain("border-top-width: 1px");
-    expect(css).toContain("border-top-style: solid");
+  it("keeps MathJax SVG overflow, display spacing, and assistive layout", () => {
+    const root = parse(sanitizeRenderedHtml(mathHtml));
+    const css = root.querySelector("style")?.textContent ?? "";
+    expect(css).toMatch(/> svg \{[^}]*overflow: visible/);
+    expect(css).toMatch(/\[display="true"\] \{[^}]*margin: 1em 0px/);
+    expect(css).toMatch(/mjx-assistive-mml \{[^}]*padding: 1px 0px 0px/);
+    expect(css).toMatch(/mjx-assistive-mml \{[^}]*border: 0px/);
   });
 
   it("removes a style element whose parent is not a MathJax wrapper", () => {
@@ -160,9 +166,26 @@ describe("sanitizeRenderedHtml MathJax stylesheet", () => {
     expect(root.querySelector("style")).toBeNull();
   });
 
-  it("removes a MathJax-shaped style element with nothing left to keep", () => {
-    expect(sanitizedCss("body{color:red}")).toBeUndefined();
-  });
+  it.each(["", "body{color:red}", "not css"])(
+    "does not use the contents of a MathJax-shaped style element: %s",
+    (css) => {
+      expect(sanitizedCss(css)).toBe(
+        sanitizedCss("#mjx-a1 { display: contents }")
+      );
+    }
+  );
+
+  it.each(["mjx-x1", "mjx-a1,body", "mjx-a1 body", "mjx-a1{color:red}"])(
+    "does not interpolate an invalid wrapper id: %s",
+    (id) => {
+      const root = parse(
+        sanitizeRenderedHtml(
+          `<span id="${id}"><style>body {color:red}</style></span>`
+        )
+      );
+      expect(root.querySelector("style")).toBeNull();
+    }
+  );
 });
 
 describe("sanitizeRenderedHtml inline style attributes", () => {

--- a/packages/react/src/components/renderedHtmlSanitizer.test.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { renderMarkdown } from "./markdownRendering";
+import { sanitizeRenderedHtml } from "./renderedHtmlSanitizer";
+
+const parse = (html: string): HTMLElement => {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  return root;
+};
+
+const mathJaxStyle = (css: string): string =>
+  `<span id="mjx-a1"><style>${css}</style><mjx-container>x</mjx-container></span>`;
+
+const sanitizedCss = (css: string): string | undefined =>
+  parse(sanitizeRenderedHtml(mathJaxStyle(css))).querySelector("style")
+    ?.textContent ?? undefined;
+
+describe("sanitizeRenderedHtml MathJax stylesheet", () => {
+  let mathHtml = "";
+  beforeAll(async () => {
+    mathHtml = await renderMarkdown("$\\frac{1}{2}$", "full");
+  });
+
+  it("keeps a genuine MathJax stylesheet, scoped and positioning its assistive MathML", () => {
+    const root = parse(sanitizeRenderedHtml(mathHtml));
+    const style = root.querySelector('span[id^="mjx-"] > style');
+    const id = style?.parentElement?.id ?? "";
+    const css = style?.textContent ?? "";
+
+    expect(root.querySelector("mjx-container")).not.toBeNull();
+    expect(css.startsWith(`#${id} {`)).toBe(true);
+    expect(css).toMatch(
+      /mjx-assistive-mml \{[^}]*position: absolute !important/
+    );
+    expect(css).toMatch(
+      /mjx-assistive-mml \{[^}]*clip: rect\(1px, 1px, 1px, 1px\)/
+    );
+    expect(css).toMatch(/mjx-container\[jax="SVG"\] > svg a \{[^}]*fill: blue/);
+    // mjx-status is fixed-positioned in MathJax's default sheet; nothing in
+    // rendered output uses it and fixed positioning is not admitted.
+    expect(css).not.toContain("fixed");
+  });
+
+  it.each([
+    [
+      "an unscoped top-level rule",
+      "#mjx-a1{display:contents} body{background-color:red}",
+      /body/,
+    ],
+    ["a top-level rule for another id", "#mjx-a2{color:red}", /mjx-a2/],
+    [
+      "a selector list that widens the top-level scope",
+      "#mjx-a1, body{color:red}",
+      /body/,
+    ],
+    [
+      "a nested selector that re-anchors with the nesting selector",
+      "#mjx-a1{ body & {color:red} }",
+      /body/,
+    ],
+    [
+      "a nested selector that escapes through :is()",
+      "#mjx-a1{ :is(body, &) {color:red} }",
+      /body/,
+    ],
+    ["a nested at-rule", "#mjx-a1{ @media screen { color:red } }", /media/],
+    [
+      "image-set() on an allowlisted property",
+      '#mjx-a1{ & div { fill: image-set("https://attacker.example/x" 1x) } }',
+      /attacker/,
+    ],
+    [
+      "a property outside the allowlist",
+      "#mjx-a1{ & div { background-image: none; content: 'x' } }",
+      /background|content/,
+    ],
+    [
+      "fixed positioning",
+      "#mjx-a1{ & div { position: fixed; top: 0; left: 0 } }",
+      /fixed/,
+    ],
+    ["sticky positioning", "#mjx-a1{ & div { position: sticky } }", /sticky/],
+    [
+      "negative margins",
+      "#mjx-a1{ & div { margin: -100vh 0 0 -50vw } }",
+      /margin[^;]*: -/,
+    ],
+  ])("drops %s", (_label, css, forbidden) => {
+    expect(sanitizedCss(css) ?? "").not.toMatch(forbidden);
+  });
+
+  it.each([
+    [
+      "a CSS-escaped url()",
+      "#mjx-a1{ & div { fill: \\75rl(https://attacker.example/x) } }",
+    ],
+    [
+      "a CSS-escaped @import",
+      '@\\69mport "https://attacker.example/x.css"; #mjx-a1{}',
+    ],
+    [
+      "a literal @import",
+      "@import url(https://attacker.example/x.css); #mjx-a1{}",
+    ],
+    [
+      "a literal url()",
+      "#mjx-a1{ & div { fill: url(https://attacker.example/x) } }",
+    ],
+  ])("removes the element entirely for %s", (_label, css) => {
+    expect(sanitizedCss(css)).toBeUndefined();
+  });
+
+  // Browsers enumerate the shorthands MathJax writes as longhands.
+  it("keeps box longhands MathJax relies on", () => {
+    const css = sanitizedCss(
+      "#mjx-a1{ & svg { overflow-x: visible; overflow-y: visible; margin-top: 1em; padding-left: 1px; border-top-width: 1px; border-top-style: solid; border-top-color: #888 } }"
+    );
+    expect(css).toContain("overflow-x: visible");
+    expect(css).toContain("overflow-y: visible");
+    expect(css).toContain("margin-top: 1em");
+    expect(css).toContain("padding-left: 1px");
+    expect(css).toContain("border-top-width: 1px");
+    expect(css).toContain("border-top-style: solid");
+  });
+
+  it("removes a style element whose parent is not a MathJax wrapper", () => {
+    const root = parse(
+      sanitizeRenderedHtml("<div><style>#x{color:red}</style>x</div>")
+    );
+    expect(root.querySelector("style")).toBeNull();
+  });
+
+  it("removes a MathJax-shaped style element with nothing left to keep", () => {
+    expect(sanitizedCss("body{color:red}")).toBeUndefined();
+  });
+});
+
+describe("sanitizeRenderedHtml inline style attributes", () => {
+  const styleOf = (style: string): string =>
+    parse(sanitizeRenderedHtml(`<div style="${style}">x</div>`))
+      .querySelector("div")
+      ?.getAttribute("style") ?? "";
+
+  it("keeps the declarations MathJax puts on its output", () => {
+    const kept = styleOf(
+      "position: relative; min-width: 14.823ex; vertical-align: -0.566ex; color: red"
+    );
+    expect(kept).toContain("position: relative");
+    expect(kept).toContain("min-width: 14.823ex");
+    expect(kept).toContain("vertical-align: -0.566ex");
+    expect(kept).toContain("color: red");
+  });
+
+  it("keeps in-flow box longhands and drops a negative margin longhand", () => {
+    const kept = styleOf(
+      "padding-left: 2px; margin-top: 1em; margin-left: -1em; overflow-x: auto"
+    );
+    expect(kept).toContain("padding-left: 2px");
+    expect(kept).toContain("margin-top: 1em");
+    expect(kept).toContain("overflow-x: auto");
+    expect(kept).not.toContain("margin-left");
+  });
+
+  it.each([
+    [
+      "a fixed full-viewport overlay",
+      "position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background-color: #fff",
+      /position|top|left/,
+    ],
+    ["absolute positioning", "position: absolute", /position/],
+    ["sticky positioning", "position: sticky", /position/],
+    [
+      "inset offsets",
+      "top: 0; right: 0; bottom: 0; left: 0",
+      /top|right|bottom|left/,
+    ],
+    [
+      "a viewport-sized box-shadow",
+      "box-shadow: 0 0 0 9999px #fff",
+      /box-shadow/,
+    ],
+    ["negative margins", "margin: -100vh 0 0 -50vw", /margin[^;]*: -/],
+    [
+      "image-set() on an allowlisted property",
+      'fill: image-set("https://attacker.example/x" 1x)',
+      /attacker/,
+    ],
+    [
+      "a CSS-escaped url()",
+      "fill: \\75rl(https://attacker.example/x)",
+      /attacker/,
+    ],
+  ])("drops %s", (_label, style, forbidden) => {
+    expect(styleOf(style)).not.toMatch(forbidden);
+  });
+});

--- a/packages/react/src/components/renderedHtmlSanitizer.test.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.test.ts
@@ -44,6 +44,34 @@ describe("sanitizeRenderedHtml MathJax stylesheet", () => {
   });
 
   it.each([
+    "& + #outside",
+    "& ~ #outside",
+    "+ #outside",
+    "~ #outside",
+    "&.formula + #outside",
+    "&:first-child ~ #outside",
+  ])(
+    "does not retain a selector reaching a wrapper sibling: %s",
+    (selector) => {
+      const css = sanitizedCss(`#mjx-a1 { ${selector} { color: red } }`);
+      expect(css ?? "").not.toContain("#outside");
+    }
+  );
+
+  it.each([
+    "#mjx-a1",
+    "#mjx-a1 { &",
+    "#mjx-a1 { & div",
+    "#mjx-a1 { & mjx-assistive-mml",
+    '#mjx-a1 { & [jax="SVG"] mjx-tool > mjx-tip',
+  ])("does not retain an authored overlay on %s", (selector) => {
+    const css = sanitizedCss(
+      `${selector} { position: absolute; top: 0; left: 0; width: 100vw; height: 100vh; box-shadow: 0 0 0 9999px white; background-color: white }${selector.includes("{") ? "}" : ""}`
+    );
+    expect(css ?? "").not.toMatch(/100vw|100vh|9999px/);
+  });
+
+  it.each([
     [
       "an unscoped top-level rule",
       "#mjx-a1{display:contents} body{background-color:red}",

--- a/packages/react/src/components/renderedHtmlSanitizer.test.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.test.ts
@@ -71,6 +71,44 @@ describe("sanitizeRenderedHtml MathJax stylesheet", () => {
     expect(css ?? "").not.toMatch(/100vw|100vh|9999px/);
   });
 
+  it("clips assistive MathML even when its author supplies an inline override", () => {
+    const root = parse(
+      sanitizeRenderedHtml(
+        '<span id="mjx-a1"><style></style><mjx-assistive-mml style="clip: auto !important; overflow: visible !important; width: 100vw !important; height: 100vh !important"><math><mtext>accessible math</mtext></math></mjx-assistive-mml></span>'
+      )
+    );
+    const assistive = root.querySelector("mjx-assistive-mml");
+    expect(assistive?.querySelector("math")?.textContent).toBe(
+      "accessible math"
+    );
+    expect(assistive?.hasAttribute("style")).toBe(false);
+    const css = root.querySelector("style")?.textContent ?? "";
+    expect(css).toMatch(/clip: rect\(1px, 1px, 1px, 1px\) !important/);
+    expect(css).not.toContain("clip: auto");
+  });
+
+  it("does not admit forged runtime tooltip elements into static math output", () => {
+    const root = parse(
+      sanitizeRenderedHtml(
+        '<span id="mjx-a1"><style></style><mjx-container jax="SVG"><mjx-tool><mjx-tip><div style="width:100vw;height:100vh;background-color:red">overlay</div></mjx-tip></mjx-tool></mjx-container></span>'
+      )
+    );
+    expect(root.querySelector("mjx-tool, mjx-tip")).toBeNull();
+    expect(root.querySelector("style")?.textContent).not.toMatch(
+      /mjx-tool|mjx-tip/
+    );
+  });
+
+  it("keeps the native SVG tooltip and accessible MathML of rendered math", async () => {
+    const html = await renderMarkdown(
+      "$\\mathtip{x^2}{\\text{square}}$",
+      "full"
+    );
+    const root = parse(sanitizeRenderedHtml(html));
+    expect(root.querySelector("svg title")?.textContent).toBe("square");
+    expect(root.querySelector("mjx-assistive-mml math")).not.toBeNull();
+  });
+
   it.each([
     [
       "an unscoped top-level rule",

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -63,7 +63,27 @@ const URL_ATTRIBUTES = new Set([
   "xlink:href",
 ]);
 
-const SAFE_STYLE_PROPERTIES = new Set([
+// Browsers enumerate a parsed shorthand as its longhands (jsdom lists both),
+// so each allowlist below names the longhands too.
+const BOX_EDGES = ["top", "right", "bottom", "left"];
+const BOX_LONGHANDS = [
+  "overflow-x",
+  "overflow-y",
+  ...BOX_EDGES.flatMap((edge) => [
+    `margin-${edge}`,
+    `padding-${edge}`,
+    `border-${edge}-color`,
+    `border-${edge}-style`,
+    `border-${edge}-width`,
+  ]),
+];
+
+// Inline styles reach the sanitizer from log content (TeX \style{}, any
+// raw-HTML producer), so they may not take an element out of normal flow or
+// paint beyond its box: no insets, no box-shadow, and isSafeStyleValue further
+// limits `position` and `margin`.
+const INLINE_STYLE_PROPERTIES = new Set([
+  ...BOX_LONGHANDS,
   "-khtml-user-select",
   "-moz-user-select",
   "-ms-user-select",
@@ -71,8 +91,6 @@ const SAFE_STYLE_PROPERTIES = new Set([
   "-webkit-user-select",
   "background-color",
   "border",
-  "bottom",
-  "box-shadow",
   "clip",
   "color",
   "direction",
@@ -81,7 +99,6 @@ const SAFE_STYLE_PROPERTIES = new Set([
   "font-family",
   "font-size",
   "height",
-  "left",
   "line-height",
   "margin",
   "min-height",
@@ -89,20 +106,47 @@ const SAFE_STYLE_PROPERTIES = new Set([
   "overflow",
   "padding",
   "position",
-  "right",
   "stroke",
   "stroke-dasharray",
   "stroke-linecap",
   "stroke-width",
   "text-align",
-  "top",
   "user-select",
   "vertical-align",
   "width",
 ]);
 
+// MathJax's per-formula stylesheet is nested under the formula's own id, so it
+// may additionally absolutely position its assistive MathML and tooltips.
+const MATHJAX_STYLESHEET_PROPERTIES = new Set([
+  ...INLINE_STYLE_PROPERTIES,
+  "bottom",
+  "box-shadow",
+  "cursor",
+  "left",
+  "right",
+  "top",
+]);
+
+type StyleScope = "inline" | "mathjax-stylesheet";
+
+const POSITION_VALUES: Record<StyleScope, Set<string>> = {
+  inline: new Set(["static", "relative"]),
+  "mathjax-stylesheet": new Set(["static", "relative", "absolute"]),
+};
+
+// Any other function (url, image-set, image, src, expression, ...) can load a
+// resource or run code; allowlisting is what makes escape spellings moot.
+const SAFE_CSS_FUNCTIONS = new Set(["hsl", "hsla", "rect", "rgb", "rgba"]);
+
 const UNSAFE_CSS_PATTERN =
   /@import|behavior\s*:|binding\s*:|expression\s*\(|javascript\s*:|vbscript\s*:|url\s*\(/i;
+
+// Backslashes are CSS escapes the tokenizer decodes but a text match does not
+// (`\75rl(` is `url(`); `@` starts an at-rule; `<` is markup. MathJax emits none.
+const RAW_CSS_REJECT_PATTERN = /[\\@<]/;
+
+const MATHJAX_WRAPPER_ID = /^mjx-[a-f0-9]+$/i;
 
 const PURIFY_CONFIG: Config = {
   ADD_ATTR: [...MATHJAX_ATTRS, "target"],
@@ -172,11 +216,13 @@ const installHooks = (purify: DOMPurifyInstance): void => {
   hooksInstalled = true;
 
   purify.addHook("uponSanitizeElement", (node, hookEvent) => {
-    if (
-      hookEvent.tagName === "style" &&
-      node instanceof Element &&
-      !isAllowedMathJaxStyleElement(node)
-    ) {
+    if (hookEvent.tagName !== "style" || !(node instanceof Element)) {
+      return;
+    }
+    const css = sanitizeMathJaxStyleElement(node);
+    if (css) {
+      node.textContent = css;
+    } else {
       node.remove();
     }
   });
@@ -286,42 +332,168 @@ const isSafeUrlAttribute = (value: string): boolean => {
 };
 
 const sanitizeStyleAttribute = (style: string): string => {
-  if (!style || UNSAFE_CSS_PATTERN.test(style)) {
+  if (
+    !style ||
+    UNSAFE_CSS_PATTERN.test(style) ||
+    RAW_CSS_REJECT_PATTERN.test(style)
+  ) {
     return "";
   }
 
   const scratch = document.createElement("span");
   scratch.setAttribute("style", style);
-
-  const safeDeclarations: string[] = [];
-  for (const property of Array.from(scratch.style)) {
-    const normalizedProperty = property.toLowerCase();
-    const value = scratch.style.getPropertyValue(property);
-
-    if (
-      SAFE_STYLE_PROPERTIES.has(normalizedProperty) &&
-      value &&
-      !UNSAFE_CSS_PATTERN.test(value)
-    ) {
-      const priority = scratch.style.getPropertyPriority(property);
-      safeDeclarations.push(
-        `${normalizedProperty}: ${value}${priority ? ` !${priority}` : ""};`
-      );
-    }
-  }
-
-  return safeDeclarations.join(" ");
+  return safeDeclarations(
+    scratch.style,
+    INLINE_STYLE_PROPERTIES,
+    "inline"
+  ).join(" ");
 };
 
-const isAllowedMathJaxStyleElement = (element: Element): boolean => {
-  const parent = element.parentElement;
-  const parentId = parent?.getAttribute("id") || "";
-  const css = element.textContent || "";
+const safeDeclarations = (
+  style: CSSStyleDeclaration,
+  allowedProperties: Set<string>,
+  scope: StyleScope
+): string[] => {
+  const declarations: string[] = [];
+  for (const property of Array.from(style)) {
+    const normalizedProperty = property.toLowerCase();
+    const value = style.getPropertyValue(property);
+    if (
+      !allowedProperties.has(normalizedProperty) ||
+      !value ||
+      !isSafeStyleValue(normalizedProperty, value, scope)
+    ) {
+      continue;
+    }
+    const priority = style.getPropertyPriority(property);
+    declarations.push(
+      `${normalizedProperty}: ${value}${priority ? ` !${priority}` : ""};`
+    );
+  }
+  return declarations;
+};
 
-  return (
-    parent?.tagName.toLowerCase() === "span" &&
-    /^mjx-[a-f0-9]+$/i.test(parentId) &&
-    css.includes(`#${parentId}`) &&
-    !UNSAFE_CSS_PATTERN.test(css)
-  );
+const isSafeStyleValue = (
+  property: string,
+  value: string,
+  scope: StyleScope
+): boolean => {
+  if (UNSAFE_CSS_PATTERN.test(value) || RAW_CSS_REJECT_PATTERN.test(value)) {
+    return false;
+  }
+  for (const call of value.matchAll(/([-\w]*)\s*\(/g)) {
+    if (!SAFE_CSS_FUNCTIONS.has((call[1] ?? "").toLowerCase())) {
+      return false;
+    }
+  }
+  if (property === "position") {
+    return POSITION_VALUES[scope].has(value);
+  }
+  // A negative margin pulls the box over neighbouring content while staying
+  // in normal flow, which the position policy above would otherwise prevent.
+  if (property.startsWith("margin") && /(?:^|\s)-/.test(value)) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * markdown-it-mathjax3 wraps each formula in `<span id="mjx-…">` whose first
+ * child is a `<style>` carrying MathJax's stylesheet nested under that id.
+ * That is the only stylesheet rendered content may contribute, so rather than
+ * trusting the text the CSS is parsed and rebuilt: only style rules survive,
+ * every rule stays nested under the wrapper's id, and declarations pass the
+ * same allowlist as inline styles. Returns the CSS to keep, or "" to drop the
+ * element.
+ */
+const sanitizeMathJaxStyleElement = (element: Element): string => {
+  const parent = element.parentElement;
+  const scopeId = parent?.getAttribute("id") ?? "";
+  if (
+    parent?.tagName.toLowerCase() !== "span" ||
+    !MATHJAX_WRAPPER_ID.test(scopeId)
+  ) {
+    return "";
+  }
+  return sanitizeScopedStyleSheet(element.textContent, scopeId);
+};
+
+const sanitizeScopedStyleSheet = (css: string, scopeId: string): string => {
+  if (
+    !css ||
+    UNSAFE_CSS_PATTERN.test(css) ||
+    RAW_CSS_REJECT_PATTERN.test(css)
+  ) {
+    return "";
+  }
+
+  // A constructed sheet is never attached to a document, so parsing it loads
+  // nothing; older engines without it (or without CSSOM nesting) fail closed.
+  try {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(css);
+    const rules: string[] = [];
+    for (const rule of Array.from(sheet.cssRules)) {
+      if (
+        !(rule instanceof CSSStyleRule) ||
+        rule.selectorText !== `#${scopeId}`
+      ) {
+        continue;
+      }
+      const body = [
+        ...safeDeclarations(
+          rule.style,
+          MATHJAX_STYLESHEET_PROPERTIES,
+          "mathjax-stylesheet"
+        ),
+        ...safeNestedRules(rule),
+      ];
+      if (body.length > 0) {
+        rules.push(`#${scopeId} { ${body.join(" ")} }`);
+      }
+    }
+    return rules.join(" ");
+  } catch {
+    return "";
+  }
+};
+
+const safeNestedRules = (parent: CSSStyleRule): string[] => {
+  const rules: string[] = [];
+  for (const rule of Array.from(parent.cssRules)) {
+    if (!(rule instanceof CSSStyleRule)) {
+      continue;
+    }
+    const selector = anchoredNestedSelector(rule.selectorText);
+    const declarations = safeDeclarations(
+      rule.style,
+      MATHJAX_STYLESHEET_PROPERTIES,
+      "mathjax-stylesheet"
+    );
+    if (selector && declarations.length > 0) {
+      rules.push(`${selector} { ${declarations.join(" ")} }`);
+    }
+  }
+  return rules;
+};
+
+// A nested selector only stays inside its parent's scope while `&` is the
+// leading token: `body &` and `:is(body, &)` match outside it. Each selector
+// in the list is re-anchored with a leading `&` (engines serialize the
+// implicit one differently) and rejected if another `&` or a functional
+// pseudo-class remains.
+const anchoredNestedSelector = (selectorText: string): string | undefined => {
+  const anchored: string[] = [];
+  for (const part of selectorText.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const selector = trimmed.startsWith("&") ? trimmed : `& ${trimmed}`;
+    if (/[&(]/.test(selector.slice(1))) {
+      return undefined;
+    }
+    anchored.push(selector);
+  }
+  return anchored.join(", ");
 };

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -6,6 +6,8 @@ import createDOMPurify, {
 
 import { canonicalImageSource } from "@tsmono/util";
 
+import { mathJaxStyles } from "./mathjaxStyles";
+
 const FORBIDDEN_TAGS = [
   "animate",
   "animatemotion",
@@ -115,25 +117,6 @@ const INLINE_STYLE_PROPERTIES = new Set([
   "vertical-align",
   "width",
 ]);
-
-// MathJax's per-formula stylesheet is nested under the formula's own id, so it
-// may additionally absolutely position its assistive MathML and tooltips.
-const MATHJAX_STYLESHEET_PROPERTIES = new Set([
-  ...INLINE_STYLE_PROPERTIES,
-  "bottom",
-  "box-shadow",
-  "cursor",
-  "left",
-  "right",
-  "top",
-]);
-
-type StyleScope = "inline" | "mathjax-stylesheet";
-
-const POSITION_VALUES: Record<StyleScope, Set<string>> = {
-  inline: new Set(["static", "relative"]),
-  "mathjax-stylesheet": new Set(["static", "relative", "absolute"]),
-};
 
 // Any other function (url, image-set, image, src, expression, ...) can load a
 // resource or run code; allowlisting is what makes escape spellings moot.
@@ -342,26 +325,18 @@ const sanitizeStyleAttribute = (style: string): string => {
 
   const scratch = document.createElement("span");
   scratch.setAttribute("style", style);
-  return safeDeclarations(
-    scratch.style,
-    INLINE_STYLE_PROPERTIES,
-    "inline"
-  ).join(" ");
+  return safeDeclarations(scratch.style).join(" ");
 };
 
-const safeDeclarations = (
-  style: CSSStyleDeclaration,
-  allowedProperties: Set<string>,
-  scope: StyleScope
-): string[] => {
+const safeDeclarations = (style: CSSStyleDeclaration): string[] => {
   const declarations: string[] = [];
   for (const property of Array.from(style)) {
     const normalizedProperty = property.toLowerCase();
     const value = style.getPropertyValue(property);
     if (
-      !allowedProperties.has(normalizedProperty) ||
+      !INLINE_STYLE_PROPERTIES.has(normalizedProperty) ||
       !value ||
-      !isSafeStyleValue(normalizedProperty, value, scope)
+      !isSafeStyleValue(normalizedProperty, value)
     ) {
       continue;
     }
@@ -373,11 +348,7 @@ const safeDeclarations = (
   return declarations;
 };
 
-const isSafeStyleValue = (
-  property: string,
-  value: string,
-  scope: StyleScope
-): boolean => {
+const isSafeStyleValue = (property: string, value: string): boolean => {
   if (UNSAFE_CSS_PATTERN.test(value) || RAW_CSS_REJECT_PATTERN.test(value)) {
     return false;
   }
@@ -387,7 +358,7 @@ const isSafeStyleValue = (
     }
   }
   if (property === "position") {
-    return POSITION_VALUES[scope].has(value);
+    return value === "static" || value === "relative";
   }
   // A negative margin pulls the box over neighbouring content while staying
   // in normal flow, which the position policy above would otherwise prevent.
@@ -397,15 +368,8 @@ const isSafeStyleValue = (
   return true;
 };
 
-/**
- * markdown-it-mathjax3 wraps each formula in `<span id="mjx-…">` whose first
- * child is a `<style>` carrying MathJax's stylesheet nested under that id.
- * That is the only stylesheet rendered content may contribute, so rather than
- * trusting the text the CSS is parsed and rebuilt: only style rules survive,
- * every rule stays nested under the wrapper's id, and declarations pass the
- * same allowlist as inline styles. Returns the CSS to keep, or "" to drop the
- * element.
- */
+// A MathJax-shaped wrapper is not proof that its CSS came from MathJax.
+// Replace the sheet with viewer-owned rules; only the validated id is reused.
 const sanitizeMathJaxStyleElement = (element: Element): string => {
   const parent = element.parentElement;
   const scopeId = parent?.getAttribute("id") ?? "";
@@ -415,85 +379,5 @@ const sanitizeMathJaxStyleElement = (element: Element): string => {
   ) {
     return "";
   }
-  return sanitizeScopedStyleSheet(element.textContent, scopeId);
-};
-
-const sanitizeScopedStyleSheet = (css: string, scopeId: string): string => {
-  if (
-    !css ||
-    UNSAFE_CSS_PATTERN.test(css) ||
-    RAW_CSS_REJECT_PATTERN.test(css)
-  ) {
-    return "";
-  }
-
-  // A constructed sheet is never attached to a document, so parsing it loads
-  // nothing; older engines without it (or without CSSOM nesting) fail closed.
-  try {
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(css);
-    const rules: string[] = [];
-    for (const rule of Array.from(sheet.cssRules)) {
-      if (
-        !(rule instanceof CSSStyleRule) ||
-        rule.selectorText !== `#${scopeId}`
-      ) {
-        continue;
-      }
-      const body = [
-        ...safeDeclarations(
-          rule.style,
-          MATHJAX_STYLESHEET_PROPERTIES,
-          "mathjax-stylesheet"
-        ),
-        ...safeNestedRules(rule),
-      ];
-      if (body.length > 0) {
-        rules.push(`#${scopeId} { ${body.join(" ")} }`);
-      }
-    }
-    return rules.join(" ");
-  } catch {
-    return "";
-  }
-};
-
-const safeNestedRules = (parent: CSSStyleRule): string[] => {
-  const rules: string[] = [];
-  for (const rule of Array.from(parent.cssRules)) {
-    if (!(rule instanceof CSSStyleRule)) {
-      continue;
-    }
-    const selector = anchoredNestedSelector(rule.selectorText);
-    const declarations = safeDeclarations(
-      rule.style,
-      MATHJAX_STYLESHEET_PROPERTIES,
-      "mathjax-stylesheet"
-    );
-    if (selector && declarations.length > 0) {
-      rules.push(`${selector} { ${declarations.join(" ")} }`);
-    }
-  }
-  return rules;
-};
-
-// A nested selector only stays inside its parent's scope while `&` is the
-// leading token: `body &` and `:is(body, &)` match outside it. Each selector
-// in the list is re-anchored with a leading `&` (engines serialize the
-// implicit one differently) and rejected if another `&` or a functional
-// pseudo-class remains.
-const anchoredNestedSelector = (selectorText: string): string | undefined => {
-  const anchored: string[] = [];
-  for (const part of selectorText.split(",")) {
-    const trimmed = part.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const selector = trimmed.startsWith("&") ? trimmed : `& ${trimmed}`;
-    if (/[&(]/.test(selector.slice(1))) {
-      return undefined;
-    }
-    anchored.push(selector);
-  }
-  return anchored.join(", ");
+  return mathJaxStyles(scopeId);
 };

--- a/packages/react/src/components/renderedHtmlSanitizer.ts
+++ b/packages/react/src/components/renderedHtmlSanitizer.ts
@@ -36,14 +36,7 @@ const FORBIDDEN_TAGS = [
   "video",
 ];
 
-const MATHJAX_TAGS = [
-  "mjx-assistive-mml",
-  "mjx-container",
-  "mjx-status",
-  "mjx-tip",
-  "mjx-tool",
-  "style",
-];
+const MATHJAX_TAGS = ["mjx-assistive-mml", "mjx-container", "style"];
 
 const MATHJAX_ATTRS = [
   "display",
@@ -212,6 +205,13 @@ const installHooks = (purify: DOMPurifyInstance): void => {
 
   purify.addHook("uponSanitizeAttribute", (node, hookEvent) => {
     if (hookEvent.attrName === "style") {
+      // The accessible copy must stay clipped; inline !important could
+      // override even the viewer-owned stylesheet's clipping rule.
+      if (node.tagName.toLowerCase() === "mjx-assistive-mml") {
+        hookEvent.keepAttr = false;
+        node.removeAttribute("style");
+        return;
+      }
       sanitizeStyleAttributeHook(node, hookEvent);
       return;
     }


### PR DESCRIPTION
## Summary

Log, scan-result, and transcript authors control reference identifiers, rendered content, and citation URLs. Escape reference-link attributes, replace incoming MathJax stylesheet text with viewer-owned styles, restrict inline CSS, and validate external links in the shared packages used by Inspect and Scout.

### Reference links

`injectReferenceLinks` escapes reference ids, citation URLs, and class names before inserting them into HTML attributes. A hostile reference id remains the literal `data-ref-id` of one anchor instead of becoming markup.

### Rendered-HTML sanitizer

A `<span id="mjx-…">` does not establish that its stylesheet came from MathJax. The sanitizer replaces incoming stylesheet text with fixed SVG rules in `mathjaxStyles.ts`; only a validated hexadecimal wrapper id is reused. Every selector is scoped explicitly to that wrapper. Author-supplied selectors, declarations, at-rules, and resource URLs are never interpreted as stylesheet policy.

This closes both selector escapes (`& + #outside`, `& ~ #outside`, and compound-selector variants) and overlays using absolute positioning, viewport dimensions, or oversized shadows on the wrapper or its descendants. The fixed sheet no longer depends on CSSOM nesting support.

Assistive MathML remains in the DOM and selectable so copied text includes formulas, while an important clipping declaration keeps it visually hidden; inline styles on its wrapper are removed so they cannot override clipping. Runtime `mjx-tool`, `mjx-tip`, and `mjx-status` elements are not admitted. Static SVG retains its native `<title>` tooltips. This also removes a duplicate visible accessibility layer on colored and bordered math.

Other inline styles retain the property and value checks: only static/relative positioning is permitted; insets, box shadows, negative margins, resource-loading functions, and CSS escapes are rejected. Ordinary MathJax inline sizing and alignment remain supported.

The fixed styles are adapted from markdown-it-mathjax3 5.2.0 / mathxyjax3 0.8.3, with third-party notices included. Renderer upgrades should include a review of this stylesheet.

### External links

`MessageCitations`, server-tool web-search results, and content-data web-search results use a shared `ExternalLink`. Absolute HTTP(S) URLs with a hostname render as new-tab anchors with `noopener noreferrer`. Other schemes and relative URLs render as inert labels with their tooltips preserved.

## Validation

- Added and committed 13 regression cases that failed before their corresponding fixes: six sibling-selector escapes, five stylesheet overlays, and two forged-element overlay cases.
- Sanitizer, markdown-security, and reference-link suites: 91 tests passed. Coverage includes genuine math output, invalid wrapper ids, hostile stylesheet replacement, inline-style restrictions, accessible MathML, and native SVG tooltips.
- Added two browser regressions that failed before the fix: selecting inline and display math must include the formula text while assistive MathML remains clipped. All 26 chat and viewer-security browser tests pass.
- Existing external-link and message-rendering tests cover accepted HTTP(S) URLs and rejected schemes.
- `pnpm check`, `pnpm test`, and `pnpm build` pass from the repo root. The required pre-push check also passed.
- Chrome 152 checks against the actual sanitizer confirm sibling targets are unaffected, wrapper overlays no longer form, and forged assistive/tooltip elements cannot cover a viewer control. All nine rendered SVG formulas retain nonzero dimensions and visible overflow; accessible MathML is clipped and the native tooltip title is preserved.

## Visual comparison

Chrome render fixtures in light and dark themes cover fractions, radicals, sums, matrices, integrals, links, tooltips, colored math, and bordered math. Before is the original PR head (`e253973`); after includes the follow-up fixes (`0c020c9`). The subsequent text-selection fix (`418429d`) produces pixel-identical light and dark renders. These are shared-renderer fixtures, not screenshots of the full apps. The visible change is removal of duplicated accessibility content on colored/bordered math.

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Before, light](https://github.com/meridianlabs-ai/ts-mono/blob/569e7124d466a4d2a1ac60054a1212b967fcd6d5/before-light.png?raw=true) | ![After, light](https://github.com/meridianlabs-ai/ts-mono/blob/569e7124d466a4d2a1ac60054a1212b967fcd6d5/after-light.png?raw=true) |
| Dark | ![Before, dark](https://github.com/meridianlabs-ai/ts-mono/blob/569e7124d466a4d2a1ac60054a1212b967fcd6d5/before-dark.png?raw=true) | ![After, dark](https://github.com/meridianlabs-ai/ts-mono/blob/569e7124d466a4d2a1ac60054a1212b967fcd6d5/after-dark.png?raw=true) |

