### PR TITLE
Regenerate types for EvalSpec.run_config_source

### DIFF
--- a/packages/inspect-common/src/types/generated.ts
+++ b/packages/inspect-common/src/types/generated.ts
@@ -1987,6 +1987,8 @@ export interface components {
                 [key: string]: string;
             };
             revision?: components["schemas"]["EvalRevision"] | null;
+            /** Run Config Source */
+            run_config_source?: string | null;
             /** Run Id */
             run_id: string;
             sandbox?: components["schemas"]["SandboxEnvironmentSpec"] | null;


### PR DESCRIPTION
## Summary

Regenerates `packages/inspect-common/src/types/generated.ts` from the updated inspect_ai OpenAPI schema, adding the optional nullable `run_config_source` field to `EvalSpec`. Inspect logs use it to record which run configuration file produced a run: a task's attached default (`task_default:<path>`) or a CLI-selected file (`cli:<path>`).

Paired with UKGovernmentBEIS/inspect_ai#5294 (implements UKGovernmentBEIS/inspect_ai#4784). Two-phase landing: this PR merges first, then the inspect_ai PR bumps its submodule gitlink.

Single optional field, so no downstream consumers break. `pnpm typecheck` (15/15) and `pnpm test` (9/9) pass across the workspace, including scout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by [Claude Code](https://claude.com/claude-code) on Matt's behalf.*